### PR TITLE
fix problems encountered during first deployment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,4 @@ repos:
     rev: 22.12.0
     hooks:
     -   id: black
-        language_version: python3.11
+        language_version: python3.10

--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -223,7 +223,7 @@ SITE_INFO = {
 # Mastodon configs
 CLIENT_NAME = os.environ.get("APP_NAME", "NiceDB")
 SITE_INFO["site_name"] = os.environ.get("APP_NAME", "NiceDB")
-APP_WEBSITE = os.environ.get("APP_URL", "https://nicedb.org")
+APP_WEBSITE = os.environ.get("APP_URL", "https://localhost")
 REDIRECT_URIS = APP_WEBSITE + "/users/OAuth2_login/"
 
 
@@ -321,7 +321,7 @@ if DEBUG:
 # https://django-debug-toolbar.readthedocs.io/en/latest/
 # maybe benchmarking before deployment
 
-REDIS_HOST = os.environ.get("REDIS_HOST", "127.0.0.1")
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 
 RQ_QUEUES = {
     "mastodon": {
@@ -337,19 +337,19 @@ RQ_QUEUES = {
         "DEFAULT_TIMEOUT": -1,
     },
     "import": {
-        "HOST": "localhost",
+        "HOST": REDIS_HOST,
         "PORT": 6379,
         "DB": 0,
         "DEFAULT_TIMEOUT": -1,
     },
     "fetch": {
-        "HOST": "localhost",
+        "HOST": REDIS_HOST,
         "PORT": 6379,
         "DB": 0,
         "DEFAULT_TIMEOUT": -1,
     },
     "crawl": {
-        "HOST": "localhost",
+        "HOST": REDIS_HOST,
         "PORT": 6379,
         "DB": 0,
         "DEFAULT_TIMEOUT": -1,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ django-ninja
 django-polymorphic
 django-maintenance-mode
 django-tz-detect
+django-debug-toolbar
 meilisearch
 easy-thumbnails
 lxml


### PR DESCRIPTION
requirements.txt
- add a module needed (django-debug-toolbar). 

settings.py:
- make redis host identical
- app_website to "localhost"

pre-commit:
- change pre-commit python version to 3.10. (As 3.10 is the lowest required version, i think this should be 3.10 as well?)