### PR TITLE
feat: add calendar_data api

### DIFF
--- a/users/apis.py
+++ b/users/apis.py
@@ -163,7 +163,7 @@ def user_calendar_data(request, handle: str):
         return 403, {"message": "unavailable"}
 
     # Determine visibility
-    max_visibility = 0  # Default specific public
+    max_visibility = 0  # Default visibility is public (0)
     if viewer:
         if viewer == target:
             max_visibility = 2


### PR DESCRIPTION
test locally, test results and endpoints see images

<img width="1572" height="594" alt="CleanShot 2025-12-14 at 13 15 50@2x" src="https://github.com/user-attachments/assets/e42fcd97-ce33-4c13-9631-8bf63259fc7d" />
<img width="1400" height="1368" alt="CleanShot 2025-12-14 at 13 16 38@2x" src="https://github.com/user-attachments/assets/1e4c0889-a3f7-4b16-a833-bdc446015bcb" />
<img width="1342" height="992" alt="CleanShot 2025-12-14 at 13 17 16@2x" src="https://github.com/user-attachments/assets/2a50afc4-2741-47f2-a717-3a03d85a8fa5" />
<img width="1022" height="868" alt="CleanShot 2025-12-14 at 13 17 42@2x" src="https://github.com/user-attachments/assets/1e378de9-2995-4adf-b6ab-4f6cfa26d4a6" />
<img width="2474" height="3700" alt="CleanShot 2025-12-14 at 13 19 11@2x" src="https://github.com/user-attachments/assets/dc5fbbbd-4072-4136-a404-65cd02eda22e" />
<img width="2444" height="5074" alt="CleanShot 2025-12-14 at 13 20 01@2x" src="https://github.com/user-attachments/assets/83dc58bb-b47d-4451-b1ee-b2877c35c15e" />
