### PR TITLE
change the schema for request from http to https for google books cover image urls

### DIFF
--- a/catalog/sites/google_books.py
+++ b/catalog/sites/google_books.py
@@ -149,7 +149,7 @@ class GoogleBooks(AbstractSite):
                         # b['volumeInfo']['infoLink'].replace('http:', 'https:')
                         url = "https://books.google.com/books?id=" + b["id"]
                         cover = (
-                            b["volumeInfo"]["imageLinks"]["thumbnail"]
+                            b["volumeInfo"]["imageLinks"]["thumbnail"].replace("http","https")
                             if "imageLinks" in b["volumeInfo"]
                             else ""
                         )


### PR DESCRIPTION
By default googlebooks returns http urls for covers, which may lead to errors in browsers that enforce HSTS.
In the future this can break but it doesn't seem like google books is going to change (really, fix) it any sooner.