### PR TITLE
fix: make populate_credits restart-safe and faster

### DIFF
--- a/catalog/common/migrations.py
+++ b/catalog/common/migrations.py
@@ -255,20 +255,69 @@ def fix_missing_cover_20250821(days=0):
     logger.success(f"{updated} items with missing covers has been fixed.")
 
 
-def populate_credits_20260412(start_pk=0):
-    """Populate ItemCredit rows from jsondata credit fields on all items."""
-    from catalog.models import Item
+def populate_credits_20260412(start_pk=0, batch_size=1000):
+    """Populate ItemCredit rows from jsondata credit fields on all items.
 
-    qs = Item.objects.filter(
-        is_deleted=False, merged_to_item__isnull=True, pk__gt=start_pk
-    ).order_by("pk")
+    Restart-safe: skips items that already have credits. Shows last processed
+    pk in the progress bar so you can resume with --start <pk>.
+    """
+    from django.db.models import Exists, OuterRef
+
+    from catalog.models import Item, ItemCredit
+
+    has_credits = ItemCredit.objects.filter(item_id=OuterRef("pk"))
+    qs = (
+        Item.objects.filter(
+            is_deleted=False, merged_to_item__isnull=True, pk__gt=start_pk
+        )
+        .exclude(Exists(has_credits))
+        .order_by("pk")
+    )
     total = qs.count()
+    logger.info(f"Items to process: {total} (starting after pk {start_pk})")
     created = 0
-    for item in tqdm(qs.iterator(), total=total, desc="Populating credits"):
-        before = item.credits.count()
-        item.sync_credits_from_metadata()
-        created += item.credits.count() - before
-    logger.success(f"Credits: {created} created")
+    last_pk = start_pk
+    pending: list[ItemCredit] = []
+
+    with tqdm(total=total, desc="Populating credits") as pbar:
+        for item in qs.iterator():
+            for field_name, credit_role in item.CREDIT_FIELD_MAPPING.items():
+                values = getattr(item, field_name, None)
+                if not values:
+                    continue
+                if isinstance(values, str):
+                    values = [values]
+                for i, value in enumerate(values):
+                    if isinstance(value, dict):
+                        name = value.get("name", "")
+                        character = value.get("role") or ""
+                    else:
+                        name = str(value)
+                        character = ""
+                    if not name:
+                        continue
+                    pending.append(
+                        ItemCredit(
+                            item=item,
+                            role=credit_role,
+                            name=name,
+                            character_name=character,
+                            order=i,
+                        )
+                    )
+            last_pk = item.pk
+            pbar.update(1)
+            pbar.set_postfix(pk=last_pk, created=created + len(pending))
+            if len(pending) >= batch_size:
+                ItemCredit.objects.bulk_create(pending)
+                created += len(pending)
+                pending = []
+
+    if pending:
+        ItemCredit.objects.bulk_create(pending)
+        created += len(pending)
+
+    logger.success(f"Credits: {created} created, last pk: {last_pk}")
 
 
 def link_credits_20260412():

--- a/catalog/common/migrations.py
+++ b/catalog/common/migrations.py
@@ -268,7 +268,7 @@ def populate_credits_20260412(start_pk=0, batch_size=1000):
     has_credits = ItemCredit.objects.filter(item_id=OuterRef("pk"))
     qs = (
         Item.objects.filter(
-            is_deleted=False, merged_to_item__isnull=True, pk__gt=start_pk
+            is_deleted=False, merged_to_item__isnull=True, pk__gte=start_pk
         )
         .exclude(Exists(has_credits))
         .order_by("pk")

--- a/catalog/management/commands/catalog.py
+++ b/catalog/management/commands/catalog.py
@@ -158,7 +158,7 @@ class Command(SiteCommand):
             help="Number of hours to look back for edited items (used with idx-catchup)",
         )
 
-    def migrate(self, m, start=None):
+    def migrate(self, m, start=None, batch_size=1000):
         match m:
             case "merge_works":
                 from catalog.common.migrations import merge_works_20250301
@@ -191,7 +191,7 @@ class Command(SiteCommand):
             case "populate_credits":
                 from catalog.common.migrations import populate_credits_20260412
 
-                populate_credits_20260412(start_pk=start or 0)
+                populate_credits_20260412(start_pk=start or 0, batch_size=batch_size)
             case _:
                 self.stdout.write(self.style.ERROR("Unknown migration."))
 
@@ -834,7 +834,7 @@ class Command(SiteCommand):
                 if not name:
                     self.stdout.write(self.style.ERROR("name is required."))
                     return
-                self.migrate(name, start=start)
+                self.migrate(name, start=start, batch_size=int(batch_size))
 
             case "idx-catchup":
                 hour = options.get("hour")


### PR DESCRIPTION
## Summary
- Skip already-processed items via `NOT EXISTS` subquery so the migration can be safely restarted without duplicating work
- Replace per-row `get_or_create` with `bulk_create` in batches, reducing DB round-trips from ~5M to ~5K for 1M items
- Show current pk in tqdm progress bar (`pk=123456`) so the user knows what value to pass to `--start` when resuming after Ctrl-C
- Pass `--batch-size` through to `populate_credits` for tuning

## Test plan
- [ ] Run `catalog migrate --name populate_credits` on a test dataset, verify credits are created
- [ ] Interrupt with Ctrl-C, note the pk shown in the progress bar
- [ ] Resume with `--start <pk>`, verify it skips already-processed items and continues from the right place
- [ ] Run again after completion, verify it finishes instantly (all items skipped)
- [ ] Existing tests in `test_people.py` still pass