### PR TITLE
fix: address bugs in Steam importer, WebAuthn, and CSRF settings

### DIFF
--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -607,7 +607,9 @@ else:  # local
 DEFAULT_ITEM_COVER = "item/default.svg"
 SITE_INFO["default_cover_url"] = MEDIA_URL + DEFAULT_ITEM_COVER
 
-CSRF_TRUSTED_ORIGINS = [SITE_INFO["site_url"]]
+CSRF_TRUSTED_ORIGINS = [SITE_INFO["site_url"]] + [
+    f"https://{d}" for d in ALTERNATIVE_DOMAINS
+]
 if DEBUG:
     CSRF_TRUSTED_ORIGINS += ["http://127.0.0.1:8000", "http://localhost:8000"]
 

--- a/catalog/sites/steam.py
+++ b/catalog/sites/steam.py
@@ -72,7 +72,7 @@ class Steam(AbstractSite):
             desc = html_to_text(data["detailed_description"])
             localized_desc.append({"lang": lang, "text": desc})
         if not en_data:
-            en_data = self.download("en")
+            en_data = self.download("en").get(self.id_value, {}).get("data", {})
         if not en_data or not en_data.get("name"):
             raise ParseError(self, "id")
         # merge data from IGDB, use localized Steam data if available

--- a/journal/importers/steam.py
+++ b/journal/importers/steam.py
@@ -5,7 +5,7 @@ import pytz
 import requests
 from django.utils import timezone
 from loguru import logger
-from requests import HTTPError
+from requests import RequestException
 
 from catalog.common.downloaders import DownloadError
 from catalog.common.sites import SiteManager
@@ -87,8 +87,8 @@ class SteamImporter(BaseImporter):
                 "file": None,
                 "include_played_free_games": False,
                 "include_free_sub": False,
-                "playing_thresh": 0,  # in hours
-                "finish_thresh": 0,  # in days
+                "playing_thresh": 0,  # in days
+                "finish_thresh": 0,  # in hours
                 "last_play_to_ctime": True,  # use last played time as created time
             },
             "allow_shelf_type_reversion": False,
@@ -145,7 +145,7 @@ class SteamImporter(BaseImporter):
                 raw_marks.extend(
                     self.fetch_library(**self.metadata["config"]["library"])
                 )
-        except HTTPError as e:
+        except RequestException as e:
             self.failfast(f"HTTP error when fetching data: {e}")
             return
         logger.debug(f"{len(raw_marks)} raw marks fetched")
@@ -282,7 +282,9 @@ class SteamImporter(BaseImporter):
                 "language": "en",  # appinfo not used, can be anything
                 "include_extended_appinfo": False,
             }
-            res = requests.get(url, params, timeout=1)
+            res = requests.get(
+                url, params, timeout=SiteConfig.system.downloader_request_timeout
+            )
             res.raise_for_status()
             file = res.json()
 
@@ -332,7 +334,9 @@ class SteamImporter(BaseImporter):
                 "key": self.steam_apikey,
                 "steamid": self.metadata["steam_id"],
             }
-            res = requests.get(url, params, timeout=1)
+            res = requests.get(
+                url, params, timeout=SiteConfig.system.downloader_request_timeout
+            )
             res.raise_for_status()
             file = res.json()
 
@@ -394,8 +398,10 @@ class SteamImporter(BaseImporter):
             "key": steam_apikey,
             "steamid": steam_id,
         }
-        resp = requests.get(url, params)
-        if resp.status_code == [401, 403]:
+        resp = requests.get(
+            url, params, timeout=SiteConfig.system.downloader_request_timeout
+        )
+        if resp.status_code in (401, 403):
             logger.error(f"Response when validating Steam API Key: {resp.status_code}")
             logger.debug(f"Full response: {resp}")
             raise InvalidSteamAPIKeyException("Invalid steam API key")

--- a/journal/importers/steam.py
+++ b/journal/importers/steam.py
@@ -146,7 +146,7 @@ class SteamImporter(BaseImporter):
                     self.fetch_library(**self.metadata["config"]["library"])
                 )
         except RequestException as e:
-            self.failfast(f"HTTP error when fetching data: {e}")
+            self.failfast(f"Request error when fetching data: {e}")
             return
         logger.debug(f"{len(raw_marks)} raw marks fetched")
 

