### PR TITLE
fix empty collection title in profile page

### DIFF
--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -297,7 +297,7 @@ class Collection(List):
             "content": content,
         }
 
-    @cached_property
+    @property
     def display_title(self) -> str:
         return self.title
 


### PR DESCRIPTION
This PR is to fix the issue that collection titles are empty in profile page, as shown in the image below. This is due to profile_items.html uses "display_title" property while Collection does not have it.

<img width="1316" height="702" alt="image" src="https://github.com/user-attachments/assets/be2e8acb-6337-45e9-b5c6-91f975dd0307" />

```python
def profile_created_collections(request: AuthedHttpRequest, user_name):
    ...
    return render(
        request,
        "profile_items.html",  # profile_items.html uses "display_title"
        {
            "title": _("collection"),
            "url": f"{target.url}collections/",
            "items": collections,  # Collection lacks the property of "display_title"
            "total": total,
            "show_create_button": target.user == request.user,
        },
    )
```
