### PR TITLE
 [WIP/ Need review] Mark history

### DIFF
--- a/journal/urls.py
+++ b/journal/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("like/<str:piece_uuid>", like, name="like"),
     path("unlike/<str:piece_uuid>", unlike, name="unlike"),
     path("mark/<str:item_uuid>", mark, name="mark"),
+    path("mark_log/<str:item_uuid>/<str:log_id>", mark_log, name="mark_log"),
     path("comment/<str:item_uuid>/<str:focus_item_uuid>", comment, name="comment"),
     path(
         "add_to_collection/<str:item_uuid>", add_to_collection, name="add_to_collection"

--- a/journal/views.py
+++ b/journal/views.py
@@ -200,10 +200,10 @@ def mark_log(request, item_uuid, log_id):
     item = get_object_or_404(Item, uid=base62.decode(item_uuid))
     if request.method == "POST":
         if request.POST.get("delete", default=False):
-            # TODO: delete the right log instead of the first availble one.
             mark_log = get_object_or_404(
-                ShelfLogEntry, owner=request.user, item=item, pk=log_id
+                ShelfLogEntry, owner=request.user, item=item, id=log_id
             )
+            print(mark_log)
             mark_log.delete()
             return HttpResponseRedirect(request.META.get("HTTP_REFERER"))
     raise BadRequest()

--- a/journal/views.py
+++ b/journal/views.py
@@ -197,14 +197,14 @@ def mark(request, item_uuid):
 
 @login_required
 def mark_log(request, item_uuid, log_id):
+    """
+    Delete log of one item by log id.
+    """
     item = get_object_or_404(Item, uid=base62.decode(item_uuid))
+    mark = Mark(request.user, item)
     if request.method == "POST":
         if request.POST.get("delete", default=False):
-            mark_log = get_object_or_404(
-                ShelfLogEntry, owner=request.user, item=item, id=log_id
-            )
-            print(mark_log)
-            mark_log.delete()
+            mark.delete_log(log_id)
             return HttpResponseRedirect(request.META.get("HTTP_REFERER"))
     raise BadRequest()
 

--- a/journal/views.py
+++ b/journal/views.py
@@ -196,6 +196,20 @@ def mark(request, item_uuid):
 
 
 @login_required
+def mark_log(request, item_uuid, log_id):
+    item = get_object_or_404(Item, uid=base62.decode(item_uuid))
+    if request.method == "POST":
+        if request.POST.get("delete", default=False):
+            # TODO: delete the right log instead of the first availble one.
+            mark_log = get_object_or_404(
+                ShelfLogEntry, owner=request.user, item=item, pk=log_id
+            )
+            mark_log.delete()
+            return HttpResponseRedirect(request.META.get("HTTP_REFERER"))
+    raise BadRequest()
+
+
+@login_required
 def comment(request, item_uuid, focus_item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     focus_item = get_object_or_404(Item, uid=get_uuid_or_404(focus_item_uuid))


### PR DESCRIPTION
issue:  #53

Still WIP (no UI design and no test) but would like to have some feedback.

Currently, this feature is completed:
- When a mark is deleted, the logs of the mark is cleared.
- When a log is deleted, the `shelf_type` of the mark will be updated according to the last log ("移除标记“ is filtered out when getting the last log).
- "移除标记“ is shown to users. 

Not sure if there's other case to consider? Any suggestion for improvements? 

Thanks in advance.