### PR TITLE
fix: resolve N+1 queries in shelf mark list and API shelf endpoint

### DIFF
--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -11,7 +11,11 @@ from ninja.pagination import paginate
 from catalog.models import AvailableItemCategory, Item, ItemCategory, ItemSchema
 from common.api import PageNumberPagination, Result, api
 from common.utils import get_uuid_or_404
-from journal.models.common import max_visiblity_to_user, q_owned_piece_visible_to_user
+from journal.models.common import (
+    max_visiblity_to_user,
+    prefetch_latest_posts,
+    q_owned_piece_visible_to_user,
+)
 from journal.models.rating import Rating
 from journal.models.shelf import ShelfMember
 from journal.models.tag import Tag
@@ -33,6 +37,9 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     # Batch-fetch item-level data (public rating/tags for ItemSchema)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
+    # Batch-fetch latest_post_id for all members to avoid N+1 queries
+    # when MarkSchema accesses latest_post_id
+    prefetch_latest_posts(members)
     # Batch-fetch user's tags for MarkSchema.tags
     owner = members[0].owner
     item_ids = [m.item_id for m in members]

--- a/journal/models/mark.py
+++ b/journal/models/mark.py
@@ -178,7 +178,11 @@ class Mark:
             marks[i.pk] = m
         q = q_owned_piece_visible_to_user(viewing_user, owner)
         q2 = q_owned_parent_piece_visible_to_user(viewing_user, owner)
-        for m in ShelfMember.objects.filter(item__in=items).filter(q):
+        for m in (
+            ShelfMember.objects.filter(item__in=items)
+            .filter(q)
+            .select_related("parent")
+        ):
             marks[m.item_id].shelfmember = m
         for c in Comment.objects.filter(item__in=items).filter(q):
             marks[c.item_id].comment = c


### PR DESCRIPTION
## Summary
- Add `select_related("parent")` to `ShelfMember` query in `Mark.get_marks_by_items()` to prevent per-item Shelf lookups when templates access `mark.shelf` / `mark.shelf_type`
- Add `prefetch_latest_posts()` call in `_prefetch_shelf_members()` so the API shelf endpoint batch-fetches `latest_post_id` instead of querying `journal_piecepost` per member

## Test plan
- [ ] Verify `/users/{name}/{shelf_type}/{category}/` page no longer triggers N+1 on `journal_shelf`
- [ ] Verify `/api/me/shelf/{type}` no longer triggers N+1 on `journal_piecepost`
- [ ] Run existing tests to confirm no regressions

Fixes EGGPLANT-19B
Fixes NEODB-SOCIAL-4FC