### PR TITLE
fix: calendar_yearview

### DIFF
--- a/journal/static/js/calendar_yearview_blocks.js
+++ b/journal/static/js/calendar_yearview_blocks.js
@@ -32,11 +32,12 @@
             var wrap_chart = _this;
 
             var end_date = new Date(settings.final_date);
-            end_date.setDate(end_date.getDate()+1);
-            var current_date = new Date();
             var start_date = new Date();
             start_date.setMonth(end_date.getMonth() - 12);
             end_year = end_date.getFullYear()
+            end_date.setDate(end_date.getDate()+1);
+            var current_date = new Date();
+
 
             var start_weekday = settings.start_monday === true?1:0;
             for (var i = 0; i < 7; i++) {


### PR DESCRIPTION
lol, bug only appear in 12.31.

`setDate` may make end_date become 1.1 next year if 12.31 today,  so  `getMonth` will return 0, and then start_date will become 1.31 in last year.

![image](https://github.com/user-attachments/assets/b95b4a96-72f7-4f09-b5b7-83c47bd25716)
