### PR TITLE
fix no referer when link to external source as some are may block us

### DIFF
--- a/catalog/templates/item_base.html
+++ b/catalog/templates/item_base.html
@@ -40,7 +40,9 @@
         </h1>
         <span class="site-list">
           {% for res in item.external_resources.all %}
-            <a href="{{ res.url }}" class="{{ res.site_name }}">{{ res.site_label }}</a>
+            <a href="{{ res.url }}"
+               class="{{ res.site_name }}"
+               rel="noopener noreferrer">{{ res.site_label }}</a>
           {% endfor %}
         </span>
       </div>


### PR DESCRIPTION
> 有什么方法禁止neodb使用豆瓣的数据，现在是每次在neodb搜索了数据后，如果有豆瓣的标记，打开豆瓣会显示流量异常🫠🫠

https://mastodon.social/@yevvda/113548563186498849