### PR TITLE
feat: standardize genre field with canonical codes

### DIFF
--- a/catalog/common/migrations.py
+++ b/catalog/common/migrations.py
@@ -142,6 +142,24 @@ def normalize_language_20250524():
     logger.warning(f"normalize_language finished. {u} of {c} items updated.")
 
 
+def normalize_genre_20260412():
+    from catalog.models import Item
+    from common.models.genre import normalize_genres
+
+    logger.warning("normalize_genre start")
+    c = Item.objects.all().count()
+    u = 0
+    for i in tqdm(Item.objects.all().iterator(), total=c):
+        genre = getattr(i, "genre", None)
+        if genre:
+            genre2 = normalize_genres(genre)
+            if genre2 != genre:
+                setattr(i, "genre", genre2)
+                i.save(update_fields=["metadata"])
+                u += 1
+    logger.warning(f"normalize_genre finished. {u} of {c} items updated.")
+
+
 def link_tmdb_wikidata_20250815(limit=None):
     """
     Scan all TMDB Movie and TVShow resources, refetch them, and link to WikiData resources if available.

--- a/catalog/forms.py
+++ b/catalog/forms.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from catalog.models import *
 from common.forms import PreviewImageInput
 from common.models import SITE_DEFAULT_LANGUAGE, detect_language, uniq
+from common.models.genre import normalize_genres
 from common.models.lang import normalize_languages
 
 CatalogForms = {}
@@ -108,6 +109,8 @@ def _EditForm(item_model):
             data["primary_lookup_id_value"] = v
             if "language" in data:
                 data["language"] = normalize_languages(data["language"])
+            if "genre" in data:
+                data["genre"] = normalize_genres(data["genre"])
             return data
 
     return EditForm

--- a/catalog/models/common.py
+++ b/catalog/models/common.py
@@ -2,7 +2,13 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from ninja import Schema
 
-from common.models import LANGUAGE_CHOICES, LOCALE_CHOICES, SCRIPT_CHOICES, jsondata
+from common.models import (
+    GENRE_CHOICES,
+    LANGUAGE_CHOICES,
+    LOCALE_CHOICES,
+    SCRIPT_CHOICES,
+    jsondata,
+)
 
 
 class SiteName(models.TextChoices):
@@ -182,6 +188,7 @@ LANGUAGE_CHOICES_JSONFORM = get_locale_choices_for_jsonform(
     LANGUAGE_CHOICES, const=True
 )
 SCRIPT_CHOICES_JSONFORM = get_locale_choices_for_jsonform(SCRIPT_CHOICES, const=True)
+GENRE_CHOICES_JSONFORM = get_locale_choices_for_jsonform(GENRE_CHOICES, const=True)
 
 LOCALIZED_LABEL_SCHEMA = {
     "type": "list",
@@ -234,6 +241,23 @@ LIST_OF_ONE_PLUS_STR_SCHEMA = {
     "minItems": 1,
     "uniqueItems": True,
 }
+
+
+def GenreListField():
+    return jsondata.ArrayField(
+        verbose_name=_("genre"),
+        base_field=models.CharField(blank=True, default="", max_length=200),
+        null=True,
+        blank=True,
+        default=list,
+        schema={
+            "type": "array",
+            "items": {
+                "oneOf": GENRE_CHOICES_JSONFORM + [{"title": "Other", "type": "string"}]
+            },
+            "uniqueItems": True,
+        },
+    )
 
 
 def LanguageListField(script=False):

--- a/catalog/models/game.py
+++ b/catalog/models/game.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    GenreListField,
     jsondata,
 )
 from .item import (
@@ -121,13 +122,7 @@ class Game(Item):
         choices=GameReleaseType.choices,
     )
 
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=True, default="", max_length=200),
-        null=True,
-        blank=True,
-        default=list,
-    )
+    genre = GenreListField()
 
     platform = jsondata.ArrayField(
         verbose_name=_("platform"),

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -21,6 +21,7 @@ from ninja import Field, Schema
 from polymorphic.models import PolymorphicModel
 
 from common.models import get_current_locales, jsondata, uniq
+from common.models.genre import normalize_genres
 from common.models.lang import normalize_languages
 from common.utils import get_file_absolute_url
 
@@ -639,9 +640,19 @@ class Item(PolymorphicModel):
                 changed = True
         return changed
 
+    def _normalize_genres(self) -> bool:
+        changed = False
+        if hasattr(self, "genre"):
+            genre = normalize_genres(self.genre)
+            if self.genre != genre:
+                self.genre = genre
+                changed = True
+        return changed
+
     def normalize_metadata(self, override_resources=[]) -> bool:
         r = self._update_primary_lookup_id(override_resources)
         r |= self._normalize_languages()
+        r |= self._normalize_genres()
         return r
 
     def merge_data_from_external_resource(

--- a/catalog/models/movie.py
+++ b/catalog/models/movie.py
@@ -5,6 +5,7 @@ from common.models.misc import int_
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    GenreListField,
     LanguageListField,
     jsondata,
 )
@@ -85,13 +86,7 @@ class Movie(Item):
         default=list,
         schema=LIST_OF_STR_SCHEMA,
     )
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=True, default="", max_length=50),
-        null=True,
-        blank=True,
-        default=list,
-    )  # , choices=MovieGenreEnum.choices
+    genre = GenreListField()
     showtime = jsondata.JSONField(
         _("release date"),
         null=True,

--- a/catalog/models/music.py
+++ b/catalog/models/music.py
@@ -1,12 +1,11 @@
 from datetime import date
 
-from django.db import models
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import pgettext_lazy
 
 from .common import (
     LIST_OF_ONE_PLUS_STR_SCHEMA,
     LIST_OF_STR_SCHEMA,
+    GenreListField,
     jsondata,
 )
 from .item import (
@@ -69,13 +68,7 @@ class Album(Item):
         default=list,
         schema=LIST_OF_ONE_PLUS_STR_SCHEMA,
     )
-    genre = jsondata.ArrayField(
-        verbose_name=pgettext_lazy("music", "genre"),
-        base_field=models.CharField(blank=True, default="", max_length=50),
-        null=True,
-        blank=True,
-        default=list,
-    )
+    genre = GenreListField()
     company = jsondata.JSONField(
         verbose_name=_("publisher"),
         null=False,

--- a/catalog/models/performance.py
+++ b/catalog/models/performance.py
@@ -9,6 +9,7 @@ from common.models.misc import datetime_
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    GenreListField,
     LanguageListField,
     jsondata,
 )
@@ -114,13 +115,7 @@ class Performance(Item):
     orig_title = jsondata.CharField(
         verbose_name=_("original name"), blank=True, max_length=500
     )
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=False, default="", max_length=200),
-        null=False,
-        blank=False,
-        default=list,
-    )
+    genre = GenreListField()
     language = LanguageListField()
     director = jsondata.JSONField(
         verbose_name=_("director"),

--- a/catalog/models/podcast.py
+++ b/catalog/models/podcast.py
@@ -7,6 +7,7 @@ from ninja import Field
 
 from .common import (
     LIST_OF_ONE_PLUS_STR_SCHEMA,
+    GenreListField,
     LanguageListField,
     jsondata,
 )
@@ -56,13 +57,7 @@ class Podcast(Item):
     # apple_podcast = PrimaryLookupIdDescriptor(IdType.ApplePodcast)
     # ximalaya = LookupIdDescriptor(IdType.Ximalaya)
     # xiaoyuzhou = LookupIdDescriptor(IdType.Xiaoyuzhou)
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=True, default="", max_length=200),
-        null=True,
-        blank=True,
-        default=list,
-    )
+    genre = GenreListField()
 
     language = LanguageListField()
 

--- a/catalog/models/tv.py
+++ b/catalog/models/tv.py
@@ -37,6 +37,7 @@ from common.models.misc import int_, uniq
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    GenreListField,
     LanguageListField,
     jsondata,
 )
@@ -157,13 +158,7 @@ class TVShow(Item):
         default=list,
         schema=LIST_OF_STR_SCHEMA,
     )
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=True, default="", max_length=50),
-        null=True,
-        blank=True,
-        default=list,
-    )  # , choices=MovieGenreEnum.choices
+    genre = GenreListField()
     showtime = jsondata.JSONField(
         _("show time"),
         null=True,
@@ -384,13 +379,7 @@ class TVSeason(Item):
         default=list,
         schema=LIST_OF_STR_SCHEMA,
     )
-    genre = jsondata.ArrayField(
-        verbose_name=_("genre"),
-        base_field=models.CharField(blank=True, default="", max_length=50),
-        null=True,
-        blank=True,
-        default=list,
-    )  # , choices=MovieGenreEnum.choices
+    genre = GenreListField()
     showtime = jsondata.JSONField(
         _("show time"),
         null=True,

--- a/catalog/sites/apple_podcast.py
+++ b/catalog/sites/apple_podcast.py
@@ -34,7 +34,7 @@ class ApplePodcast(AbstractSite):
                 "title": title,
                 "feed_url": feed_url,
                 "host": [r["artistName"]],
-                "genres": r["genres"],
+                "genre": r["genres"],
                 "cover_image_url": r["artworkUrl600"],
             }
         )

--- a/catalog/sites/rss.py
+++ b/catalog/sites/rss.py
@@ -104,7 +104,12 @@ class RSS(AbstractSite):
                 ),
                 "official_site": feed.get("link"),
                 "cover_image_url": feed.get("cover_url"),
-                "genre": [x for x in feed.get("itunes_categories", []) if x],
+                "genre": [
+                    item
+                    for cat in feed.get("itunes_categories", [])
+                    for item in (cat if isinstance(cat, list) else [cat])
+                    if item
+                ],
             }
         )
         pd.lookup_ids[IdType.RSS] = RSS.url_to_id(self.url)

--- a/catalog/sites/rss.py
+++ b/catalog/sites/rss.py
@@ -104,7 +104,7 @@ class RSS(AbstractSite):
                 ),
                 "official_site": feed.get("link"),
                 "cover_image_url": feed.get("cover_url"),
-                "genre": feed.get("itunes_categories", [None])[0],
+                "genre": [x for x in feed.get("itunes_categories", []) if x],
             }
         )
         pd.lookup_ids[IdType.RSS] = RSS.url_to_id(self.url)

--- a/catalog/templates/_genre_list.html
+++ b/catalog/templates/_genre_list.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+{% load duration %}
+{% if list %}
+  <span>
+    {% trans 'genre' %}:
+    {% for p in list %}
+      {% if forloop.counter <= max %}
+        {% if not forloop.first %}/{% endif %}
+        <span>{{ p|code_to_genre }}</span>
+      {% elif forloop.last %}
+        …
+      {% endif %}
+    {% endfor %}
+  </span>
+{% endif %}

--- a/catalog/templates/_item_card_metadata_album.html
+++ b/catalog/templates/_item_card_metadata_album.html
@@ -7,7 +7,7 @@
       <span class="solo-hidden">{{ item.rating | floatformat:1 }} <small>({{ item.rating_count }} {% trans "ratings" %})</small></span>
     {% endif %}
     {% include '_people.html' with people=item.artist role='' max=2 %}
-    {% include '_people.html' with people=item.genre role='genre' max=5 %}
+    {% include '_genre_list.html' with list=item.genre max=5 %}
   </div>
 {% endblock brief %}
 {% block full %}

--- a/catalog/templates/_item_card_metadata_game.html
+++ b/catalog/templates/_item_card_metadata_game.html
@@ -12,7 +12,7 @@
 {% endblock brief %}
 {% block full %}
   <div class="multi-fields">
-    {% include '_people.html' with people=item.genre role='genre' max=2 %}
+    {% include '_genre_list.html' with list=item.genre max=2 %}
     {% include '_people.html' with people=item.platform role='platform' max=5 %}
     {% include '_people.html' with people=item.developer role='developer' max=2 %}
     {% include '_people.html' with people=item.publisher role='publisher' max=2 %}

--- a/catalog/templates/_item_card_metadata_performance.html
+++ b/catalog/templates/_item_card_metadata_performance.html
@@ -6,7 +6,7 @@
     {% if item.rating %}
       <span class="solo-hidden">{{ item.rating | floatformat:1 }} <small>({{ item.rating_count }} {% trans "ratings" %})</small></span>
     {% endif %}
-    {% include '_people.html' with people=item.genre role='genre' max=2 %}
+    {% include '_genre_list.html' with list=item.genre max=2 %}
     {% include '_people.html' with people=item.playwright role='playwright' max=2 %}
     {% include '_people.html' with people=item.composer role='composer' max=2 %}
     {% include '_people.html' with people=item.choreographer role='choreographer' max=2 %}

--- a/catalog/templates/_item_card_metadata_performanceproduction.html
+++ b/catalog/templates/_item_card_metadata_performanceproduction.html
@@ -6,7 +6,7 @@
     {% if item.rating %}
       <span class="solo-hidden">{{ item.rating | floatformat:1 }} <small>({{ item.rating_count }} {% trans "ratings" %})</small></span>
     {% endif %}
-    {% include '_people.html' with people=item.genre role='genre' max=2 %}
+    {% include '_genre_list.html' with list=item.genre max=2 %}
     {% include '_language_list.html' with list=item.language max=5 %}
     {% include '_people.html' with people=item.troupe role='troupe' max=2 %}
     {% include '_people.html' with people=item.location role='theater' max=2 %}

--- a/catalog/templates/album.html
+++ b/catalog/templates/album.html
@@ -22,7 +22,7 @@
       {% trans 'duration' %}: {{ item.duration|duration_format:1000 }}
     {% endif %}
   </div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=5 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>
     {% if item.barcode %}
       {% trans 'barcode' %}: {{ item.barcode }}

--- a/catalog/templates/game.html
+++ b/catalog/templates/game.html
@@ -24,7 +24,7 @@
     {% endif %}
   </div>
   <div>{% include '_people.html' with people=item.platform role='platform' max=8 %}</div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=5 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>{% include '_people.html' with people=item.designer role='designer' max=3 %}</div>
   <div>{% include '_people.html' with people=item.artist role='artist' max=3 %}</div>
   <div>{% include '_people.html' with people=item.developer role='developer' max=2 %}</div>

--- a/catalog/templates/movie.html
+++ b/catalog/templates/movie.html
@@ -12,7 +12,7 @@
   <div>{% include '_people.html' with people=item.director role='director' max=5 %}</div>
   <div>{% include '_people.html' with people=item.playwright role='playwright' max=5 %}</div>
   <div>{% include '_people.html' with people=item.actor role='actor' max=5 %}</div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=10 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
   <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   <div>

--- a/catalog/templates/performance.html
+++ b/catalog/templates/performance.html
@@ -16,7 +16,7 @@
       {% if item.closing_date %}~ <span>{{ item.closing_date }}</span>{% endif %}
     {% endif %}
   </div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=5 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>{% include '_people.html' with people=item.troupe role='troupe' max=5 %}</div>
   <div>{% include '_people.html' with people=item.location role='theater' max=5 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>

--- a/catalog/templates/performanceproduction.html
+++ b/catalog/templates/performanceproduction.html
@@ -16,7 +16,7 @@
     {% endif %}
   </div>
   <div>{% include '_people.html' with people=item.additional_title _role='' max=99 %}</div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=5 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>{% include '_people.html' with people=item.troupe role='troupe' max=5 %}</div>
   <div>{% include '_people.html' with people=item.location role='theater' max=5 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>

--- a/catalog/templates/podcast.html
+++ b/catalog/templates/podcast.html
@@ -13,7 +13,7 @@
 <script src="{% static 'js/podcast.js' %}"></script>
 {% endblock %}
 {% block details %}
-  <div>{% include '_people.html' with people=item.genre role='genre' max=5 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>{% include '_people.html' with people=item.host role='host' max=5 %}</div>
   <div>
     {% if item.official_site %}

--- a/catalog/templates/tvseason.html
+++ b/catalog/templates/tvseason.html
@@ -24,7 +24,7 @@
   <div>{% include '_people.html' with people=item.director role='director' max=5 %}</div>
   <div>{% include '_people.html' with people=item.playwright role='playwright' max=5 %}</div>
   <div>{% include '_people.html' with people=item.actor role='actor' max=5 %}</div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=10 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
   <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   <div>

--- a/catalog/templates/tvshow.html
+++ b/catalog/templates/tvshow.html
@@ -12,7 +12,7 @@
   <div>{% include '_people.html' with people=item.director role='director' max=5 %}</div>
   <div>{% include '_people.html' with people=item.playwright role='playwright' max=5 %}</div>
   <div>{% include '_people.html' with people=item.actor role='actor' max=5 %}</div>
-  <div>{% include '_people.html' with people=item.genre role='genre' max=10 %}</div>
+  <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
   <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   {% with item.all_seasons as seasons %}

--- a/common/models/__init__.py
+++ b/common/models/__init__.py
@@ -1,4 +1,10 @@
 from .cron import BaseJob, JobManager
+from .genre import (
+    GENRE_CHOICES,
+    GENRE_CODES,
+    normalize_genre,
+    normalize_genres,
+)
 from .lang import (
     LANGUAGE_CHOICES,
     LOCALE_CHOICES,
@@ -14,6 +20,8 @@ from .site_config import SiteConfig
 
 __all__ = [
     "BaseJob",
+    "GENRE_CHOICES",
+    "GENRE_CODES",
     "JobManager",
     "LANGUAGE_CHOICES",
     "LOCALE_CHOICES",
@@ -24,6 +32,8 @@ __all__ = [
     "SiteConfig",
     "detect_language",
     "get_current_locales",
+    "normalize_genre",
+    "normalize_genres",
     "uniq",
     "int_",
 ]

--- a/common/models/genre.py
+++ b/common/models/genre.py
@@ -87,6 +87,7 @@ GENRE_CATALOG = {
     "puzzle": _("Puzzle"),
     "platformer": _("Platformer"),
     "shooter": _("Shooter"),
+    "fps": _("FPS"),
     "fighting": _("Fighting"),
     "survival": _("Survival"),
     "sandbox": _("Sandbox"),
@@ -216,6 +217,10 @@ _SCRAPER_ALIASES: dict[str, str] = {
     # -----------------------------------------------------------
     "massively multiplayer": "mmo",
     "quiz/trivia": "puzzle",
+    # -----------------------------------------------------------
+    # Douban Game (Chinese)
+    # -----------------------------------------------------------
+    "第一人称射击": "fps",
     # -----------------------------------------------------------
     # MusicBrainz / Spotify (only confident mappings)
     # -----------------------------------------------------------

--- a/common/models/genre.py
+++ b/common/models/genre.py
@@ -87,7 +87,6 @@ GENRE_CATALOG = {
     "puzzle": _("Puzzle"),
     "platformer": _("Platformer"),
     "shooter": _("Shooter"),
-    "fps": _("FPS"),
     "fighting": _("Fighting"),
     "survival": _("Survival"),
     "sandbox": _("Sandbox"),
@@ -220,7 +219,7 @@ _SCRAPER_ALIASES: dict[str, str] = {
     # -----------------------------------------------------------
     # Douban Game (Chinese)
     # -----------------------------------------------------------
-    "第一人称射击": "fps",
+    "第一人称射击": "shooter",
     # -----------------------------------------------------------
     # MusicBrainz / Spotify (only confident mappings)
     # -----------------------------------------------------------

--- a/common/models/genre.py
+++ b/common/models/genre.py
@@ -1,0 +1,335 @@
+"""
+Genre support utilities
+
+Provides a canonical genre list for all media types (movies, TV, music, games,
+podcasts, performances) with translatable labels, normalization from various
+scraper sources, and alias-based matching.
+
+Pattern follows common/models/lang.py for language support.
+"""
+
+from django.conf import settings
+from django.utils import translation
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy
+
+# Canonical genre catalog: slug -> translatable label
+# One flat list shared across all media types.
+GENRE_CATALOG = {
+    # Universal / cross-media
+    "action": _("Action"),
+    "adventure": _("Adventure"),
+    "comedy": _("Comedy"),
+    "drama": _("Drama"),
+    "fantasy": _("Fantasy"),
+    "horror": _("Horror"),
+    "mystery": _("Mystery"),
+    "romance": _("Romance"),
+    "sci-fi": _("Sci-Fi"),
+    "thriller": _("Thriller"),
+    "animation": _("Animation"),
+    "documentary": _("Documentary"),
+    "family": _("Family"),
+    "history": _("History"),
+    "biographical": _("Biographical"),
+    "war": _("War"),
+    "western": _("Western"),
+    "crime": _("Crime"),
+    "sports": _("Sports"),
+    "music": _("Music"),
+    # Film/TV
+    "film-noir": _("Film Noir"),
+    "musical": _("Musical"),
+    "reality": _("Reality"),
+    "talk-show": _("Talk Show"),
+    "news": _("News"),
+    "game-show": _("Game Show"),
+    "martial-arts": _("Martial Arts"),
+    "period-drama": _("Period Drama"),
+    "superhero": _("Superhero"),
+    "disaster": _("Disaster"),
+    "erotic": _("Erotic"),
+    "short-film": _("Short Film"),
+    "lgbtq": _("LGBTQ"),
+    "tv-movie": _("TV Movie"),
+    # Music
+    "rock": _("Rock"),
+    "pop": _("Pop"),
+    "hip-hop": _("Hip Hop"),
+    "electronic": _("Electronic"),
+    "jazz": _("Jazz"),
+    "classical": _("Classical"),
+    "blues": _("Blues"),
+    "country": _("Country"),
+    "folk": _("Folk"),
+    "r-and-b": _("R&B"),
+    "metal": _("Metal"),
+    "punk": _("Punk"),
+    "soul": _("Soul"),
+    "reggae": _("Reggae"),
+    "latin": pgettext_lazy("genre", "Latin"),
+    "world-music": _("World Music"),
+    "ambient": _("Ambient"),
+    "new-age": _("New Age"),
+    "indie": _("Indie"),
+    "alternative": _("Alternative"),
+    "dance": _("Dance"),
+    "funk": _("Funk"),
+    "gospel": _("Gospel"),
+    "soundtrack": _("Soundtrack"),
+    "k-pop": _("K-Pop"),
+    "easy-listening": _("Easy Listening"),
+    # Game
+    "rpg": _("RPG"),
+    "strategy": _("Strategy"),
+    "simulation": _("Simulation"),
+    "racing": _("Racing"),
+    "puzzle": _("Puzzle"),
+    "platformer": _("Platformer"),
+    "shooter": _("Shooter"),
+    "fighting": _("Fighting"),
+    "survival": _("Survival"),
+    "sandbox": _("Sandbox"),
+    "roguelike": _("Roguelike"),
+    "visual-novel": _("Visual Novel"),
+    "card-game": _("Card Game"),
+    "board-game": _("Board Game"),
+    "arcade": _("Arcade"),
+    "mmo": _("MMO"),
+    "moba": _("MOBA"),
+    "pinball": _("Pinball"),
+    "point-and-click": _("Point-and-Click"),
+    "casual": _("Casual"),
+    # Performance
+    "opera": _("Opera"),
+    "ballet": _("Ballet"),
+    "theater": _("Theater"),
+    "cabaret": _("Cabaret"),
+    "xiqu": _("Xiqu"),
+    # Podcast-relevant
+    "true-crime": _("True Crime"),
+    "self-help": _("Self-Help"),
+    "business": _("Business"),
+    "technology": _("Technology"),
+    "education": _("Education"),
+    "religion": _("Religion"),
+    "leisure": _("Leisure"),
+    "health": _("Health"),
+}
+
+GENRE_CHOICES = list(GENRE_CATALOG.items())
+GENRE_CODES = dict(GENRE_CATALOG)
+
+
+# Explicit mappings from scraped strings to canonical codes.
+# If a value is not here and not in GENRE_CODES, it passes through as custom.
+_SCRAPER_ALIASES: dict[str, str] = {
+    # -----------------------------------------------------------
+    # TMDB Movie genres
+    # -----------------------------------------------------------
+    "science fiction": "sci-fi",
+    "tv movie": "tv-movie",
+    # -----------------------------------------------------------
+    # TMDB TV genres
+    # -----------------------------------------------------------
+    "kids": "family",
+    "talk": "talk-show",
+    # -----------------------------------------------------------
+    # Douban Movie (Chinese)
+    # -----------------------------------------------------------
+    "剧情": "drama",
+    "喜剧": "comedy",
+    "动作": "action",
+    "爱情": "romance",
+    "科幻": "sci-fi",
+    "动画": "animation",
+    "悬疑": "mystery",
+    "惊悚": "thriller",
+    "恐怖": "horror",
+    "纪录片": "documentary",
+    "紀錄片": "documentary",
+    "短片": "short-film",
+    "情色": "erotic",
+    "同性": "lgbtq",
+    "音乐": "music",
+    "歌舞": "musical",
+    "家庭": "family",
+    "儿童": "family",
+    "传记": "biographical",
+    "历史": "history",
+    "战争": "war",
+    "犯罪": "crime",
+    "西部": "western",
+    "奇幻": "fantasy",
+    "冒险": "adventure",
+    "灾难": "disaster",
+    "武侠": "martial-arts",
+    "古装": "period-drama",
+    "运动": "sports",
+    "黑色电影": "film-noir",
+    "真人秀": "reality",
+    "脱口秀": "talk-show",
+    "鬼怪": "thriller",
+    # -----------------------------------------------------------
+    # Douban Music (Chinese)
+    # -----------------------------------------------------------
+    "摇滚": "rock",
+    "流行": "pop",
+    "民谣": "folk",
+    "电子": "electronic",
+    "说唱": "hip-hop",
+    "爵士": "jazz",
+    "古典": "classical",
+    "蓝调": "blues",
+    "乡村": "country",
+    "轻音乐": "easy-listening",
+    "世界音乐": "world-music",
+    "拉丁": "latin",
+    "朋克": "punk",
+    "金属": "metal",
+    "雷鬼": "reggae",
+    "放克": "funk",
+    "灵魂乐": "soul",
+    "原声": "soundtrack",
+    "新世纪": "new-age",
+    # -----------------------------------------------------------
+    # Douban Drama / Performance (Chinese)
+    # -----------------------------------------------------------
+    "话剧": "theater",
+    "音乐剧": "musical",
+    "歌剧": "opera",
+    "舞蹈": "dance",
+    "戏曲": "xiqu",
+    # -----------------------------------------------------------
+    # IGDB game genres
+    # -----------------------------------------------------------
+    "role-playing (rpg)": "rpg",
+    "real time strategy (rts)": "strategy",
+    "turn-based strategy (tbs)": "strategy",
+    "point-and-click": "point-and-click",
+    "simulator": "simulation",
+    "sport": "sports",
+    "platform": "platformer",
+    "visual novel": "visual-novel",
+    # -----------------------------------------------------------
+    # Steam
+    # -----------------------------------------------------------
+    "massively multiplayer": "mmo",
+    "quiz/trivia": "puzzle",
+    # -----------------------------------------------------------
+    # MusicBrainz / Spotify (only confident mappings)
+    # -----------------------------------------------------------
+    "rhythm and blues": "r-and-b",
+    "r&b": "r-and-b",
+    "rnb": "r-and-b",
+    "hip hop": "hip-hop",
+    "sci fi": "sci-fi",
+    "science-fiction": "sci-fi",
+    # -----------------------------------------------------------
+    # Apple Podcast categories (only confident mappings)
+    # -----------------------------------------------------------
+    "health & fitness": "health",
+    "kids & family": "family",
+    "religion & spirituality": "religion",
+    "true crime": "true-crime",
+    "tv & film": "drama",
+    # -----------------------------------------------------------
+    # Bangumi (Japanese)
+    # -----------------------------------------------------------
+    "アクション": "action",
+    "アドベンチャー": "adventure",
+    "コメディ": "comedy",
+    "ドラマ": "drama",
+    "ファンタジー": "fantasy",
+    "ホラー": "horror",
+    "ミステリー": "mystery",
+    "ロマンス": "romance",
+    "シミュレーション": "simulation",
+    "パズル": "puzzle",
+    "シューティング": "shooter",
+    "アニメーション": "animation",
+    "ロールプレイング": "rpg",
+    "レース": "racing",
+    "スポーツ": "sports",
+    "アーケード": "arcade",
+    "格闘": "fighting",
+}
+
+
+def _build_genre_aliases() -> dict[str, str]:
+    """
+    Build a mapping of genre name aliases to their canonical slug code.
+    Combines Django i18n translations of canonical labels with explicit
+    scraper aliases.
+    """
+    aliases: dict[str, str] = {}
+
+    # From Django translations: for each UI language, translate each
+    # canonical genre label and map the lowercase form back to the slug.
+    available_languages = settings.SUPPORTED_UI_LANGUAGES.keys()
+    current_language = translation.get_language()
+    for lang_code in available_languages:
+        with translation.override(lang_code):
+            for code, name in GENRE_CATALOG.items():
+                name_str = str(name).lower().strip()
+                if name_str and name_str != code:
+                    aliases[name_str] = code
+    if current_language:
+        translation.activate(current_language)
+
+    # Explicit scraper aliases (take precedence over i18n-derived ones)
+    aliases.update(_SCRAPER_ALIASES)
+
+    return aliases
+
+
+_genre_aliases: dict[str, str] = _build_genre_aliases()
+
+# Compound genres that expand to multiple canonical codes.
+# Checked before single-code normalization in normalize_genres().
+_COMPOUND_GENRES: dict[str, list[str]] = {
+    "action & adventure": ["action", "adventure"],
+    "sci-fi & fantasy": ["sci-fi", "fantasy"],
+    "war & politics": ["war"],
+}
+
+
+def normalize_genre(genre: str) -> str | None:
+    """Normalize a single genre string to a canonical code.
+
+    Returns the canonical slug if a mapping exists, otherwise returns
+    the input as-is (lowercased, stripped). Never returns None for
+    non-empty input -- unknown genres pass through as custom values.
+    """
+    if not genre or not isinstance(genre, str):
+        return None
+    g = genre.strip()
+    gl = g.lower()
+    # Already a canonical code
+    if gl in GENRE_CODES:
+        return gl
+    # Check aliases
+    if gl in _genre_aliases:
+        return _genre_aliases[gl]
+    # Pass through as-is (preserve original casing for custom values)
+    return g
+
+
+def normalize_genres(genres: list[str]) -> list[str]:
+    """Normalize a list of genre strings, removing duplicates and empty values.
+
+    Compound genres (e.g. "Action & Adventure") are expanded to multiple codes.
+    """
+    result: list[str] = []
+    for g in genres:
+        if not g or not isinstance(g, str):
+            continue
+        gl = g.strip().lower()
+        if gl in _COMPOUND_GENRES:
+            result.extend(_COMPOUND_GENRES[gl])
+        else:
+            normalized = normalize_genre(g)
+            if normalized:
+                result.append(normalized)
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(result))

--- a/common/templatetags/duration.py
+++ b/common/templatetags/duration.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from catalog.models import item_categories
 from catalog.views import visible_categories as _visible_categories
+from common.models.genre import GENRE_CODES
 from common.models.lang import (
     LANGUAGE_CODES,
     LOCALE_CODES,
@@ -100,3 +101,9 @@ def code_to_lang(code):
         or LOCALE_CODES.get(code)
         or code
     )
+
+
+@register.filter
+def code_to_genre(code):
+    label = GENRE_CODES.get(code)
+    return str(label) if label else code

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 18:27-0400\n"
+"POT-Creation-Date: 2026-04-12 20:18-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1989,106 +1989,110 @@ msgid "Shooter"
 msgstr ""
 
 #: common/models/genre.py:90
-msgid "Fighting"
+msgid "FPS"
 msgstr ""
 
 #: common/models/genre.py:91
-msgid "Survival"
+msgid "Fighting"
 msgstr ""
 
 #: common/models/genre.py:92
-msgid "Sandbox"
+msgid "Survival"
 msgstr ""
 
 #: common/models/genre.py:93
-msgid "Roguelike"
+msgid "Sandbox"
 msgstr ""
 
 #: common/models/genre.py:94
-msgid "Visual Novel"
+msgid "Roguelike"
 msgstr ""
 
 #: common/models/genre.py:95
-msgid "Card Game"
+msgid "Visual Novel"
 msgstr ""
 
 #: common/models/genre.py:96
-msgid "Board Game"
+msgid "Card Game"
 msgstr ""
 
 #: common/models/genre.py:97
-msgid "Arcade"
+msgid "Board Game"
 msgstr ""
 
 #: common/models/genre.py:98
-msgid "MMO"
+msgid "Arcade"
 msgstr ""
 
 #: common/models/genre.py:99
-msgid "MOBA"
+msgid "MMO"
 msgstr ""
 
 #: common/models/genre.py:100
-msgid "Pinball"
+msgid "MOBA"
 msgstr ""
 
 #: common/models/genre.py:101
-msgid "Point-and-Click"
+msgid "Pinball"
 msgstr ""
 
 #: common/models/genre.py:102
+msgid "Point-and-Click"
+msgstr ""
+
+#: common/models/genre.py:103
 msgid "Casual"
 msgstr ""
 
-#: common/models/genre.py:104
+#: common/models/genre.py:105
 msgid "Opera"
 msgstr ""
 
-#: common/models/genre.py:105
+#: common/models/genre.py:106
 msgid "Ballet"
 msgstr ""
 
-#: common/models/genre.py:106
+#: common/models/genre.py:107
 msgid "Theater"
 msgstr ""
 
-#: common/models/genre.py:107
+#: common/models/genre.py:108
 msgid "Cabaret"
 msgstr ""
 
-#: common/models/genre.py:108
+#: common/models/genre.py:109
 msgid "Xiqu"
 msgstr ""
 
-#: common/models/genre.py:110
+#: common/models/genre.py:111
 msgid "True Crime"
 msgstr ""
 
-#: common/models/genre.py:111
+#: common/models/genre.py:112
 msgid "Self-Help"
 msgstr ""
 
-#: common/models/genre.py:112
+#: common/models/genre.py:113
 msgid "Business"
 msgstr ""
 
-#: common/models/genre.py:113
+#: common/models/genre.py:114
 msgid "Technology"
 msgstr ""
 
-#: common/models/genre.py:114
+#: common/models/genre.py:115
 msgid "Education"
 msgstr ""
 
-#: common/models/genre.py:115
+#: common/models/genre.py:116
 msgid "Religion"
 msgstr ""
 
-#: common/models/genre.py:116
+#: common/models/genre.py:117
 msgid "Leisure"
 msgstr ""
 
-#: common/models/genre.py:117
+#: common/models/genre.py:118
 msgid "Health"
 msgstr ""
 

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 15:46-0400\n"
+"POT-Creation-Date: 2026-04-12 18:27-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,21 +59,21 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:28 catalog/models/item.py:156
+#: catalog/forms.py:29 catalog/models/item.py:157
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:33 catalog/models/item.py:159
+#: catalog/forms.py:34 catalog/models/item.py:160
 msgid "Primary ID Value"
 msgstr ""
 
 #: catalog/models/book.py:80 catalog/models/book.py:99
-#: catalog/models/common.py:193 catalog/models/common.py:211
+#: catalog/models/common.py:200 catalog/models/common.py:218
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:83 catalog/models/book.py:102
-#: catalog/models/common.py:196 catalog/models/common.py:216
+#: catalog/models/common.py:203 catalog/models/common.py:223
 msgid "text content"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:124 catalog/models/game.py:31
+#: catalog/models/book.py:124 catalog/models/game.py:32
 msgid "Other"
 msgstr ""
 
@@ -105,9 +105,9 @@ msgstr ""
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:173 catalog/models/movie.py:65
-#: catalog/models/performance.py:317 catalog/models/tv.py:137
-#: catalog/models/tv.py:364
+#: catalog/models/book.py:173 catalog/models/movie.py:66
+#: catalog/models/performance.py:312 catalog/models/tv.py:138
+#: catalog/models/tv.py:359
 msgid "original title"
 msgstr ""
 
@@ -163,433 +163,431 @@ msgstr ""
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:9 common/models/lang.py:249
+#: catalog/models/common.py:15 common/models/lang.py:249
 msgid "Unknown"
 msgstr ""
 
-#: catalog/models/common.py:10
+#: catalog/models/common.py:16
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:11 catalog/models/common.py:58
+#: catalog/models/common.py:17 catalog/models/common.py:64
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:12 catalog/models/common.py:60
+#: catalog/models/common.py:18 catalog/models/common.py:66
 msgid "Google Books"
 msgstr ""
 
-#: catalog/models/common.py:13
+#: catalog/models/common.py:19
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:14 catalog/models/common.py:69
-#: catalog/models/common.py:71
+#: catalog/models/common.py:20 catalog/models/common.py:75
+#: catalog/models/common.py:77
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:15 catalog/models/common.py:70
+#: catalog/models/common.py:21 catalog/models/common.py:76
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:16 catalog/models/common.py:53
+#: catalog/models/common.py:22 catalog/models/common.py:59
 #: catalog/templates/movie.html:51 catalog/templates/tvseason.html:68
 #: catalog/templates/tvshow.html:63
 msgid "IMDb"
 msgstr ""
 
-#: catalog/models/common.py:17
+#: catalog/models/common.py:23
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:18 catalog/models/common.py:72
+#: catalog/models/common.py:24 catalog/models/common.py:78
 msgid "Bandcamp"
 msgstr ""
 
-#: catalog/models/common.py:19
+#: catalog/models/common.py:25
 msgid "Spotify"
 msgstr ""
 
-#: catalog/models/common.py:20
+#: catalog/models/common.py:26
 msgid "IGDB"
 msgstr ""
 
-#: catalog/models/common.py:21
+#: catalog/models/common.py:27
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:22 catalog/models/common.py:90
+#: catalog/models/common.py:28 catalog/models/common.py:96
 msgid "Bangumi"
 msgstr ""
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:29
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:24 catalog/models/common.py:91
+#: catalog/models/common.py:30 catalog/models/common.py:97
 msgid "Apple Podcast"
 msgstr ""
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:31
 msgid "RSS"
 msgstr ""
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:32
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:27 catalog/models/common.py:92
+#: catalog/models/common.py:33 catalog/models/common.py:98
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:94
+#: catalog/models/common.py:34 catalog/models/common.py:100
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:95
+#: catalog/models/common.py:35 catalog/models/common.py:101
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:30 catalog/models/common.py:96
+#: catalog/models/common.py:36 catalog/models/common.py:102
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:97
+#: catalog/models/common.py:37 catalog/models/common.py:103
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:98
+#: catalog/models/common.py:38 catalog/models/common.py:104
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:43
+#: catalog/models/common.py:39 catalog/models/common.py:49
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:34 catalog/models/common.py:99
+#: catalog/models/common.py:40 catalog/models/common.py:105
 msgid "Open Library"
 msgstr ""
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:41
 msgid "MusicBrainz"
 msgstr ""
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:42
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:37 catalog/models/common.py:101
+#: catalog/models/common.py:43 catalog/models/common.py:107
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:102
+#: catalog/models/common.py:44 catalog/models/common.py:108
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:93
+#: catalog/models/common.py:45 catalog/models/common.py:99
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:44
+#: catalog/models/common.py:50
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/templates/edition.html:19
+#: catalog/models/common.py:51 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:46
+#: catalog/models/common.py:52
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:53
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:48
+#: catalog/models/common.py:54
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:49
+#: catalog/models/common.py:55
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:50
+#: catalog/models/common.py:56
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:57
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:58
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:60
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:61
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:62
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:63
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:65
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:67
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:68
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:69
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:70
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:71
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:72
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:73
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:74
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:79
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:80
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:81
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:82
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:85
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:87
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:93
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:94
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:95
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:106
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:121
+#: catalog/models/common.py:127
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:122 catalog/templates/_sidebar_edit.html:224
+#: catalog/models/common.py:128 catalog/templates/_sidebar_edit.html:224
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:123
+#: catalog/models/common.py:129
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:124 catalog/templates/_sidebar_edit.html:145
+#: catalog/models/common.py:130 catalog/templates/_sidebar_edit.html:145
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:131
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:126 catalog/models/common.py:142
-#: catalog/models/common.py:156 catalog/templates/_sidebar_edit.html:138
+#: catalog/models/common.py:132 catalog/models/common.py:148
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:138
 #: journal/templates/_sidebar_user_mark_list.html:32
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:127
+#: catalog/models/common.py:133
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:128 catalog/models/common.py:145
-#: catalog/models/common.py:159 common/templates/_header.html:41
+#: catalog/models/common.py:134 catalog/models/common.py:151
+#: catalog/models/common.py:165 common/templates/_header.html:41
 #: journal/templates/_sidebar_user_mark_list.html:45
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:129
+#: catalog/models/common.py:135
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:130
+#: catalog/models/common.py:136
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:131 catalog/models/common.py:147
-#: catalog/models/common.py:161 common/templates/_header.html:45
+#: catalog/models/common.py:137 catalog/models/common.py:153
+#: catalog/models/common.py:167 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:49
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:138
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:139
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:134 catalog/models/common.py:151
+#: catalog/models/common.py:140 catalog/models/common.py:157
 #: journal/templates/collection.html:23 journal/templates/collection.html:29
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:141 catalog/models/common.py:155
+#: catalog/models/common.py:147 catalog/models/common.py:161
 #: common/templates/_header.html:25
 #: journal/templates/_sidebar_user_mark_list.html:29
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:143 catalog/models/common.py:157
+#: catalog/models/common.py:149 catalog/models/common.py:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:144 catalog/models/common.py:158
-#: common/templates/_header.html:37
+#: catalog/models/common.py:150 catalog/models/common.py:164
+#: common/models/genre.py:39 common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:42
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:146 catalog/models/common.py:160
+#: catalog/models/common.py:152 catalog/models/common.py:166
 #: catalog/templates/_sidebar_edit.html:157 common/templates/_header.html:33
 #: journal/templates/_sidebar_user_mark_list.html:39
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:241 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:248 catalog/templates/_genre_list.html:5
+msgid "genre"
+msgstr ""
+
+#: catalog/models/common.py:265 catalog/templates/_language_list.html:5
 #: users/models/user.py:128
 msgid "language"
 msgstr ""
 
-#: catalog/models/game.py:23
+#: catalog/models/game.py:24
 msgid "Main Game"
 msgstr ""
 
-#: catalog/models/game.py:24
+#: catalog/models/game.py:25
 msgid "Expansion"
 msgstr ""
 
-#: catalog/models/game.py:25
+#: catalog/models/game.py:26
 msgid "Downloadable Content"
 msgstr ""
 
-#: catalog/models/game.py:26
+#: catalog/models/game.py:27
 msgid "Mod"
 msgstr ""
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:28
 msgid "Bundle"
 msgstr ""
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:29
 msgid "Remaster"
 msgstr ""
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:30
 msgid "Remake"
 msgstr ""
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:31
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:73
+#: catalog/models/game.py:74
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:81 catalog/models/music.py:66
+#: catalog/models/game.py:82 catalog/models/music.py:65
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:89
+#: catalog/models/game.py:90
 msgid "developer"
 msgstr ""
 
-#: catalog/models/game.py:97 catalog/models/music.py:80
+#: catalog/models/game.py:98 catalog/models/music.py:73
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/game.py:105
+#: catalog/models/game.py:106
 msgid "year of publication"
 msgstr ""
 
-#: catalog/models/game.py:109 catalog/models/podcast.py:161
+#: catalog/models/game.py:110 catalog/models/podcast.py:156
 msgid "date of publication"
 msgstr ""
 
-#: catalog/models/game.py:114 catalog/models/music.py:60
-#: catalog/models/tv.py:181
+#: catalog/models/game.py:115 catalog/models/music.py:59
+#: catalog/models/tv.py:176
 msgid "YYYY-MM-DD"
 msgstr ""
 
-#: catalog/models/game.py:118 catalog/templates/game.html:16
+#: catalog/models/game.py:119 catalog/templates/game.html:16
 msgid "release type"
 msgstr ""
 
-#: catalog/models/game.py:125 catalog/models/movie.py:89
-#: catalog/models/performance.py:118 catalog/models/podcast.py:60
-#: catalog/models/tv.py:161 catalog/models/tv.py:388
-msgid "genre"
-msgstr ""
-
-#: catalog/models/game.py:133
+#: catalog/models/game.py:128
 msgid "platform"
 msgstr ""
 
-#: catalog/models/game.py:139 catalog/models/movie.py:123
-#: catalog/models/performance.py:202 catalog/models/performance.py:397
-#: catalog/models/podcast.py:79 catalog/models/tv.py:195
-#: catalog/models/tv.py:423 catalog/templates/game.html:34
+#: catalog/models/game.py:134 catalog/models/movie.py:118
+#: catalog/models/performance.py:197 catalog/models/performance.py:392
+#: catalog/models/podcast.py:74 catalog/models/tv.py:190
+#: catalog/models/tv.py:412 catalog/templates/game.html:34
 #: catalog/templates/movie.html:58 catalog/templates/performance.html:33
 #: catalog/templates/performanceproduction.html:33
 #: catalog/templates/podcast.html:20 catalog/templates/tvseason.html:75
@@ -597,67 +595,67 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:153 catalog/models/item.py:185
+#: catalog/models/item.py:154 catalog/models/item.py:186
 #: journal/models/collection.py:64
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:154 catalog/models/item.py:193
+#: catalog/models/item.py:155 catalog/models/item.py:194
 #: journal/models/collection.py:65
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:165
+#: catalog/models/item.py:166
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:167 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:168 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:743
+#: catalog/models/item.py:754
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:745
+#: catalog/models/item.py:756
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:747
+#: catalog/models/item.py:758
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:763
+#: catalog/models/item.py:774
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:769
+#: catalog/models/item.py:780
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:772
+#: catalog/models/item.py:783
 msgid "url to the resource"
 msgstr ""
 
-#: catalog/models/movie.py:68 catalog/models/performance.py:126
-#: catalog/models/performance.py:321 catalog/models/tv.py:140
-#: catalog/models/tv.py:367
+#: catalog/models/movie.py:69 catalog/models/performance.py:121
+#: catalog/models/performance.py:316 catalog/models/tv.py:141
+#: catalog/models/tv.py:362
 msgid "director"
 msgstr ""
 
-#: catalog/models/movie.py:75 catalog/models/performance.py:133
-#: catalog/models/performance.py:328 catalog/models/tv.py:147
-#: catalog/models/tv.py:374
+#: catalog/models/movie.py:76 catalog/models/performance.py:128
+#: catalog/models/performance.py:323 catalog/models/tv.py:148
+#: catalog/models/tv.py:369
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/movie.py:82 catalog/models/performance.py:161
-#: catalog/models/performance.py:356 catalog/models/tv.py:154
-#: catalog/models/tv.py:381
+#: catalog/models/movie.py:83 catalog/models/performance.py:156
+#: catalog/models/performance.py:351 catalog/models/tv.py:155
+#: catalog/models/tv.py:376
 msgid "actor"
 msgstr ""
 
-#: catalog/models/movie.py:96 catalog/models/music.py:60
+#: catalog/models/movie.py:91 catalog/models/music.py:59
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
@@ -665,161 +663,156 @@ msgstr ""
 msgid "release date"
 msgstr ""
 
-#: catalog/models/movie.py:108 catalog/models/tv.py:407
+#: catalog/models/movie.py:103 catalog/models/tv.py:396
 #: journal/templates/_sidebar_user_mark_list.html:60
 msgid "date"
 msgstr ""
 
-#: catalog/models/movie.py:109 catalog/models/performance.py:84
-#: catalog/models/tv.py:408
+#: catalog/models/movie.py:104 catalog/models/performance.py:85
+#: catalog/models/tv.py:397
 msgid "required"
 msgstr ""
 
-#: catalog/models/movie.py:113 catalog/models/tv.py:412
+#: catalog/models/movie.py:108 catalog/models/tv.py:401
 msgid "region or event"
 msgstr ""
 
-#: catalog/models/movie.py:115 catalog/models/tv.py:187
-#: catalog/models/tv.py:414
+#: catalog/models/movie.py:110 catalog/models/tv.py:182
+#: catalog/models/tv.py:403
 msgid "Germany or Toronto International Film Festival"
 msgstr ""
 
-#: catalog/models/movie.py:125 catalog/models/tv.py:197
-#: catalog/models/tv.py:426
+#: catalog/models/movie.py:120 catalog/models/tv.py:192
+#: catalog/models/tv.py:415
 msgid "region"
 msgstr ""
 
-#: catalog/models/movie.py:136 catalog/models/tv.py:209
-#: catalog/models/tv.py:437
+#: catalog/models/movie.py:131 catalog/models/tv.py:204
+#: catalog/models/tv.py:426
 msgid "year"
 msgstr ""
 
-#: catalog/models/movie.py:137 catalog/models/music.py:63
+#: catalog/models/movie.py:132 catalog/models/music.py:62
 #: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
 #: catalog/templates/tvshow.html:47
 msgid "length"
 msgstr ""
 
-#: catalog/models/music.py:63
+#: catalog/models/music.py:62
 msgid "milliseconds"
 msgstr ""
 
-#: catalog/models/music.py:73
-msgctxt "music"
-msgid "genre"
-msgstr ""
-
-#: catalog/models/music.py:86
+#: catalog/models/music.py:79
 msgid "tracks"
 msgstr ""
 
-#: catalog/models/music.py:87 catalog/templates/album.html:33
+#: catalog/models/music.py:80 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/music.py:88
+#: catalog/models/music.py:81
 msgid "media type"
 msgstr ""
 
-#: catalog/models/music.py:91 catalog/templates/album.html:43
+#: catalog/models/music.py:84 catalog/templates/album.html:43
 msgid "number of discs"
 msgstr ""
 
-#: catalog/models/performance.py:68 catalog/models/performance.py:83
+#: catalog/models/performance.py:69 catalog/models/performance.py:84
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/performance.py:69 catalog/models/performance.py:88
+#: catalog/models/performance.py:70 catalog/models/performance.py:89
 msgid "role"
 msgstr ""
 
-#: catalog/models/performance.py:89
+#: catalog/models/performance.py:90
 msgid "optional"
 msgstr ""
 
-#: catalog/models/performance.py:115
+#: catalog/models/performance.py:116
 msgid "original name"
 msgstr ""
 
-#: catalog/models/performance.py:140 catalog/models/performance.py:335
+#: catalog/models/performance.py:135 catalog/models/performance.py:330
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/performance.py:147 catalog/models/performance.py:342
+#: catalog/models/performance.py:142 catalog/models/performance.py:337
 msgid "composer"
 msgstr ""
 
-#: catalog/models/performance.py:154 catalog/models/performance.py:349
+#: catalog/models/performance.py:149 catalog/models/performance.py:344
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/performance.py:168 catalog/models/performance.py:363
+#: catalog/models/performance.py:163 catalog/models/performance.py:358
 msgid "performer"
 msgstr ""
 
-#: catalog/models/performance.py:175 catalog/models/performance.py:370
+#: catalog/models/performance.py:170 catalog/models/performance.py:365
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/performance.py:182 catalog/models/performance.py:377
+#: catalog/models/performance.py:177 catalog/models/performance.py:372
 msgid "crew"
 msgstr ""
 
-#: catalog/models/performance.py:189 catalog/models/performance.py:384
+#: catalog/models/performance.py:184 catalog/models/performance.py:379
 msgid "theater"
 msgstr ""
 
-#: catalog/models/performance.py:196 catalog/models/performance.py:391
+#: catalog/models/performance.py:191 catalog/models/performance.py:386
 #: catalog/templates/performance.html:14
 #: catalog/templates/performanceproduction.html:13
 msgid "opening date"
 msgstr ""
 
-#: catalog/models/performance.py:199 catalog/models/performance.py:394
+#: catalog/models/performance.py:194 catalog/models/performance.py:389
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/podcast.py:70
+#: catalog/models/podcast.py:65
 msgid "host"
 msgstr ""
 
-#: catalog/models/tv.py:112 catalog/templates/tvseason.html:37
+#: catalog/models/tv.py:113 catalog/templates/tvseason.html:37
 #: catalog/templates/tvshow.html:32
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:115 catalog/models/tv.py:342
+#: catalog/models/tv.py:116 catalog/models/tv.py:337
 #: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:168 catalog/models/tv.py:395
+#: catalog/models/tv.py:163 catalog/models/tv.py:384
 msgid "show time"
 msgstr ""
 
-#: catalog/models/tv.py:180
+#: catalog/models/tv.py:175
 msgid "Date"
 msgstr ""
 
-#: catalog/models/tv.py:185
+#: catalog/models/tv.py:180
 msgid "Region or Event"
 msgstr ""
 
-#: catalog/models/tv.py:211 catalog/models/tv.py:439
+#: catalog/models/tv.py:206 catalog/models/tv.py:428
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:339 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:334 catalog/templates/tvseason.html:32
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:472
+#: catalog/models/tv.py:461
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:620
+#: catalog/models/tv.py:609
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr ""
@@ -1728,6 +1721,375 @@ msgstr ""
 
 #: catalog/views/view.py:57 catalog/views/view.py:86
 msgid "Item no longer exists"
+msgstr ""
+
+#: common/models/genre.py:20
+msgid "Action"
+msgstr ""
+
+#: common/models/genre.py:21
+msgid "Adventure"
+msgstr ""
+
+#: common/models/genre.py:22
+msgid "Comedy"
+msgstr ""
+
+#: common/models/genre.py:23
+msgid "Drama"
+msgstr ""
+
+#: common/models/genre.py:24
+msgid "Fantasy"
+msgstr ""
+
+#: common/models/genre.py:25
+msgid "Horror"
+msgstr ""
+
+#: common/models/genre.py:26
+msgid "Mystery"
+msgstr ""
+
+#: common/models/genre.py:27
+msgid "Romance"
+msgstr ""
+
+#: common/models/genre.py:28
+msgid "Sci-Fi"
+msgstr ""
+
+#: common/models/genre.py:29
+msgid "Thriller"
+msgstr ""
+
+#: common/models/genre.py:30
+msgid "Animation"
+msgstr ""
+
+#: common/models/genre.py:31
+msgid "Documentary"
+msgstr ""
+
+#: common/models/genre.py:32
+msgid "Family"
+msgstr ""
+
+#: common/models/genre.py:33
+msgid "History"
+msgstr ""
+
+#: common/models/genre.py:34
+msgid "Biographical"
+msgstr ""
+
+#: common/models/genre.py:35
+msgid "War"
+msgstr ""
+
+#: common/models/genre.py:36
+msgid "Western"
+msgstr ""
+
+#: common/models/genre.py:37
+msgid "Crime"
+msgstr ""
+
+#: common/models/genre.py:38
+msgid "Sports"
+msgstr ""
+
+#: common/models/genre.py:41
+msgid "Film Noir"
+msgstr ""
+
+#: common/models/genre.py:42
+msgid "Musical"
+msgstr ""
+
+#: common/models/genre.py:43
+msgid "Reality"
+msgstr ""
+
+#: common/models/genre.py:44
+msgid "Talk Show"
+msgstr ""
+
+#: common/models/genre.py:45
+msgid "News"
+msgstr ""
+
+#: common/models/genre.py:46
+msgid "Game Show"
+msgstr ""
+
+#: common/models/genre.py:47
+msgid "Martial Arts"
+msgstr ""
+
+#: common/models/genre.py:48
+msgid "Period Drama"
+msgstr ""
+
+#: common/models/genre.py:49
+msgid "Superhero"
+msgstr ""
+
+#: common/models/genre.py:50
+msgid "Disaster"
+msgstr ""
+
+#: common/models/genre.py:51
+msgid "Erotic"
+msgstr ""
+
+#: common/models/genre.py:52
+msgid "Short Film"
+msgstr ""
+
+#: common/models/genre.py:53
+msgid "LGBTQ"
+msgstr ""
+
+#: common/models/genre.py:54
+msgid "TV Movie"
+msgstr ""
+
+#: common/models/genre.py:56
+msgid "Rock"
+msgstr ""
+
+#: common/models/genre.py:57
+msgid "Pop"
+msgstr ""
+
+#: common/models/genre.py:58
+msgid "Hip Hop"
+msgstr ""
+
+#: common/models/genre.py:59
+msgid "Electronic"
+msgstr ""
+
+#: common/models/genre.py:60
+msgid "Jazz"
+msgstr ""
+
+#: common/models/genre.py:61
+msgid "Classical"
+msgstr ""
+
+#: common/models/genre.py:62
+msgid "Blues"
+msgstr ""
+
+#: common/models/genre.py:63
+msgid "Country"
+msgstr ""
+
+#: common/models/genre.py:64
+msgid "Folk"
+msgstr ""
+
+#: common/models/genre.py:65
+msgid "R&B"
+msgstr ""
+
+#: common/models/genre.py:66
+msgid "Metal"
+msgstr ""
+
+#: common/models/genre.py:67
+msgid "Punk"
+msgstr ""
+
+#: common/models/genre.py:68
+msgid "Soul"
+msgstr ""
+
+#: common/models/genre.py:69
+msgid "Reggae"
+msgstr ""
+
+#: common/models/genre.py:70
+msgctxt "genre"
+msgid "Latin"
+msgstr ""
+
+#: common/models/genre.py:71
+msgid "World Music"
+msgstr ""
+
+#: common/models/genre.py:72
+msgid "Ambient"
+msgstr ""
+
+#: common/models/genre.py:73
+msgid "New Age"
+msgstr ""
+
+#: common/models/genre.py:74
+msgid "Indie"
+msgstr ""
+
+#: common/models/genre.py:75
+msgid "Alternative"
+msgstr ""
+
+#: common/models/genre.py:76
+msgid "Dance"
+msgstr ""
+
+#: common/models/genre.py:77
+msgid "Funk"
+msgstr ""
+
+#: common/models/genre.py:78
+msgid "Gospel"
+msgstr ""
+
+#: common/models/genre.py:79
+msgid "Soundtrack"
+msgstr ""
+
+#: common/models/genre.py:80
+msgid "K-Pop"
+msgstr ""
+
+#: common/models/genre.py:81
+msgid "Easy Listening"
+msgstr ""
+
+#: common/models/genre.py:83
+msgid "RPG"
+msgstr ""
+
+#: common/models/genre.py:84
+msgid "Strategy"
+msgstr ""
+
+#: common/models/genre.py:85
+msgid "Simulation"
+msgstr ""
+
+#: common/models/genre.py:86
+msgid "Racing"
+msgstr ""
+
+#: common/models/genre.py:87
+msgid "Puzzle"
+msgstr ""
+
+#: common/models/genre.py:88
+msgid "Platformer"
+msgstr ""
+
+#: common/models/genre.py:89
+msgid "Shooter"
+msgstr ""
+
+#: common/models/genre.py:90
+msgid "Fighting"
+msgstr ""
+
+#: common/models/genre.py:91
+msgid "Survival"
+msgstr ""
+
+#: common/models/genre.py:92
+msgid "Sandbox"
+msgstr ""
+
+#: common/models/genre.py:93
+msgid "Roguelike"
+msgstr ""
+
+#: common/models/genre.py:94
+msgid "Visual Novel"
+msgstr ""
+
+#: common/models/genre.py:95
+msgid "Card Game"
+msgstr ""
+
+#: common/models/genre.py:96
+msgid "Board Game"
+msgstr ""
+
+#: common/models/genre.py:97
+msgid "Arcade"
+msgstr ""
+
+#: common/models/genre.py:98
+msgid "MMO"
+msgstr ""
+
+#: common/models/genre.py:99
+msgid "MOBA"
+msgstr ""
+
+#: common/models/genre.py:100
+msgid "Pinball"
+msgstr ""
+
+#: common/models/genre.py:101
+msgid "Point-and-Click"
+msgstr ""
+
+#: common/models/genre.py:102
+msgid "Casual"
+msgstr ""
+
+#: common/models/genre.py:104
+msgid "Opera"
+msgstr ""
+
+#: common/models/genre.py:105
+msgid "Ballet"
+msgstr ""
+
+#: common/models/genre.py:106
+msgid "Theater"
+msgstr ""
+
+#: common/models/genre.py:107
+msgid "Cabaret"
+msgstr ""
+
+#: common/models/genre.py:108
+msgid "Xiqu"
+msgstr ""
+
+#: common/models/genre.py:110
+msgid "True Crime"
+msgstr ""
+
+#: common/models/genre.py:111
+msgid "Self-Help"
+msgstr ""
+
+#: common/models/genre.py:112
+msgid "Business"
+msgstr ""
+
+#: common/models/genre.py:113
+msgid "Technology"
+msgstr ""
+
+#: common/models/genre.py:114
+msgid "Education"
+msgstr ""
+
+#: common/models/genre.py:115
+msgid "Religion"
+msgstr ""
+
+#: common/models/genre.py:116
+msgid "Leisure"
+msgstr ""
+
+#: common/models/genre.py:117
+msgid "Health"
 msgstr ""
 
 #: common/models/lang.py:47
@@ -2800,7 +3162,7 @@ msgstr ""
 msgid "Database Admin"
 msgstr ""
 
-#: common/templatetags/duration.py:54
+#: common/templatetags/duration.py:55
 msgid "just now"
 msgstr ""
 

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 20:18-0400\n"
+"POT-Creation-Date: 2026-04-12 20:19-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1989,110 +1989,106 @@ msgid "Shooter"
 msgstr ""
 
 #: common/models/genre.py:90
-msgid "FPS"
-msgstr ""
-
-#: common/models/genre.py:91
 msgid "Fighting"
 msgstr ""
 
-#: common/models/genre.py:92
+#: common/models/genre.py:91
 msgid "Survival"
 msgstr ""
 
-#: common/models/genre.py:93
+#: common/models/genre.py:92
 msgid "Sandbox"
 msgstr ""
 
-#: common/models/genre.py:94
+#: common/models/genre.py:93
 msgid "Roguelike"
 msgstr ""
 
-#: common/models/genre.py:95
+#: common/models/genre.py:94
 msgid "Visual Novel"
 msgstr ""
 
-#: common/models/genre.py:96
+#: common/models/genre.py:95
 msgid "Card Game"
 msgstr ""
 
-#: common/models/genre.py:97
+#: common/models/genre.py:96
 msgid "Board Game"
 msgstr ""
 
-#: common/models/genre.py:98
+#: common/models/genre.py:97
 msgid "Arcade"
 msgstr ""
 
-#: common/models/genre.py:99
+#: common/models/genre.py:98
 msgid "MMO"
 msgstr ""
 
-#: common/models/genre.py:100
+#: common/models/genre.py:99
 msgid "MOBA"
 msgstr ""
 
-#: common/models/genre.py:101
+#: common/models/genre.py:100
 msgid "Pinball"
 msgstr ""
 
-#: common/models/genre.py:102
+#: common/models/genre.py:101
 msgid "Point-and-Click"
 msgstr ""
 
-#: common/models/genre.py:103
+#: common/models/genre.py:102
 msgid "Casual"
 msgstr ""
 
-#: common/models/genre.py:105
+#: common/models/genre.py:104
 msgid "Opera"
 msgstr ""
 
-#: common/models/genre.py:106
+#: common/models/genre.py:105
 msgid "Ballet"
 msgstr ""
 
-#: common/models/genre.py:107
+#: common/models/genre.py:106
 msgid "Theater"
 msgstr ""
 
-#: common/models/genre.py:108
+#: common/models/genre.py:107
 msgid "Cabaret"
 msgstr ""
 
-#: common/models/genre.py:109
+#: common/models/genre.py:108
 msgid "Xiqu"
 msgstr ""
 
-#: common/models/genre.py:111
+#: common/models/genre.py:110
 msgid "True Crime"
 msgstr ""
 
-#: common/models/genre.py:112
+#: common/models/genre.py:111
 msgid "Self-Help"
 msgstr ""
 
-#: common/models/genre.py:113
+#: common/models/genre.py:112
 msgid "Business"
 msgstr ""
 
-#: common/models/genre.py:114
+#: common/models/genre.py:113
 msgid "Technology"
 msgstr ""
 
-#: common/models/genre.py:115
+#: common/models/genre.py:114
 msgid "Education"
 msgstr ""
 
-#: common/models/genre.py:116
+#: common/models/genre.py:115
 msgid "Religion"
 msgstr ""
 
-#: common/models/genre.py:117
+#: common/models/genre.py:116
 msgid "Leisure"
 msgstr ""
 
-#: common/models/genre.py:118
+#: common/models/genre.py:117
 msgid "Health"
 msgstr ""
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 18:27-0400\n"
+"POT-Creation-Date: 2026-04-12 20:18-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1990,106 +1990,110 @@ msgid "Shooter"
 msgstr "射击"
 
 #: common/models/genre.py:90
+msgid "FPS"
+msgstr "第一人称射击"
+
+#: common/models/genre.py:91
 msgid "Fighting"
 msgstr "格斗"
 
-#: common/models/genre.py:91
+#: common/models/genre.py:92
 msgid "Survival"
 msgstr "生存"
 
-#: common/models/genre.py:92
+#: common/models/genre.py:93
 msgid "Sandbox"
 msgstr "沙盒"
 
-#: common/models/genre.py:93
+#: common/models/genre.py:94
 msgid "Roguelike"
 msgstr "肉鸽"
 
-#: common/models/genre.py:94
+#: common/models/genre.py:95
 msgid "Visual Novel"
 msgstr "视觉小说"
 
-#: common/models/genre.py:95
+#: common/models/genre.py:96
 msgid "Card Game"
 msgstr "卡牌"
 
-#: common/models/genre.py:96
+#: common/models/genre.py:97
 msgid "Board Game"
 msgstr "桌游"
 
-#: common/models/genre.py:97
+#: common/models/genre.py:98
 msgid "Arcade"
 msgstr "街机"
 
-#: common/models/genre.py:98
+#: common/models/genre.py:99
 msgid "MMO"
 msgstr "MMO"
 
-#: common/models/genre.py:99
+#: common/models/genre.py:100
 msgid "MOBA"
 msgstr "MOBA"
 
-#: common/models/genre.py:100
+#: common/models/genre.py:101
 msgid "Pinball"
 msgstr "弹珠"
 
-#: common/models/genre.py:101
+#: common/models/genre.py:102
 msgid "Point-and-Click"
 msgstr "点击冒险"
 
-#: common/models/genre.py:102
+#: common/models/genre.py:103
 msgid "Casual"
 msgstr "休闲"
 
-#: common/models/genre.py:104
+#: common/models/genre.py:105
 msgid "Opera"
 msgstr "歌剧"
 
-#: common/models/genre.py:105
+#: common/models/genre.py:106
 msgid "Ballet"
 msgstr "芭蕾"
 
-#: common/models/genre.py:106
+#: common/models/genre.py:107
 msgid "Theater"
 msgstr "话剧"
 
-#: common/models/genre.py:107
+#: common/models/genre.py:108
 msgid "Cabaret"
 msgstr "歌舞表演"
 
-#: common/models/genre.py:108
+#: common/models/genre.py:109
 msgid "Xiqu"
 msgstr "戏曲"
 
-#: common/models/genre.py:110
+#: common/models/genre.py:111
 msgid "True Crime"
 msgstr "真实犯罪"
 
-#: common/models/genre.py:111
+#: common/models/genre.py:112
 msgid "Self-Help"
 msgstr "个人成长"
 
-#: common/models/genre.py:112
+#: common/models/genre.py:113
 msgid "Business"
 msgstr "商业"
 
-#: common/models/genre.py:113
+#: common/models/genre.py:114
 msgid "Technology"
 msgstr "科技"
 
-#: common/models/genre.py:114
+#: common/models/genre.py:115
 msgid "Education"
 msgstr "教育"
 
-#: common/models/genre.py:115
+#: common/models/genre.py:116
 msgid "Religion"
 msgstr "宗教"
 
-#: common/models/genre.py:116
+#: common/models/genre.py:117
 msgid "Leisure"
 msgstr "休闲娱乐"
 
-#: common/models/genre.py:117
+#: common/models/genre.py:118
 msgid "Health"
 msgstr "健康"
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 20:18-0400\n"
+"POT-Creation-Date: 2026-04-12 20:19-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1990,110 +1990,106 @@ msgid "Shooter"
 msgstr "射击"
 
 #: common/models/genre.py:90
-msgid "FPS"
-msgstr "第一人称射击"
-
-#: common/models/genre.py:91
 msgid "Fighting"
 msgstr "格斗"
 
-#: common/models/genre.py:92
+#: common/models/genre.py:91
 msgid "Survival"
 msgstr "生存"
 
-#: common/models/genre.py:93
+#: common/models/genre.py:92
 msgid "Sandbox"
 msgstr "沙盒"
 
-#: common/models/genre.py:94
+#: common/models/genre.py:93
 msgid "Roguelike"
 msgstr "肉鸽"
 
-#: common/models/genre.py:95
+#: common/models/genre.py:94
 msgid "Visual Novel"
 msgstr "视觉小说"
 
-#: common/models/genre.py:96
+#: common/models/genre.py:95
 msgid "Card Game"
 msgstr "卡牌"
 
-#: common/models/genre.py:97
+#: common/models/genre.py:96
 msgid "Board Game"
 msgstr "桌游"
 
-#: common/models/genre.py:98
+#: common/models/genre.py:97
 msgid "Arcade"
 msgstr "街机"
 
-#: common/models/genre.py:99
+#: common/models/genre.py:98
 msgid "MMO"
 msgstr "MMO"
 
-#: common/models/genre.py:100
+#: common/models/genre.py:99
 msgid "MOBA"
 msgstr "MOBA"
 
-#: common/models/genre.py:101
+#: common/models/genre.py:100
 msgid "Pinball"
 msgstr "弹珠"
 
-#: common/models/genre.py:102
+#: common/models/genre.py:101
 msgid "Point-and-Click"
 msgstr "点击冒险"
 
-#: common/models/genre.py:103
+#: common/models/genre.py:102
 msgid "Casual"
 msgstr "休闲"
 
-#: common/models/genre.py:105
+#: common/models/genre.py:104
 msgid "Opera"
 msgstr "歌剧"
 
-#: common/models/genre.py:106
+#: common/models/genre.py:105
 msgid "Ballet"
 msgstr "芭蕾"
 
-#: common/models/genre.py:107
+#: common/models/genre.py:106
 msgid "Theater"
 msgstr "话剧"
 
-#: common/models/genre.py:108
+#: common/models/genre.py:107
 msgid "Cabaret"
 msgstr "歌舞表演"
 
-#: common/models/genre.py:109
+#: common/models/genre.py:108
 msgid "Xiqu"
 msgstr "戏曲"
 
-#: common/models/genre.py:111
+#: common/models/genre.py:110
 msgid "True Crime"
 msgstr "真实犯罪"
 
-#: common/models/genre.py:112
+#: common/models/genre.py:111
 msgid "Self-Help"
 msgstr "个人成长"
 
-#: common/models/genre.py:113
+#: common/models/genre.py:112
 msgid "Business"
 msgstr "商业"
 
-#: common/models/genre.py:114
+#: common/models/genre.py:113
 msgid "Technology"
 msgstr "科技"
 
-#: common/models/genre.py:115
+#: common/models/genre.py:114
 msgid "Education"
 msgstr "教育"
 
-#: common/models/genre.py:116
+#: common/models/genre.py:115
 msgid "Religion"
 msgstr "宗教"
 
-#: common/models/genre.py:117
+#: common/models/genre.py:116
 msgid "Leisure"
 msgstr "休闲娱乐"
 
-#: common/models/genre.py:118
+#: common/models/genre.py:117
 msgid "Health"
 msgstr "健康"
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 15:46-0400\n"
+"POT-Creation-Date: 2026-04-12 18:27-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -58,21 +58,21 @@ msgstr "简体中文"
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: catalog/forms.py:28 catalog/models/item.py:156
+#: catalog/forms.py:29 catalog/models/item.py:157
 msgid "Primary ID Type"
 msgstr "主要标识类型"
 
-#: catalog/forms.py:33 catalog/models/item.py:159
+#: catalog/forms.py:34 catalog/models/item.py:160
 msgid "Primary ID Value"
 msgstr "主要标识数据"
 
 #: catalog/models/book.py:80 catalog/models/book.py:99
-#: catalog/models/common.py:193 catalog/models/common.py:211
+#: catalog/models/common.py:200 catalog/models/common.py:218
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:83 catalog/models/book.py:102
-#: catalog/models/common.py:196 catalog/models/common.py:216
+#: catalog/models/common.py:203 catalog/models/common.py:223
 msgid "text content"
 msgstr "文本内容"
 
@@ -96,7 +96,7 @@ msgstr "有声书"
 msgid "Web Fiction"
 msgstr "网络作品"
 
-#: catalog/models/book.py:124 catalog/models/game.py:31
+#: catalog/models/book.py:124 catalog/models/game.py:32
 msgid "Other"
 msgstr "其它"
 
@@ -104,9 +104,9 @@ msgstr "其它"
 msgid "subtitle"
 msgstr "副标题"
 
-#: catalog/models/book.py:173 catalog/models/movie.py:65
-#: catalog/models/performance.py:317 catalog/models/tv.py:137
-#: catalog/models/tv.py:364
+#: catalog/models/book.py:173 catalog/models/movie.py:66
+#: catalog/models/performance.py:312 catalog/models/tv.py:138
+#: catalog/models/tv.py:359
 msgid "original title"
 msgstr "原名"
 
@@ -162,433 +162,431 @@ msgstr "价格"
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:9 common/models/lang.py:249
+#: catalog/models/common.py:15 common/models/lang.py:249
 msgid "Unknown"
 msgstr "未知"
 
-#: catalog/models/common.py:10
+#: catalog/models/common.py:16
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:11 catalog/models/common.py:58
+#: catalog/models/common.py:17 catalog/models/common.py:64
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:12 catalog/models/common.py:60
+#: catalog/models/common.py:18 catalog/models/common.py:66
 msgid "Google Books"
 msgstr "谷歌图书"
 
-#: catalog/models/common.py:13
+#: catalog/models/common.py:19
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:14 catalog/models/common.py:69
-#: catalog/models/common.py:71
+#: catalog/models/common.py:20 catalog/models/common.py:75
+#: catalog/models/common.py:77
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:15 catalog/models/common.py:70
+#: catalog/models/common.py:21 catalog/models/common.py:76
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:16 catalog/models/common.py:53
+#: catalog/models/common.py:22 catalog/models/common.py:59
 #: catalog/templates/movie.html:51 catalog/templates/tvseason.html:68
 #: catalog/templates/tvshow.html:63
 msgid "IMDb"
 msgstr "IMDb"
 
-#: catalog/models/common.py:17
+#: catalog/models/common.py:23
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:18 catalog/models/common.py:72
+#: catalog/models/common.py:24 catalog/models/common.py:78
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
-#: catalog/models/common.py:19
+#: catalog/models/common.py:25
 msgid "Spotify"
 msgstr "Spotify"
 
-#: catalog/models/common.py:20
+#: catalog/models/common.py:26
 msgid "IGDB"
 msgstr "IGDB"
 
-#: catalog/models/common.py:21
+#: catalog/models/common.py:27
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:22 catalog/models/common.py:90
+#: catalog/models/common.py:28 catalog/models/common.py:96
 msgid "Bangumi"
 msgstr "Bangumi"
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:29
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:24 catalog/models/common.py:91
+#: catalog/models/common.py:30 catalog/models/common.py:97
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:31
 msgid "RSS"
 msgstr "RSS"
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:32
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:27 catalog/models/common.py:92
+#: catalog/models/common.py:33 catalog/models/common.py:98
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:28 catalog/models/common.py:94
+#: catalog/models/common.py:34 catalog/models/common.py:100
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:29 catalog/models/common.py:95
+#: catalog/models/common.py:35 catalog/models/common.py:101
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:30 catalog/models/common.py:96
+#: catalog/models/common.py:36 catalog/models/common.py:102
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:31 catalog/models/common.py:97
+#: catalog/models/common.py:37 catalog/models/common.py:103
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:32 catalog/models/common.py:98
+#: catalog/models/common.py:38 catalog/models/common.py:104
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:33 catalog/models/common.py:43
+#: catalog/models/common.py:39 catalog/models/common.py:49
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:34 catalog/models/common.py:99
+#: catalog/models/common.py:40 catalog/models/common.py:105
 msgid "Open Library"
 msgstr "开放图书馆"
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:41
 msgid "MusicBrainz"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:42
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:37 catalog/models/common.py:101
+#: catalog/models/common.py:43 catalog/models/common.py:107
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:38 catalog/models/common.py:102
+#: catalog/models/common.py:44 catalog/models/common.py:108
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:93
+#: catalog/models/common.py:45 catalog/models/common.py:99
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:44
+#: catalog/models/common.py:50
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:45 catalog/templates/edition.html:19
+#: catalog/models/common.py:51 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:46
+#: catalog/models/common.py:52
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:53
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:48
+#: catalog/models/common.py:54
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:49
+#: catalog/models/common.py:55
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:50
+#: catalog/models/common.py:56
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:57
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:58
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:60
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:61
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:62
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:63
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:65
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:67
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:68
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:69
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:70
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:71
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:72
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:73
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:74
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:79
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:80
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:81
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:82
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:85
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:87
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:93
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:94
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:95
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:106
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:121
+#: catalog/models/common.py:127
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:122 catalog/templates/_sidebar_edit.html:224
+#: catalog/models/common.py:128 catalog/templates/_sidebar_edit.html:224
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:123
+#: catalog/models/common.py:129
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:124 catalog/templates/_sidebar_edit.html:145
+#: catalog/models/common.py:130 catalog/templates/_sidebar_edit.html:145
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:131
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:126 catalog/models/common.py:142
-#: catalog/models/common.py:156 catalog/templates/_sidebar_edit.html:138
+#: catalog/models/common.py:132 catalog/models/common.py:148
+#: catalog/models/common.py:162 catalog/templates/_sidebar_edit.html:138
 #: journal/templates/_sidebar_user_mark_list.html:32
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:127
+#: catalog/models/common.py:133
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:128 catalog/models/common.py:145
-#: catalog/models/common.py:159 common/templates/_header.html:41
+#: catalog/models/common.py:134 catalog/models/common.py:151
+#: catalog/models/common.py:165 common/templates/_header.html:41
 #: journal/templates/_sidebar_user_mark_list.html:45
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:129
+#: catalog/models/common.py:135
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:130
+#: catalog/models/common.py:136
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:131 catalog/models/common.py:147
-#: catalog/models/common.py:161 common/templates/_header.html:45
+#: catalog/models/common.py:137 catalog/models/common.py:153
+#: catalog/models/common.py:167 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:49
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:138
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:133
+#: catalog/models/common.py:139
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:134 catalog/models/common.py:151
+#: catalog/models/common.py:140 catalog/models/common.py:157
 #: journal/templates/collection.html:23 journal/templates/collection.html:29
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:141 catalog/models/common.py:155
+#: catalog/models/common.py:147 catalog/models/common.py:161
 #: common/templates/_header.html:25
 #: journal/templates/_sidebar_user_mark_list.html:29
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:143 catalog/models/common.py:157
+#: catalog/models/common.py:149 catalog/models/common.py:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:144 catalog/models/common.py:158
-#: common/templates/_header.html:37
+#: catalog/models/common.py:150 catalog/models/common.py:164
+#: common/models/genre.py:39 common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:42
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:146 catalog/models/common.py:160
+#: catalog/models/common.py:152 catalog/models/common.py:166
 #: catalog/templates/_sidebar_edit.html:157 common/templates/_header.html:33
 #: journal/templates/_sidebar_user_mark_list.html:39
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:241 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:248 catalog/templates/_genre_list.html:5
+msgid "genre"
+msgstr "类型"
+
+#: catalog/models/common.py:265 catalog/templates/_language_list.html:5
 #: users/models/user.py:128
 msgid "language"
 msgstr "语言"
 
-#: catalog/models/game.py:23
+#: catalog/models/game.py:24
 msgid "Main Game"
 msgstr "游戏"
 
-#: catalog/models/game.py:24
+#: catalog/models/game.py:25
 msgid "Expansion"
 msgstr "资料片"
 
-#: catalog/models/game.py:25
+#: catalog/models/game.py:26
 msgid "Downloadable Content"
 msgstr "可下载内容"
 
-#: catalog/models/game.py:26
+#: catalog/models/game.py:27
 msgid "Mod"
 msgstr "模组"
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:28
 msgid "Bundle"
 msgstr "合集"
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:29
 msgid "Remaster"
 msgstr "复刻"
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:30
 msgid "Remake"
 msgstr "重制"
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:31
 msgid "Special Edition"
 msgstr "特别版"
 
-#: catalog/models/game.py:73
+#: catalog/models/game.py:74
 msgid "designer"
 msgstr "设计者"
 
-#: catalog/models/game.py:81 catalog/models/music.py:66
+#: catalog/models/game.py:82 catalog/models/music.py:65
 msgid "artist"
 msgstr "艺术家"
 
-#: catalog/models/game.py:89
+#: catalog/models/game.py:90
 msgid "developer"
 msgstr "开发者"
 
-#: catalog/models/game.py:97 catalog/models/music.py:80
+#: catalog/models/game.py:98 catalog/models/music.py:73
 msgid "publisher"
 msgstr "出版发行"
 
-#: catalog/models/game.py:105
+#: catalog/models/game.py:106
 msgid "year of publication"
 msgstr "发行年份"
 
-#: catalog/models/game.py:109 catalog/models/podcast.py:161
+#: catalog/models/game.py:110 catalog/models/podcast.py:156
 msgid "date of publication"
 msgstr "发行日期"
 
-#: catalog/models/game.py:114 catalog/models/music.py:60
-#: catalog/models/tv.py:181
+#: catalog/models/game.py:115 catalog/models/music.py:59
+#: catalog/models/tv.py:176
 msgid "YYYY-MM-DD"
 msgstr "YYYY-MM-DD"
 
-#: catalog/models/game.py:118 catalog/templates/game.html:16
+#: catalog/models/game.py:119 catalog/templates/game.html:16
 msgid "release type"
 msgstr "发布类型"
 
-#: catalog/models/game.py:125 catalog/models/movie.py:89
-#: catalog/models/performance.py:118 catalog/models/podcast.py:60
-#: catalog/models/tv.py:161 catalog/models/tv.py:388
-msgid "genre"
-msgstr "类型"
-
-#: catalog/models/game.py:133
+#: catalog/models/game.py:128
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/game.py:139 catalog/models/movie.py:123
-#: catalog/models/performance.py:202 catalog/models/performance.py:397
-#: catalog/models/podcast.py:79 catalog/models/tv.py:195
-#: catalog/models/tv.py:423 catalog/templates/game.html:34
+#: catalog/models/game.py:134 catalog/models/movie.py:118
+#: catalog/models/performance.py:197 catalog/models/performance.py:392
+#: catalog/models/podcast.py:74 catalog/models/tv.py:190
+#: catalog/models/tv.py:412 catalog/templates/game.html:34
 #: catalog/templates/movie.html:58 catalog/templates/performance.html:33
 #: catalog/templates/performanceproduction.html:33
 #: catalog/templates/podcast.html:20 catalog/templates/tvseason.html:75
@@ -596,67 +594,67 @@ msgstr "平台"
 msgid "website"
 msgstr "网站"
 
-#: catalog/models/item.py:153 catalog/models/item.py:185
+#: catalog/models/item.py:154 catalog/models/item.py:186
 #: journal/models/collection.py:64
 msgid "title"
 msgstr "标题"
 
-#: catalog/models/item.py:154 catalog/models/item.py:193
+#: catalog/models/item.py:155 catalog/models/item.py:194
 #: journal/models/collection.py:65
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:165
+#: catalog/models/item.py:166
 msgid "metadata"
 msgstr "元数据"
 
-#: catalog/models/item.py:167 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:168 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:743
+#: catalog/models/item.py:754
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:745
+#: catalog/models/item.py:756
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:747
+#: catalog/models/item.py:758
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:763
+#: catalog/models/item.py:774
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:769
+#: catalog/models/item.py:780
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:772
+#: catalog/models/item.py:783
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
-#: catalog/models/movie.py:68 catalog/models/performance.py:126
-#: catalog/models/performance.py:321 catalog/models/tv.py:140
-#: catalog/models/tv.py:367
+#: catalog/models/movie.py:69 catalog/models/performance.py:121
+#: catalog/models/performance.py:316 catalog/models/tv.py:141
+#: catalog/models/tv.py:362
 msgid "director"
 msgstr "导演"
 
-#: catalog/models/movie.py:75 catalog/models/performance.py:133
-#: catalog/models/performance.py:328 catalog/models/tv.py:147
-#: catalog/models/tv.py:374
+#: catalog/models/movie.py:76 catalog/models/performance.py:128
+#: catalog/models/performance.py:323 catalog/models/tv.py:148
+#: catalog/models/tv.py:369
 msgid "playwright"
 msgstr "编剧"
 
-#: catalog/models/movie.py:82 catalog/models/performance.py:161
-#: catalog/models/performance.py:356 catalog/models/tv.py:154
-#: catalog/models/tv.py:381
+#: catalog/models/movie.py:83 catalog/models/performance.py:156
+#: catalog/models/performance.py:351 catalog/models/tv.py:155
+#: catalog/models/tv.py:376
 msgid "actor"
 msgstr "演员"
 
-#: catalog/models/movie.py:96 catalog/models/music.py:60
+#: catalog/models/movie.py:91 catalog/models/music.py:59
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
@@ -664,161 +662,156 @@ msgstr "演员"
 msgid "release date"
 msgstr "发布日期"
 
-#: catalog/models/movie.py:108 catalog/models/tv.py:407
+#: catalog/models/movie.py:103 catalog/models/tv.py:396
 #: journal/templates/_sidebar_user_mark_list.html:60
 msgid "date"
 msgstr "日期"
 
-#: catalog/models/movie.py:109 catalog/models/performance.py:84
-#: catalog/models/tv.py:408
+#: catalog/models/movie.py:104 catalog/models/performance.py:85
+#: catalog/models/tv.py:397
 msgid "required"
 msgstr "必填"
 
-#: catalog/models/movie.py:113 catalog/models/tv.py:412
+#: catalog/models/movie.py:108 catalog/models/tv.py:401
 msgid "region or event"
 msgstr "地区或类型"
 
-#: catalog/models/movie.py:115 catalog/models/tv.py:187
-#: catalog/models/tv.py:414
+#: catalog/models/movie.py:110 catalog/models/tv.py:182
+#: catalog/models/tv.py:403
 msgid "Germany or Toronto International Film Festival"
 msgstr "德国或多伦多国际电影节"
 
-#: catalog/models/movie.py:125 catalog/models/tv.py:197
-#: catalog/models/tv.py:426
+#: catalog/models/movie.py:120 catalog/models/tv.py:192
+#: catalog/models/tv.py:415
 msgid "region"
 msgstr "地区"
 
-#: catalog/models/movie.py:136 catalog/models/tv.py:209
-#: catalog/models/tv.py:437
+#: catalog/models/movie.py:131 catalog/models/tv.py:204
+#: catalog/models/tv.py:426
 msgid "year"
 msgstr "年份"
 
-#: catalog/models/movie.py:137 catalog/models/music.py:63
+#: catalog/models/movie.py:132 catalog/models/music.py:62
 #: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
 #: catalog/templates/tvshow.html:47
 msgid "length"
 msgstr "长度"
 
-#: catalog/models/music.py:63
+#: catalog/models/music.py:62
 msgid "milliseconds"
 msgstr "微秒"
 
-#: catalog/models/music.py:73
-msgctxt "music"
-msgid "genre"
-msgstr "风格"
-
-#: catalog/models/music.py:86
+#: catalog/models/music.py:79
 msgid "tracks"
 msgstr "曲目"
 
-#: catalog/models/music.py:87 catalog/templates/album.html:33
+#: catalog/models/music.py:80 catalog/templates/album.html:33
 msgid "album type"
 msgstr "专辑类型"
 
-#: catalog/models/music.py:88
+#: catalog/models/music.py:81
 msgid "media type"
 msgstr "介质类型"
 
-#: catalog/models/music.py:91 catalog/templates/album.html:43
+#: catalog/models/music.py:84 catalog/templates/album.html:43
 msgid "number of discs"
 msgstr "碟片数"
 
-#: catalog/models/performance.py:68 catalog/models/performance.py:83
+#: catalog/models/performance.py:69 catalog/models/performance.py:84
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/performance.py:69 catalog/models/performance.py:88
+#: catalog/models/performance.py:70 catalog/models/performance.py:89
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/performance.py:89
+#: catalog/models/performance.py:90
 msgid "optional"
 msgstr "可选"
 
-#: catalog/models/performance.py:115
+#: catalog/models/performance.py:116
 msgid "original name"
 msgstr "原名"
 
-#: catalog/models/performance.py:140 catalog/models/performance.py:335
+#: catalog/models/performance.py:135 catalog/models/performance.py:330
 msgid "original creator"
 msgstr "原始创作者"
 
-#: catalog/models/performance.py:147 catalog/models/performance.py:342
+#: catalog/models/performance.py:142 catalog/models/performance.py:337
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/performance.py:154 catalog/models/performance.py:349
+#: catalog/models/performance.py:149 catalog/models/performance.py:344
 msgid "choreographer"
 msgstr "编舞"
 
-#: catalog/models/performance.py:168 catalog/models/performance.py:363
+#: catalog/models/performance.py:163 catalog/models/performance.py:358
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/performance.py:175 catalog/models/performance.py:370
+#: catalog/models/performance.py:170 catalog/models/performance.py:365
 msgid "troupe"
 msgstr "剧团"
 
-#: catalog/models/performance.py:182 catalog/models/performance.py:377
+#: catalog/models/performance.py:177 catalog/models/performance.py:372
 msgid "crew"
 msgstr "工作人员"
 
-#: catalog/models/performance.py:189 catalog/models/performance.py:384
+#: catalog/models/performance.py:184 catalog/models/performance.py:379
 msgid "theater"
 msgstr "剧院"
 
-#: catalog/models/performance.py:196 catalog/models/performance.py:391
+#: catalog/models/performance.py:191 catalog/models/performance.py:386
 #: catalog/templates/performance.html:14
 #: catalog/templates/performanceproduction.html:13
 msgid "opening date"
 msgstr "上演日期"
 
-#: catalog/models/performance.py:199 catalog/models/performance.py:394
+#: catalog/models/performance.py:194 catalog/models/performance.py:389
 msgid "closing date"
 msgstr "结束日期"
 
-#: catalog/models/podcast.py:70
+#: catalog/models/podcast.py:65
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/tv.py:112 catalog/templates/tvseason.html:37
+#: catalog/models/tv.py:113 catalog/templates/tvseason.html:37
 #: catalog/templates/tvshow.html:32
 msgid "number of seasons"
 msgstr "季数"
 
-#: catalog/models/tv.py:115 catalog/models/tv.py:342
+#: catalog/models/tv.py:116 catalog/models/tv.py:337
 #: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
 msgid "number of episodes"
 msgstr "集数"
 
-#: catalog/models/tv.py:168 catalog/models/tv.py:395
+#: catalog/models/tv.py:163 catalog/models/tv.py:384
 msgid "show time"
 msgstr "上映时间"
 
-#: catalog/models/tv.py:180
+#: catalog/models/tv.py:175
 msgid "Date"
 msgstr "日期"
 
-#: catalog/models/tv.py:185
+#: catalog/models/tv.py:180
 msgid "Region or Event"
 msgstr "地区或场合"
 
-#: catalog/models/tv.py:211 catalog/models/tv.py:439
+#: catalog/models/tv.py:206 catalog/models/tv.py:428
 msgid "episode length"
 msgstr "单集长度"
 
-#: catalog/models/tv.py:339 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:334 catalog/templates/tvseason.html:32
 msgid "season number"
 msgstr "本季序号"
 
-#: catalog/models/tv.py:472
+#: catalog/models/tv.py:461
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:620
+#: catalog/models/tv.py:609
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
@@ -1728,6 +1721,377 @@ msgstr "条目不存在"
 #: catalog/views/view.py:57 catalog/views/view.py:86
 msgid "Item no longer exists"
 msgstr "条目已不存在"
+
+#: common/models/genre.py:20
+msgid "Action"
+msgstr "动作"
+
+#: common/models/genre.py:21
+msgid "Adventure"
+msgstr "冒险"
+
+#: common/models/genre.py:22
+msgid "Comedy"
+msgstr "喜剧"
+
+#: common/models/genre.py:23
+msgid "Drama"
+msgstr "剧情"
+
+#: common/models/genre.py:24
+msgid "Fantasy"
+msgstr "奇幻"
+
+#: common/models/genre.py:25
+msgid "Horror"
+msgstr "恐怖"
+
+#: common/models/genre.py:26
+msgid "Mystery"
+msgstr "悬疑"
+
+#: common/models/genre.py:27
+msgid "Romance"
+msgstr "爱情"
+
+#: common/models/genre.py:28
+msgid "Sci-Fi"
+msgstr "科幻"
+
+#: common/models/genre.py:29
+msgid "Thriller"
+msgstr "惊悚"
+
+#: common/models/genre.py:30
+msgid "Animation"
+msgstr "动画"
+
+#: common/models/genre.py:31
+msgid "Documentary"
+msgstr "纪录片"
+
+#: common/models/genre.py:32
+msgid "Family"
+msgstr "家庭"
+
+#: common/models/genre.py:33
+msgid "History"
+msgstr "历史"
+
+#: common/models/genre.py:34
+msgid "Biographical"
+msgstr "传记"
+
+#: common/models/genre.py:35
+msgid "War"
+msgstr "战争"
+
+#: common/models/genre.py:36
+msgid "Western"
+msgstr "西部"
+
+#: common/models/genre.py:37
+msgid "Crime"
+msgstr "犯罪"
+
+#: common/models/genre.py:38
+msgid "Sports"
+msgstr "运动"
+
+#: common/models/genre.py:41
+msgid "Film Noir"
+msgstr "黑色电影"
+
+#: common/models/genre.py:42
+msgid "Musical"
+msgstr "音乐剧"
+
+#: common/models/genre.py:43
+msgid "Reality"
+msgstr "真人秀"
+
+#: common/models/genre.py:44
+msgid "Talk Show"
+msgstr "脱口秀"
+
+#: common/models/genre.py:45
+msgid "News"
+msgstr "新闻"
+
+#: common/models/genre.py:46
+msgid "Game Show"
+msgstr "综艺"
+
+#: common/models/genre.py:47
+msgid "Martial Arts"
+msgstr "武侠"
+
+#: common/models/genre.py:48
+msgid "Period Drama"
+msgstr "古装"
+
+#: common/models/genre.py:49
+msgid "Superhero"
+msgstr "超级英雄"
+
+#: common/models/genre.py:50
+msgid "Disaster"
+msgstr "灾难"
+
+#: common/models/genre.py:51
+msgid "Erotic"
+msgstr "情色"
+
+#: common/models/genre.py:52
+msgid "Short Film"
+msgstr "短片"
+
+#: common/models/genre.py:53
+msgid "LGBTQ"
+msgstr "多元性别"
+
+#: common/models/genre.py:54
+msgid "TV Movie"
+msgstr "电视电影"
+
+#: common/models/genre.py:56
+msgid "Rock"
+msgstr "摇滚"
+
+#: common/models/genre.py:57
+msgid "Pop"
+msgstr "流行"
+
+#: common/models/genre.py:58
+msgid "Hip Hop"
+msgstr "说唱"
+
+#: common/models/genre.py:59
+msgid "Electronic"
+msgstr "电子"
+
+#: common/models/genre.py:60
+msgid "Jazz"
+msgstr "爵士"
+
+#: common/models/genre.py:61
+msgid "Classical"
+msgstr "古典"
+
+#: common/models/genre.py:62
+msgid "Blues"
+msgstr "蓝调"
+
+#: common/models/genre.py:63
+msgid "Country"
+msgstr "乡村"
+
+#: common/models/genre.py:64
+msgid "Folk"
+msgstr "民谣"
+
+#: common/models/genre.py:65
+msgid "R&B"
+msgstr "节奏布鲁斯"
+
+#: common/models/genre.py:66
+msgid "Metal"
+msgstr "金属"
+
+#: common/models/genre.py:67
+msgid "Punk"
+msgstr "朋克"
+
+#: common/models/genre.py:68
+msgid "Soul"
+msgstr "灵魂乐"
+
+#: common/models/genre.py:69
+msgid "Reggae"
+msgstr "雷鬼"
+
+#: common/models/genre.py:70
+#, fuzzy
+#| msgid "Latin"
+msgctxt "genre"
+msgid "Latin"
+msgstr "拉丁"
+
+#: common/models/genre.py:71
+msgid "World Music"
+msgstr "世界音乐"
+
+#: common/models/genre.py:72
+msgid "Ambient"
+msgstr "氛围"
+
+#: common/models/genre.py:73
+msgid "New Age"
+msgstr "新世纪"
+
+#: common/models/genre.py:74
+msgid "Indie"
+msgstr "独立"
+
+#: common/models/genre.py:75
+msgid "Alternative"
+msgstr "另类"
+
+#: common/models/genre.py:76
+msgid "Dance"
+msgstr "舞曲"
+
+#: common/models/genre.py:77
+msgid "Funk"
+msgstr "放克"
+
+#: common/models/genre.py:78
+msgid "Gospel"
+msgstr "福音"
+
+#: common/models/genre.py:79
+msgid "Soundtrack"
+msgstr "原声"
+
+#: common/models/genre.py:80
+msgid "K-Pop"
+msgstr "韩流"
+
+#: common/models/genre.py:81
+msgid "Easy Listening"
+msgstr "轻音乐"
+
+#: common/models/genre.py:83
+msgid "RPG"
+msgstr "角色扮演"
+
+#: common/models/genre.py:84
+msgid "Strategy"
+msgstr "策略"
+
+#: common/models/genre.py:85
+msgid "Simulation"
+msgstr "模拟"
+
+#: common/models/genre.py:86
+msgid "Racing"
+msgstr "竞速"
+
+#: common/models/genre.py:87
+msgid "Puzzle"
+msgstr "益智"
+
+#: common/models/genre.py:88
+msgid "Platformer"
+msgstr "平台"
+
+#: common/models/genre.py:89
+msgid "Shooter"
+msgstr "射击"
+
+#: common/models/genre.py:90
+msgid "Fighting"
+msgstr "格斗"
+
+#: common/models/genre.py:91
+msgid "Survival"
+msgstr "生存"
+
+#: common/models/genre.py:92
+msgid "Sandbox"
+msgstr "沙盒"
+
+#: common/models/genre.py:93
+msgid "Roguelike"
+msgstr "肉鸽"
+
+#: common/models/genre.py:94
+msgid "Visual Novel"
+msgstr "视觉小说"
+
+#: common/models/genre.py:95
+msgid "Card Game"
+msgstr "卡牌"
+
+#: common/models/genre.py:96
+msgid "Board Game"
+msgstr "桌游"
+
+#: common/models/genre.py:97
+msgid "Arcade"
+msgstr "街机"
+
+#: common/models/genre.py:98
+msgid "MMO"
+msgstr "MMO"
+
+#: common/models/genre.py:99
+msgid "MOBA"
+msgstr "MOBA"
+
+#: common/models/genre.py:100
+msgid "Pinball"
+msgstr "弹珠"
+
+#: common/models/genre.py:101
+msgid "Point-and-Click"
+msgstr "点击冒险"
+
+#: common/models/genre.py:102
+msgid "Casual"
+msgstr "休闲"
+
+#: common/models/genre.py:104
+msgid "Opera"
+msgstr "歌剧"
+
+#: common/models/genre.py:105
+msgid "Ballet"
+msgstr "芭蕾"
+
+#: common/models/genre.py:106
+msgid "Theater"
+msgstr "话剧"
+
+#: common/models/genre.py:107
+msgid "Cabaret"
+msgstr "歌舞表演"
+
+#: common/models/genre.py:108
+msgid "Xiqu"
+msgstr "戏曲"
+
+#: common/models/genre.py:110
+msgid "True Crime"
+msgstr "真实犯罪"
+
+#: common/models/genre.py:111
+msgid "Self-Help"
+msgstr "个人成长"
+
+#: common/models/genre.py:112
+msgid "Business"
+msgstr "商业"
+
+#: common/models/genre.py:113
+msgid "Technology"
+msgstr "科技"
+
+#: common/models/genre.py:114
+msgid "Education"
+msgstr "教育"
+
+#: common/models/genre.py:115
+msgid "Religion"
+msgstr "宗教"
+
+#: common/models/genre.py:116
+msgid "Leisure"
+msgstr "休闲娱乐"
+
+#: common/models/genre.py:117
+msgid "Health"
+msgstr "健康"
 
 #: common/models/lang.py:47
 msgid "Afar"
@@ -2824,7 +3188,7 @@ msgstr ""
 msgid "Database Admin"
 msgstr "数据库"
 
-#: common/templatetags/duration.py:54
+#: common/templatetags/duration.py:55
 msgid "just now"
 msgstr "刚刚"
 

--- a/tests/catalog/test_game.py
+++ b/tests/catalog/test_game.py
@@ -126,7 +126,7 @@ class TestDoubanGame:
         titles = sorted([t["text"] for t in site.resource.item.localized_title])
         assert titles == ["Portal 2", "传送门2"]
         assert site.resource.item.douban_game == "10734307"
-        assert site.resource.item.genre == ["fps", "puzzle"]
+        assert site.resource.item.genre == ["shooter", "puzzle"]
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/catalog/test_game.py
+++ b/tests/catalog/test_game.py
@@ -126,7 +126,7 @@ class TestDoubanGame:
         titles = sorted([t["text"] for t in site.resource.item.localized_title])
         assert titles == ["Portal 2", "传送门2"]
         assert site.resource.item.douban_game == "10734307"
-        assert site.resource.item.genre == ["第一人称射击", "puzzle"]
+        assert site.resource.item.genre == ["fps", "puzzle"]
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/catalog/test_game.py
+++ b/tests/catalog/test_game.py
@@ -33,10 +33,10 @@ class TestIGDB:
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.steam == "620"
         assert site.resource.item.genre == [
-            "Shooter",
-            "Platform",
-            "Puzzle",
-            "Adventure",
+            "shooter",
+            "platformer",
+            "puzzle",
+            "adventure",
         ]
 
     @use_local_response
@@ -54,7 +54,7 @@ class TestIGDB:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.primary_lookup_id_type == IdType.IGDB
-        assert site.resource.item.genre == ["Puzzle", "Role-playing (RPG)", "Adventure"]
+        assert site.resource.item.genre == ["puzzle", "rpg", "adventure"]
         assert (
             site.resource.item.primary_lookup_id_value
             == "the-legend-of-zelda-breath-of-the-wild"
@@ -91,10 +91,10 @@ class TestSteam:
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.steam == "620"
         assert site.resource.item.genre == [
-            "Shooter",
-            "Platform",
-            "Puzzle",
-            "Adventure",
+            "shooter",
+            "platformer",
+            "puzzle",
+            "adventure",
         ]
 
 

--- a/tests/catalog/test_game.py
+++ b/tests/catalog/test_game.py
@@ -126,7 +126,7 @@ class TestDoubanGame:
         titles = sorted([t["text"] for t in site.resource.item.localized_title])
         assert titles == ["Portal 2", "传送门2"]
         assert site.resource.item.douban_game == "10734307"
-        assert site.resource.item.genre == ["第一人称射击", "益智"]
+        assert site.resource.item.genre == ["第一人称射击", "puzzle"]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -214,7 +214,7 @@ class TestMobyGames:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.developer == ["Valve Corporation"]
-        assert "Action" in site.resource.item.genre
+        assert "action" in site.resource.item.genre
         assert "Windows" in site.resource.item.platform
 
 

--- a/tests/catalog/test_music.py
+++ b/tests/catalog/test_music.py
@@ -92,7 +92,7 @@ class TestDoubanMusic:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.barcode == "0077774644020"
-        assert site.resource.item.genre == ["摇滚"]
+        assert site.resource.item.genre == ["rock"]
         assert len(site.resource.item.localized_title) == 2
 
 
@@ -205,7 +205,7 @@ class TestDiscogsRelease:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.barcode == "0602445804689"
-        assert site.resource.item.genre == ["Hip Hop"]
+        assert site.resource.item.genre == ["hip-hop"]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -236,7 +236,7 @@ class TestDiscogsMaster:
         assert site.resource.metadata["artist"] == ["The XX"]
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
-        assert site.resource.item.genre == ["Electronic", "Rock", "Pop"]
+        assert site.resource.item.genre == ["electronic", "rock", "pop"]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -267,7 +267,7 @@ class TestAppleMusic:
         assert site.resource.metadata["artist"] == ["Leah Dou"]
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
-        assert site.resource.item.genre == ["Pop", "Music"]
+        assert site.resource.item.genre == ["pop", "music"]
         assert site.resource.item.duration == 2368000
 
 

--- a/tests/catalog/test_performance.py
+++ b/tests/catalog/test_performance.py
@@ -40,7 +40,7 @@ class TestDoubanDrama:
         assert isinstance(item, Performance)
         assert item.display_title == "不眠之人·拿破仑"
         assert len(item.localized_title) == 2
-        assert item.genre == ["音乐剧"]
+        assert item.genre == ["musical"]
         assert item.troupe == ["宝塚歌剧团"]
         assert item.composer == ["ジェラール・プレスギュルヴィック"]
 
@@ -86,7 +86,7 @@ class TestDoubanDrama:
         assert item.display_title == "THE SCARLET PIMPERNEL"
         assert len(item.localized_title) == 3
         assert len(item.display_description) == 545
-        assert item.genre == ["音乐剧"]
+        assert item.genre == ["musical"]
         # assert item.version == ["08星组公演版", "10年月組公演版", "17年星組公演版", "ュージカル（2017年）版"]
         assert item.director == ["小池修一郎", "小池 修一郎", "石丸さち子"]
         assert item.playwright == [

--- a/tests/core/test_genre.py
+++ b/tests/core/test_genre.py
@@ -395,10 +395,11 @@ class TestBuildGenreAliases:
     def test_aliases_include_i18n_translations(self):
         """Aliases should include translated labels from supported UI languages."""
         aliases = _build_genre_aliases()
-        # The English labels should be in aliases (lowercased)
-        assert aliases.get("action") == "action"
-        assert aliases.get("comedy") == "comedy"
-        assert aliases.get("drama") == "drama"
+        # Translated labels from non-English locales should map to codes
+        # (English "action" == code "action" so it's skipped, but other
+        # languages' translations should be present)
+        action_aliases = [a for a, c in aliases.items() if c == "action"]
+        assert len(action_aliases) > 0
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/core/test_genre.py
+++ b/tests/core/test_genre.py
@@ -1,0 +1,543 @@
+import pytest
+from django.utils import translation
+
+from common.models.genre import (
+    GENRE_CATALOG,
+    GENRE_CHOICES,
+    GENRE_CODES,
+    _build_genre_aliases,
+    normalize_genre,
+    normalize_genres,
+)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestGenreCatalog:
+    def test_genre_catalog_not_empty(self):
+        assert len(GENRE_CATALOG) > 80
+
+    def test_genre_choices_matches_catalog(self):
+        assert len(GENRE_CHOICES) == len(GENRE_CATALOG)
+        for code, label in GENRE_CHOICES:
+            assert code in GENRE_CATALOG
+
+    def test_genre_codes_matches_catalog(self):
+        assert GENRE_CODES == GENRE_CATALOG
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestNormalizeGenre:
+    def test_empty_input(self):
+        assert normalize_genre("") is None
+
+    def test_canonical_codes_pass_through(self):
+        assert normalize_genre("action") == "action"
+        assert normalize_genre("sci-fi") == "sci-fi"
+        assert normalize_genre("rpg") == "rpg"
+        assert normalize_genre("hip-hop") == "hip-hop"
+        assert normalize_genre("r-and-b") == "r-and-b"
+
+    def test_canonical_codes_case_insensitive(self):
+        assert normalize_genre("Action") == "action"
+        assert normalize_genre("COMEDY") == "comedy"
+        assert normalize_genre("Sci-Fi") == "sci-fi"
+        assert normalize_genre("RPG") == "rpg"
+
+    def test_custom_values_pass_through(self):
+        """Unknown genres should pass through preserving original casing."""
+        assert (
+            normalize_genre("Hack and slash/Beat 'em up")
+            == "Hack and slash/Beat 'em up"
+        )
+        assert normalize_genre("Card & Board Game") == "Card & Board Game"
+        assert normalize_genre("Some Custom Genre") == "Some Custom Genre"
+        assert normalize_genre("默剧") == "默剧"
+        assert normalize_genre("多媒体") == "多媒体"
+
+    # ----- TMDB Movie genres -----
+
+    def test_tmdb_movie_genres(self):
+        assert normalize_genre("Action") == "action"
+        assert normalize_genre("Adventure") == "adventure"
+        assert normalize_genre("Animation") == "animation"
+        assert normalize_genre("Comedy") == "comedy"
+        assert normalize_genre("Crime") == "crime"
+        assert normalize_genre("Documentary") == "documentary"
+        assert normalize_genre("Drama") == "drama"
+        assert normalize_genre("Family") == "family"
+        assert normalize_genre("Fantasy") == "fantasy"
+        assert normalize_genre("History") == "history"
+        assert normalize_genre("Horror") == "horror"
+        assert normalize_genre("Music") == "music"
+        assert normalize_genre("Mystery") == "mystery"
+        assert normalize_genre("Romance") == "romance"
+        assert normalize_genre("Science Fiction") == "sci-fi"
+        assert normalize_genre("TV Movie") == "tv-movie"
+        assert normalize_genre("Thriller") == "thriller"
+        assert normalize_genre("War") == "war"
+        assert normalize_genre("Western") == "western"
+
+    # ----- TMDB TV genres -----
+
+    def test_tmdb_tv_simple_genres(self):
+        assert normalize_genre("Kids") == "family"
+        assert normalize_genre("Talk") == "talk-show"
+
+    # ----- Douban Movie genres (Chinese) -----
+
+    def test_douban_movie_genres(self):
+        assert normalize_genre("剧情") == "drama"
+        assert normalize_genre("喜剧") == "comedy"
+        assert normalize_genre("动作") == "action"
+        assert normalize_genre("爱情") == "romance"
+        assert normalize_genre("科幻") == "sci-fi"
+        assert normalize_genre("动画") == "animation"
+        assert normalize_genre("悬疑") == "mystery"
+        assert normalize_genre("惊悚") == "thriller"
+        assert normalize_genre("恐怖") == "horror"
+        assert normalize_genre("纪录片") == "documentary"
+        assert normalize_genre("紀錄片") == "documentary"
+        assert normalize_genre("短片") == "short-film"
+        assert normalize_genre("情色") == "erotic"
+        assert normalize_genre("同性") == "lgbtq"
+        assert normalize_genre("音乐") == "music"
+        assert normalize_genre("歌舞") == "musical"
+        assert normalize_genre("家庭") == "family"
+        assert normalize_genre("儿童") == "family"
+        assert normalize_genre("传记") == "biographical"
+        assert normalize_genre("历史") == "history"
+        assert normalize_genre("战争") == "war"
+        assert normalize_genre("犯罪") == "crime"
+        assert normalize_genre("西部") == "western"
+        assert normalize_genre("奇幻") == "fantasy"
+        assert normalize_genre("冒险") == "adventure"
+        assert normalize_genre("灾难") == "disaster"
+        assert normalize_genre("武侠") == "martial-arts"
+        assert normalize_genre("古装") == "period-drama"
+        assert normalize_genre("运动") == "sports"
+        assert normalize_genre("黑色电影") == "film-noir"
+        assert normalize_genre("真人秀") == "reality"
+        assert normalize_genre("脱口秀") == "talk-show"
+        assert normalize_genre("鬼怪") == "thriller"
+
+    # ----- Douban Music genres (Chinese) -----
+
+    def test_douban_music_genres(self):
+        assert normalize_genre("摇滚") == "rock"
+        assert normalize_genre("流行") == "pop"
+        assert normalize_genre("民谣") == "folk"
+        assert normalize_genre("电子") == "electronic"
+        assert normalize_genre("说唱") == "hip-hop"
+        assert normalize_genre("爵士") == "jazz"
+        assert normalize_genre("古典") == "classical"
+        assert normalize_genre("蓝调") == "blues"
+        assert normalize_genre("乡村") == "country"
+        assert normalize_genre("轻音乐") == "easy-listening"
+        assert normalize_genre("世界音乐") == "world-music"
+        assert normalize_genre("拉丁") == "latin"
+        assert normalize_genre("朋克") == "punk"
+        assert normalize_genre("金属") == "metal"
+        assert normalize_genre("雷鬼") == "reggae"
+        assert normalize_genre("放克") == "funk"
+        assert normalize_genre("灵魂乐") == "soul"
+        assert normalize_genre("原声") == "soundtrack"
+        assert normalize_genre("新世纪") == "new-age"
+
+    # ----- Douban Drama genres (Chinese) -----
+
+    def test_douban_drama_genres(self):
+        assert normalize_genre("话剧") == "theater"
+        assert normalize_genre("音乐剧") == "musical"
+        assert normalize_genre("歌剧") == "opera"
+        assert normalize_genre("舞蹈") == "dance"
+        assert normalize_genre("戏曲") == "xiqu"
+        assert normalize_genre("默剧") == "默剧"
+        assert normalize_genre("多媒体") == "多媒体"
+
+    # ----- IGDB game genres -----
+
+    def test_igdb_genres(self):
+        assert normalize_genre("Role-playing (RPG)") == "rpg"
+        assert normalize_genre("Real Time Strategy (RTS)") == "strategy"
+        assert normalize_genre("Turn-based strategy (TBS)") == "strategy"
+        assert normalize_genre("Point-and-click") == "point-and-click"
+        assert normalize_genre("Simulator") == "simulation"
+        assert normalize_genre("Sport") == "sports"
+        assert normalize_genre("Platform") == "platformer"
+        assert normalize_genre("Shooter") == "shooter"
+        assert normalize_genre("Fighting") == "fighting"
+        assert normalize_genre("Puzzle") == "puzzle"
+        assert normalize_genre("Racing") == "racing"
+        assert normalize_genre("Adventure") == "adventure"
+        assert normalize_genre("Arcade") == "arcade"
+        assert normalize_genre("Visual Novel") == "visual-novel"
+        assert normalize_genre("Indie") == "indie"
+        assert normalize_genre("MOBA") == "moba"
+        assert normalize_genre("Pinball") == "pinball"
+        assert normalize_genre("Strategy") == "strategy"
+        # These pass through as custom
+        assert (
+            normalize_genre("Hack and slash/Beat 'em up")
+            == "Hack and slash/Beat 'em up"
+        )
+        assert normalize_genre("Card & Board Game") == "Card & Board Game"
+        assert normalize_genre("Tactical") == "Tactical"
+        assert normalize_genre("Quiz/Trivia") == "puzzle"
+
+    # ----- Steam genres -----
+
+    def test_steam_genres(self):
+        assert normalize_genre("Massively Multiplayer") == "mmo"
+        # Non-genre tags pass through as custom
+        assert normalize_genre("Early Access") == "Early Access"
+        assert normalize_genre("Free to Play") == "Free to Play"
+        assert normalize_genre("Casual") == "casual"
+
+    # ----- MusicBrainz / Spotify -----
+
+    def test_musicbrainz_genres(self):
+        assert normalize_genre("rhythm and blues") == "r-and-b"
+        assert normalize_genre("r&b") == "r-and-b"
+        assert normalize_genre("rnb") == "r-and-b"
+        assert normalize_genre("hip hop") == "hip-hop"
+        # Sub-genres pass through as custom
+        assert normalize_genre("death metal") == "death metal"
+        assert normalize_genre("indie rock") == "indie rock"
+        assert normalize_genre("dream pop") == "dream pop"
+
+    # ----- Apple Podcast categories -----
+
+    def test_apple_podcast_categories(self):
+        assert normalize_genre("Health & Fitness") == "health"
+        assert normalize_genre("Kids & Family") == "family"
+        assert normalize_genre("Religion & Spirituality") == "religion"
+        assert normalize_genre("True Crime") == "true-crime"
+        assert normalize_genre("TV & Film") == "drama"
+        # These pass through as custom
+        assert normalize_genre("Arts") == "Arts"
+        assert normalize_genre("Government") == "Government"
+        assert normalize_genre("Society & Culture") == "Society & Culture"
+
+    # ----- Bangumi Japanese genres -----
+
+    def test_bangumi_genres(self):
+        assert normalize_genre("アクション") == "action"
+        assert normalize_genre("アドベンチャー") == "adventure"
+        assert normalize_genre("コメディ") == "comedy"
+        assert normalize_genre("ドラマ") == "drama"
+        assert normalize_genre("ファンタジー") == "fantasy"
+        assert normalize_genre("ホラー") == "horror"
+        assert normalize_genre("ミステリー") == "mystery"
+        assert normalize_genre("ロマンス") == "romance"
+        assert normalize_genre("シミュレーション") == "simulation"
+        assert normalize_genre("パズル") == "puzzle"
+        assert normalize_genre("シューティング") == "shooter"
+        assert normalize_genre("アニメーション") == "animation"
+        assert normalize_genre("ロールプレイング") == "rpg"
+        assert normalize_genre("レース") == "racing"
+        assert normalize_genre("スポーツ") == "sports"
+        assert normalize_genre("アーケード") == "arcade"
+        assert normalize_genre("格闘") == "fighting"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestNormalizeGenres:
+    def test_empty_list(self):
+        assert normalize_genres([]) == []
+
+    def test_already_canonical_codes(self):
+        assert normalize_genres(["action", "comedy", "drama"]) == [
+            "action",
+            "comedy",
+            "drama",
+        ]
+
+    def test_mixed_input(self):
+        assert normalize_genres(["Action", "科幻", "rock", "Some Custom"]) == [
+            "action",
+            "sci-fi",
+            "rock",
+            "Some Custom",
+        ]
+
+    def test_compound_genres_expanded(self):
+        """TMDB compound TV genres should expand to multiple codes."""
+        assert normalize_genres(["Action & Adventure"]) == ["action", "adventure"]
+        assert normalize_genres(["Sci-Fi & Fantasy"]) == ["sci-fi", "fantasy"]
+        assert normalize_genres(["War & Politics"]) == ["war"]
+
+    def test_compound_genres_deduplicated(self):
+        """Compound expansion should not create duplicates."""
+        assert normalize_genres(["Action & Adventure", "Action"]) == [
+            "action",
+            "adventure",
+        ]
+        assert normalize_genres(["Sci-Fi & Fantasy", "Fantasy"]) == [
+            "sci-fi",
+            "fantasy",
+        ]
+
+    def test_deduplication(self):
+        """Duplicates after normalization should be removed."""
+        assert normalize_genres(["Action", "action", "动作"]) == ["action"]
+        assert normalize_genres(["Science Fiction", "sci-fi", "科幻"]) == ["sci-fi"]
+
+    def test_empty_strings_filtered(self):
+        assert normalize_genres(["action", "", " ", "comedy"]) == [
+            "action",
+            "comedy",
+        ]
+
+    def test_preserves_order(self):
+        assert normalize_genres(["comedy", "action", "drama"]) == [
+            "comedy",
+            "action",
+            "drama",
+        ]
+
+    def test_full_tmdb_movie_genre_list(self):
+        """Simulate a full TMDB movie genre list being normalized."""
+        tmdb_genres = [
+            "Action",
+            "Adventure",
+            "Animation",
+            "Comedy",
+            "Crime",
+            "Documentary",
+            "Drama",
+            "Family",
+            "Fantasy",
+            "History",
+            "Horror",
+            "Music",
+            "Mystery",
+            "Romance",
+            "Science Fiction",
+            "Thriller",
+            "War",
+            "Western",
+        ]
+        result = normalize_genres(tmdb_genres)
+        assert result == [
+            "action",
+            "adventure",
+            "animation",
+            "comedy",
+            "crime",
+            "documentary",
+            "drama",
+            "family",
+            "fantasy",
+            "history",
+            "horror",
+            "music",
+            "mystery",
+            "romance",
+            "sci-fi",
+            "thriller",
+            "war",
+            "western",
+        ]
+
+    def test_douban_movie_typical_input(self):
+        """Typical Douban movie genre list."""
+        assert normalize_genres(["剧情", "喜剧", "爱情"]) == [
+            "drama",
+            "comedy",
+            "romance",
+        ]
+
+    def test_douban_music_typical_input(self):
+        """Typical Douban music genre list."""
+        assert normalize_genres(["摇滚", "流行", "电子"]) == [
+            "rock",
+            "pop",
+            "electronic",
+        ]
+
+    def test_igdb_typical_input(self):
+        """IGDB genre list for a game like Portal 2."""
+        assert normalize_genres(["Shooter", "Platform", "Puzzle", "Adventure"]) == [
+            "shooter",
+            "platformer",
+            "puzzle",
+            "adventure",
+        ]
+
+    def test_mixed_custom_and_canonical(self):
+        """Mix of normalizable and custom values."""
+        assert normalize_genres(["Action", "Hack and slash/Beat 'em up", "RPG"]) == [
+            "action",
+            "Hack and slash/Beat 'em up",
+            "rpg",
+        ]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestBuildGenreAliases:
+    def test_aliases_not_empty(self):
+        aliases = _build_genre_aliases()
+        assert len(aliases) > 50
+
+    def test_aliases_include_scraper_entries(self):
+        aliases = _build_genre_aliases()
+        assert aliases.get("science fiction") == "sci-fi"
+        assert aliases.get("剧情") == "drama"
+        assert aliases.get("role-playing (rpg)") == "rpg"
+        assert aliases.get("アクション") == "action"
+
+    def test_aliases_preserves_current_language(self):
+        original_language = translation.get_language()
+        _build_genre_aliases()
+        current_after = translation.get_language()
+        assert original_language == current_after
+
+    def test_aliases_include_i18n_translations(self):
+        """Aliases should include translated labels from supported UI languages."""
+        aliases = _build_genre_aliases()
+        # The English labels should be in aliases (lowercased)
+        assert aliases.get("action") == "action"
+        assert aliases.get("comedy") == "comedy"
+        assert aliases.get("drama") == "drama"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestGenreNormalizationInModel:
+    """Test that genre normalization works through the model save pipeline."""
+
+    def test_normalize_metadata_normalizes_genres(self):
+        from catalog.models import Movie
+
+        movie = Movie.objects.create(
+            title="Test Movie",
+            localized_title=[{"lang": "en", "text": "Test Movie"}],
+        )
+        movie.genre = ["Science Fiction", "动作", "comedy"]
+        changed = movie._normalize_genres()
+        assert changed is True
+        assert movie.genre == ["sci-fi", "action", "comedy"]
+
+    def test_normalize_metadata_no_change_for_canonical(self):
+        from catalog.models import Movie
+
+        movie = Movie.objects.create(
+            title="Test Movie 2",
+            localized_title=[{"lang": "en", "text": "Test Movie 2"}],
+        )
+        movie.genre = ["action", "comedy", "drama"]
+        changed = movie._normalize_genres()
+        assert changed is False
+        assert movie.genre == ["action", "comedy", "drama"]
+
+    def test_normalize_metadata_preserves_custom(self):
+        from catalog.models import Movie
+
+        movie = Movie.objects.create(
+            title="Test Movie 3",
+            localized_title=[{"lang": "en", "text": "Test Movie 3"}],
+        )
+        movie.genre = ["Action", "Some Custom Genre", "默剧"]
+        changed = movie._normalize_genres()
+        assert changed is True
+        assert movie.genre == ["action", "Some Custom Genre", "默剧"]
+
+    def test_normalize_metadata_deduplicates(self):
+        from catalog.models import Movie
+
+        movie = Movie.objects.create(
+            title="Test Movie 4",
+            localized_title=[{"lang": "en", "text": "Test Movie 4"}],
+        )
+        movie.genre = ["Action", "action", "动作"]
+        changed = movie._normalize_genres()
+        assert changed is True
+        assert movie.genre == ["action"]
+
+    def test_normalize_metadata_called_from_normalize_metadata(self):
+        from catalog.models import Movie
+
+        movie = Movie.objects.create(
+            title="Test Movie 5",
+            localized_title=[{"lang": "en", "text": "Test Movie 5"}],
+        )
+        movie.genre = ["Science Fiction", "Comedy"]
+        changed = movie.normalize_metadata()
+        assert changed is True
+        assert movie.genre == ["sci-fi", "comedy"]
+
+    def test_game_genre_normalization(self):
+        from catalog.models import Game
+
+        game = Game.objects.create(
+            title="Test Game",
+            localized_title=[{"lang": "en", "text": "Test Game"}],
+        )
+        game.genre = ["Role-playing (RPG)", "Shooter", "Platform"]
+        changed = game._normalize_genres()
+        assert changed is True
+        assert game.genre == ["rpg", "shooter", "platformer"]
+
+    def test_album_genre_normalization(self):
+        from catalog.models import Album
+
+        album = Album.objects.create(
+            title="Test Album",
+            localized_title=[{"lang": "en", "text": "Test Album"}],
+            artist=["Test Artist"],
+        )
+        album.genre = ["摇滚", "流行"]
+        changed = album._normalize_genres()
+        assert changed is True
+        assert album.genre == ["rock", "pop"]
+
+    def test_podcast_genre_normalization(self):
+        from catalog.models import Podcast
+
+        podcast = Podcast.objects.create(
+            title="Test Podcast",
+            localized_title=[{"lang": "en", "text": "Test Podcast"}],
+        )
+        podcast.genre = ["True Crime", "Health & Fitness"]
+        changed = podcast._normalize_genres()
+        assert changed is True
+        assert podcast.genre == ["true-crime", "health"]
+
+    def test_performance_genre_normalization(self):
+        from catalog.models import Performance
+
+        performance = Performance.objects.create(
+            title="Test Performance",
+            localized_title=[{"lang": "en", "text": "Test Performance"}],
+        )
+        performance.genre = ["话剧", "音乐剧"]
+        changed = performance._normalize_genres()
+        assert changed is True
+        assert performance.genre == ["theater", "musical"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestFederatedItemGenreNormalization:
+    """Test that genres from federated items are normalized during import."""
+
+    def test_merge_normalizes_genres(self):
+        from catalog.models import ExternalResource, IdType, Movie
+
+        movie = Movie.objects.create(
+            title="Federated Movie",
+            localized_title=[{"lang": "en", "text": "Federated Movie"}],
+        )
+        resource = ExternalResource.objects.create(
+            item=movie,
+            id_type=IdType.Fediverse,
+            id_value="https://remote.example/movie/123",
+            url="https://remote.example/movie/123",
+        )
+        # Simulate federated metadata with non-normalized genres
+        resource.metadata = {
+            "title": "Federated Movie",
+            "genre": ["Science Fiction", "Action", "动作"],
+        }
+        resource.save()
+        movie.merge_data_from_external_resource(resource, ignore_existing_content=True)
+        # After merge, genres should be normalized and deduplicated
+        assert movie.genre == ["sci-fi", "action"]


### PR DESCRIPTION
## Summary

- Add a pre-supported genre list (~90 canonical codes) shared across all media types, following the existing `LanguageListField` pattern
- Genres from scrapers are normalized to canonical slugs via an alias system covering TMDB, Douban, IGDB, Steam, MusicBrainz, Spotify, Apple Podcasts, and Bangumi
- Unknown/custom genres pass through as-is (nothing is ever discarded)
- TMDB compound TV genres (e.g. "Action & Adventure") expand to multiple codes
- Genre dropdown UI with free-text "Other" option for manual editing
- Chinese (zh_Hans) translations for all genre labels
- Federated items from older instances are auto-normalized on import

### Key files
- `common/models/genre.py` - genre catalog, aliases, normalization
- `catalog/models/common.py` - `GenreListField()` factory
- `catalog/templates/_genre_list.html` - localized genre display

### Bug fixes included
- Fix `apple_podcast.py` genre key mismatch (`genres` -> `genre`)
- Fix `rss.py` to return genre as list instead of single string

## Test plan
- [ ] Run `tests/core/test_genre.py` for normalization unit tests
- [ ] Run `tests/catalog/test_game.py`, `test_music.py`, `test_performance.py` for scraper integration
- [ ] Verify genre dropdown in catalog edit form shows pre-supported list + "Other"
- [ ] Verify genre displays as localized names in item detail pages
- [ ] Run data migration `normalize_genre_20260412()` on staging