### PR TITLE
fix: alt text overflow when avatar src is absent

### DIFF
--- a/common/static/scss/_common.scss
+++ b/common/static/scss/_common.scss
@@ -194,6 +194,8 @@ form img {
 
 .avatar {
   display: inline-block;
+  overflow: hidden;
+  max-width: 3em;
 
   img {
     max-width: unset;


### PR DESCRIPTION
Before:

![image](https://github.com/neodb-social/neodb/assets/32487868/c7eda2d3-e97b-43cf-a675-d1126bbc372b)


After:

![image](https://github.com/neodb-social/neodb/assets/32487868/0370dd28-705f-4b0a-ad07-7b9639e5677d)