--- a/users/views/account.py
+++ b/users/views/account.py
@@ -175,10 +175,20 @@ def register(request: AuthedHttpRequest):
         if verified_account and verified_account.platform == Platform.MASTODON:
             # directly create a new user
             mastodon_account: MastodonAccount = verified_account
-            new_user = User.register(
-                account=mastodon_account,
-                username=mastodon_account.username,
-            )
+            try:
+                new_user = User.register(
+                    account=mastodon_account,
+                    username=mastodon_account.username,
+                )
+            except ValidationError:
+                return render(
+                    request,
+                    "common/error.html",
+                    {
+                        "msg": _("Registration failed"),
+                        "secondary_msg": _("Username already taken. Please try again."),
+                    },
+                )
             auth_login(request, new_user)
             return render(request, "users/welcome.html")
         else:

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -477,9 +477,9 @@ def import_steam(request):
 
     # core metadatas
     metadata = copy.deepcopy(SteamImporter.DefaultMetadata)
-    steam_id = request.POST.get("steam_id", "").strip()
-    if not steam_id:
-        steam_id = request.session.pop("steam_id", "")
+    steam_id = (
+        request.session.pop("steam_id", "") or request.POST.get("steam_id", "").strip()
+    )
     metadata["steam_id"] = steam_id
     metadata["steam_api_key"] = request.POST.get("steam_api_key", "").strip()
     metadata["visibility"] = VisibilityType(int(request.POST.get("visibility", 0)))

--- a/users/views/webauthn.py
+++ b/users/views/webauthn.py
@@ -1,8 +1,10 @@
 import base64
 import json
+import time
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.db import IntegrityError
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -58,22 +60,27 @@ def passkey_register_options(request):
         user_display_name=user.display_name or user.username,
         authenticator_selection=AuthenticatorSelectionCriteria(
             resident_key=ResidentKeyRequirement.REQUIRED,
-            user_verification=UserVerificationRequirement.PREFERRED,
+            user_verification=UserVerificationRequirement.REQUIRED,
         ),
         exclude_credentials=existing_credentials,
     )
-    request.session["webauthn_register_challenge"] = base64.b64encode(
-        options.challenge
-    ).decode("ascii")
+    request.session["webauthn_register_challenge"] = {
+        "challenge": base64.b64encode(options.challenge).decode("ascii"),
+        "ts": time.time(),
+    }
     return JsonResponse(json.loads(options_to_json(options)), safe=True)
 
 
 @require_http_methods(["POST"])
 @login_required
 def passkey_register_verify(request):
-    challenge_b64 = request.session.pop("webauthn_register_challenge", None)
-    if not challenge_b64:
+    CHALLENGE_TIMEOUT = 300  # 5 minutes
+    entry = request.session.pop("webauthn_register_challenge", None)
+    if not entry:
         return HttpResponseBadRequest("No registration challenge in session")
+    challenge_b64 = entry["challenge"]
+    if time.time() - entry.get("ts", 0) > CHALLENGE_TIMEOUT:
+        return HttpResponseBadRequest("Registration challenge expired")
 
     try:
         body = json.loads(request.body)
@@ -100,14 +107,19 @@ def passkey_register_verify(request):
         t for t in raw_transports if isinstance(t, str) and t in _VALID_TRANSPORTS
     ]
 
-    WebAuthnCredential.objects.create(
-        user=request.user,
-        name=name,
-        credential_id=verification.credential_id,
-        public_key=verification.credential_public_key,
-        sign_count=verification.sign_count,
-        transports=transports,
-    )
+    try:
+        WebAuthnCredential.objects.create(
+            user=request.user,
+            name=name,
+            credential_id=verification.credential_id,
+            public_key=verification.credential_public_key,
+            sign_count=verification.sign_count,
+            transports=transports,
+        )
+    except IntegrityError:
+        return JsonResponse(
+            {"ok": False, "error": _("Credential already registered")}, status=409
+        )
     request.session["has_passkeys"] = True
     return JsonResponse({"ok": True})
 
@@ -116,19 +128,24 @@ def passkey_register_verify(request):
 def passkey_login_options(request):
     options = generate_authentication_options(
         rp_id=_get_rp_id(),
-        user_verification=UserVerificationRequirement.PREFERRED,
+        user_verification=UserVerificationRequirement.REQUIRED,
     )
