### PR TITLE
Style note content as cards

### DIFF
--- a/catalog/templates/_item_notes.html
+++ b/catalog/templates/_item_notes.html
@@ -28,24 +28,37 @@
       {% if note.item != item %}
         <a href="{{ note.item.url }}">{{ note.item.display_title }}</a><small class="title_deco">{{ note.item.title_deco }}</small>
       {% endif %}
-      <blockquote {% if note.sensitive %}class="spoiler tldr" _="on click toggle .revealed .tldr on me"{% else %}class="tldr" _="on click toggle .tldr on me"{% endif %}>
-        {% if note.title %}<strong>{{ note.title|default:'' }}</strong> -{% endif %}
-        {{ note.content|linebreaksbr }}
-        <div class="attachments">
-          {% for attachment in note.attachments %}
-            {% if attachment.type == 'image' %}
-              <a href="#img_{{ note.uuid }}_{{ loop.index }}">
-                <img src="{{ attachment.preview_url }}"
-                     alt="image attachment"
-                     class="preview">
-              </a>
-              <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
-                <span style="background-image: url('{{ attachment.url }}')"></span>
-              </a>
-            {% endif %}
-          {% endfor %}
+      <div class="note-card{% if note.sensitive %} spoiler{% endif %}"
+           {% if note.sensitive %}_="on click toggle .revealed on me"{% endif %}>
+        <div class="note-card-quote-mark">&ldquo;</div>
+        <div class="note-card-content{% if not note.sensitive %} tldr{% endif %}"
+             {% if not note.sensitive %}_="on click toggle .tldr on me"{% endif %}>
+          {% if note.title %}<strong>{{ note.title|default:'' }}</strong> -{% endif %}
+          {{ note.content|linebreaksbr }}
+          <div class="attachments">
+            {% for attachment in note.attachments %}
+              {% if attachment.type == 'image' %}
+                <a href="#img_{{ note.uuid }}_{{ loop.index }}">
+                  <img src="{{ attachment.preview_url }}"
+                       alt="image attachment"
+                       class="preview">
+                </a>
+                <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
+                  <span style="background-image: url('{{ attachment.url }}')"></span>
+                </a>
+              {% endif %}
+            {% endfor %}
+          </div>
         </div>
-      </blockquote>
+        <div class="note-card-footer">
+          <span>{{ note.item.display_title }}</span>
+          <a href="{{ note.owner.url }}" title="@{{ note.owner.handle }}">
+            <img src="{{ note.owner.avatar }}"
+                 alt="{{ note.owner.display_name }}"
+                 class="note-card-avatar">
+          </a>
+        </div>
+      </div>
       {% if note.rows and note.rows > 1 %}
         <a hx-get="{% url 'catalog:notes' note.item.url_path note.item.uuid %}?from={{ note.uuid }}"
            hx-trigger="click"

--- a/catalog/templates/_item_user_pieces.html
+++ b/catalog/templates/_item_user_pieces.html
@@ -90,25 +90,28 @@
         {% include "action_open_post.html" with post=note.latest_post %}
       {% endif %}
     </span>
-    {% if note.title %}<h6>{{ note.title|default:'' }}</h6>{% endif %}
-    <p>
-      {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
-      {{ note.content|linebreaksbr }}
-      <div class="attachments">
-        {% for attachment in note.attachments %}
-          {% if attachment.type == 'image' %}
-            <a href="#img_{{ note.uuid }}_{{ loop.index }}">
-              <img src="{{ attachment.preview_url }}"
-                   alt="image attachment"
-                   class="preview">
-            </a>
-            <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
-              <span style="background-image: url('{{ attachment.url }}')"></span>
-            </a>
-          {% endif %}
-        {% endfor %}
+    <div class="note-card">
+      <div class="note-card-quote-mark">&ldquo;</div>
+      <div class="note-card-content tldr" _="on click toggle .tldr on me">
+        {% if note.title %}<strong>{{ note.title|default:'' }}</strong> -{% endif %}
+        {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
+        {{ note.content|linebreaksbr }}
+        <div class="attachments">
+          {% for attachment in note.attachments %}
+            {% if attachment.type == 'image' %}
+              <a href="#img_{{ note.uuid }}_{{ loop.index }}">
+                <img src="{{ attachment.preview_url }}"
+                     alt="image attachment"
+                     class="preview">
+              </a>
+              <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
+                <span style="background-image: url('{{ attachment.url }}')"></span>
+              </a>
+            {% endif %}
+          {% endfor %}
+        </div>
       </div>
-    </p>
+    </div>
   {% endfor %}
 </section>
 <section>

--- a/common/static/scss/_post.scss
+++ b/common/static/scss/_post.scss
@@ -99,6 +99,56 @@ section.activity.post>section.replies {
 	margin: 0;
 }
 
+.note-card {
+	border: 1px solid var(--pico-muted-border-color);
+	border-radius: 12px;
+	padding: 1.25em 1.25em 1em;
+	margin: 0.5em 0;
+	position: relative;
+	background: var(--pico-card-background-color);
+
+	.note-card-quote-mark {
+		font-size: 3em;
+		line-height: 1;
+		color: var(--pico-muted-color);
+		opacity: 0.3;
+		font-family: Georgia, "Times New Roman", serif;
+		margin-bottom: -0.25em;
+		user-select: none;
+	}
+
+	.note-card-content {
+		font-size: 0.95em;
+		line-height: 1.6;
+		word-break: break-word;
+
+		strong {
+			display: block;
+			margin-bottom: 0.25em;
+		}
+
+		.attachments {
+			margin-top: 0.5em;
+		}
+	}
+
+	.note-card-footer {
+		margin-top: 0.75em;
+		font-size: 0.85em;
+		color: var(--pico-muted-color);
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.note-card-avatar {
+		width: 2em;
+		height: 2em;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+}
+
 .quote-post {
 	background: var(--pico-card-sectioning-background-color);
 	border: 1px solid var(--pico-card-border-color);


### PR DESCRIPTION
## Summary
- Wrap note content in a card with rounded corners (12px), subtle border, and card background color
- Add decorative serif quote mark at top-left of each note card
- Card footer shows item title on the left and a circular user avatar on the right
- Applied to both public notes section (`_item_notes.html`) and "my notes" on item pages (`_item_user_pieces.html`)
- No changes to comments or other components

## Test plan
- [ ] View an item page with notes and verify the card styling renders correctly
- [ ] Check the "my notes" section on an item page for consistent card styling
- [ ] Verify spoiler/sensitive notes still toggle correctly
- [ ] Verify click-to-expand (tldr) still works on long notes
- [ ] Check dark mode rendering
- [ ] Check mobile responsiveness