### PR TITLE
fix: batch-prefetch parent items and child IDs to eliminate N+1 queries

### DIFF
--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -116,6 +116,7 @@ def search_item(
         prepare_external=False,
         exclude_categories=exclude_categories,
     )
+    Item.prefetch_parent_items(items)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     if request.user.is_authenticated:

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -13,7 +13,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.signing import b62_decode, b62_encode
 from django.db import connection, models
-from django.db.models import Q, QuerySet
+from django.db.models import Q, QuerySet, prefetch_related_objects
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
@@ -544,6 +544,43 @@ class Item(PolymorphicModel):
     @classmethod
     def get_final_items(cls, items: Iterable["Item"]) -> list["Item"]:
         return [j for j in [i.final_item for i in items] if not j.is_deleted]
+
+    @staticmethod
+    def prefetch_parent_items(items: "Iterable[Item]") -> None:
+        """Batch-prefetch parent item relationships to avoid N+1 queries.
+
+        Call this on a list of polymorphic Item instances before rendering
+        templates that access item.parent_item (e.g. _item_card_metadata_base).
+        Note: Edition is excluded because the template short-circuits
+        parent_item access for editions (type.value == 'edition').
+        """
+        from .performance import PerformanceProduction
+        from .podcast import PodcastEpisode
+        from .tv import TVEpisode, TVSeason
+
+        tvseasons: list[TVSeason] = []
+        tvepisodes: list[TVEpisode] = []
+        podcastepisodes: list[PodcastEpisode] = []
+        performanceproductions: list[PerformanceProduction] = []
+
+        for i in items:
+            if isinstance(i, TVSeason):
+                tvseasons.append(i)
+            elif isinstance(i, TVEpisode):
+                tvepisodes.append(i)
+            elif isinstance(i, PodcastEpisode):
+                podcastepisodes.append(i)
+            elif isinstance(i, PerformanceProduction):
+                performanceproductions.append(i)
+
+        if tvseasons:
+            prefetch_related_objects(tvseasons, "show")
+        if tvepisodes:
+            prefetch_related_objects(tvepisodes, "season")
+        if podcastepisodes:
+            prefetch_related_objects(podcastepisodes, "program")
+        if performanceproductions:
+            prefetch_related_objects(performanceproductions, "show")
 
     METADATA_COPY_LIST = [
         # "title",

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -25,7 +25,7 @@ from journal.models.rating import Rating
 from users.views import query_identity
 
 from ..common.sites import AbstractSite, SiteManager
-from ..models import ExternalResource, ItemCategory, SiteName, item_categories
+from ..models import ExternalResource, Item, ItemCategory, SiteName, item_categories
 from ..search import ExternalSources, enqueue_fetch, get_fetch_lock, query_index
 
 
@@ -156,6 +156,7 @@ def search(request):
     items, num_pages, __, by_cat, q = query_index(
         keywords, categories, p, exclude_categories=excl, per_page=per_page
     )
+    Item.prefetch_parent_items(items)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     if request.user.is_authenticated:

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.db.models import Count, F, Window
+from django.db.models import Count, F, Window, prefetch_related_objects
 from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -88,6 +88,9 @@ def retrieve(request, item_path, item_uuid):
         return JsonResponse(item.ap_object, content_type="application/activity+json")
     if request.method == "HEAD":
         return HttpResponse()
+    # Prefetch parent item and external resources to avoid N+1 in templates
+    prefetch_related_objects([item], "external_resources")
+    Item.prefetch_parent_items([item])
     focus_item = None
     if request.GET.get("focus"):
         focus_item = get_object_or_404(

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -34,7 +34,8 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     if not members:
         return
     items = [m.item for m in members]
-    # Batch-fetch item-level data (public rating/tags for ItemSchema)
+    # Batch-fetch parent items and item-level data to avoid N+1 queries
+    Item.prefetch_parent_items(items)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     # Batch-fetch latest_post_id for all members to avoid N+1 queries

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -166,6 +166,7 @@ class Collection(List):
                 r = JournalIndex.instance().search(q)
                 items = r.items
                 pages = r.pages
+                Item.prefetch_parent_items(items)
                 Rating.attach_to_items(items)
                 Tag.attach_to_items(items)
                 if viewer:
@@ -198,6 +199,7 @@ class Collection(List):
                 items_map = {i.pk: i for i in items}
                 for member in members:
                     member.item = items_map.get(member.item_id)
+                Item.prefetch_parent_items(items)
                 Rating.attach_to_items(items)
                 Tag.attach_to_items(items)
                 if viewer:

--- a/journal/models/rating.py
+++ b/journal/models/rating.py
@@ -6,6 +6,8 @@ from django.db import models
 from django.db.models import Avg, Count
 
 from catalog.models import Item, Performance, TVShow
+from catalog.models.performance import PerformanceProduction
+from catalog.models.tv import TVSeason
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -136,10 +138,36 @@ class Rating(Content):
         item_to_parent = {}
         all_item_ids = set(item_ids)
 
-        # Handle items with child items and build mapping
+        # Batch-fetch child IDs for parent item types (TVShow, Performance)
+        # to avoid per-item queries from item.child_item_ids
+        tvshow_ids = [i.pk for i in items if isinstance(i, TVShow)]
+        perf_ids = [i.pk for i in items if isinstance(i, Performance)]
+        child_id_map: dict[int, list[int]] = {}
+        if tvshow_ids:
+            for show_id, season_id in (
+                TVSeason.objects.filter(
+                    show_id__in=tvshow_ids,
+                    is_deleted=False,
+                    merged_to_item=None,
+                )
+                .values_list("show_id", "pk")
+                .iterator()
+            ):
+                child_id_map.setdefault(show_id, []).append(season_id)
+        if perf_ids:
+            for show_id, prod_id in (
+                PerformanceProduction.objects.filter(
+                    show_id__in=perf_ids,
+                    is_deleted=False,
+                    merged_to_item=None,
+                )
+                .values_list("show_id", "pk")
+                .iterator()
+            ):
+                child_id_map.setdefault(show_id, []).append(prod_id)
         for item in items:
             if item.__class__ in RATING_INCLUDES_CHILD_ITEMS:
-                for child_id in item.child_item_ids:
+                for child_id in child_id_map.get(item.pk, []):
                     item_to_parent[child_id] = item.pk
                     all_item_ids.add(child_id)
             if item.pk not in item_to_parent:

--- a/journal/models/rating.py
+++ b/journal/models/rating.py
@@ -140,8 +140,13 @@ class Rating(Content):
 
         # Batch-fetch child IDs for parent item types (TVShow, Performance)
         # to avoid per-item queries from item.child_item_ids
-        tvshow_ids = [i.pk for i in items if isinstance(i, TVShow)]
-        perf_ids = [i.pk for i in items if isinstance(i, Performance)]
+        tvshow_ids: list[int] = []
+        perf_ids: list[int] = []
+        for i in items:
+            if isinstance(i, TVShow):
+                tvshow_ids.append(i.pk)
+            elif isinstance(i, Performance):
+                perf_ids.append(i.pk)
         child_id_map: dict[int, list[int]] = {}
         if tvshow_ids:
             for show_id, season_id in (

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from catalog.models import Item
 from common.models.misc import int_
 from common.utils import (
     AuthedHttpRequest,
@@ -153,6 +154,7 @@ def render_list(
     # Batch-fetch marks and rating info for all items on this page to avoid N+1 queries
     items = [m.item for m in members]
     if items:
+        Item.prefetch_parent_items(items)
         Rating.attach_to_items(items)
         marks = Mark.get_marks_by_items(target, items, request.user)
         for m in members:

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -442,6 +442,7 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
         items = [member.item for member in members_queryset[:20]]
         total = members_queryset.count()
     if items:
+        Item.prefetch_parent_items(items)
         Rating.attach_to_items(items)
 
     if not label:


### PR DESCRIPTION
## Summary
- Add `Item.prefetch_parent_items()` to batch-prefetch parent FK relationships (TVSeason.show, TVEpisode.season, PodcastEpisode.program, PerformanceProduction.show) before template rendering, applied to all item list views
- Optimize `Rating.get_info_for_items()` to batch-fetch child item IDs for TVShow/Performance types instead of per-item `child_item_ids` queries (N queries reduced to 2)
- Add `prefetch_related_objects` for external_resources on item detail page

## Context
Sentry performance data over 30 days showed high-volume per-item queries:
- `/users/{user_name}/tags/{tag_title}/`: 62M+ individual `catalog_item` lookups, 14M+ per-item rating aggregations
- `/search`: 15M+ individual work lookups per edition
- `/{item_path}/{item_uuid}`: 12M+ per-page-view queries

## Test plan
- [x] All 61 existing N+1, rating, tag, and piece tests pass
- [x] Pre-commit checks (ruff, djlint, ty) all pass
- [ ] Verify reduced query counts in Sentry after deploy