-    request.session["webauthn_login_challenge"] = base64.b64encode(
-        options.challenge
-    ).decode("ascii")
+    request.session["webauthn_login_challenge"] = {
+        "challenge": base64.b64encode(options.challenge).decode("ascii"),
+        "ts": time.time(),
+    }
     return JsonResponse(json.loads(options_to_json(options)), safe=True)
 
 
 @require_http_methods(["POST"])
 def passkey_login_verify(request):
-    challenge_b64 = request.session.pop("webauthn_login_challenge", None)
-    if not challenge_b64:
+    CHALLENGE_TIMEOUT = 300  # 5 minutes
+    entry = request.session.pop("webauthn_login_challenge", None)
+    if not entry:
         return HttpResponseBadRequest("No login challenge in session")
+    challenge_b64 = entry["challenge"]
+    if time.time() - entry.get("ts", 0) > CHALLENGE_TIMEOUT:
+        return HttpResponseBadRequest("Login challenge expired")
 
     try:
         body = json.loads(request.body)

--- a/users/views/webauthn.py
+++ b/users/views/webauthn.py
@@ -30,6 +30,7 @@ from ..models import WebAuthnCredential
 from .account import auth_login
 
 _VALID_TRANSPORTS = {"usb", "nfc", "ble", "hybrid", "internal"}
+_CHALLENGE_TIMEOUT = 300  # 5 minutes
 
 
 def _get_rp_id() -> str:
@@ -74,12 +75,11 @@ def passkey_register_options(request):
 @require_http_methods(["POST"])
 @login_required
 def passkey_register_verify(request):
-    CHALLENGE_TIMEOUT = 300  # 5 minutes
     entry = request.session.pop("webauthn_register_challenge", None)
     if not entry:
         return HttpResponseBadRequest("No registration challenge in session")
     challenge_b64 = entry["challenge"]
-    if time.time() - entry.get("ts", 0) > CHALLENGE_TIMEOUT:
+    if time.time() - entry.get("ts", 0) > _CHALLENGE_TIMEOUT:
         return HttpResponseBadRequest("Registration challenge expired")
 
     try:
@@ -139,12 +139,11 @@ def passkey_login_options(request):
 
 @require_http_methods(["POST"])
 def passkey_login_verify(request):
-    CHALLENGE_TIMEOUT = 300  # 5 minutes
     entry = request.session.pop("webauthn_login_challenge", None)
     if not entry:
         return HttpResponseBadRequest("No login challenge in session")
     challenge_b64 = entry["challenge"]
-    if time.time() - entry.get("ts", 0) > CHALLENGE_TIMEOUT:
+    if time.time() - entry.get("ts", 0) > _CHALLENGE_TIMEOUT:
         return HttpResponseBadRequest("Login challenge expired")
 
     try:


### PR DESCRIPTION
## Summary

- **Steam importer**: Fix `status_code == [401, 403]` comparison (always False, making invalid-API-key detection dead code); replace 1-second timeouts with configurable `downloader_request_timeout`; add missing timeout to `validate()`; catch `RequestException` instead of only `HTTPError` to handle timeouts; fix swapped unit comments on thresholds; prioritize session `steam_id` over POST to prevent OpenID verification bypass
- **Steam catalog scraper**: Fix `en_data` fallback to extract nested `.data` field, matching the loop logic
- **WebAuthn/passkey**: Add 5-minute challenge expiry; change `user_verification` from `PREFERRED` to `REQUIRED`; handle `IntegrityError` on duplicate credential registration
- **Registration**: Catch `ValidationError` in closed-community registration path to prevent 500 on duplicate username race
- **Settings**: Include `ALTERNATIVE_DOMAINS` in `CSRF_TRUSTED_ORIGINS` so POST requests from alternative domains are not rejected

## Test plan

- [ ] Verify Steam import with invalid API key shows proper error message
- [ ] Verify Steam import completes without timeout errors
- [ ] Verify Steam catalog scrape works for games available only in non-English languages
- [ ] Test passkey registration and login flow end-to-end
- [ ] Verify expired challenges (>5 min) are rejected
- [ ] Verify duplicate passkey registration returns 409 instead of 500
- [ ] Test registration in closed-community mode with duplicate username
- [ ] Verify CSRF works correctly when accessing site via alternative domain