### PR TITLE
Bugfix for imdb scraper

### DIFF
--- a/catalog/sites/imdb.py
+++ b/catalog/sites/imdb.py
@@ -91,7 +91,9 @@ class IMDB(AbstractSite):
             "genre": (
                 [x["text"] for x in d["genres"]["genres"]] if d.get("genres") else []
             ),
-            "brief": d["plot"].get("plotText") if d.get("plot") else None,
+            "brief": (
+                d["plot"].get("plotText").get("plainText") if d.get("plot") else None
+            ),
             "cover_image_url": (
                 d["primaryImage"].get("url") if d.get("primaryImage") else None
             ),


### PR DESCRIPTION
The default value for TMDB_V3_API_KEY is TESTONLY. This raises an unhandled exception in the IMDb scraper, making it unusable without configuration.

This makes the imdb scraper default to parsing the imdb page on all errors in the tmdb scraper. Additionally a minor change in the imdb json parsing is added to extract the plotText correctly.