### PR TITLE
把 mark.html 的文本输入框的placeholder 同步到 comment.html 的文本输入框的placeholder去

### DIFF
--- a/journal/templates/comment.html
+++ b/journal/templates/comment.html
@@ -25,7 +25,7 @@
         <textarea name="text"
                   cols="40"
                   rows="10"
-                  placeholder="超过360字部分实例可能无法显示"
+                  placeholder="提示： 善用 &gt;!文字!&lt; 标记可隐藏剧透； 超过360字可能无法分享到联邦宇宙实例时间轴。"
                   id="id_text">{% if comment.text %}{{ comment.text }}{% endif %}</textarea>
         <div class="grid">
           <div>


### PR DESCRIPTION
在comment.html的文本输入框里，同样提示一下用户如何隐藏剧透。