### PR TITLE
fix Federation doc link

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -1,3 +1,3 @@
 # Federation
 
-see [doc](https://neodb.net/internals/federation.md) for FEP-67ff related information.
+see [doc](https://neodb.net/internals/federation) for FEP-67ff related information.


### PR DESCRIPTION
I found that the link returned a 404 page, and then realized that the problem was the extra .md extension in the URL.