### PR TITLE
fix discogs language url

### DIFF
--- a/catalog/sites/discogs.py
+++ b/catalog/sites/discogs.py
@@ -18,7 +18,10 @@ _logger = logging.getLogger(__name__)
 class DiscogsRelease(AbstractSite):
     SITE_NAME = SiteName.Discogs
     ID_TYPE = IdType.Discogs_Release
-    URL_PATTERNS = [r"https://www\.discogs\.com/release/(\d+)[^\d]*"]
+    URL_PATTERNS = [
+        r"https://www\.discogs\.com/release/(\d+)[^\d]*",
+        r"https://www\.discogs\.com/[a-z]{2}/release/(\d+)[^\d]*",
+    ]
     WIKI_PROPERTY_ID = "?"
     DEFAULT_MODEL = Album
 

--- a/catalog/sites/discogs.py
+++ b/catalog/sites/discogs.py
@@ -21,6 +21,7 @@ class DiscogsRelease(AbstractSite):
     URL_PATTERNS = [
         r"https://www\.discogs\.com/release/(\d+)[^\d]*",
         r"https://www\.discogs\.com/[a-z]{2}/release/(\d+)[^\d]*",
+        r"https://www\.discogs\.com/[a-z]{2}_[A-Z]{2}/release/(\d+)[^\d]*",
     ]
     WIKI_PROPERTY_ID = "?"
     DEFAULT_MODEL = Album


### PR DESCRIPTION
@alphatownsman 

this should fix the problem but i didn't test it... I am sorry but I have some VPN issues to run the project.

The fix aims to add new regex matches: language and language + country

language example:
https://www.discogs.com/ja/release/2898836-Warpig-Warpig

language + country example:
https://www.discogs.com/pt_BR/release/2898836-Warpig-Warpig