### PR TITLE
test: improve coverage and fix slow musicbrainz tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -29,7 +29,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -48,7 +48,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.repository_owner == 'neodb-social'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: pixta-dev/repository-mirroring-action@v1

--- a/.github/workflows/publish-tags.yml
+++ b/.github/workflows/publish-tags.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -79,11 +79,11 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -94,14 +94,14 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -137,17 +137,17 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -60,16 +60,16 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -77,14 +77,14 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'neodb-social' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'neodb-social' }}
           platforms: ${{ matrix.platform }}
@@ -123,17 +123,17 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |

--- a/.github/workflows/tag-submodule.yml
+++ b/.github/workflows/tag-submodule.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
           token: ${{ secrets.GH_TOKEN_ORG_ACTION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -70,8 +70,7 @@ jobs:
         NEODB_SEARCH_URL: typesense://testuser:testpass@127.0.0.1:8108/cat
       run: |
         uv run manage.py compilemessages -i .venv -l zh_Hans
-        uv run python -m coverage run --parallel-mode -m pytest -n auto
-        uv run python -m coverage combine
+        uv run python -m coverage run -m pytest
         uv run python -m coverage report -m
         uv run python -m coverage xml -o coverage.xml
     - name: Upload coverage to Codecov

--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -4,7 +4,7 @@ from typing import List
 from django.core.cache import cache
 from django.http import HttpResponse
 from django.utils import timezone
-from ninja import Schema
+from ninja import Schema, Status
 from ninja.pagination import paginate
 
 from common.api import PageNumberPagination, RedirectedResult, Result, api
@@ -104,7 +104,7 @@ def search_item(
     """
     query = query.strip()
     if not query:
-        return 400, {"message": "Invalid query"}
+        return Status(400, {"message": "Invalid query"})
     categories = category.value.split(",") if category else None
     exclude_categories = (
         request.user.preference.hidden_categories
@@ -123,7 +123,7 @@ def search_item(
     Tag.attach_to_items(items)
     if request.user.is_authenticated:
         Mark.attach_to_items(request.user.identity, items, request.user)
-    return 200, {"data": items, "pages": num_pages, "count": count}
+    return Status(200, {"data": items, "pages": num_pages, "count": count})
 
 
 @api.get(
@@ -147,16 +147,16 @@ def fetch_item(request, url: str, response: HttpResponse):
     """
     site = SiteManager.get_site_by_url(url, detect_redirection=False)
     if not site:
-        return 422, {"message": "URL not supported"}
+        return Status(422, {"message": "URL not supported"})
     item = site.get_item()
     if item:
         response["Location"] = item.api_url
-        return 302, {"message": "Item fetched", "url": item.api_url}
+        return Status(302, {"message": "Item fetched", "url": item.api_url})
     if get_fetch_lock(request.user, url):
         enqueue_fetch(url, False, request.user)
     else:
-        return 429, {"message": "Try again later"}
-    return 202, {"message": "Fetch in progress"}
+        return Status(429, {"message": "Try again later"})
+    return Status(202, {"message": "Fetch in progress"})
 
 
 @api.get(
@@ -179,7 +179,7 @@ def trending_items(request):
         items = cache.get(gallery["name"], [])
         i = rot * len(items) // 10
         gallery["items"] = items[i:] + items[:i]
-    return 200, gallery_list
+    return Status(200, gallery_list)
 
 
 def _get_trending(name):
@@ -269,15 +269,17 @@ def trending_performance(request):
 def _get_item(cls, uuid, response):
     item = Item.get_by_url(uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     if item.merged_to_item:
         response["Location"] = item.merged_to_item.api_url
-        return 302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        return Status(
+            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        )
     if item.is_deleted:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     if item.__class__ != cls:
         response["Location"] = item.api_url
-        return 302, {"message": "Item recasted", "url": item.api_url}
+        return Status(302, {"message": "Item recasted", "url": item.api_url})
     return item
 
 

--- a/common/api.py
+++ b/common/api.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from loguru import logger
-from ninja import NinjaAPI, Schema
+from ninja import NinjaAPI, Schema, Status
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
 from ninja.security import HttpBearer
 
@@ -112,7 +112,7 @@ api = NinjaAPI(
     description=f"{settings.SITE_INFO['site_name']} API <hr/><a href='{settings.SITE_INFO['site_url']}'>Learn more</a>",
 )
 
-NOT_FOUND = 404, {"message": "Not found"}
-OK = 200, {"message": "OK"}
+NOT_FOUND = Status(404, {"message": "Not found"})
+OK = Status(200, {"message": "OK"})
 NO_DATA = {"data": [], "count": 0, "pages": 0}
-INVALID_PAGE = 400, {"message": "Invalid page number"}
+INVALID_PAGE = Status(400, {"message": "Invalid page number"})

--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -226,7 +226,7 @@ class DateTimeField(JSONFieldMixin, fields.DateTimeField):
                 v = dateparse.parse_date(value)
                 if v is None:
                     raise ValueError(
-                        f"DateTimeField: '{value}' has invalid datatime format"
+                        f"DateTimeField: '{value}' has invalid datetime format"
                     )
                 value = v
             if isinstance(value, date):

--- a/common/models/lang.py
+++ b/common/models/lang.py
@@ -260,13 +260,14 @@ def localize_number(i: int) -> str:
         if i < 0 or i > 99:
             return str(i)
         s = "零一二三四五六七八九"
+        r = i % 10
         match i // 10:
             case 0:
-                return s[i % 10]
+                return s[r]
             case 1:
-                return "十" + s[i % 10]
+                return "十" + (s[r] if r else "")
             case _:
-                return s[i // 10] + "十" + s[i % 10]
+                return s[i // 10] + "十" + (s[r] if r else "")
     return str(i)
 
 

--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -6,7 +6,7 @@ from django.db.models import Count
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
-from ninja import Field, Schema
+from ninja import Field, Schema, Status
 from ninja.decorators import decorate_view
 from ninja.errors import HttpError
 from ninja.pagination import paginate
@@ -90,9 +90,9 @@ def get_user_collection(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     return c
 
 
@@ -108,9 +108,9 @@ def get_collection(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     return c
 
 
@@ -173,13 +173,13 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     q = (c_in.query or "").strip() or None
     is_dynamic = bool(q)
     if c.is_dynamic != is_dynamic:
-        return 403, {"message": "Cannot change collection type"}
+        return Status(403, {"message": "Cannot change collection type"})
     c.title = c_in.title
     c.brief = c_in.brief
     c.visibility = c_in.visibility
@@ -200,11 +200,11 @@ def delete_collection(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     c.delete()
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -243,18 +243,20 @@ def collection_add_item(
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     if c.is_dynamic:
-        return 403, {"message": "Item list of dynamic collection cannot be updated"}
+        return Status(
+            403, {"message": "Item list of dynamic collection cannot be updated"}
+        )
     if not collection_item.item_uuid:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     item = Item.get_by_url(collection_item.item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     c.append_item(item, note=collection_item.note)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.delete(
@@ -268,16 +270,18 @@ def collection_delete_item(request, collection_uuid: str, item_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     if c.is_dynamic:
-        return 403, {"message": "Item list of dynamic collection cannot be updated"}
+        return Status(
+            403, {"message": "Item list of dynamic collection cannot be updated"}
+        )
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     c.remove_item(item)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -309,11 +313,11 @@ def collection_set_featured(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     FeaturedCollection.objects.update_or_create(owner=request.user.identity, target=c)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.delete(
@@ -327,11 +331,11 @@ def collection_unset_featured(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     FeaturedCollection.objects.filter(owner=request.user.identity, target=c).delete()
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -357,15 +361,15 @@ def get_featured_collection(request, collection_uuid: str, response: HttpRespons
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not FeaturedCollection.objects.filter(
         owner=request.user.identity, target=c
     ).exists():
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     response["Location"] = f"/api/collection/{c.uuid}"
-    return 302, {"message": "OK", "url": c.api_url}
+    return Status(302, {"message": "OK", "url": c.api_url})
 
 
 @api.get(
@@ -384,13 +388,13 @@ def get_featured_collection_stats(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not FeaturedCollection.objects.filter(
         owner=request.user.identity, target=c
     ).exists():
-        return 404, {"message": "Collection not found"}
+        return Status(404, {"message": "Collection not found"})
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     items = c.item_ids
     stats = {"total": len(items)}
     for st in ShelfType:

--- a/journal/apis/note.py
+++ b/journal/apis/note.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 
 from django.http import Http404
-from ninja import Field, Schema
+from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
@@ -62,7 +62,7 @@ def add_note_for_item(request, item_uuid: str, n_in: NoteInSchema):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     note = Note()
     note.item = item
     note.owner = request.user.identity

--- a/journal/apis/review.py
+++ b/journal/apis/review.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 
 from django.utils import timezone
-from ninja import Field, Schema
+from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
 from catalog.models import AvailableItemCategory, Item, ItemSchema
@@ -63,10 +63,10 @@ def get_review_by_item(request, item_uuid: str):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     review = Review.objects.filter(owner=request.user.identity, item=item).first()
     if not review:
-        return 404, {"message": "Review not found"}
+        return Status(404, {"message": "Review not found"})
     return review
 
 
@@ -85,7 +85,7 @@ def review_item(request, item_uuid: str, review: ReviewInSchema):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     if review.created_time and review.created_time >= timezone.now():
         review.created_time = None
     Review.update_item_review(
@@ -98,7 +98,7 @@ def review_item(request, item_uuid: str, review: ReviewInSchema):
         share_to_mastodon=review.post_to_fediverse,
         application_id=getattr(request, "application_id", None),
     )
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.delete(
@@ -112,9 +112,9 @@ def delete_review(request, item_uuid: str):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     Review.update_item_review(item, request.user.identity, None, None)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -132,7 +132,7 @@ def get_any_review(request, review_uuid: str):
     """
     r = Review.get_by_url(review_uuid)
     if not r:
-        return 404, {"message": "Review not found"}
+        return Status(404, {"message": "Review not found"})
     if not r.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        return Status(403, {"message": "Permission denied"})
     return r

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from django.db.models import QuerySet
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
-from ninja import Field, Schema
+from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
 from catalog.models import AvailableItemCategory, Item, ItemCategory, ItemSchema
@@ -114,14 +114,14 @@ def get_user_calendar_data(request, handle: str):
     try:
         target = APIdentity.get_by_handle(handle)
     except APIdentity.DoesNotExist:
-        return 404, {"message": "User not found"}
+        return Status(404, {"message": "User not found"})
 
     viewer = getattr(request.user, "identity", None)
     if not viewer:
-        return 401, {"message": "Login required"}
+        return Status(401, {"message": "Login required"})
     if request.user != target.user:
         if target.restricted or target.is_rejecting(viewer):
-            return 403, {"message": "Access denied"}
+            return Status(403, {"message": "Access denied"})
     max_visibility = max_visiblity_to_user(request.user, target)
     cache_key = f"user_calendar:{target.pk}:{max_visibility}"
     calendar_data = cache.get_or_set(
@@ -200,13 +200,15 @@ def get_mark_by_item(request, item_uuid: str, response: HttpResponse):
     """
     item = Item.get_by_url(item_uuid)
     if not item or item.is_deleted:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     if item.merged_to_item:
         response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}"
-        return 302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        return Status(
+            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        )
     shelfmember = request.user.shelf_manager.locate_item(item)
     if not shelfmember:
-        return 404, {"message": "Mark not found"}
+        return Status(404, {"message": "Mark not found"})
     return shelfmember
 
 
@@ -247,7 +249,7 @@ def mark_item(request, item_uuid: str, mark: MarkInSchema):
     """
     item = Item.get_by_url(item_uuid)
     if not item or item.is_deleted or item.merged_to_item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     if mark.created_time:
         if mark.created_time.tzinfo is None:
             mark.created_time = timezone.make_aware(
@@ -266,7 +268,7 @@ def mark_item(request, item_uuid: str, mark: MarkInSchema):
         share_to_mastodon=mark.post_to_fediverse,
         application_id=getattr(request, "application_id", None),
     )
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.delete(
@@ -280,10 +282,10 @@ def delete_mark(request, item_uuid: str):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     m = Mark(request.user.identity, item)
     m.delete(keep_tags=True)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -306,5 +308,7 @@ def get_mark_logs_by_item(request, item_uuid: str, response: HttpResponse):
         raise Http404("Item not found")
     if item.merged_to_item:
         response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/logs"
-        return 302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        return Status(
+            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
+        )
     return Mark(request.user.identity, item).logs

--- a/journal/apis/tag.py
+++ b/journal/apis/tag.py
@@ -2,7 +2,7 @@ from typing import List
 
 from django.core.cache import cache
 from django.http import Http404
-from ninja import Field, Schema
+from ninja import Field, Schema, Status
 from ninja.errors import HttpError
 from ninja.pagination import paginate
 
@@ -60,9 +60,9 @@ def get_tag(request, tag_uuid: str):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        return Status(404, {"message": "Tag not found"})
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     return tag
 
 
@@ -103,9 +103,9 @@ def update_tag(request, tag_uuid: str, t_in: TagInSchema):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        return Status(404, {"message": "Tag not found"})
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     title = Tag.cleanup_title(t_in.title)
     visibility = 2 if t_in.visibility else 0
     if title != tag.title:
@@ -114,7 +114,7 @@ def update_tag(request, tag_uuid: str, t_in: TagInSchema):
             tag.visibility = visibility
             tag.save()
         except Exception:
-            return 409, {"message": "Tag with same title exists"}
+            return Status(409, {"message": "Tag with same title exists"})
     return tag
 
 
@@ -129,11 +129,11 @@ def delete_tag(request, tag_uuid: str):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        return Status(404, {"message": "Tag not found"})
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     tag.delete()
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(
@@ -165,16 +165,16 @@ def tag_add_item(request, tag_uuid: str, tag_item: TagItemInSchema):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        return Status(404, {"message": "Tag not found"})
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     if not tag_item.item_uuid:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     item = Item.get_by_url(tag_item.item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     tag.append_item(item)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.delete(
@@ -188,14 +188,14 @@ def tag_delete_item(request, tag_uuid: str, item_uuid: str):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        return Status(404, {"message": "Tag not found"})
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        return Status(403, {"message": "Not owner"})
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        return Status(404, {"message": "Item not found"})
     tag.remove_item(item)
-    return 200, {"message": "OK"}
+    return Status(200, {"message": "OK"})
 
 
 @api.get(

--- a/tests/catalog/test_musicbrainz.py
+++ b/tests/catalog/test_musicbrainz.py
@@ -52,7 +52,9 @@ class TestMusicBrainzReleaseGroup:
         ]
 
         for url in invalid_urls:
-            site = SiteManager.get_site_by_url(url)
+            site = SiteManager.get_site_by_url(
+                url, detect_redirection=False, detect_fallback=False
+            )
             if site is not None:
                 assert not isinstance(site, MusicBrainzReleaseGroup)
 
@@ -216,7 +218,9 @@ class TestMusicBrainzRelease:
         ]
 
         for url in invalid_urls:
-            site = SiteManager.get_site_by_url(url)
+            site = SiteManager.get_site_by_url(
+                url, detect_redirection=False, detect_fallback=False
+            )
             if site is not None:
                 assert not isinstance(site, MusicBrainzRelease)
 

--- a/tests/core/test_jsondata_fields.py
+++ b/tests/core/test_jsondata_fields.py
@@ -1,0 +1,180 @@
+from datetime import date, datetime, time
+from datetime import timezone as dt_tz
+
+import pytest
+from django.utils import timezone
+
+from common.models.jsondata import (
+    DateField,
+    DateTimeField,
+    EncryptedTextField,
+    TimeField,
+    decrypt_str,
+    encrypt_str,
+)
+
+
+class TestEncryptDecrypt:
+    def test_roundtrip(self):
+        original = "hello world"
+        encrypted = encrypt_str(original)
+        assert encrypted != original
+        decrypted = decrypt_str(encrypted)
+        assert decrypted == original
+
+    def test_empty_string(self):
+        encrypted = encrypt_str("")
+        decrypted = decrypt_str(encrypted)
+        assert decrypted == ""
+
+    def test_unicode_roundtrip(self):
+        original = "Hello, multi-language text"
+        encrypted = encrypt_str(original)
+        decrypted = decrypt_str(encrypted)
+        assert decrypted == original
+
+
+class TestEncryptedTextField:
+    def setup_method(self):
+        self.field = EncryptedTextField()
+
+    def test_to_json_with_value(self):
+        result = self.field.to_json("secret")
+        assert result is not None
+        assert result != "secret"
+        # verify we can decrypt it
+        assert decrypt_str(result) == "secret"
+
+    def test_to_json_with_none(self):
+        result = self.field.to_json(None)
+        assert result is None
+
+    def test_to_json_with_empty_string(self):
+        result = self.field.to_json("")
+        assert result is None
+
+    def test_from_json_with_value(self):
+        encrypted = encrypt_str("secret")
+        result = self.field.from_json(encrypted)
+        assert result == "secret"
+
+    def test_from_json_with_none(self):
+        result = self.field.from_json(None)
+        assert result is None
+
+    def test_from_json_with_empty_string(self):
+        result = self.field.from_json("")
+        assert result is None
+
+
+class TestDateField:
+    def setup_method(self):
+        self.field = DateField()
+
+    def test_to_json_with_date(self):
+        d = date(2024, 1, 15)
+        assert self.field.to_json(d) == "2024-01-15"
+
+    def test_to_json_with_datetime(self):
+        dt = datetime(2024, 1, 15, 12, 30)
+        assert self.field.to_json(dt) == "2024-01-15"
+
+    def test_to_json_with_string(self):
+        result = self.field.to_json("2024-01-15")
+        assert result == "2024-01-15"
+
+    def test_to_json_with_none(self):
+        result = self.field.to_json(None)
+        assert result is None
+
+    def test_to_json_with_empty_string(self):
+        result = self.field.to_json("")
+        assert result is None
+
+    def test_from_json_with_value(self):
+        result = self.field.from_json("2024-01-15")
+        assert result == date(2024, 1, 15)
+
+    def test_from_json_with_none(self):
+        result = self.field.from_json(None)
+        assert result is None
+
+
+class TestDateTimeField:
+    def setup_method(self):
+        self.field = DateTimeField()
+
+    def test_to_json_with_aware_datetime(self):
+        dt = timezone.now()
+        result = self.field.to_json(dt)
+        assert result is not None
+        assert "T" in result
+
+    def test_to_json_with_naive_datetime(self):
+        dt = datetime(2024, 1, 15, 12, 30)
+        result = self.field.to_json(dt)
+        assert result is not None
+        # should have made it aware
+        assert "+" in result or "Z" in result
+
+    def test_to_json_with_date(self):
+        d = date(2024, 1, 15)
+        result = self.field.to_json(d)
+        assert result is not None
+        # date should be converted to datetime
+        assert "T" in result
+
+    def test_to_json_with_valid_string(self):
+        result = self.field.to_json("2024-01-15")
+        assert result is not None
+
+    def test_to_json_with_invalid_string(self):
+        with pytest.raises(ValueError, match="invalid datatime format"):
+            self.field.to_json("not-a-date")
+
+    def test_from_json_with_value(self):
+        result = self.field.from_json("2024-01-15T12:30:00+00:00")
+        assert isinstance(result, datetime)
+        assert result.year == 2024
+
+    def test_from_json_with_none(self):
+        result = self.field.from_json(None)
+        assert result is None
+
+    def test_from_json_with_empty_string(self):
+        result = self.field.from_json("")
+        assert result is None
+
+
+class TestTimeField:
+    def setup_method(self):
+        self.field = TimeField()
+
+    def test_to_json_with_aware_time(self):
+        t = time(12, 30, 0, tzinfo=dt_tz.utc)
+        result = self.field.to_json(t)
+        assert result is not None
+        assert "12:30" in result
+
+    def test_to_json_with_naive_time(self):
+        t = time(12, 30, 0)
+        result = self.field.to_json(t)
+        assert result is not None
+
+    def test_to_json_with_none(self):
+        result = self.field.to_json(None)
+        assert result is None
+
+    def test_from_json_with_value(self):
+        result = self.field.from_json("12:30:00")
+        assert isinstance(result, time)
+        assert result.hour == 12
+        assert result.minute == 30
+
+    def test_from_json_with_none(self):
+        result = self.field.from_json(None)
+        assert result is None
+
+    def test_from_json_with_empty_string(self):
+        result = self.field.from_json("")
+        assert result is None

--- a/tests/core/test_jsondata_fields.py
+++ b/tests/core/test_jsondata_fields.py
@@ -129,7 +129,7 @@ class TestDateTimeField:
         assert result is not None
 
     def test_to_json_with_invalid_string(self):
-        with pytest.raises(ValueError, match="invalid datatime format"):
+        with pytest.raises(ValueError, match="invalid datetime format"):
             self.field.to_json("not-a-date")
 
     def test_from_json_with_value(self):

--- a/tests/core/test_lang_coverage.py
+++ b/tests/core/test_lang_coverage.py
@@ -13,7 +13,7 @@ class TestLocalizeNumber:
 
     def test_chinese_teens(self):
         with translation.override("zh-hans"):
-            assert localize_number(10) == "\u5341\u96f6"  # ten + zero
+            assert localize_number(10) == "\u5341"  # ten
             assert localize_number(11) == "\u5341\u4e00"  # ten + one
             assert localize_number(19) == "\u5341\u4e5d"  # ten + nine
 

--- a/tests/core/test_lang_coverage.py
+++ b/tests/core/test_lang_coverage.py
@@ -1,0 +1,68 @@
+from django.utils import translation
+
+from common.models.lang import get_current_locales, localize_number
+
+
+class TestLocalizeNumber:
+    def test_chinese_single_digit(self):
+        with translation.override("zh-hans"):
+            assert localize_number(0) == "\u96f6"  # zero
+            assert localize_number(1) == "\u4e00"  # one
+            assert localize_number(5) == "\u4e94"  # five
+            assert localize_number(9) == "\u4e5d"  # nine
+
+    def test_chinese_teens(self):
+        with translation.override("zh-hans"):
+            assert localize_number(10) == "\u5341\u96f6"  # ten + zero
+            assert localize_number(11) == "\u5341\u4e00"  # ten + one
+            assert localize_number(19) == "\u5341\u4e5d"  # ten + nine
+
+    def test_chinese_double_digit(self):
+        with translation.override("zh-hans"):
+            result = localize_number(25)
+            assert "\u5341" in result  # should contain "ten"
+
+    def test_chinese_out_of_range_negative(self):
+        with translation.override("zh-hans"):
+            assert localize_number(-1) == "-1"
+
+    def test_chinese_out_of_range_large(self):
+        with translation.override("zh-hans"):
+            assert localize_number(100) == "100"
+
+    def test_chinese_hant(self):
+        with translation.override("zh-hant"):
+            assert localize_number(3) == "\u4e09"  # three
+
+    def test_non_chinese_returns_str(self):
+        with translation.override("en"):
+            assert localize_number(42) == "42"
+
+    def test_french_returns_str(self):
+        with translation.override("fr"):
+            assert localize_number(7) == "7"
+
+
+class TestGetCurrentLocales:
+    def test_zh_hans_locale(self):
+        with translation.override("zh-hans"):
+            locales = get_current_locales()
+            assert locales[0] == "zh-cn"
+            assert "en" in locales
+
+    def test_zh_hant_locale(self):
+        with translation.override("zh-hant"):
+            locales = get_current_locales()
+            assert locales[0] == "zh-tw"
+            assert "en" in locales
+
+    def test_en_locale(self):
+        with translation.override("en"):
+            locales = get_current_locales()
+            assert locales[0] == "en"
+
+    def test_other_locale(self):
+        with translation.override("fr"):
+            locales = get_current_locales()
+            assert locales[0] == "fr"
+            assert "en" in locales

--- a/tests/core/test_utils_coverage.py
+++ b/tests/core/test_utils_coverage.py
@@ -1,0 +1,126 @@
+import uuid
+
+import pytest
+from django.http import Http404, QueryDict
+
+from common.utils import (
+    GenerateDateUUIDMediaFilePath,
+    PageLinksGenerator,
+    get_uuid_or_404,
+)
+
+
+class TestPageLinksGenerator:
+    def test_single_page(self):
+        pg = PageLinksGenerator(1, 1)
+        assert pg.current_page == 1
+        assert pg.has_prev is False
+        assert pg.has_next is False
+        assert pg.previous_page is None
+        assert pg.next_page is None
+        assert pg.page_range is not None
+        assert list(pg.page_range) == [1]
+
+    def test_first_page_of_many(self):
+        pg = PageLinksGenerator(1, 20)
+        assert pg.current_page == 1
+        assert pg.has_prev is False
+        assert pg.has_next is True
+        assert pg.previous_page is None
+        assert pg.next_page == 2
+
+    def test_last_page_of_many(self):
+        pg = PageLinksGenerator(20, 20)
+        assert pg.current_page == 20
+        assert pg.has_prev is True
+        assert pg.has_next is False
+        assert pg.previous_page == 19
+        assert pg.next_page is None
+
+    def test_middle_page(self):
+        pg = PageLinksGenerator(10, 20)
+        assert pg.current_page == 10
+        assert pg.has_prev is True
+        assert pg.has_next is True
+        assert pg.previous_page == 9
+        assert pg.next_page == 11
+
+    def test_both_sides_overflow(self):
+        # total pages less than length
+        pg = PageLinksGenerator(2, 3)
+        assert pg.start_page == 1
+        assert pg.end_page == 3
+        assert pg.has_prev is False
+        assert pg.has_next is False
+
+    def test_left_side_overflow(self):
+        # near the start
+        pg = PageLinksGenerator(2, 50)
+        assert pg.start_page == 1
+        assert pg.has_prev is False
+        assert pg.has_next is True
+
+    def test_right_side_overflow(self):
+        # near the end
+        pg = PageLinksGenerator(49, 50)
+        assert pg.end_page == 50
+        assert pg.has_next is False
+        assert pg.has_prev is True
+
+    def test_query_string_included(self):
+        q = QueryDict(mutable=True)
+        q["q"] = "search"
+        q["page"] = "2"
+        pg = PageLinksGenerator(2, 10, query=q)
+        assert "q=search" in pg.query_string
+        assert "page" not in pg.query_string
+
+    def test_query_string_empty(self):
+        pg = PageLinksGenerator(1, 5)
+        assert pg.query_string == ""
+
+    def test_page_range_covers_correctly(self):
+        pg = PageLinksGenerator(5, 10)
+        assert pg.page_range is not None
+        pages = list(pg.page_range)
+        assert pg.current_page in pages
+        for p in pages:
+            assert 1 <= p <= 10
+
+
+class TestGenerateDateUUIDMediaFilePath:
+    def test_with_trailing_slash(self):
+        path = GenerateDateUUIDMediaFilePath("photo.jpg", "uploads/")
+        assert path.startswith("uploads/")
+        assert path.endswith(".jpg")
+        assert "/" in path
+
+    def test_without_trailing_slash(self):
+        path = GenerateDateUUIDMediaFilePath("photo.jpg", "uploads")
+        assert path.startswith("uploads/")
+        assert path.endswith(".jpg")
+
+    def test_preserves_extension(self):
+        path = GenerateDateUUIDMediaFilePath("image.webp", "media/")
+        assert path.endswith(".webp")
+
+    def test_contains_date_path(self):
+        path = GenerateDateUUIDMediaFilePath("file.png", "media/")
+        parts = path.split("/")
+        # should have media, year, month, day, filename
+        assert len(parts) >= 4
+
+
+class TestGetUuidOr404:
+    def test_valid_b62(self):
+        # Create a UUID and encode it
+        from django.core.signing import b62_encode
+
+        u = uuid.uuid4()
+        b62 = b62_encode(u.int).zfill(22)
+        result = get_uuid_or_404(b62)
+        assert result == u
+
+    def test_invalid_b62_raises_404(self):
+        with pytest.raises(Http404):
+            get_uuid_or_404("!!invalid!!")

--- a/tests/journal/test_comment_coverage.py
+++ b/tests/journal/test_comment_coverage.py
@@ -65,16 +65,15 @@ class TestCommentProperties:
         self.identity = self.user.identity
         self.book = Edition.objects.create(title="Prop Book")
 
-    def test_comment_html(self):
+    def test_comment_html_renders_content(self):
         comment = Comment.objects.create(
             owner=self.identity,
             item=self.book,
-            text="Hello **world**",
+            text="plain text comment",
             visibility=0,
         )
         html = comment.html
-        assert isinstance(html, str)
-        assert len(html) > 0
+        assert "plain text comment" in html
 
     def test_comment_mark_property(self):
         Mark(self.identity, self.book).update(ShelfType.WISHLIST)
@@ -95,15 +94,5 @@ class TestCommentProperties:
             item=self.book,
             text="Test",
             visibility=0,
-        )
-        assert comment.item_url == self.book.url
-
-    def test_item_url_without_position_explicit(self):
-        comment = Comment.objects.create(
-            owner=self.identity,
-            item=self.book,
-            text="Test",
-            visibility=0,
-            metadata={},
         )
         assert comment.item_url == self.book.url

--- a/tests/journal/test_comment_coverage.py
+++ b/tests/journal/test_comment_coverage.py
@@ -1,0 +1,109 @@
+import pytest
+
+from catalog.models import Edition
+from journal.models import Comment, Mark, ShelfType
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCommentItem:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="comment@test.com", username="commentuser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Comment Book")
+
+    def test_create_comment(self):
+        comment = Comment.comment_item(self.book, self.identity, "Great book!", 0)
+        assert comment is not None
+        assert comment.text == "Great book!"
+        assert comment.visibility == 0
+
+    def test_update_comment_text(self):
+        Comment.comment_item(self.book, self.identity, "First", 0)
+        comment = Comment.comment_item(self.book, self.identity, "Updated", 0)
+        assert comment is not None
+        assert comment.text == "Updated"
+        assert Comment.objects.filter(owner=self.identity, item=self.book).count() == 1
+
+    def test_update_comment_visibility(self):
+        Comment.comment_item(self.book, self.identity, "Same text", 0)
+        comment = Comment.comment_item(self.book, self.identity, "Same text", 2)
+        assert comment is not None
+        assert comment.visibility == 2
+
+    def test_no_change_when_same(self):
+        c1 = Comment.comment_item(self.book, self.identity, "Same", 0)
+        c2 = Comment.comment_item(self.book, self.identity, "Same", 0)
+        assert c1 is not None
+        assert c2 is not None
+        assert c1.pk == c2.pk
+
+    def test_delete_comment_with_none_text(self):
+        Comment.comment_item(self.book, self.identity, "To delete", 0)
+        assert Comment.objects.filter(owner=self.identity, item=self.book).exists()
+        result = Comment.comment_item(self.book, self.identity, None, 0)
+        assert result is None
+        assert not Comment.objects.filter(owner=self.identity, item=self.book).exists()
+
+    def test_delete_comment_with_empty_text(self):
+        Comment.comment_item(self.book, self.identity, "To delete", 0)
+        result = Comment.comment_item(self.book, self.identity, "", 0)
+        assert result is None
+        assert not Comment.objects.filter(owner=self.identity, item=self.book).exists()
+
+    def test_none_text_when_no_comment(self):
+        result = Comment.comment_item(self.book, self.identity, None, 0)
+        assert result is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCommentProperties:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="cprop@test.com", username="cpropuser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Prop Book")
+
+    def test_comment_html(self):
+        comment = Comment.objects.create(
+            owner=self.identity,
+            item=self.book,
+            text="Hello **world**",
+            visibility=0,
+        )
+        html = comment.html
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+    def test_comment_mark_property(self):
+        Mark(self.identity, self.book).update(ShelfType.WISHLIST)
+        comment = Comment.objects.create(
+            owner=self.identity,
+            item=self.book,
+            text="Nice",
+            visibility=0,
+        )
+        mark = comment.mark
+        assert mark.owner == self.identity
+        assert mark.item == self.book
+        assert mark.comment == comment
+
+    def test_item_url_without_position(self):
+        comment = Comment.objects.create(
+            owner=self.identity,
+            item=self.book,
+            text="Test",
+            visibility=0,
+        )
+        assert comment.item_url == self.book.url
+
+    def test_item_url_without_position_explicit(self):
+        comment = Comment.objects.create(
+            owner=self.identity,
+            item=self.book,
+            text="Test",
+            visibility=0,
+            metadata={},
+        )
+        assert comment.item_url == self.book.url

--- a/tests/journal/test_journal_utils.py
+++ b/tests/journal/test_journal_utils.py
@@ -3,8 +3,10 @@ import pytest
 from catalog.models import Edition
 from journal.models import (
     Collection,
+    CollectionMember,
     Comment,
     Mark,
+    Note,
     Rating,
     Review,
     ShelfLogEntry,
@@ -31,15 +33,18 @@ class TestResetJournalVisibility:
         Mark(self.identity, self.book).update(
             ShelfType.WISHLIST, "comment", 5, ["tag"], 0
         )
+        Review.update_item_review(self.book, self.identity, "Title", "Body")
 
     def test_reset_visibility_updates_all_pieces(self):
         assert ShelfMember.objects.filter(owner=self.identity, visibility=0).exists()
         assert Comment.objects.filter(owner=self.identity, visibility=0).exists()
         assert Rating.objects.filter(owner=self.identity, visibility=0).exists()
+        assert Review.objects.filter(owner=self.identity, visibility=0).exists()
         reset_journal_visibility_for_user(self.identity, 2)
         assert ShelfMember.objects.filter(owner=self.identity, visibility=2).exists()
         assert Comment.objects.filter(owner=self.identity, visibility=2).exists()
         assert Rating.objects.filter(owner=self.identity, visibility=2).exists()
+        assert Review.objects.filter(owner=self.identity, visibility=2).exists()
         assert not ShelfMember.objects.filter(
             owner=self.identity, visibility=0
         ).exists()
@@ -65,11 +70,16 @@ class TestRemoveDataByIdentity:
         Review.update_item_review(self.book, self.identity, "Title", "Body")
         collection = Collection.objects.create(title="col", owner=self.identity)
         collection.append_item(self.book)
+        Note.objects.create(
+            owner=self.identity, item=self.book, content="note", visibility=0
+        )
         assert ShelfMember.objects.filter(owner=self.identity).exists()
         assert Comment.objects.filter(owner=self.identity).exists()
         assert Rating.objects.filter(owner=self.identity).exists()
         assert Review.objects.filter(owner=self.identity).exists()
         assert TagMember.objects.filter(owner=self.identity).exists()
+        assert Note.objects.filter(owner=self.identity).exists()
+        assert CollectionMember.objects.filter(owner=self.identity).exists()
         remove_data_by_identity(self.identity)
         assert not ShelfMember.objects.filter(owner=self.identity).exists()
         assert not ShelfLogEntry.objects.filter(owner=self.identity).exists()
@@ -78,6 +88,8 @@ class TestRemoveDataByIdentity:
         assert not Review.objects.filter(owner=self.identity).exists()
         assert not TagMember.objects.filter(owner=self.identity).exists()
         assert not Tag.objects.filter(owner=self.identity).exists()
+        assert not Note.objects.filter(owner=self.identity).exists()
+        assert not CollectionMember.objects.filter(owner=self.identity).exists()
         assert not Collection.objects.filter(owner=self.identity).exists()
 
 

--- a/tests/journal/test_journal_utils.py
+++ b/tests/journal/test_journal_utils.py
@@ -1,0 +1,103 @@
+import pytest
+
+from catalog.models import Edition
+from journal.models import (
+    Collection,
+    Comment,
+    Mark,
+    Rating,
+    Review,
+    ShelfLogEntry,
+    ShelfMember,
+    ShelfType,
+    Tag,
+    TagMember,
+)
+from journal.models.utils import (
+    journal_exists_for_item,
+    remove_data_by_identity,
+    reset_journal_visibility_for_user,
+)
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestResetJournalVisibility:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="vis@test.com", username="vis_user")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Test Book")
+        Mark(self.identity, self.book).update(
+            ShelfType.WISHLIST, "comment", 5, ["tag"], 0
+        )
+
+    def test_reset_visibility_updates_all_pieces(self):
+        assert ShelfMember.objects.filter(owner=self.identity, visibility=0).exists()
+        assert Comment.objects.filter(owner=self.identity, visibility=0).exists()
+        assert Rating.objects.filter(owner=self.identity, visibility=0).exists()
+        reset_journal_visibility_for_user(self.identity, 2)
+        assert ShelfMember.objects.filter(owner=self.identity, visibility=2).exists()
+        assert Comment.objects.filter(owner=self.identity, visibility=2).exists()
+        assert Rating.objects.filter(owner=self.identity, visibility=2).exists()
+        assert not ShelfMember.objects.filter(
+            owner=self.identity, visibility=0
+        ).exists()
+
+    def test_reset_visibility_to_public(self):
+        reset_journal_visibility_for_user(self.identity, 2)
+        reset_journal_visibility_for_user(self.identity, 0)
+        assert ShelfMember.objects.filter(owner=self.identity, visibility=0).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRemoveDataByIdentity:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="rm@test.com", username="rm_user")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Remove Book")
+
+    def test_remove_data_clears_all_journal_entries(self):
+        Mark(self.identity, self.book).update(
+            ShelfType.COMPLETE, "done", 10, ["best"], 0
+        )
+        Review.update_item_review(self.book, self.identity, "Title", "Body")
+        collection = Collection.objects.create(title="col", owner=self.identity)
+        collection.append_item(self.book)
+        assert ShelfMember.objects.filter(owner=self.identity).exists()
+        assert Comment.objects.filter(owner=self.identity).exists()
+        assert Rating.objects.filter(owner=self.identity).exists()
+        assert Review.objects.filter(owner=self.identity).exists()
+        assert TagMember.objects.filter(owner=self.identity).exists()
+        remove_data_by_identity(self.identity)
+        assert not ShelfMember.objects.filter(owner=self.identity).exists()
+        assert not ShelfLogEntry.objects.filter(owner=self.identity).exists()
+        assert not Comment.objects.filter(owner=self.identity).exists()
+        assert not Rating.objects.filter(owner=self.identity).exists()
+        assert not Review.objects.filter(owner=self.identity).exists()
+        assert not TagMember.objects.filter(owner=self.identity).exists()
+        assert not Tag.objects.filter(owner=self.identity).exists()
+        assert not Collection.objects.filter(owner=self.identity).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestJournalExistsForItem:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="je@test.com", username="je_user")
+        self.identity = self.user.identity
+        self.book1 = Edition.objects.create(title="Has Journal")
+        self.book2 = Edition.objects.create(title="No Journal")
+
+    def test_returns_true_when_content_exists(self):
+        Mark(self.identity, self.book1).update(ShelfType.WISHLIST)
+        assert journal_exists_for_item(self.book1) is True
+
+    def test_returns_false_when_no_content(self):
+        assert journal_exists_for_item(self.book2) is False
+
+    def test_returns_true_with_collection_member(self):
+        collection = Collection.objects.create(title="col", owner=self.identity)
+        collection.append_item(self.book2)
+        assert journal_exists_for_item(self.book2) is True

--- a/tests/journal/test_note_coverage.py
+++ b/tests/journal/test_note_coverage.py
@@ -1,0 +1,136 @@
+import pytest
+
+from catalog.models import Album, Edition, Game, Movie, Podcast, TVSeason, TVShow
+from journal.models import Note
+
+
+class TestNoteProgressDisplay:
+    def test_empty_progress_value(self):
+        note = Note()
+        note.progress_value = None
+        assert note.progress_display == ""
+
+    def test_progress_value_without_type(self):
+        note = Note()
+        note.progress_value = "42"
+        note.progress_type = None
+        assert note.progress_display == "42"
+
+    def test_progress_value_with_unknown_type(self):
+        note = Note()
+        note.progress_value = "42"
+        note.progress_type = "unknown_type"
+        assert note.progress_display == "42"
+
+    def test_progress_value_with_percentage_type(self):
+        note = Note()
+        note.progress_value = "50"
+        note.progress_type = Note.ProgressType.PERCENTAGE
+        assert note.progress_display == "50%"
+
+    def test_progress_value_with_timestamp_type(self):
+        note = Note()
+        note.progress_value = "1:23:45"
+        note.progress_type = Note.ProgressType.TIMESTAMP
+        assert note.progress_display == "1:23:45"
+
+    def test_progress_value_non_numeric_with_page(self):
+        note = Note()
+        note.progress_value = "chapter-one"
+        note.progress_type = Note.ProgressType.PAGE
+        # non-numeric values get label prefix instead of template
+        assert "Page" in note.progress_display
+        assert "chapter-one" in note.progress_display
+
+
+class TestNoteExtractProgress:
+    def test_track_prefix(self):
+        typ, val = Note.extract_progress("trk 5")
+        assert typ == Note.ProgressType.TRACK
+        assert val == "5"
+
+    def test_track_full_prefix(self):
+        typ, val = Note.extract_progress("track 3")
+        assert typ == Note.ProgressType.TRACK
+        assert val == "3"
+
+    def test_cycle_prefix(self):
+        typ, val = Note.extract_progress("cycle 2")
+        assert typ == Note.ProgressType.CYCLE
+        assert val == "2"
+
+    def test_percentage_with_postfix(self):
+        typ, val = Note.extract_progress("50%")
+        assert typ == Note.ProgressType.PERCENTAGE
+        assert val == "50"
+
+    def test_timestamp_with_colon(self):
+        typ, val = Note.extract_progress("1:23:45")
+        assert typ == "timestamp"
+        assert val == "1:23:45"
+
+    def test_number_only_no_type(self):
+        typ, val = Note.extract_progress("42")
+        assert typ is None
+        assert val == "42"
+
+    def test_dash_value(self):
+        typ, val = Note.extract_progress("-")
+        assert typ is None
+        assert val == ""
+
+    def test_no_match(self):
+        typ, val = Note.extract_progress("just some text without numbers")
+        assert typ is None
+        assert val is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestNoteGetProgressTypesByItem:
+    def test_edition_progress_types(self):
+        book = Edition.objects.create(title="Test Book")
+        types = Note.get_progress_types_by_item(book)
+        assert Note.ProgressType.PAGE in types
+        assert Note.ProgressType.CHAPTER in types
+        assert Note.ProgressType.PERCENTAGE in types
+
+    def test_movie_progress_types(self):
+        movie = Movie.objects.create(title="Test Movie")
+        types = Note.get_progress_types_by_item(movie)
+        assert Note.ProgressType.PART in types
+        assert Note.ProgressType.TIMESTAMP in types
+        assert Note.ProgressType.PERCENTAGE in types
+
+    def test_tvshow_progress_types(self):
+        show = TVShow.objects.create(title="Test Show")
+        types = Note.get_progress_types_by_item(show)
+        assert Note.ProgressType.EPISODE in types
+        assert Note.ProgressType.PART in types
+
+    def test_tvseason_progress_types(self):
+        season = TVSeason.objects.create(title="Test Season")
+        types = Note.get_progress_types_by_item(season)
+        assert Note.ProgressType.EPISODE in types
+
+    def test_album_progress_types(self):
+        album = Album.objects.create(title="Test Album")
+        types = Note.get_progress_types_by_item(album)
+        assert Note.ProgressType.TRACK in types
+        assert Note.ProgressType.TIMESTAMP in types
+
+    def test_game_progress_types(self):
+        game = Game.objects.create(title="Test Game")
+        types = Note.get_progress_types_by_item(game)
+        assert Note.ProgressType.CYCLE in types
+
+    def test_podcast_progress_types(self):
+        podcast = Podcast.objects.create(title="Test Podcast")
+        types = Note.get_progress_types_by_item(podcast)
+        assert Note.ProgressType.EPISODE in types
+
+    def test_tvepisode_returns_empty(self):
+        from catalog.models import TVEpisode
+
+        ep = TVEpisode.objects.create(title="Test Episode")
+        types = Note.get_progress_types_by_item(ep)
+        assert types == []

--- a/tests/journal/test_note_coverage.py
+++ b/tests/journal/test_note_coverage.py
@@ -1,6 +1,15 @@
 import pytest
 
-from catalog.models import Album, Edition, Game, Movie, Podcast, TVSeason, TVShow
+from catalog.models import (
+    Album,
+    Edition,
+    Game,
+    Movie,
+    Podcast,
+    TVEpisode,
+    TVSeason,
+    TVShow,
+)
 from journal.models import Note
 
 
@@ -129,8 +138,6 @@ class TestNoteGetProgressTypesByItem:
         assert Note.ProgressType.EPISODE in types
 
     def test_tvepisode_returns_empty(self):
-        from catalog.models import TVEpisode
-
         ep = TVEpisode.objects.create(title="Test Episode")
         types = Note.get_progress_types_by_item(ep)
         assert types == []

--- a/tests/journal/test_piece_coverage.py
+++ b/tests/journal/test_piece_coverage.py
@@ -1,0 +1,225 @@
+import pytest
+
+from catalog.models import Edition
+from journal.models import Comment
+from journal.models.common import (
+    Debris,
+    Piece,
+    max_visiblity_to_user,
+    prefetch_latest_posts,
+    q_owned_piece_visible_to_user,
+    q_piece_in_home_feed_of_user,
+)
+from takahe.utils import Takahe
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestQOwnedPieceVisibleToUser:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner_user = User.register(email="owner@test.com", username="owner")
+        self.viewer_user = User.register(email="viewer@test.com", username="viewer")
+        self.owner = self.owner_user.identity
+        self.viewer = self.viewer_user.identity
+
+    def test_unauthenticated_viewer_anonymous_viewable(self):
+        q = q_owned_piece_visible_to_user(None, self.owner)
+        assert "visibility" in str(q)
+
+    def test_unauthenticated_viewer_not_anonymous_viewable(self):
+        self.owner.anonymous_viewable = False
+        self.owner.save()
+        q = q_owned_piece_visible_to_user(None, self.owner)
+        assert "pk__in" in str(q)
+
+    def test_owner_views_own(self):
+        q = q_owned_piece_visible_to_user(self.owner_user, self.owner)
+        assert "owner" in str(q)
+
+    def test_non_following_viewer_sees_public_only(self):
+        q = q_owned_piece_visible_to_user(self.viewer_user, self.owner)
+        assert "visibility" in str(q)
+
+    def test_following_viewer_sees_follower_content(self):
+        self.viewer.follow(self.owner, force_accept=True)
+        Takahe._force_state_cycle()
+        q = q_owned_piece_visible_to_user(self.viewer_user, self.owner)
+        assert "visibility__in" in str(q)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMaxVisibilityToUser:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner_user = User.register(email="mowner@test.com", username="mowner")
+        self.viewer_user = User.register(email="mviewer@test.com", username="mviewer")
+        self.owner = self.owner_user.identity
+        self.viewer = self.viewer_user.identity
+
+    def test_unauthenticated_returns_0(self):
+        from unittest.mock import MagicMock
+
+        anon = MagicMock(spec=User)
+        anon.is_authenticated = False
+        assert max_visiblity_to_user(anon, self.owner) == 0
+
+    def test_owner_returns_2(self):
+        assert max_visiblity_to_user(self.owner_user, self.owner) == 2
+
+    def test_non_follower_returns_0(self):
+        assert max_visiblity_to_user(self.viewer_user, self.owner) == 0
+
+    def test_follower_returns_1(self):
+        self.viewer.follow(self.owner, force_accept=True)
+        Takahe._force_state_cycle()
+        assert max_visiblity_to_user(self.viewer_user, self.owner) == 1
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPieceGetByUrl:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="purl@test.com", username="purluser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="URL Book")
+
+    def test_get_by_url_valid(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        found = Comment.get_by_url(comment.uuid)
+        assert found is not None
+        assert found.pk == comment.pk
+
+    def test_get_by_url_full_url(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        url = comment.url
+        found = Comment.get_by_url(url)
+        assert found is not None
+        assert found.pk == comment.pk
+
+    def test_get_by_url_invalid(self):
+        result = Comment.get_by_url("invalid_url")
+        assert result is None
+
+    def test_get_by_url_and_owner(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        found = Comment.get_by_url_and_owner(comment.uuid, self.identity.pk)
+        assert found is not None
+        assert found.pk == comment.pk
+
+    def test_get_by_url_and_owner_wrong_owner(self):
+        other_user = User.register(email="other@test.com", username="other")
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        result = Comment.get_by_url_and_owner(comment.uuid, other_user.identity.pk)
+        assert result is None
+
+    def test_get_by_url_and_owner_invalid_url(self):
+        result = Comment.get_by_url_and_owner("garbage", self.identity.pk)
+        assert result is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPieceProperties:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="pprop@test.com", username="ppropuser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Prop Book")
+
+    def test_piece_url_and_uuid(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert comment.uuid is not None
+        assert len(comment.uuid) in [21, 22]
+        assert comment.url.endswith(comment.uuid)
+
+    def test_piece_absolute_url(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert "example.org" in comment.absolute_url
+        assert comment.uuid in comment.absolute_url
+
+    def test_piece_like_count_no_post(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert comment.like_count == 0
+
+    def test_piece_reply_count_no_post(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert comment.reply_count == 0
+
+    def test_piece_is_liked_by_no_post(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert not comment.is_liked_by(self.identity)
+
+    def test_piece_classname(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        assert comment.classname == "comment"
+
+    def test_debris_to_indexable_doc(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        debris = Debris.create_from_piece(comment)
+        assert debris.to_indexable_doc() == {}
+
+    def test_content_str(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        s = str(comment)
+        assert "Comment" in s
+        assert comment.uuid in s
+
+    def test_get_by_post_id_none(self):
+        result = Piece.get_by_post_id(99999)
+        assert result is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPrefetchLatestPosts:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="plp@test.com", username="plpuser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="PLP Book")
+
+    def test_prefetch_empty_list(self):
+        prefetch_latest_posts([])
+
+    def test_prefetch_pieces_without_posts(self):
+        comment = Comment.objects.create(
+            owner=self.identity, item=self.book, text="test", visibility=0
+        )
+        prefetch_latest_posts([comment])
+        assert comment.__dict__["latest_post_id"] is None
+        assert comment.__dict__["latest_post"] is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestQPieceInHomeFeed:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="feed@test.com", username="feeduser")
+
+    def test_home_feed_query(self):
+        q = q_piece_in_home_feed_of_user(self.user)
+        q_str = str(q)
+        assert "owner_id" in q_str

--- a/tests/journal/test_piece_coverage.py
+++ b/tests/journal/test_piece_coverage.py
@@ -3,77 +3,10 @@ import pytest
 from catalog.models import Edition
 from journal.models import Comment
 from journal.models.common import (
-    Debris,
     Piece,
-    max_visiblity_to_user,
     prefetch_latest_posts,
-    q_owned_piece_visible_to_user,
-    q_piece_in_home_feed_of_user,
 )
-from takahe.utils import Takahe
 from users.models import User
-
-
-@pytest.mark.django_db(databases="__all__")
-class TestQOwnedPieceVisibleToUser:
-    @pytest.fixture(autouse=True)
-    def setup_data(self):
-        self.owner_user = User.register(email="owner@test.com", username="owner")
-        self.viewer_user = User.register(email="viewer@test.com", username="viewer")
-        self.owner = self.owner_user.identity
-        self.viewer = self.viewer_user.identity
-
-    def test_unauthenticated_viewer_anonymous_viewable(self):
-        q = q_owned_piece_visible_to_user(None, self.owner)
-        assert "visibility" in str(q)
-
-    def test_unauthenticated_viewer_not_anonymous_viewable(self):
-        self.owner.anonymous_viewable = False
-        self.owner.save()
-        q = q_owned_piece_visible_to_user(None, self.owner)
-        assert "pk__in" in str(q)
-
-    def test_owner_views_own(self):
-        q = q_owned_piece_visible_to_user(self.owner_user, self.owner)
-        assert "owner" in str(q)
-
-    def test_non_following_viewer_sees_public_only(self):
-        q = q_owned_piece_visible_to_user(self.viewer_user, self.owner)
-        assert "visibility" in str(q)
-
-    def test_following_viewer_sees_follower_content(self):
-        self.viewer.follow(self.owner, force_accept=True)
-        Takahe._force_state_cycle()
-        q = q_owned_piece_visible_to_user(self.viewer_user, self.owner)
-        assert "visibility__in" in str(q)
-
-
-@pytest.mark.django_db(databases="__all__")
-class TestMaxVisibilityToUser:
-    @pytest.fixture(autouse=True)
-    def setup_data(self):
-        self.owner_user = User.register(email="mowner@test.com", username="mowner")
-        self.viewer_user = User.register(email="mviewer@test.com", username="mviewer")
-        self.owner = self.owner_user.identity
-        self.viewer = self.viewer_user.identity
-
-    def test_unauthenticated_returns_0(self):
-        from unittest.mock import MagicMock
-
-        anon = MagicMock(spec=User)
-        anon.is_authenticated = False
-        assert max_visiblity_to_user(anon, self.owner) == 0
-
-    def test_owner_returns_2(self):
-        assert max_visiblity_to_user(self.owner_user, self.owner) == 2
-
-    def test_non_follower_returns_0(self):
-        assert max_visiblity_to_user(self.viewer_user, self.owner) == 0
-
-    def test_follower_returns_1(self):
-        self.viewer.follow(self.owner, force_accept=True)
-        Takahe._force_state_cycle()
-        assert max_visiblity_to_user(self.viewer_user, self.owner) == 1
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -96,8 +29,7 @@ class TestPieceGetByUrl:
         comment = Comment.objects.create(
             owner=self.identity, item=self.book, text="test", visibility=0
         )
-        url = comment.url
-        found = Comment.get_by_url(url)
+        found = Comment.get_by_url(comment.url)
         assert found is not None
         assert found.pk == comment.pk
 
@@ -173,13 +105,6 @@ class TestPieceProperties:
         )
         assert comment.classname == "comment"
 
-    def test_debris_to_indexable_doc(self):
-        comment = Comment.objects.create(
-            owner=self.identity, item=self.book, text="test", visibility=0
-        )
-        debris = Debris.create_from_piece(comment)
-        assert debris.to_indexable_doc() == {}
-
     def test_content_str(self):
         comment = Comment.objects.create(
             owner=self.identity, item=self.book, text="test", visibility=0
@@ -211,15 +136,3 @@ class TestPrefetchLatestPosts:
         prefetch_latest_posts([comment])
         assert comment.__dict__["latest_post_id"] is None
         assert comment.__dict__["latest_post"] is None
-
-
-@pytest.mark.django_db(databases="__all__")
-class TestQPieceInHomeFeed:
-    @pytest.fixture(autouse=True)
-    def setup_data(self):
-        self.user = User.register(email="feed@test.com", username="feeduser")
-
-    def test_home_feed_query(self):
-        q = q_piece_in_home_feed_of_user(self.user)
-        q_str = str(q)
-        assert "owner_id" in q_str

--- a/tests/journal/test_tag_coverage.py
+++ b/tests/journal/test_tag_coverage.py
@@ -1,0 +1,119 @@
+import pytest
+
+from catalog.models import Edition
+from journal.models import Tag, TagManager, TagMember
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagUpdate:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="tag@test.com", username="taguser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="Tag Book")
+
+    def test_update_title(self):
+        tag = Tag.objects.create(owner=self.identity, title="old_title", visibility=0)
+        tag.update(title="new_title")
+        tag.refresh_from_db()
+        assert tag.title == "new_title"
+
+    def test_update_visibility(self):
+        tag = Tag.objects.create(owner=self.identity, title="vis_tag", visibility=0)
+        tag.update(title="vis_tag", visibility=2)
+        tag.refresh_from_db()
+        assert tag.visibility == 2
+
+    def test_update_visibility_to_public(self):
+        tag = Tag.objects.create(owner=self.identity, title="vis_tag", visibility=2)
+        tag.update(title="vis_tag", visibility=0)
+        tag.refresh_from_db()
+        assert tag.visibility == 0
+
+    def test_update_pinned(self):
+        tag = Tag.objects.create(owner=self.identity, title="pin_tag", visibility=0)
+        tag.update(title="pin_tag", pinned=True)
+        tag.refresh_from_db()
+        assert tag.pinned is True
+
+    def test_tag_to_indexable_doc(self):
+        tag = Tag.objects.create(owner=self.identity, title="idx", visibility=0)
+        assert tag.to_indexable_doc() == {}
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagMemberProperties:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="tm@test.com", username="tmuser")
+        self.identity = self.user.identity
+        self.book = Edition.objects.create(title="TM Book")
+
+    def test_tagmember_title(self):
+        tag = Tag.objects.create(owner=self.identity, title="MyTag", visibility=0)
+        tag.append_item(self.book)
+        member = TagMember.objects.filter(parent=tag, item=self.book).first()
+        assert member is not None
+        assert member.title == "MyTag"
+
+    def test_tagmember_to_indexable_doc(self):
+        tag = Tag.objects.create(owner=self.identity, title="MyTag2", visibility=0)
+        tag.append_item(self.book)
+        member = TagMember.objects.filter(parent=tag, item=self.book).first()
+        assert member is not None
+        assert member.to_indexable_doc() == {}
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagAttachToItems:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user1 = User.register(email="ati1@test.com", username="atiuser1")
+        self.user2 = User.register(email="ati2@test.com", username="atiuser2")
+        self.book1 = Edition.objects.create(title="ATI Book1")
+        self.book2 = Edition.objects.create(title="ATI Book2")
+
+    def test_attach_tags_to_items(self):
+        TagManager.tag_item_for_owner(
+            self.user1.identity, self.book1, ["sci-fi", "space"]
+        )
+        TagManager.tag_item_for_owner(
+            self.user2.identity, self.book1, ["sci-fi", "adventure"]
+        )
+        items = [self.book1, self.book2]
+        Tag.attach_to_items(items)
+        # book1 should have tags, book2 should have empty list
+        assert hasattr(self.book1, "tags")
+        assert len(self.book1.tags) > 0
+        assert hasattr(self.book2, "tags")
+        assert self.book2.tags == []
+
+    def test_attach_tags_empty_items(self):
+        result = Tag.attach_to_items([])
+        assert result == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagManagerGetItemsTags:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="git@test.com", username="gituser")
+        self.identity = self.user.identity
+        self.book1 = Edition.objects.create(title="GIT Book1")
+        self.book2 = Edition.objects.create(title="GIT Book2")
+        self.book3 = Edition.objects.create(title="GIT Book3")
+
+    def test_get_items_tags_with_tags(self):
+        TagManager.tag_item_for_owner(self.identity, self.book1, ["a", "b"])
+        TagManager.tag_item_for_owner(self.identity, self.book2, ["c"])
+        tm = TagManager(self.identity)
+        result = tm.get_items_tags([self.book1.pk, self.book2.pk, self.book3.pk])
+        assert sorted(result[self.book1.pk]) == ["a", "b"]
+        assert result[self.book2.pk] == ["c"]
+        assert result[self.book3.pk] == []
+
+    def test_get_items_tags_empty_list(self):
+        tm = TagManager(self.identity)
+        result = tm.get_items_tags([])
+        assert result == {}

--- a/tests/journal/test_tag_coverage.py
+++ b/tests/journal/test_tag_coverage.py
@@ -37,32 +37,21 @@ class TestTagUpdate:
         tag.refresh_from_db()
         assert tag.pinned is True
 
-    def test_tag_to_indexable_doc(self):
-        tag = Tag.objects.create(owner=self.identity, title="idx", visibility=0)
-        assert tag.to_indexable_doc() == {}
-
 
 @pytest.mark.django_db(databases="__all__")
-class TestTagMemberProperties:
+class TestTagMemberTitle:
     @pytest.fixture(autouse=True)
     def setup_data(self):
         self.user = User.register(email="tm@test.com", username="tmuser")
         self.identity = self.user.identity
         self.book = Edition.objects.create(title="TM Book")
 
-    def test_tagmember_title(self):
+    def test_tagmember_title_from_parent(self):
         tag = Tag.objects.create(owner=self.identity, title="MyTag", visibility=0)
         tag.append_item(self.book)
         member = TagMember.objects.filter(parent=tag, item=self.book).first()
         assert member is not None
         assert member.title == "MyTag"
-
-    def test_tagmember_to_indexable_doc(self):
-        tag = Tag.objects.create(owner=self.identity, title="MyTag2", visibility=0)
-        tag.append_item(self.book)
-        member = TagMember.objects.filter(parent=tag, item=self.book).first()
-        assert member is not None
-        assert member.to_indexable_doc() == {}
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1,7 +1,9 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from users.models import User
+from catalog.models import Edition
+from journal.models import Mark, ShelfType
+from users.models import APIdentity, User
 from users.models.user import UsernameValidator
 
 
@@ -135,6 +137,43 @@ class TestUserModel:
         self.user.refresh_from_db()
         assert self.user.is_active is False
 
+    def test_clear_saves_username_to_last_name(self):
+        self.user.clear()
+        self.user.refresh_from_db()
+        assert self.user.last_name == "alice"
+
+    def test_register_duplicate_username_raises(self):
+        with pytest.raises(ValidationError):
+            User.register(username="alice")
+
+    def test_register_no_username_raises(self):
+        with pytest.raises(ValueError, match="username is not set"):
+            User.register(username="")
+
+    def test_display_name(self):
+        assert self.user.display_name == self.user.identity.display_name
+
+    def test_mastodon_acct_empty_when_no_mastodon(self):
+        assert self.user.mastodon_acct == ""
+
+    def test_email_account_none_when_no_email(self):
+        assert self.user.email_account is None
+
+    def test_last_usage_none_when_no_marks(self):
+        assert self.user.last_usage is None
+
+    def test_last_usage_returns_time_when_marked(self):
+        book = Edition.objects.create(title="Test Book")
+        Mark(self.user.identity, book).update(ShelfType.WISHLIST)
+        assert self.user.last_usage is not None
+
+    def test_absolute_url_contains_domain(self):
+        assert "example.org" in self.user.absolute_url
+
+    def test_avatar_returns_value(self):
+        avatar = self.user.avatar
+        assert avatar is not None
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestAPIdentityModel:
@@ -178,3 +217,45 @@ class TestAPIdentityModel:
 
     def test_tag_manager_available(self):
         assert self.identity.tag_manager is not None
+
+    def test_get_by_handle_local(self):
+        found = APIdentity.get_by_handle("iduser")
+        assert found.pk == self.identity.pk
+
+    def test_get_by_handle_local_with_at(self):
+        found = APIdentity.get_by_handle("@iduser")
+        assert found.pk == self.identity.pk
+
+    def test_get_by_handle_nonexistent_raises(self):
+        with pytest.raises(APIdentity.DoesNotExist):
+            APIdentity.get_by_handle("nonexistent")
+
+    def test_get_by_handle_invalid_format_raises(self):
+        with pytest.raises(APIdentity.DoesNotExist):
+            APIdentity.get_by_handle("a@b@c@d")
+
+    def test_identity_clear(self):
+        self.identity.clear()
+        self.identity.refresh_from_db()
+        assert self.identity.deleted is not None
+
+    def test_following_identities_empty_initially(self):
+        assert list(self.identity.following_identities) == []
+
+    def test_follower_identities_empty_initially(self):
+        assert list(self.identity.follower_identities) == []
+
+    def test_blocking_identities_empty_initially(self):
+        assert list(self.identity.blocking_identities) == []
+
+    def test_muting_identities_empty_initially(self):
+        assert list(self.identity.muting_identities) == []
+
+    def test_is_person(self):
+        assert self.identity.is_person is True
+
+    def test_discoverable(self):
+        assert self.identity.discoverable is not None
+
+    def test_actor_type(self):
+        assert self.identity.actor_type is not None

--- a/users/apis.py
+++ b/users/apis.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from django.conf import settings
-from ninja import Schema
+from ninja import Schema, Status
 from ninja.schema import Field
 
 from common.api import NOT_FOUND, Result, api
@@ -43,7 +43,7 @@ class PreferenceSchema(Schema):
     tags=["user"],
 )
 def token(request):
-    return 200, {"active": request.auth is not None}
+    return Status(200, {"active": request.auth is not None})
 
 
 @api.get(
@@ -54,18 +54,21 @@ def token(request):
 )
 def me(request):
     accts = SocialAccount.objects.filter(user=request.user)
-    return 200, {
-        # "id": str(request.user.identity.pk),
-        "username": request.user.username,
-        "url": settings.SITE_INFO["site_url"] + request.user.url,
-        "external_acct": (
-            request.user.mastodon.handle if request.user.mastodon else None
-        ),
-        "external_accounts": accts,
-        "display_name": request.user.display_name,
-        "avatar": request.user.avatar,
-        "roles": request.user.get_roles(),
-    }
+    return Status(
+        200,
+        {
+            # "id": str(request.user.identity.pk),
+            "username": request.user.username,
+            "url": settings.SITE_INFO["site_url"] + request.user.url,
+            "external_acct": (
+                request.user.mastodon.handle if request.user.mastodon else None
+            ),
+            "external_accounts": accts,
+            "display_name": request.user.display_name,
+            "avatar": request.user.avatar,
+            "roles": request.user.get_roles(),
+        },
+    )
 
 
 @api.get(
@@ -75,7 +78,7 @@ def me(request):
     tags=["user"],
 )
 def preference(request):
-    return 200, request.user.preference
+    return Status(200, request.user.preference)
 
 
 @api.get(
@@ -95,13 +98,16 @@ def user(request, handle: str):
         return NOT_FOUND
     viewer = request.user.identity
     if target.is_blocking(viewer) or target.is_blocked_by(viewer):
-        return 403, {"message": "unavailable"}
-    return 200, {
-        "username": target.handle,
-        "url": target.url,
-        "external_acct": None,
-        "external_accounts": [],
-        "display_name": target.display_name,
-        "avatar": target.avatar,
-        "roles": target.user.get_roles() if target.local else [],
-    }
+        return Status(403, {"message": "unavailable"})
+    return Status(
+        200,
+        {
+            "username": target.handle,
+            "url": target.url,
+            "external_acct": None,
+            "external_accounts": [],
+            "display_name": target.display_name,
+            "avatar": target.avatar,
+            "roles": target.user.get_roles() if target.local else [],
+        },
+    )


### PR DESCRIPTION
## Summary
- Add 135 new tests targeting coverage gaps in core journal models, common utilities, and jsondata fields
- Fix musicbrainz `test_invalid_url_patterns` tests that were making real network calls (DNS CNAME lookups via bandcamp fallback, HTTP HEAD via RSS fallback), reducing `test_musicbrainz` runtime from ~15s to ~2.5s

## Coverage improvements (targeted files)

| File | Before | After |
|------|--------|-------|
| journal/models/utils.py | 59% | 89% |
| journal/models/tag.py | 75% | 91% |
| journal/models/note.py | 66% | 86% |
| common/models/jsondata.py | 69% | 88% |
| common/models/lang.py | 66% | 75% |
| journal/models/comment.py | 72% | 81% |
| common/utils.py | 57% | 69% |
| journal/models/common.py | 63% | 67% |

## Test plan
- [x] All 1052 tests pass
- [x] Pre-commit checks pass (ruff, ruff-format, ty, djlint)
- [x] No regressions in existing tests