### PR TITLE
feat: extract Douban author/musician links as related People

### DIFF
--- a/catalog/sites/douban.py
+++ b/catalog/sites/douban.py
@@ -2,11 +2,64 @@ import json
 import re
 
 from ..common import *
-from ..models import ItemCategory, SiteName
+from ..models import IdType, ItemCategory, SiteName
 from ..search import ExternalSearchResultItem
 
 RE_NUMBERS = re.compile(r"\d+\d*")
 RE_WHITESPACES = re.compile(r"\s+")
+
+_RE_PERSONAGE = re.compile(r"personage/(\d+)")
+_RE_AUTHOR = re.compile(r"(?:https?://book\.douban\.com)?/author/(\d+)")
+_RE_MUSICIAN = re.compile(r"(?:https?://music\.douban\.com)?/musician/(\d+)")
+
+_AUTHOR_URL_FMT = "https://book.douban.com/author/{}/"
+_MUSICIAN_URL_FMT = "https://music.douban.com/musician/{}/"
+
+
+def extract_people_links_from_anchors(anchors: list, limit: int = 15) -> list[dict]:
+    """Extract Douban person links from <a> elements.
+
+    Handles personage/N (direct), author/N, and musician/N (redirect) patterns.
+    Both absolute and relative URLs are supported.
+    """
+    seen: set[str] = set()
+    resources: list[dict] = []
+    for a in anchors:
+        href = a.get("href", "")
+        if not href:
+            continue
+        # Direct personage link
+        m = _RE_PERSONAGE.search(href)
+        if m:
+            pid = m.group(1)
+            if pid in seen:
+                continue
+            seen.add(pid)
+            resources.append(
+                {
+                    "model": "People",
+                    "id_type": IdType.DoubanPersonage,
+                    "id_value": pid,
+                    "url": f"https://www.douban.com/personage/{pid}/",
+                }
+            )
+        else:
+            # Author or musician link -- resolved via HTTP redirect
+            m_author = _RE_AUTHOR.search(href)
+            m_musician = _RE_MUSICIAN.search(href)
+            if m_author:
+                url = _AUTHOR_URL_FMT.format(m_author.group(1))
+            elif m_musician:
+                url = _MUSICIAN_URL_FMT.format(m_musician.group(1))
+            else:
+                continue
+            if url in seen:
+                continue
+            seen.add(url)
+            resources.append({"url": url})
+        if len(resources) >= limit:
+            break
+    return resources
 
 
 class DoubanDownloader(ScrapDownloader):

--- a/catalog/sites/douban_book.py
+++ b/catalog/sites/douban_book.py
@@ -3,7 +3,13 @@ from catalog.models import *
 from catalog.models.utils import *
 from common.models.lang import detect_language
 
-from .douban import RE_NUMBERS, RE_WHITESPACES, DoubanDownloader, DoubanSearcher
+from .douban import (
+    RE_NUMBERS,
+    RE_WHITESPACES,
+    DoubanDownloader,
+    DoubanSearcher,
+    extract_people_links_from_anchors,
+)
 
 
 @SiteManager.register
@@ -183,6 +189,31 @@ class DoubanBook(AbstractSite):
         else:
             translators = None
 
+        # Extract author/translator person links for related resources
+        author_anchors = self.query_list(
+            content,
+            """//div[@id='info']//span[text()='作者:']/following-sibling::br[1]/
+            preceding-sibling::a[preceding-sibling::span[text()='作者:']]""",
+        )
+        if not author_anchors:
+            author_anchors = self.query_list(
+                content,
+                """//div[@id='info']//span[text()=' 作者']/following-sibling::a""",
+            )
+        translator_anchors = self.query_list(
+            content,
+            """//div[@id='info']//span[text()='译者:']/following-sibling::br[1]/
+            preceding-sibling::a[preceding-sibling::span[text()='译者:']]""",
+        )
+        if not translator_anchors:
+            translator_anchors = self.query_list(
+                content,
+                """//div[@id='info']//span[text()=' 译者']/following-sibling::a""",
+            )
+        related_people = extract_people_links_from_anchors(
+            author_anchors + translator_anchors
+        )
+
         cncode_elem = self.query_list(
             content, "//div[@id='info']//span[text()='统一书号:']/following::text()"
         )
@@ -248,6 +279,9 @@ class DoubanBook(AbstractSite):
                     },
                 }
             ]
+
+        if related_people:
+            data["related_resources"] = related_people
 
         pd = ResourceContent(metadata=data)
         t, n = detect_isbn_asin(isbn or "")

--- a/catalog/sites/douban_movie.py
+++ b/catalog/sites/douban_movie.py
@@ -8,7 +8,7 @@ from catalog.models import *
 from common.models.lang import detect_language
 from common.models.misc import int_
 
-from .douban import DoubanDownloader, DoubanSearcher
+from .douban import DoubanDownloader, DoubanSearcher, extract_people_links_from_anchors
 from .tmdb import TMDB_TV, search_tmdb_by_imdb_id
 
 
@@ -329,31 +329,9 @@ def _extract_personage_links(content) -> list[dict]:
 
     Collects directors, playwrights, and top 10 actors as related People resources.
     """
-    seen_ids: set[str] = set()
-    resources: list[dict] = []
-
+    anchors = []
     for role_label in ["导演", "编剧", "主演"]:
-        anchors = content.xpath(
+        anchors += content.xpath(
             f"//div[@id='info']//span[text()='{role_label}']/following-sibling::span[1]/a"
         )
-        for a in anchors:
-            href = a.get("href", "")
-            name = "".join(a.itertext()).strip()
-            m = re.search(r"personage/(\d+)", href)
-            if not m or not name:
-                continue
-            pid = m.group(1)
-            if pid in seen_ids:
-                continue
-            seen_ids.add(pid)
-            resources.append(
-                {
-                    "model": "People",
-                    "id_type": IdType.DoubanPersonage,
-                    "id_value": pid,
-                    "url": f"https://www.douban.com/personage/{pid}/",
-                }
-            )
-            if len(resources) >= 15:
-                return resources
-    return resources
+    return extract_people_links_from_anchors(anchors)

--- a/catalog/sites/douban_music.py
+++ b/catalog/sites/douban_music.py
@@ -5,7 +5,7 @@ from catalog.models import *
 from catalog.models.utils import upc_to_gtin_13
 from common.models.lang import detect_language
 
-from .douban import DoubanDownloader, DoubanSearcher
+from .douban import DoubanDownloader, DoubanSearcher, extract_people_links_from_anchors
 
 
 @SiteManager.register
@@ -38,12 +38,17 @@ class DoubanMusic(AbstractSite):
         if not title:
             raise ParseError(self, "title")
 
-        artists_elem = self.query_list(
-            content, "//div[@id='info']/span/span[@class='pl']/a/text()"
+        artist_anchors = self.query_list(
+            content, "//div[@id='info']/span/span[@class='pl']/a"
         )
         artist = (
-            None if not artists_elem else list(map(lambda a: a[:200], artists_elem))
+            None
+            if not artist_anchors
+            else list(
+                map(lambda a: "".join(a.itertext()).strip()[:200], artist_anchors)
+            )
         )
+        related_people = extract_people_links_from_anchors(artist_anchors)
 
         genre_elem = self.query_list(
             content, "//div[@id='info']//span[text()='流派:']/following::text()[1]"
@@ -103,6 +108,8 @@ class DoubanMusic(AbstractSite):
             "brief": brief,
             "cover_image_url": img_url,
         }
+        if related_people:
+            data["related_resources"] = related_people
         gtin = None
         isrc = None
         other_elem = self.query_list(

--- a/test_data/https___book_douban_com_subject_36255848_
+++ b/test_data/https___book_douban_com_subject_36255848_
@@ -1,0 +1,3484 @@
+<!DOCTYPE html><html lang="zh-cmn-Hans" class="ua-mac ua-webkit book-new-nav"><head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>
+  工厂日记 (豆瓣)
+ </title>
+  
+<script type="text/javascript" defer="" async="" src="https://s.doubanio.com/dae/fundin/piwik.js"></script><script type="text/javascript" src="//img1.doubanio.com/ZHdhZ2Y4eC9mL2FkanMvZmE3NGZkMWY5NzhhZmM4NmZhZjMxMTllNTQ5MGIyYWRlNTUwYmI0NS9hZC5yZWxlYXNlLmpz?company_token=kX69T8w1wyOE-dale" async="true"></script><script type="text/javascript" async="" src="https://dn-growing.qbox.me/vds.js"></script><script>!function(e){var o=function(o,n,t){var c,i,r=new Date;n=n||30,t=t||"/",r.setTime(r.getTime()+24*n*60*60*1e3),c="; expires="+r.toGMTString();for(i in o)e.cookie=i+"="+o[i]+c+"; path="+t},n=function(o){var n,t,c,i=o+"=",r=e.cookie.split(";");for(t=0,c=r.length;t<c;t++)if(n=r[t].replace(/^\s+|\s+$/g,""),0==n.indexOf(i))return n.substring(i.length,n.length).replace(/\"/g,"");return null},t=e.write,c={"douban.com":1,"douban.fm":1,"google.com":1,"google.cn":1,"googleapis.com":1,"gmaptiles.co.kr":1,"gstatic.com":1,"gstatic.cn":1,"google-analytics.com":1,"googleadservices.com":1},i=function(e,o){var n=new Image;n.onload=function(){},n.src="https://www.douban.com/j/except_report?kind=ra022&reason="+encodeURIComponent(e)+"&environment="+encodeURIComponent(o)},r=function(o){try{t.call(e,o)}catch(e){t(o)}},a=/<script.*?src\=["']?([^"'\s>]+)/gi,g=/http:\/\/(.+?)\.([^\/]+).+/i;e.writeln=e.write=function(e){var t,l=a.exec(e);return l&&(t=g.exec(l[1]))?c[t[2]]?void r(e):void("tqs"!==n("hj")&&(i(l[1],location.href),o({hj:"tqs"},1),setTimeout(function(){location.replace(location.href)},50))):void r(e)}}(document);</script>
+
+  
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="Sun, 6 Mar 2005 01:00:00 GMT">
+  <meta name="referrer" content="always">
+  <meta name="renderer" content="webkit">
+  
+<meta http-equiv="mobile-agent" content="format=html5; url=https://m.douban.com/book/subject/36255848/">
+<meta name="keywords" content="工厂日记,[法]西蒙娜·薇依,上海人民出版社,2023-4-30,简介,作者,书评,论坛,推荐,二手">
+<meta name="description" content="图书工厂日记 介绍、书评、论坛及推荐 ">
+
+  <script>var _head_start = new Date();</script>
+  
+  <link href="https://img1.doubanio.com/f/vendors/fae7e145bf16b2f427ba0fe7ef3d47c04af3a6c0/css/douban.css" rel="stylesheet" type="text/css">
+  <link href="https://img1.doubanio.com/cuphead/book-static/common/master.dfbf0.css" rel="stylesheet" type="text/css">
+
+  <link href="https://img3.doubanio.com/cuphead/book-static/base/init.e399f.css" rel="stylesheet">
+  <style type="text/css"></style>
+  <script src="https://img1.doubanio.com/f/vendors/0511abe9863c2ea7084efa7e24d1d86c5b3974f1/js/jquery-1.10.2.min.js"></script>
+  <script src="https://img1.doubanio.com/f/vendors/e258329ca4b2122b4efe53fddc418967441e0e7f/js/douban.js"></script>
+  <script src="https://img3.doubanio.com/cuphead/book-static/common/master.3c0a3.js"></script>
+  
+
+  
+  <link rel="stylesheet" href="https://img1.doubanio.com/f/vendors/b6814ac068f705a1366083b58858a468706a60dc/css/lib/jquery.snippet.css">
+  <link rel="stylesheet" href="https://img3.doubanio.com/cuphead/book-static/subject/index.616aa.css">
+  <link rel="stylesheet" href="https://img1.doubanio.com/f/vendors/e8a7261937da62636d22ca4c579efc4a4d759b1b/css/ui/dialog.css">
+  <script src="https://img1.doubanio.com/f/vendors/7965e09b0065d26bfd22d390de956c22a48b9008/js/lib/jquery.snippet.js"></script>
+  <script src="https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js"></script>
+  <script src="https://img3.doubanio.com/cuphead/book-static/mod/hide.dd5b3.js"></script>
+  <script src="https://img1.doubanio.com/cuphead/book-static/subject/unfold.55bcc.js"></script>
+    <link rel="alternate" href="https://book.douban.com/feed/subject/36255848/reviews" type="application/rss+xml" title="RSS">
+  <style type="text/css"> h2 {color: #007722;} </style>
+  <script type="text/javascript">
+    var _vds = _vds || [];
+    (function(){ _vds.push(['setAccountId', '22c937bbd8ebd703f2d8e9445f7dfd03']);
+        _vds.push(['setCS1','user_id','0']);
+            (function() {var vds = document.createElement('script');
+                vds.type='text/javascript';
+                vds.async = true;
+                vds.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'dn-growing.qbox.me/vds.js';
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(vds, s);
+            })();
+    })();
+</script>
+
+  
+  <script type="text/javascript">
+    var _vwo_code=(function(){
+      var account_id=249272,
+          settings_tolerance=2000,
+          library_tolerance=2500,
+          use_existing_jquery=false,
+          // DO NOT EDIT BELOW THIS LINE
+          f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random());return settings_timer;}};}());_vwo_settings_timer=_vwo_code.init();
+  </script><script src="//dev.visualwebsiteoptimizer.com/j.php?a=249272&amp;u=https%3A%2F%2Fbook.douban.com%2Fsubject%2F36255848%2F&amp;r=0.3402730189546731" type="text/javascript"></script>
+
+  
+
+
+<script type="application/ld+json">
+{
+  "@context":"http://schema.org",
+  "@type":"Book",
+  "workExample": [],
+  "name" : "工厂日记",
+  "author": 
+  [
+    {
+      "@type": "Person",
+      "name": "[法]西蒙娜·薇依"
+    }
+  ]
+,
+  "url" : "https://book.douban.com/subject/36255848/",
+  "isbn" : "9787208181564",
+  "sameAs": "https://book.douban.com/subject/36255848/"
+}
+</script>
+
+  
+  
+  <meta property="og:title" content="工厂日记">
+  <meta property="og:description" content="****
+法国向当代世界奉献出的一份珍贵礼物：西蒙娜·薇依。
+——切斯瓦夫·米沃什
+*****内容简介******
+如何摆脱工作中的痛苦和烦闷？为了像被压迫者那样感受压迫并尽可能真实地追求她所认为的自...">
+  <meta property="og:site_name" content="豆瓣">
+  <meta property="og:url" content="https://book.douban.com/subject/36255848/">
+  <meta property="og:image" content="https://img1.doubanio.com/view/subject/l/public/s34501309.jpg">
+  <meta property="og:type" content="book">
+      <meta property="book:author" content="[法]西蒙娜·薇依">
+  <meta property="book:isbn" content="9787208181564">
+
+
+  <script>  </script>
+  <style type="text/css">
+#db-discussion-section .olt { margin-bottom: 7px; }
+</style>
+
+  <link rel="shortcut icon" href="https://img1.doubanio.com/favicon.ico" type="image/x-icon">
+<style type="text/css" id="css-share-button">.bn-sharing{padding-right:10px;background-image:url(//img3.doubanio.com/pics/a1.png) !important;background-repeat:no-repeat !important;background-position:100% -19px !important;}a.bn-sharing:hover{text-decoration:underline;}.bn-sharing-on{background-position:100% 4px !important;position:relative !important;z-index:1 !important;}#db-div-sharing{position:absolute;width:100px;}#db-div-sharing .bd{border:1px solid #aaa;background:#fff;padding:10px 0 0 10px;}#db-div-sharing .bd li{line-height:20px;margin-bottom:5px;}#db-div-sharing .hd{position:absolute;height:24px;overflow:hidden;right:0;top:-24px;padding:0 5px;border:1px solid #aaa;border-bottom:none;background:#fff;}.rec-ren,.rec-sin,.rec-douban,.rec-tx,.rec-sohu,.rec-qqim,.rec-wechat{padding-left:23px;background:url(//img3.doubanio.com/img/files/file-1395904010.png) no-repeat 0 0;}.rec-wechat{background-position:0 0;}.rec-sin{background-position:0 -20px;}.rec-qqim{background-position:0 -40px;}.rec-tx{background-position:0 -60px;}.rec-ren{background-position:0 -80px;}.rec-douban{background-position:0 -100px;}</style><script src="https://ssl.google-analytics.com/ga.js" async="true"></script></head>
+<body style="">
+  
+    <script>var _body_start = new Date();</script>
+    
+  
+
+
+
+    <link href="//img3.doubanio.com/dae/accounts/resources/f8b2226/shire/bundle.css" rel="stylesheet" type="text/css">
+
+
+
+<div id="db-global-nav" class="global-nav">
+  <div class="bd">
+    
+<div class="top-nav-info">
+  <a href="https://accounts.douban.com/passport/login?source=book" class="nav-login" rel="nofollow">登录/注册</a>
+</div>
+
+
+    <div class="top-nav-doubanapp">
+  <a href="https://www.douban.com/doubanapp/app?channel=top-nav" class="lnk-doubanapp">下载豆瓣客户端</a>
+  <div id="doubanapp-tip">
+    <a href="https://www.douban.com/doubanapp/app?channel=qipao" class="tip-link">豆瓣 <span class="version">6.0</span> 全新发布</a>
+    <a href="javascript: void 0;" class="tip-close">×</a>
+  </div>
+  <div id="top-nav-appintro" class="more-items">
+    <p class="appintro-title">豆瓣</p>
+    <p class="qrcode">扫码直接下载</p>
+    <div class="download">
+      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&amp;direct_dl=1&amp;download=iOS">iPhone</a>
+      <span>·</span>
+      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&amp;direct_dl=1&amp;download=Android" class="download-android">Android</a>
+    </div>
+  </div>
+</div>
+
+    
+
+
+<div class="global-nav-items">
+  <ul>
+    <li class="">
+      <a href="https://www.douban.com" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-main&quot;,&quot;uid&quot;:&quot;0&quot;}">豆瓣</a>
+    </li>
+    <li class="on">
+      <a href="https://book.douban.com" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-book&quot;,&quot;uid&quot;:&quot;0&quot;}">读书</a>
+    </li>
+    <li class="">
+      <a href="https://movie.douban.com" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-movie&quot;,&quot;uid&quot;:&quot;0&quot;}">电影</a>
+    </li>
+    <li class="">
+      <a href="https://music.douban.com" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-music&quot;,&quot;uid&quot;:&quot;0&quot;}">音乐</a>
+    </li>
+    <li class="">
+      <a href="https://www.douban.com/podcast/" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-podcast&quot;,&quot;uid&quot;:&quot;0&quot;}">播客</a>
+    </li>
+    <li class="">
+      <a href="https://www.douban.com/location" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-location&quot;,&quot;uid&quot;:&quot;0&quot;}">同城</a>
+    </li>
+    <li class="">
+      <a href="https://www.douban.com/group" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-group&quot;,&quot;uid&quot;:&quot;0&quot;}">小组</a>
+    </li>
+    <li class="">
+      <a href="https://read.douban.com/?dcs=top-nav&amp;dcm=douban" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-read&quot;,&quot;uid&quot;:&quot;0&quot;}">阅读</a>
+    </li>
+    <li class="">
+      <a href="https://fm.douban.com/?from_=shire_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-fm&quot;,&quot;uid&quot;:&quot;0&quot;}">FM</a>
+    </li>
+    <li class="">
+      <a href="https://time.douban.com/?dt_time_source=douban-web_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-time&quot;,&quot;uid&quot;:&quot;0&quot;}">时间</a>
+    </li>
+    <li class="">
+      <a href="https://market.douban.com/?utm_campaign=douban_top_nav&amp;utm_source=douban&amp;utm_medium=pc_web" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-market&quot;,&quot;uid&quot;:&quot;0&quot;}">豆品</a>
+    </li>
+  </ul>
+</div>
+
+  </div>
+</div>
+<script>
+  ;window._GLOBAL_NAV = {
+    DOUBAN_URL: "https://www.douban.com",
+    N_NEW_NOTIS: 0,
+    N_NEW_DOUMAIL: 0
+  };
+</script>
+
+
+
+    <script src="//img3.doubanio.com/dae/accounts/resources/f8b2226/shire/bundle.js" defer="defer"></script>
+
+
+
+
+  
+
+
+    <link href="//img3.doubanio.com/dae/accounts/resources/f8b2226/book/bundle.css" rel="stylesheet" type="text/css">
+
+
+
+
+<div id="db-nav-book" class="nav">
+  <div class="nav-wrap">
+  <div class="nav-primary">
+    <div class="nav-logo">
+      <a href="https://book.douban.com">豆瓣读书</a>
+    </div>
+    <div class="nav-search">
+      <form action="https://search.douban.com/book/subject_search" method="get">
+        <fieldset>
+          <legend>搜索：</legend>
+          <label for="inp-query">
+          </label>
+          <div class="inp"><input id="inp-query" name="search_text" size="22" maxlength="60" placeholder="书名、作者、ISBN" value="" autocomplete="off"></div>
+          <div class="inp-btn"><input type="submit" value="搜索"></div>
+          <input type="hidden" name="cat" value="1001">
+        </fieldset>
+      </form>
+    </div>
+  </div>
+  </div>
+  <div class="nav-secondary">
+    
+
+<div class="nav-items">
+  <ul>
+    <li><a href="https://book.douban.com/cart/">购书单</a>
+    </li>
+    <li><a href="https://read.douban.com/ebooks/?dcs=book-nav&amp;dcm=douban" target="_blank">电子图书</a>
+    </li>
+    <li><a href="https://book.douban.com/annual/2025/?fullscreen=1&amp;dt_from=navigation" target="_blank">2025年度榜单</a>
+    </li>
+    <li><a href="https://c9.douban.com/app/standbyme-2025/?autorotate=false&amp;fullscreen=true&amp;hidenav=true&amp;monitor_screenshot=true&amp;dt_from=web_navigation" target="_blank">2025年度报告</a>
+    </li>
+  </ul>
+</div>
+
+    <a href="https://book.douban.com/annual/2025/?fullscreen=1&amp;&amp;dt_from=book_navigation" class="bookannual"></a>
+  </div>
+</div>
+
+<script id="suggResult" type="text/x-jquery-tmpl">
+  <li data-link="{{= url}}">
+            <a href="{{= url}}" onclick="moreurl(this, {from:'book_search_sugg', query:'{{= keyword }}', subject_id:'{{= id}}', i: '{{= index}}', type: '{{= type}}'})">
+            <img src="{{= pic}}" width="40" />
+            <div>
+                <em>{{= title}}</em>
+                {{if year}}
+                    <span>{{= year}}</span>
+                {{/if}}
+                <p>
+                {{if type == "b"}}
+                    {{= author_name}}
+                {{else type == "a" }}
+                    {{if en_name}}
+                        {{= en_name}}
+                    {{/if}}
+                {{/if}}
+                 </p>
+            </div>
+        </a>
+        </li>
+  </script>
+
+
+
+
+    <script src="//img3.doubanio.com/dae/accounts/resources/f8b2226/book/bundle.js" defer="defer"></script>
+
+
+
+
+    <div id="wrapper">
+        
+
+  
+    <!-- rank label begin -->
+    <link rel="stylesheet" href="https://img1.doubanio.com/cuphead/book-static/subject/rank_label.dda40.css">
+    <div class="rank-label rank-label-other">
+        <span class="rank-label-no">
+          <span>No.10</span>
+        </span>
+      <span class="rank-label-link">
+        <a href="https://m.douban.com/subject_collection/ECTY6MD2Y" target="_blank">豆瓣2023年度社会·纪实图书</a>
+      </span>
+    </div>
+
+    <!-- rank label end -->
+
+    <h1 class="title">
+      <span property="v:itemreviewed">工厂日记</span>
+      <div class="clear"></div>
+    </h1>
+
+
+        
+  <div id="content">
+    
+    <div class="grid-16-8 clearfix">
+      
+      <div class="article">
+<div class="indent">
+  <div class="subjectwrap clearfix">
+    
+    
+
+
+
+<div class="subject clearfix">
+<div id="mainpic" class="">
+
+  
+
+  <a class="nbg" href="https://img1.doubanio.com/view/subject/l/public/s34501309.jpg" title="工厂日记">
+      <img src="https://img1.doubanio.com/view/subject/s/public/s34501309.jpg" title="点击看大图" alt="工厂日记" rel="v:photo" style="max-width: 135px;max-height: 200px;">
+  </a>
+</div>
+
+
+
+
+
+<div id="info" class="">
+
+
+
+    
+    
+  
+    <span>
+      <span class="pl"> 作者</span>:
+        
+            <a class="" href="/author/4608425">[法]西蒙娜·薇依</a>
+    </span><br>
+
+    
+    
+  
+    <span>
+      <span class="pl"> 译者</span>:
+        
+            
+            <a class="" href="/search/%E7%8E%8B%E5%A4%A9%E5%AE%87">王天宇</a>
+    </span><br>
+
+    
+    
+  
+
+    
+    
+  
+
+    
+    
+  
+
+    
+    
+  
+
+    
+    
+  
+    <span class="pl">出版社:</span>
+      <a href="https://book.douban.com/press/2733">上海人民出版社</a>
+    <br>
+
+    
+    
+  
+
+    
+    
+  
+    <span class="pl">出版年:</span> 2023-4-30<br>
+
+    
+    
+  
+    
+      
+      <span class="pl">ISBN:</span> 9787208181564<br>
+
+    
+    
+  
+
+    
+    
+  
+    <span class="pl">页数:</span> 340<br>
+
+    
+    
+  
+    <span class="pl">装帧:</span> 精装<br>
+
+    
+    
+  
+    <span class="pl">定价:</span> 58.00<br>
+
+    
+    
+  
+    <span class="pl">原作名:</span> La Condition ouvrière<br>
+
+    
+    
+  
+
+
+</div>
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+        
+
+
+
+
+
+<div id="interest_sectl" class="">
+  <div class="rating_wrap clearbox" rel="v:rating">
+    <div class="rating_logo">
+            豆瓣评分
+    </div>
+    <div class="rating_self clearfix" typeof="v:Rating">
+      <strong class="ll rating_num " property="v:average"> 8.8 </strong>
+      <span property="v:best" content="10.0"></span>
+      <div class="rating_right ">
+          <div class="ll bigstar45"></div>
+            <div class="rating_sum">
+                <span class="">
+                    <a href="comments" class="rating_people"><span property="v:votes">2159</span>人评价</a>
+                </span>
+            </div>
+
+
+      </div>
+    </div>
+          
+            
+            
+<span class="stars5 starstop" title="力荐">
+    5星
+</span>
+
+            
+<div class="power" style="width:64px"></div>
+
+            <span class="rating_per">50.0%</span>
+            <br>
+            
+            
+<span class="stars4 starstop" title="推荐">
+    4星
+</span>
+
+            
+<div class="power" style="width:49px"></div>
+
+            <span class="rating_per">38.8%</span>
+            <br>
+            
+            
+<span class="stars3 starstop" title="还行">
+    3星
+</span>
+
+            
+<div class="power" style="width:11px"></div>
+
+            <span class="rating_per">9.3%</span>
+            <br>
+            
+            
+<span class="stars2 starstop" title="较差">
+    2星
+</span>
+
+            
+<div class="power" style="width:1px"></div>
+
+            <span class="rating_per">1.3%</span>
+            <br>
+            
+            
+<span class="stars1 starstop" title="很差">
+    1星
+</span>
+
+            
+<div class="power" style="width:0px"></div>
+
+            <span class="rating_per">0.7%</span>
+            <br>
+  </div>
+</div>
+
+  </div>
+  
+      
+
+
+
+
+
+
+  
+  <div id="interest_sect_level" class="clearfix">
+      <a href="#" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-36255848-wish">
+        <span>
+          
+<form method="POST" action="https://www.douban.com/register?reason=collectwish" class="miniform">
+    <input type="submit" class="minisubmit j  " value="想读" title="">
+</form>
+
+        </span>
+      </a>
+      <a href="#" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-36255848-do">
+        <span>
+          
+<form method="POST" action="https://www.douban.com/register?reason=collectdo" class="miniform">
+    <input type="submit" class="minisubmit j  " value="在读" title="">
+</form>
+
+        </span>
+      </a>
+      <a href="#" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-36255848-collect">
+        <span>
+          
+<form method="POST" action="https://www.douban.com/register?reason=collectcollect" class="miniform">
+    <input type="submit" class="minisubmit j  " value="读过" title="">
+</form>
+
+        </span>
+      </a>
+    <div class="ll j a_stars">
+        
+
+<span class="j a_stars">
+  <span class="rate_stars">
+    评价: 
+    <span id="rating">
+        <span id="stars" data-solid="https://img1.doubanio.com/f/vendors/5a2327c04c0c231bced131ddf3f4467eb80c1c86/pics/rating_icons/star_onmouseover.png" data-hollow="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png">        <a href="https://www.douban.com/accounts/passport/login?source=book" class="j a_show_login" name="pbtn-36255848-1"><img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star1" width="16" height="16"></a>        <a href="https://www.douban.com/accounts/passport/login?source=book" class="j a_show_login" name="pbtn-36255848-2"><img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star2" width="16" height="16"></a>        <a href="https://www.douban.com/accounts/passport/login?source=book" class="j a_show_login" name="pbtn-36255848-3"><img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star3" width="16" height="16"></a>        <a href="https://www.douban.com/accounts/passport/login?source=book" class="j a_show_login" name="pbtn-36255848-4"><img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star4" width="16" height="16"></a>        <a href="https://www.douban.com/accounts/passport/login?source=book" class="j a_show_login" name="pbtn-36255848-5"><img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star5" width="16" height="16"></a>      </span>
+      <span id="rateword" class="pl"></span>
+      <input id="n_rating" type="hidden" value="">
+    </span>
+  </span>
+</span>
+
+
+
+
+
+
+    </div>
+  </div>
+
+
+  
+
+
+
+
+
+
+
+  
+  <div class="gtleft">
+    <ul class="ul_subject_menu bicelink color_gray pt6 clearfix">
+        <li>
+          <img src="https://img1.doubanio.com/f/vendors/5bbf02b7b5ec12b23e214a580b6f9e481108488c/pics/add-review.gif">&nbsp;
+          <a class="j a_show_login" href="https://book.douban.com/annotation/write?sid=36255848" rel="nofollow">写笔记</a>
+        </li>
+
+        <li>
+          <img src="https://img1.doubanio.com/f/vendors/5bbf02b7b5ec12b23e214a580b6f9e481108488c/pics/add-review.gif">&nbsp;<a class="j a_show_login" href="https://book.douban.com/subject/36255848/new_review" rel="nofollow">写书评</a>
+        </li>
+
+        <li>
+
+<span class="rr">
+
+
+    <img src="https://img1.doubanio.com/f/shire/46e66a46baff206223e608c521bb3724536b03b6/pics/add-cart.gif">
+      <a class="j a_show_login" href="https://www.douban.com/accounts/passport/login?source=book" rel="nofollow">加入购书单</a>
+  <span class="hidden">已在<a href="https://book.douban.com/cart">购书单</a></span>
+</span><br class="clearfix">
+</li>
+
+
+        
+        
+    
+    <li class="rec" id="C-36255848">
+        <a href="#" data-url="https://book.douban.com/subject/36255848/" data-desc="" data-title="书籍《工厂日记》 (来自豆瓣) " data-pic="https://img1.doubanio.com/view/subject/l/public/s34501309.jpg" class="bn-sharing ">分享到</a> &nbsp;&nbsp;
+    </li>
+    <script>
+      window.DoubanShareIcons = "https://img1.doubanio.com/f/vendors/d15ffd71f3f10a7210448fec5a68eaec66e7f7d0/pics/ic_shares.png";
+    </script>
+    <script src="https://img1.doubanio.com/f/vendors/b6e0770163b1da14217b0f1ca39189d47b95f51f/js/lib/sharebutton.js"></script>
+
+    </ul>
+  </div>
+
+
+
+
+
+    
+
+
+
+
+
+
+
+<div class="rec-sec">
+
+    <span class="rec">
+
+<a href="https://www.douban.com/accounts/register?reason=collect" class="j a_show_login lnk-sharing lnk-douban-sharing">推荐</a>
+</span>
+</div>
+
+
+<script>
+  //bind events for collection button.
+  $('.collect_btn', '#interest_sect_level').each(function(){
+      Douban.init_collect_btn(this);
+  });
+</script>
+
+</div>
+
+<br clear="all">
+<div id="collect_form_36255848"></div>
+<div class="related_info">
+  
+
+
+
+
+
+
+  
+
+  <h2>
+    <span>内容简介</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+<div class="indent" id="link-report">
+    
+      <div class="">
+        <style type="text/css" media="screen">
+.intro p{text-indent:2em;word-break:normal;}
+</style>
+<div class="intro">
+    <p>****</p>    <p>法国向当代世界奉献出的一份珍贵礼物：西蒙娜·薇依。</p>    <p>——切斯瓦夫·米沃什</p>    <p>*****内容简介******</p>    <p>如何摆脱工作中的痛苦和烦闷？为了像被压迫者那样感受压迫并尽可能真实地追求她所认为的自由社会，1934年12月，西蒙娜·薇依抛下哲学教师的身份，进入工厂。在将近一年的时间里，这位反叛的哲学教师轮流做切割工、包装工和铣床工，经历疾病、事故、解雇的折磨，遭受服从、羞辱和不公。这种残酷性给她留下了终生的烙印。</p>    <p>在这本《工厂日记》中，薇依记录下自己的观察、遭遇、工作时间和收入、肉体和精神的痛苦，以及对这段经历的哲学和道德的思考。这本书是一份原始的文件，没有抒情，也没有感伤，展现出西蒙娜·薇依对当下现实的关注和她始终站在劳动者一边的立场。</p></div>
+
+      </div>
+    
+
+</div>
+
+
+  
+
+
+
+
+<link rel="stylesheet" href="https://img3.doubanio.com/cuphead/book-static/subject/authors_section.6a54a.css">
+<h2>
+    
+  
+
+  </h2><h2>
+    <span>工厂日记的创作者</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+<div class="indent">
+  <p></p>
+  <div id="authors" class="authors">
+  <ul class="authors-list from-subject __oneline">
+          
+          <li class="author">
+              <a href="https://book.douban.com/author/4608425/" title="[法国] 西蒙娜·薇依">
+                  <img src="https://img1.doubanio.com/img/author/medium/public/k_EVqCd9P1gcel_avatar_uploaded1510746366.38.jpg" alt="[法国] 西蒙娜·薇依" class="avatar">
+              </a>
+              <div class="info">
+                  <a href="https://book.douban.com/author/4608425/" title="[法国] 西蒙娜·薇依" class="name">西蒙娜·薇依</a>
+                  <span class="role">作者</span>
+              </div>
+          </li>
+      <li class="author fake fake5"></li>
+  </ul>
+  </div>
+</div>
+
+
+  
+
+
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+    
+  
+
+  <h2>
+    <span>作者简介</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+      <div class="indent ">
+          
+            <div class="">
+            <style type="text/css" media="screen">
+.intro p{text-indent:2em;word-break:normal;}
+</style>
+<div class="intro">
+    <p>西蒙娜·薇依(Simone Weil,1909-1943)，20世纪最具原创性的法国哲学家、政治思想家、社会活动家。1909年2月3日生于法国巴黎一个文化教养很高的富裕的中产阶级家庭。1926年到1931年，薇依以第一名成绩考入巴黎高师从事哲学学习和研究。1931年到1934年，薇依先后在外省的几所中学任哲学教师。从1940年到1943年，薇依对以往的劳动、战斗、政治参与和社会活动的经历进行理论总结。在马赛、纽约，最后到伦敦，她写了一本又一本的笔记，内容涉及哲学、历史、政治直至1943年8月因饥饿、重病死于伦敦郊区的修道院，年仅34岁。她的大部分作品都是在死后出版的，受到广泛好评。其主要著作有：《柏拉图对话中的神》《被拯救的威尼斯》《在期待之中》《工厂日记》等。</p></div>
+
+            </div>
+      </div>
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+  
+
+
+
+
+
+
+  
+
+  
+    
+
+
+
+
+  
+
+  <h2>
+    <span>目录</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+<div class="indent" id="dir_36255848_short">
+        前言<br>
+        一、给阿尔贝蒂娜·泰弗农女士的三封信（1934-1935年）<br>
+        二、给一位学生的信（1934年）<br>
+        三、给鲍里斯·苏瓦林的信（1935年）<br>
+        四、致X的信件片段（1933-1934年？）<br>
+        五、工厂日记（1934-1935年）<br>
+    · · · · · ·
+    (<a href="javascript:$('#dir_36255848_short').hide();$('#dir_36255848_full').show();$.get('/j/subject/j_dir_count',{id:36255848});void(0);">更多</a>)
+</div>
+
+<div class="indent" id="dir_36255848_full" style="display:none">
+        前言<br>
+        一、给阿尔贝蒂娜·泰弗农女士的三封信（1934-1935年）<br>
+        二、给一位学生的信（1934年）<br>
+        三、给鲍里斯·苏瓦林的信（1935年）<br>
+        四、致X的信件片段（1933-1934年？）<br>
+        五、工厂日记（1934-1935年）<br>
+        六、片段<br>
+        七、致一位工程师兼工厂经理的信（布尔日，1936年1月-6月）<br>
+        八、（工作中的）冶金女工的生活及罢工运动（1936年6月10日）<br>
+        九、致工会会员的一封公开信（1936年6月后）<br>
+        十、给奥古斯特·德留夫的信（1936—1937年）<br>
+        十一、关于从北方冲突中吸取教训的建议（1936—1937年？）<br>
+        十二、建立工业企业内部新制度的计划准则（1936—1937年？）<br>
+        十三、合理化改革（1937年2月23日）<br>
+        十四、工人的境况（1937年9月30日）<br>
+        十五、工厂生活经历（马赛，1941—1942年）<br>
+        十六、非奴役性工作的首要条件（马赛，1941—1942年）<br>
+     · · · · · ·     (<a href="javascript:$('#dir_36255848_full').hide();$('#dir_36255848_short').show();void(0);">收起</a>)
+</div>
+
+
+
+
+  
+
+
+<link rel="stylesheet" href="https://img1.doubanio.com/f/verify/a5bc0bc0aea4221d751bc4809fd4b0a1075ad25e/entry_creator/dist/author_subject/style.css">
+
+<div id="author_subject" class="author-wrapper"><div class="author-subject"></div></div>
+
+<script type="text/javascript">
+  var answerObj = {
+    TYPE: 'book',
+    SUBJECT_ID: '36255848',
+    ISALL: 'False' || false,
+    USER_ID: 'None'
+  }
+</script>
+<!-- 使用 vendors 提供的 react & react-dom -->
+<script src="https://img1.doubanio.com/f/vendors/bd6325a12f40c34cbf2668aafafb4ccd60deab7e/vendors.js"></script>
+<script src="https://img1.doubanio.com/f/vendors/6242a400cfd25992da35ace060e58f160efc9c50/shared_rc.js"></script>
+<script type="text/javascript" src="https://img1.doubanio.com/f/verify/5a013657caa2324bb2a3d51d2b020556fe6f0878/entry_creator/dist/author_subject/index.js"></script> 
+
+  
+      
+
+
+
+
+
+<link rel="stylesheet" href="https://img3.doubanio.com/cuphead/book-static/subject/blockquote-list.ddba7.css">
+
+<div class="ugc-mod blockquote-list-wrapper">
+  <div class="hd">
+    <h2>
+      原文摘录
+      &nbsp;&nbsp;· · · · · ·&nbsp;
+      <span class="pl">( <a href="blockquotes">全部</a> )</span>
+    </h2>
+
+    <ul class="blockquote-list">
+      
+        <li>
+          <figure>
+            吉埃诺夫：没有学过数学，机器对工人来说就是个谜。他没有看到其中力的平衡。所以他缺乏安全感。例如：车工摸索着找到了一种工具，让他能够同时将钢和镍加工成圆柱，不需要因为金属变化而更换工具。在吉埃诺夫看来，这只是一次切割；直接去做就行。另一个人对此则带着迷信般的敬意。一台不运行的机器也是一样。工人会看到需要做这样或那样的事……日常的修理尽管能让机器继续运行，但也注定了它会加速磨损，或出现新的故障。工程师从不这样做。即使他从没用过微积分，但研究材料电阻的微分公式能够帮助他清楚地了解机器就是一个由力决定的游戏。
+无法运行的冲压机和“雅克定额”。显然对于“雅克定额”而言，冲压机是一个谜，它停止运行的原因也是。（它）不仅仅是作为一个未知的因素，而且在某种程度上，其自身就是个谜。它无法运行……就好像是机器自己拒绝运行。
+我无法理解冲压机的是：“雅克定额”和连续敲击10次的冲压机。 (<a href="https://book.douban.com/annotation/129424742/">查看原文</a>)
+
+            <div class="blockquote-extra">
+              <div class="blockquote-meta">
+                <a href="https://www.douban.com/people/ariel-y/" class="author-avatar">
+                  <img width="20" height="20" src="https://img1.doubanio.com/icon/u23459970-30.jpg">
+                </a>
+                <a class="author-name" href="https://www.douban.com/people/ariel-y/">小兔雷特</a>
+                  <span>8赞</span>
+                <datetime>2023-11-14 02:13:31</datetime>
+              </div>
+
+              
+              <figcaption title="引自章节：五、工厂日记（1934-1935年）">
+                —— 引自章节：五、工厂日记（1934-1935年）
+              </figcaption>
+            </div>
+          </figure>
+        </li>
+      
+        <li>
+          <figure>
+            我的事情说得差不多了。说说你吧。你的信吓到我了。如果你坚持把体验所有可能的感觉作为你的主要目标一这是一种暂时的心态，在你这个年龄段很正常一，你将有远大的前程。我更喜欢你说的想要与现实生活接触。你可能认为这是一回事；事实上，恰恰相反。有些人只靠感觉、为感觉而活；安德烈·纪德就是如此。他们实际上被生活欺骗了，他们隐约感觉到了这一点，因而总是陷入一种深深的悲哀。除了麻痹自己，悲惨地自欺欺人外，他们别无他法。因为真实的生活不是感觉，而是活动一我指的是思想和行动的活动。工人和创造者才是真正的人，与他们相比，那些靠感觉生活的人在物质和道德上都只是寄生虫。我想补充的是，前者不追求感觉，但却比追求感觉的人得到了更生动、更深刻、更不造作和更真实的感觉。最终，在我看来，对感觉的追求成为了一种很可怕的利己主义。当然，这并不妨碍人们去爱，但它导致人们把所爱的人仅仅视作带来享乐或苦痛的缘由，而完全忘记他们本身的存在。他们生活在空想之中。他们在做梦而非生活。 (<a href="https://book.douban.com/annotation/126574350/">查看原文</a>)
+
+            <div class="blockquote-extra">
+              <div class="blockquote-meta">
+                <a href="https://www.douban.com/people/Colonellll/" class="author-avatar">
+                  <img width="20" height="20" src="https://img3.doubanio.com/icon/u161350576-12.jpg">
+                </a>
+                <a class="author-name" href="https://www.douban.com/people/Colonellll/">Colonel</a>
+                  <span>6赞</span>
+                <datetime>2023-07-23 14:18:04</datetime>
+              </div>
+
+              
+              <figcaption title="引自章节：一、给阿尔贝蒂娜·泰弗农女士的三封信（1934-1935年）">
+                —— 引自章节：一、给阿尔贝蒂娜·泰弗农女士的三封信（1934-1935年）
+              </figcaption>
+            </div>
+          </figure>
+        </li>
+    </ul>
+
+      <p class="pl"> &gt; <a href="blockquotes">全部原文摘录</a> </p>
+  </div>
+</div>
+
+
+  
+      
+
+
+
+
+
+  
+      
+
+
+
+
+  
+
+
+
+
+  
+
+
+
+
+    <div id="rec-ebook-section" class="block5 subject_show">
+    
+
+    
+  
+
+  <h2>
+    <span>喜欢读"工厂日记"的人也喜欢的电子书</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+    <div class="tips-mod">
+        支持 Web、iPhone、iPad、Android 阅读器
+    </div>
+    <div class="content clearfix">
+        
+        <dl>
+            <dt>
+            <a href="https://read.douban.com/ebook/445826872/?dcs=subject-rec&amp;dcm=douban&amp;dct=36255848" target="_blank">
+                <span class="cover-outer">
+                <img src="https://pic.arkread.com/cover/ebook/f/445826872.1698052188.jpg!cover_default.jpg">
+                </span>
+            </a>
+            </dt>
+            <dd>
+            <div class="title">
+                <a href="https://read.douban.com/ebook/445826872/" target="_blank">疼痛部</a>
+            </div>
+            <div class="price">
+                
+    27.00元
+
+            </div>
+            </dd>
+        </dl>
+        
+        <dl>
+            <dt>
+            <a href="https://read.douban.com/ebook/477134704/?dcs=subject-rec&amp;dcm=douban&amp;dct=36255848" target="_blank">
+                <span class="cover-outer">
+                <img src="https://pic.arkread.com/cover/ebook/f/477134704.1723530681.jpg!cover_default.jpg">
+                </span>
+            </a>
+            </dt>
+            <dd>
+            <div class="title">
+                <a href="https://read.douban.com/ebook/477134704/" target="_blank">贫穷的质感：王梆的英国观察</a>
+            </div>
+            <div class="price">
+                
+    33.80元
+
+            </div>
+            </dd>
+        </dl>
+        
+        <dl>
+            <dt>
+            <a href="https://read.douban.com/ebook/635402191/?dcs=subject-rec&amp;dcm=douban&amp;dct=36255848" target="_blank">
+                <span class="cover-outer">
+                <img src="https://pic.arkread.com/cover/ebook/f/635402191.1750145244.jpg!cover_default.jpg">
+                </span>
+            </a>
+            </dt>
+            <dd>
+            <div class="title">
+                <a href="https://read.douban.com/ebook/635402191/" target="_blank">要命还是要灵魂</a>
+            </div>
+            <div class="price">
+                
+    36.00元
+
+            </div>
+            </dd>
+        </dl>
+        
+        <dl>
+            <dt>
+            <a href="https://read.douban.com/ebook/444721797/?dcs=subject-rec&amp;dcm=douban&amp;dct=36255848" target="_blank">
+                <span class="cover-outer">
+                <img src="https://pic.arkread.com/cover/ebook/f/444721797.1697097138.jpg!cover_default.jpg">
+                </span>
+            </a>
+            </dt>
+            <dd>
+            <div class="title">
+                <a href="https://read.douban.com/ebook/444721797/" target="_blank">我以文字为业（独家首发）</a>
+            </div>
+            <div class="price">
+                
+    39.90元
+
+            </div>
+            </dd>
+        </dl>
+        
+        <dl>
+            <dt>
+            <a href="https://read.douban.com/ebook/433888788/?dcs=subject-rec&amp;dcm=douban&amp;dct=36255848" target="_blank">
+                <span class="cover-outer">
+                <img src="https://pic.arkread.com/cover/ebook/f/433888788.1685692655.jpg!cover_default.jpg">
+                </span>
+            </a>
+            </dt>
+            <dd>
+            <div class="title">
+                <a href="https://read.douban.com/ebook/433888788/" target="_blank">生而为女</a>
+            </div>
+            <div class="price">
+                
+    39.99元
+
+            </div>
+            </dd>
+        </dl>
+    </div>
+    </div>
+
+<div id="db-rec-section" class="block5 subject_show knnlike">
+  
+  
+  
+
+  <h2>
+    <span>喜欢读"工厂日记"的人也喜欢</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+  <div class="content clearfix">
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36413884/" onclick="moreurl(this, {'total': 10, 'clicked': '36413884', 'pos': 0, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/s/public/s34677293.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36413884/" onclick="moreurl(this, {'total': 10, 'clicked': '36413884', 'pos': 0, 'identifier': 'book-rec-books'})" class="">
+            脏活
+          </a>
+          <span class="subject-rate">7.7</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36207115/" onclick="moreurl(this, {'total': 10, 'clicked': '36207115', 'pos': 1, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/s/public/s34397607.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36207115/" onclick="moreurl(this, {'total': 10, 'clicked': '36207115', 'pos': 1, 'identifier': 'book-rec-books'})" class="">
+            维塔
+          </a>
+          <span class="subject-rate">9.1</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36985251/" onclick="moreurl(this, {'total': 10, 'clicked': '36985251', 'pos': 2, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/s/public/s35027839.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36985251/" onclick="moreurl(this, {'total': 10, 'clicked': '36985251', 'pos': 2, 'identifier': 'book-rec-books'})" class="">
+            过渡劳动
+          </a>
+          <span class="subject-rate">8.1</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/30367977/" onclick="moreurl(this, {'total': 10, 'clicked': '30367977', 'pos': 3, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img2.doubanio.com/view/subject/s/public/s30012531.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/30367977/" onclick="moreurl(this, {'total': 10, 'clicked': '30367977', 'pos': 3, 'identifier': 'book-rec-books'})" class="">
+            重负与神恩
+          </a>
+          <span class="subject-rate">9.0</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36716709/" onclick="moreurl(this, {'total': 10, 'clicked': '36716709', 'pos': 4, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/s/public/s34815264.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36716709/" onclick="moreurl(this, {'total': 10, 'clicked': '36716709', 'pos': 4, 'identifier': 'book-rec-books'})" class="">
+            文学与恶
+          </a>
+          <span class="subject-rate">8.0</span>
+        </dd>
+      </dl>
+        <dl class="clear"></dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36409321/" onclick="moreurl(this, {'total': 10, 'clicked': '36409321', 'pos': 5, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/s/public/s34593512.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36409321/" onclick="moreurl(this, {'total': 10, 'clicked': '36409321', 'pos': 5, 'identifier': 'book-rec-books'})" class="">
+            将熟悉变为陌生
+          </a>
+          <span class="subject-rate">8.7</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36283425/" onclick="moreurl(this, {'total': 10, 'clicked': '36283425', 'pos': 6, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/s/public/s34708197.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36283425/" onclick="moreurl(this, {'total': 10, 'clicked': '36283425', 'pos': 6, 'identifier': 'book-rec-books'})" class="">
+            现实主义的报复
+          </a>
+          <span class="subject-rate">7.9</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36494272/" onclick="moreurl(this, {'total': 10, 'clicked': '36494272', 'pos': 7, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/s/public/s34696785.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36494272/" onclick="moreurl(this, {'total': 10, 'clicked': '36494272', 'pos': 7, 'identifier': 'book-rec-books'})" class="">
+            诗的九重门
+          </a>
+          <span class="subject-rate">9.1</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/36443489/" onclick="moreurl(this, {'total': 10, 'clicked': '36443489', 'pos': 8, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/s/public/s34564626.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/36443489/" onclick="moreurl(this, {'total': 10, 'clicked': '36443489', 'pos': 8, 'identifier': 'book-rec-books'})" class="">
+            自己的房子
+          </a>
+          <span class="subject-rate">8.5</span>
+        </dd>
+      </dl>
+      
+      <dl class="">
+        <dt>
+            <a href="https://book.douban.com/subject/35379215/" onclick="moreurl(this, {'total': 10, 'clicked': '35379215', 'pos': 9, 'identifier': 'book-rec-books'})"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/s/public/s33840745.jpg"></a>
+        </dt>
+        <dd>
+          <a href="https://book.douban.com/subject/35379215/" onclick="moreurl(this, {'total': 10, 'clicked': '35379215', 'pos': 9, 'identifier': 'book-rec-books'})" class="">
+            她来自马里乌波尔
+          </a>
+          <span class="subject-rate">9.0</span>
+        </dd>
+      </dl>
+        <dl class="clear"></dl>
+  </div>
+</div>
+
+  
+      
+
+
+
+
+<div id="comments-section">
+    <link rel="stylesheet" href="https://img1.doubanio.com/f/vendors/d63a579a99fd372b4398731a279a1382e6eac71e/subject-comments/comments-section.css">
+    <div class="mod-hd">
+        
+
+        <a class="redbutt j a_show_login rr" href="https://www.douban.com/register?reason=review" rel="nofollow">
+            <span> 我来说两句 </span>
+        </a>
+
+            
+  
+
+  <h2>
+    <span>短评</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+      <span class="pl">&nbsp;(
+          <a href="https://book.douban.com/subject/36255848/comments/">全部 1123 条</a>
+        ) </span>
+
+  </h2>
+
+
+    </div>
+    <div class="nav-tab">
+        
+    <div class="tabs-wrapper  line">
+                <a class="short-comment-tabs on-tab" href="https://book.douban.com/subject/36255848/comments?sort=score" data-tab="score">热门</a>
+    </div>
+
+    </div>
+    <div id="comment-list-wrapper" class="indent">
+        
+  
+  <div class="comment-list score show" id="score">
+      <ul>
+          
+  <li class="comment-item" data-cid="3746439299">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+            <span id="c-3746439299" class="vote-count">111</span>
+              <a id="btn-3746439299" href="" class="j a_show_login" data-cid="3746439299">有用</a>
+
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/babulliu/">把噗</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <a class="comment-time" href="/comment/3746439299">2023-07-04 18:57:39</a>
+          <span class="comment-location">北京</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">注意力是唯一能让人的灵魂与上帝接触的能力。</span>
+      </p>
+        <div class="report-comment" data-url="https://book.douban.com/subject/36255848/?comment_id=3746439299"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="4068130605">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+            <span id="c-4068130605" class="vote-count">8</span>
+              <a id="btn-4068130605" href="" class="j a_show_login" data-cid="4068130605">有用</a>
+
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/133190360/">瞌睡鱼</a>
+            <span class="user-stars allstar10 rating" title="很差"></span>
+          <a class="comment-time" href="/comment/4068130605">2024-01-24 13:07:56</a>
+          <span class="comment-location">浙江</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">被骗了，就一章是工厂日记，前后夹杂了书信。这些书信应该都不是作者本人意愿的发表。书信阅读，一方面是觉得在窥探别人的隐私，一方面是并不感兴趣。工厂日记章节就是流水线日记，基本是工作内容描述，本人的思考内容很少，很乏味，因为本意就不是拿来发表的吧。名人的手稿拼凑起来就能出一本新书，无语。</span>
+      </p>
+        <div class="report-comment" data-url="https://book.douban.com/subject/36255848/?comment_id=4068130605"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="4101848652">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+            <span id="c-4101848652" class="vote-count">14</span>
+              <a id="btn-4101848652" href="" class="j a_show_login" data-cid="4101848652">有用</a>
+
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/180966522/">solaris</a>
+          <a class="comment-time" href="/comment/4101848652">2024-06-24 00:15:26</a>
+          <span class="comment-location">日本</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">想想这是快一百年前的书，想想刚在冷藏柜中死去的八名女工。这世界变了分毫吗</span>
+      </p>
+        <div class="report-comment" data-url="https://book.douban.com/subject/36255848/?comment_id=4101848652"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="3924656771">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+            <span id="c-3924656771" class="vote-count">21</span>
+              <a id="btn-3924656771" href="" class="j a_show_login" data-cid="3924656771">有用</a>
+
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/72489669/">Oracle</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <a class="comment-time" href="/comment/3924656771">2024-01-09 19:11:44</a>
+          <span class="comment-location">安徽</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">与薇依无关的，在初高中有很长一段时间的职业理想是成为车间女工，想象中用重复的体力劳动避免出卖智力的可耻，而今可以意识到当时脑中的浪漫幻想实则是完全不理解成为“工具的人”、对仅被作为手段、剥削了生活意义的可耻无知。入职电子厂的一年多，接触到了在以前不曾“看见”的很多人。从云贵川等地被“打包”发送来的学生工；两班倒工作时长12小时需穿着无尘服的厂内大多数人；六人或八人间的宿舍；夕阳里无从知晓的他人的情...</span>
+        <span class="hide-item full">与薇依无关的，在初高中有很长一段时间的职业理想是成为车间女工，想象中用重复的体力劳动避免出卖智力的可耻，而今可以意识到当时脑中的浪漫幻想实则是完全不理解成为“工具的人”、对仅被作为手段、剥削了生活意义的可耻无知。入职电子厂的一年多，接触到了在以前不曾“看见”的很多人。从云贵川等地被“打包”发送来的学生工；两班倒工作时长12小时需穿着无尘服的厂内大多数人；六人或八人间的宿舍；夕阳里无从知晓的他人的情绪。浮云望眼，日复一日。 直视世界的残酷与真实面貌需要太大的勇气。</span>
+        <span class="expand">(<a href="javascript:;">展开</a>)</span>
+      </p>
+        <div class="report-comment" data-url="https://book.douban.com/subject/36255848/?comment_id=3924656771"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="4340876921">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+            <span id="c-4340876921" class="vote-count">16</span>
+              <a id="btn-4340876921" href="" class="j a_show_login" data-cid="4340876921">有用</a>
+
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/47929578/">安提戈涅</a>
+            <span class="user-stars allstar40 rating" title="推荐"></span>
+          <a class="comment-time" href="/comment/4340876921">2025-03-17 14:56:45</a>
+          <span class="comment-location">云南</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">读者越是在薇依对每日工作的琐碎记录中感到枯燥，越是应该注意到这种枯燥活计背后的责任与判断。如果《白痴》中的梅诗金公爵尚显虚构，那么薇依这个活过的、活着的、也将活下去的人则以肉身显现出向普遍的苦难现身的真实质地，她以枯燥的工作记录证明梅诗金公爵的那一吻或者佐西马长老的那一跪并非虚妄。往往人们不信，乃是因为他们没有见过超出经验的所在。此书宜与《伦敦文稿》对读，文稿更像是薇依对工厂日记的潜在自我解释。</span>
+      </p>
+        <div class="report-comment" data-url="https://book.douban.com/subject/36255848/?comment_id=4340876921"></div>
+    </div>
+  </li>
+
+      </ul>
+  </div>
+
+        
+
+    </div>
+    <script src="https://img1.doubanio.com/f/vendors/6eba6f43fb7592ab783e390f654c0d6a96b1598e/subject-comments/comments-section.js"></script>
+    <script>
+     (function () {
+            if (window.SUBJECT_COMMENTS_SECTION) {
+                // tab handler
+                SUBJECT_COMMENTS_SECTION.createTabHandler();
+                // expand handler
+                SUBJECT_COMMENTS_SECTION.createExpandHandler({
+                    root: document.getElementById('comment-list-wrapper'),
+                });
+                SUBJECT_COMMENTS_SECTION.createVoteHandler({
+                    api: '/j/comment/:id/vote',
+                    root: document.getElementById('comment-list-wrapper'),
+                    voteSelector: '.vote-comment',
+                    textSelector: '.vote-count',
+                    afterVote: function (elem) {
+                        var parentNode = elem.parentNode;
+                        var successElem = document.createElement('span');
+                        successElem.innerHTML = '已投票';
+                        parentNode.removeChild(elem);
+                        parentNode.appendChild(successElem);
+                    }
+                });
+            }
+        })()
+    </script>
+</div>
+
+
+
+
+    
+
+
+<!-- COLLECTED CSS -->
+
+    <section id="reviews-wrapper" class="reviews mod book-content">
+        <header>
+            
+                <a href="new_review" rel="nofollow" class="create-review redbutt rr " data-isverify="False" data-verify-url="https://www.douban.com/accounts/phone/verify?redir=https://book.douban.com/subject/36255848/new_review">
+                    <span>我要写书评</span>
+                </a>
+            <h2>
+                    工厂日记的书评 · · · · · ·
+
+                    <span class="pl">( <a href="reviews">全部 42 条</a> )</span>
+            </h2>
+        </header>
+
+            
+            <div class="review_filter">
+                                <span class="link"><a href="javascript:;;" class="cur" data-sort="">热门</a></span>
+                        <a href="/subject/36255848/reviews?version=1" data-sort="version">只看本版本的评论</a>
+            </div>
+            <script>
+                var cur_sort = '';
+                $('#reviews-wrapper .review_filter a').on('click', function () {
+                    var sort = $(this).data('sort');
+                    if(sort === cur_sort) return;
+
+                    if(sort === 'follow' && true){
+                        window.location.href = '//www.douban.com/accounts/login?source=movie';
+                        return;
+                    }
+
+                    if($('#reviews-wrapper .review_filter').data('doing')) return;
+                    $('#reviews-wrapper .review_filter').data('doing', true);
+
+                    cur_sort = sort;
+
+                    $('#reviews-wrapper .review_filter a').removeClass('cur');
+                    $(this).addClass('cur');
+
+                    $.getJSON('reviews', { sort: sort }, function(res) {
+                        $('#reviews-wrapper .review-list').remove();
+                        $('#reviews-wrapper [href="reviews?sort=follow"]').parent().remove();
+                        $('#reviews-wrapper .review_filter').after(res.html);
+                        $('#reviews-wrapper .review_filter').data('doing', false);
+                        $('#reviews-wrapper .review_filter').removeData('doing');
+
+                        if (res.count === 0) {
+                            $('#reviews-wrapper .review-list').html('<span class="no-review">你关注的人还没写过长评</span>');
+                        }
+                    });
+                });
+            </script>
+
+
+            
+
+
+
+<link rel="stylesheet" href="https://img1.doubanio.com/cuphead/zerkalo-static/review/list.f3448.css">
+
+<div class="review-list  ">
+        
+    
+
+            
+    
+    <div data-cid="15088502">
+        <div class="main review-item" id="15088502">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/wangbang/" class="avator">
+            <img width="24" height="24" src="https://img3.doubanio.com/icon/u1359032-23.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/wangbang/" class="name">王梆</a>
+
+        <span content="2023-04-06" class="main-meta">2023-04-06 23:34:04</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15088502/">给西蒙薇依的信</a></h2>
+
+                <div id="review_15088502_short" class="review-short" data-rid="15088502">
+                    <div class="short-content">
+
+                        Simone Weil — 'Attention, taken to its highest degree, is the same thing as prayer. It presupposes faith and love. Absolutely unmixed attention is prayer.' 一直想去肯特郡看你，去Bybrook公墓，在一个盛夏的黄昏，在猫头鹰出没之际，在一天中最安静的时光里，绕过...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15088502-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15088502_full" class="hidden">
+                    <div id="review_15088502_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15088502" title="有用">
+                            121
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15088502" title="没用">
+                            4
+                    </a>
+                    <a href="https://book.douban.com/review/15088502/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15088502">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15491165">
+        <div class="main review-item" id="15491165">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/ibookreview/" class="avator">
+            <img width="24" height="24" src="https://img9.doubanio.com/icon/u161147127-4.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/ibookreview/" class="name">新京报书评周刊</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2023-10-08" class="main-meta">2023-10-08 13:39:32</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15491165/">逃离抽象的世界，走进真正的人类中间 | 西蒙娜·薇依逝世八十周年</a></h2>
+
+                <div id="review_15491165_short" class="review-short" data-rid="15491165">
+                    <div class="short-content">
+
+                        2023年是法国哲学家、社会活动家西蒙娜·薇依（Simone Weil，1909–1943）逝世八十周年。 西蒙娜·薇依（下称薇依）是与萨特、波伏娃、加缪等人同时代的法国哲学家，由于西蒙娜·薇依时常被当成宗教神秘主义思想家看待，国内的读者对她的了解有限。此次由王天宇翻译、上海人民...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15491165-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15491165_full" class="hidden">
+                    <div id="review_15491165_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15491165" title="有用">
+                            31
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15491165" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/15491165/#comments" class="reply ">1回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15491165">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15901353">
+        <div class="main review-item" id="15901353">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/blueswing/" class="avator">
+            <img width="24" height="24" src="https://img3.doubanio.com/icon/u2529736-253.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/blueswing/" class="name">的里雅斯特の火</a>
+            <span class="allstar40 main-title-rating" title="推荐"></span>
+
+        <span content="2024-04-25" class="main-meta">2024-04-25 16:33:17</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15901353/">死局</a></h2>
+
+                <div id="review_15901353_short" class="review-short" data-rid="15901353">
+                    <div class="short-content">
+
+                        这两天读完了《工厂日记》，有不少共鸣和感想，于是简单写点自己这十几年在工作中接触的企业现状。 毕业至今，我一直在一个与专业风马牛不相及的协会工作，负责纳管上海与制造业配套的企业。协会的会员数从我刚入行的四百余家已经减少到如今的七十来家，导致数量骤减的主要原因...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15901353-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15901353_full" class="hidden">
+                    <div id="review_15901353_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15901353" title="有用">
+                            21
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15901353" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/15901353/#comments" class="reply ">5回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15901353">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15454329">
+        <div class="main review-item" id="15454329">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/Braveryzero/" class="avator">
+            <img width="24" height="24" src="https://img2.doubanio.com/icon/u64757290-111.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/Braveryzero/" class="name">卧听南窗雨</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2023-09-16" class="main-meta">2023-09-16 23:26:26</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15454329/">西蒙娜·薇依：“有时，当生活太过困难，你甚至会忘了自己是一个人”</a></h2>
+
+                <div id="review_15454329_short" class="review-short" data-rid="15454329">
+                    <div class="short-content">
+
+                        “你每天都见证着，在资本主义社会中，只有那些口袋里有钱的人才能活得像个人，才能要求得到尊重。如果你要求得到尊重，别人只会嘲笑你。” 在所有的20世纪法国哲学家当中，西蒙娜·薇依(Simone Weil,1909-1943)是惟一让我看到名字就心碎到痉挛的！ 1909年2月3日，薇依生于法国...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15454329-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15454329_full" class="hidden">
+                    <div id="review_15454329_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15454329" title="有用">
+                            21
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15454329" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/15454329/#comments" class="reply ">3回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15454329">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15280511">
+        <div class="main review-item" id="15280511">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/babulliu/" class="avator">
+            <img width="24" height="24" src="https://img9.doubanio.com/icon/u42097517-14.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/babulliu/" class="name">把噗</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2023-07-07" class="main-meta">2023-07-07 22:00:52</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15280511/">赤裸的真理</a></h2>
+
+                <div id="review_15280511_short" class="review-short" data-rid="15280511">
+                    <div class="short-content">
+                            <p class="spoiler-tip">这篇书评可能有关键情节透露</p>
+
+                        通过工厂的劳动，西蒙娜·薇依发现，工作会使人的注意力涣散。 注意力是薇依思想中一个核心概念，极为寻常，又极其深刻，与宗教神秘地联系在一起。 在手工业时代，劳动类似手艺创作，注意力是全神贯注的。 随着资本主义的兴起，工厂诞生，生产者与生产资料分离，工人与产品之间...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15280511-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15280511_full" class="hidden">
+                    <div id="review_15280511_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15280511" title="有用">
+                            16
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15280511" title="没用">
+                            1
+                    </a>
+                    <a href="https://book.douban.com/review/15280511/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15280511">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="17284780">
+        <div class="main review-item" id="17284780">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/191527103/" class="avator">
+            <img width="24" height="24" src="https://img1.doubanio.com/icon/u191527103-40.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/191527103/" class="name">meme</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2025-12-03" class="main-meta">2025-12-03 22:36:37</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/17284780/">流水线上的孔雀：女工劳动叙事</a></h2>
+
+                <div id="review_17284780_short" class="review-short" data-rid="17284780">
+                    <div class="short-content">
+                            <p class="spoiler-tip">这篇书评可能有关键情节透露</p>
+
+                        你佩戴着闪亮的项链 像一只盛开的孔雀 行走着在乌泱的大街 同样的剧情为我们编写  --蛙池《孔雀》 近期阅读了四部女工相关的作品：《工厂日记》、《我在底层的生活：当专栏作家化身女服务生》、《中国女工——新兴打工者主体的形成》和《游鸭：被迫迁徙的我们》（以下简称《工...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-17284780-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_17284780_full" class="hidden">
+                    <div id="review_17284780_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="17284780" title="有用">
+                            12
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="17284780" title="没用">
+                            1
+                    </a>
+                    <a href="https://book.douban.com/review/17284780/#comments" class="reply ">2回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="17284780">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15848525">
+        <div class="main review-item" id="15848525">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/73277903/" class="avator">
+            <img width="24" height="24" src="https://img1.doubanio.com/icon/u73277903-20.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/73277903/" class="name">阿北Noah</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2024-04-03" class="main-meta">2024-04-03 01:57:29</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15848525/">注意力是唯一能使灵魂与上帝接触的能力</a></h2>
+
+                <div id="review_15848525_short" class="review-short" data-rid="15848525">
+                    <div class="short-content">
+                            <p class="spoiler-tip">这篇书评可能有关键情节透露</p>
+
+                        薇依的最后一篇《非奴役性工作的首要条件》初看是在理想化地让工人以一种自欺欺人的方式，用上帝信仰去麻醉自己，抛弃消费主义，从而“将工作转变为诗”，但如果我们关注到文中的这一段话，其实薇依的重点不是站在工人之外去让工人安于现状，而是在工人群体内来看，如何让工人...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15848525-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15848525_full" class="hidden">
+                    <div id="review_15848525_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15848525" title="有用">
+                            9
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15848525" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/15848525/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15848525">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="15480671">
+        <div class="main review-item" id="15480671">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/checkshin/" class="avator">
+            <img width="24" height="24" src="https://img3.doubanio.com/icon/u115658890-62.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/checkshin/" class="name">原生麦子🎄</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2023-10-02" class="main-meta">2023-10-02 14:14:36</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/15480671/">为了生活出卖生活</a></h2>
+
+                <div id="review_15480671_short" class="review-short" data-rid="15480671">
+                    <div class="short-content">
+                            <p class="spoiler-tip">这篇书评可能有关键情节透露</p>
+
+                        正如看到友邻在“她们缺乏同情心，是因为一份‘坏’工作如果放过一个人，还会由另一个人承担”下的笔记，说如今的写字楼女工面临同样的问题一样，读的时候我时时忘记书里的内容写的是近90年前的工厂生活。 这么说吧，不管你是哪里的女工（或工人），1934年还是2023年；不管你是...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-15480671-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_15480671_full" class="hidden">
+                    <div id="review_15480671_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="15480671" title="有用">
+                            10
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="15480671" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/15480671/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="15480671">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="16020695">
+        <div class="main review-item" id="16020695">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/69154897/" class="avator">
+            <img width="24" height="24" src="https://img2.doubanio.com/icon/u69154897-41.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/69154897/" class="name">会用大尾巴钓鱼</a>
+
+        <span content="2024-06-26" class="main-meta">2024-06-26 22:58:59</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://book.douban.com/review/16020695/">行走的基督</a></h2>
+
+                <div id="review_16020695_short" class="review-short" data-rid="16020695">
+                    <div class="short-content">
+                            <p class="spoiler-tip">这篇书评可能有关键情节透露</p>
+
+                        读完的那一天头痛剧烈，想到薇依带着这样的身体进入工厂愈发感佩。感慨良多，却写不出来什么，我理解加缪为何对她的著作未做评述，对于有些作品，阐释是一种削减。“人因为想表达而贬低了不可表达之物。”毫不犹豫地践行自己的信念是只有纯粹的灵魂做得到的壮举，勇敢者先行，...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-16020695-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_16020695_full" class="hidden">
+                    <div id="review_16020695_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="16020695" title="有用">
+                            6
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="16020695" title="没用">
+                    </a>
+                    <a href="https://book.douban.com/review/16020695/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="16020695">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+
+    <!-- COLLECTED JS -->
+    <!-- COLLECTED CSS -->
+</div>
+
+    <script src="https://img1.doubanio.com/cuphead/zerkalo-static/review/list.c3cec.js"></script>
+    <script src="https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js"></script>
+
+
+
+
+
+
+
+
+
+
+
+                <p class="pl">
+                    &gt;
+                        <a href="reviews">
+                            更多书评
+                                42篇
+                        </a>
+                </p>
+    </section>
+<!-- COLLECTED JS -->
+
+  
+<div class="annotation">
+
+
+
+
+
+<div class="ugc-mod reading-notes">
+  <div class="hd">
+    <h2>
+    读书笔记
+    &nbsp;· · · · · ·&nbsp;
+      <span class="pl">( <a href="https://book.douban.com/subject/36255848/annotation">共<span property="v:count"> 202 </span>篇</a> )</span>
+    </h2>
+
+      <a class="redbutt j a_show_login rr" href="https://www.douban.com/register?reason=annotate" rel="nofollow">
+        <span>我来写笔记</span>
+      </a>
+  </div>
+  <div class="bd">
+      <ul class="inline-tabs">
+        <li class="on"><a href="#rank" id="by_rank">按有用程度</a></li>
+        <li><a href="#page" id="by_page">按页码先后</a></li>
+        <li><a href="#time" id="by_time">最新笔记</a></li>
+      </ul>
+      
+  <ul class="comments by_rank">
+      
+      <li class="ctsh clearfix" data-cid="129424742">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/ariel-y/">
+            <img src="https://img1.doubanio.com/icon/up23459970-30.jpg" width="48" height="48" alt="小兔雷特" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/129424742/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/129424742/" class="">五、工厂日记（1934-1935年）</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/ariel-y/" title="小兔雷特">小兔雷特</a>
+              
+            </p>
+            <div class="reading-note" data-cid="129424742">
+              <div class="short">
+                  <span>吉埃诺夫：没有学过数学，机器对工人来说就是个谜。他没有看到其中力的平衡。所以他缺乏安全感。例如：车工摸索着找到了一种工具，让他能够同时将钢和镍加工成圆柱，不需要因为金属变化而更换工具。在吉埃诺夫看...</span>
+                <p class="pl">
+                  <span>2023-11-14 02:13:31</span>
+                    &nbsp;&nbsp;<span>8人喜欢</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="127436592">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/rosenzweig/">
+            <img src="https://img1.doubanio.com/icon/up70969820-50.jpg" width="48" height="48" alt="笹子" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/127436592/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/127436592/" class="">给一位学生的信（1934年）</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/rosenzweig/" title="笹子">笹子</a>
+              
+            </p>
+            <div class="reading-note" data-cid="127436592">
+              <div class="short">
+                  <span>我感觉自己逃离了抽象的世界，走进真正的人类中间——不是简单的好坏，而是真正的善恶。特别是善，在工厂里，当它存在时，它就是真实的；因为从一个简单的微笑到帮忙，最小的善意行为都需要人们克服疲劳和对工资...</span>
+                <p class="pl">
+                  <span>2023-08-26 22:58:21</span>
+                    &nbsp;&nbsp;<span>7人喜欢</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="126574350">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/Colonellll/">
+            <img src="https://img3.doubanio.com/icon/up161350576-12.jpg" width="48" height="48" alt="Colonel" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/126574350/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/126574350/" class="">一、给阿尔贝蒂娜·泰弗农女士的三封信（1934-1935年）</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/Colonellll/" title="Colonel">Colonel</a>
+              
+            </p>
+            <div class="reading-note" data-cid="126574350">
+              <div class="short">
+                  <span>我的事情说得差不多了。说说你吧。你的信吓到我了。如果你坚持把体验所有可能的感觉作为你的主要目标一这是一种暂时的心态，在你这个年龄段很正常一，你将有远大的前程。我更喜欢你说的想要与现实生活接触。你可...</span>
+                <p class="pl">
+                  <span>2023-07-23 14:18:04</span>
+                    &nbsp;&nbsp;<span>6人喜欢</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="139554302">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/257298476/">
+            <img src="https://img3.doubanio.com/icon/up257298476-22.jpg" width="48" height="48" alt="PÆLĪMPSËST" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/139554302/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/139554302/" class="">Sentences that haunt me</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/257298476/" title="PÆLĪMPSËST">PÆLĪMPSËST</a>
+                (.)
+              
+            </p>
+            <div class="reading-note" data-cid="139554302">
+              <div class="short">
+                  <span>“我太了解（因为头痛）活生生地体会死亡是什么感觉了；看着时间在你面前流逝，你有一千次的机会去填满它，但一想到自己身体虚弱，又不得不让它空虚下去，仅仅是一天天地度过时间就是一项繁重的任务。” (5) “当...</span>
+                <p class="pl">
+                  <span>2024-12-04 02:47:09</span>
+                    &nbsp;&nbsp;<span>4人喜欢</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+  </ul>
+  
+
+      
+  <ul class="comments by_page" style="display: none">
+      
+      <li class="ctsh clearfix" data-cid="149778883">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/Andorpheus/">
+            <img src="https://img3.doubanio.com/icon/up219390345-2.jpg" width="48" height="48" alt="风知" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/149778883/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/149778883/" class="">二、给一位学生的信（1934年）</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/Andorpheus/" title="风知">风知</a>
+              
+            </p>
+            <div class="reading-note" data-cid="149778883">
+              <div class="short">
+                  <span>有些人只靠感觉、为感觉而活；安德烈·纪德就是如此。他们实际上被生活欺骗了，他们隐约感觉到这一点，因而总是陷入一种深深的悲哀。除了麻痹自己，悲惨地自欺欺人外，他们别无他法。因为真实的生活不是感觉，而...</span>
+                <p class="pl">
+                  <span>2026-03-11 12:03:45</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148386080">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148386080/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148386080/" class="">以有限追寻无限，是我们的错误</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148386080">
+              <div class="short">
+                  <span>除了我们身上标志起源的欲望，所有生物的东西都是有限的；而我们却贪婪地在人世间寻求着无限，这也成了我们唯一的过错和犯罪之源。</span>
+                <p class="pl">
+                  <span>2025-12-30 15:29:57</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148385932">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148385932/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148385932/" class="">只有“美”才能让人忍受单调</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148385932">
+              <div class="short">
+                  <span>解药只有一种。唯一能让人忍受住单调的是永恒的光明，是美。 只有在一种情况下，人的本性才允许灵魂的欲望对象并非可能或将来拥有之物，而是已存在的东西。这种情况就是美。所有美的东西都是欲望的对象，人们并不...</span>
+                <p class="pl">
+                  <span>2025-12-30 15:22:50</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148385834">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148385834/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148385834/" class="">金钱本身不能让人致富</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148385834">
+              <div class="short">
+                  <span>金钱作为欲望和努力的目标，其本身并不能让人致富。一个小工厂主、一个小商人可以变得富有，成为一个大工业家、一个大商人。教师、作家或部长，他们的贫富程度各不相同。但一个工人如果变得非常富有，就不再是工...</span>
+                <p class="pl">
+                  <span>2025-12-30 15:17:06</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+  </ul>
+  
+
+      
+  <ul class="comments by_time" style="display: none">
+      
+      <li class="ctsh clearfix" data-cid="149778883">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/Andorpheus/">
+            <img src="https://img3.doubanio.com/icon/up219390345-2.jpg" width="48" height="48" alt="风知" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/149778883/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/149778883/" class="">二、给一位学生的信（1934年）</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/Andorpheus/" title="风知">风知</a>
+              
+            </p>
+            <div class="reading-note" data-cid="149778883">
+              <div class="short">
+                  <span>有些人只靠感觉、为感觉而活；安德烈·纪德就是如此。他们实际上被生活欺骗了，他们隐约感觉到这一点，因而总是陷入一种深深的悲哀。除了麻痹自己，悲惨地自欺欺人外，他们别无他法。因为真实的生活不是感觉，而...</span>
+                <p class="pl">
+                  <span>2026-03-11 12:03:45</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148386080">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148386080/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148386080/" class="">以有限追寻无限，是我们的错误</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148386080">
+              <div class="short">
+                  <span>除了我们身上标志起源的欲望，所有生物的东西都是有限的；而我们却贪婪地在人世间寻求着无限，这也成了我们唯一的过错和犯罪之源。</span>
+                <p class="pl">
+                  <span>2025-12-30 15:29:57</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148385932">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148385932/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148385932/" class="">只有“美”才能让人忍受单调</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148385932">
+              <div class="short">
+                  <span>解药只有一种。唯一能让人忍受住单调的是永恒的光明，是美。 只有在一种情况下，人的本性才允许灵魂的欲望对象并非可能或将来拥有之物，而是已存在的东西。这种情况就是美。所有美的东西都是欲望的对象，人们并不...</span>
+                <p class="pl">
+                  <span>2025-12-30 15:22:50</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+      
+      <li class="ctsh clearfix" data-cid="148385834">
+        <div class="ilst">
+          <a href="https://www.douban.com/people/215753766/">
+            <img src="https://img9.doubanio.com/icon/up215753766-16.jpg" width="48" height="48" alt="尘字书" class="">
+          </a>
+        </div>
+        <div class="con">
+          <div class="nlst">
+            <h3>
+              <div class="note-toggle rr">
+                <a href="https://book.douban.com/annotation/148385834/" class="note-unfolder">展开</a>
+                <a href="javascript:void(0);" class="note-folder">收起</a>
+              </div>
+              <a href="https://book.douban.com/annotation/148385834/" class="">金钱本身不能让人致富</a></h3>
+          </div>
+          <div class="clst">
+            <p class="user"><a href="https://www.douban.com/people/215753766/" title="尘字书">尘字书</a>
+              
+            </p>
+            <div class="reading-note" data-cid="148385834">
+              <div class="short">
+                  <span>金钱作为欲望和努力的目标，其本身并不能让人致富。一个小工厂主、一个小商人可以变得富有，成为一个大工业家、一个大商人。教师、作家或部长，他们的贫富程度各不相同。但一个工人如果变得非常富有，就不再是工...</span>
+                <p class="pl">
+                  <span>2025-12-30 15:17:06</span>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+  </ul>
+  
+
+  </div>
+      <div class="ft">
+        <p class="trr">&gt; <a href="https://book.douban.com/subject/36255848/annotation">更多读书笔记（ 共202篇 ）</a></p>
+      </div>
+
+</div>
+<script src="https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js"></script>
+<script type="text/javascript">
+  $(document).ready(function(){
+    var TEMPL_ADD_COL = '<a href="" id="n-{NOTE_ID}" class="colbutt ll add-col"><span>收藏</span></a>',
+      TEMPL_DEL_COL = '<span class="pl">已收藏 &gt;<a href="" id="n-{NOTE_ID}" class="del-col">取消收藏</a></span>';
+
+    $('body').delegate('.add-col', 'click', function(e){
+      e.preventDefault();
+      var nnid = $(this).attr('id').split('-')[1],
+        bn_add = $(this);
+      $.post_withck("/j/book/annotation_collect",{nid:nnid},function(){
+        var a = $(TEMPL_DEL_COL.replace('{NOTE_ID}', nnid));
+        bn_add.before(a);
+        bn_add.remove();
+      })
+    });
+
+    $('body').delegate('.del-col', 'click', function(e){
+      e.preventDefault();
+      var nnid = $(this).attr('id').split('-')[1],
+        bn_del = $(this).parent();
+      $.post_withck("/j/book/annotation_uncollect", {nid: nnid}, function() {
+        var a = $(TEMPL_ADD_COL.replace('{NOTE_ID}', nnid));
+        bn_del.before(a);
+        bn_del.remove();
+      })
+    });
+
+    $("pre.source").each(function(){
+      var cn = $(this).attr('class').split(' ');
+      l = cn[1];
+      s = 'rand01';
+      n = cn[2];
+      $(this).snippet(n,{style: s, showNum: l});
+    });
+
+    var annotationMod = $('.reading-notes .bd')
+      , annotationTabs = annotationMod.find('.inline-tabs li')
+      , annotationTabLinks = annotationTabs.find('a')
+      , annotationTabContents = annotationMod.find('ul.comments');
+
+    annotationTabLinks.click(function(e){
+      e.preventDefault();
+      var el = $(this)
+        , kind = el.attr('id');
+
+      annotationTabs.removeClass('on');
+      el.parent().addClass('on');
+      annotationTabContents.hide();
+      annotationTabContents.filter('.' + kind).show();
+    });
+  });
+</script>
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+	jax: ["input/TeX", "output/HTML-CSS"],
+    extensions: ["tex2jax.js","TeX/AMSmath.js","TeX/AMSsymbols.js","TeX/noUndefined.js"],
+    tex2jax: {
+		inlineMath: [ ["($", "$)"], ['\\(','\\)'] ],
+		displayMath: [ ["($$","$$)"], ['\\[','\\]']],
+		skipTags: ["script","noscript","style","textarea"],
+		processEscapes: true,
+		processEnvironments: true,
+		preview: "TeX"
+	},
+	showProcessingMessages: false
+  });
+</script>
+
+</div>
+
+<script>
+  $('document').ready(function () {
+    $.get(`/subject/36255848/annotation_html`, function (r) {
+      $('.annotation').html(r.html);
+    });
+  });
+</script>
+
+  
+    
+
+
+
+
+
+<div id="db-discussion-section" class="indent ugc-mod">
+
+
+    
+  
+
+  <h2>
+    <span>论坛</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+        
+<table class="olt"><tbody><tr><td></td><td></td><td></td><td></td></tr>
+        
+        <tr>
+            <td class="pl"><a href="https://book.douban.com/subject/36255848/discussion/637745669/" title="奥古斯特·德留夫是谁">奥古斯特·德留夫是谁</a></td>
+            <td class="pl"><span>来自</span><a href="https://www.douban.com/people/simonyao/">simonfaye</a></td>
+            <td class="pl"><span></span></td>
+            <td class="pl"><span>2024-12-14 20:12:51</span></td>
+        </tr>
+        
+        <tr>
+            <td class="pl"><a href="https://book.douban.com/subject/36255848/discussion/637743357/" title="阿尔贝蒂娜泰弗农是谁">阿尔贝蒂娜泰弗农是谁</a></td>
+            <td class="pl"><span>来自</span><a href="https://www.douban.com/people/simonyao/">simonfaye</a></td>
+            <td class="pl"><span>4 回应</span></td>
+            <td class="pl"><span>2024-12-10 14:09:29</span></td>
+        </tr>
+        
+        <tr>
+            <td class="pl"><a href="https://book.douban.com/subject/36255848/discussion/637559143/" title="失败凭单和基础工资还有工资偏差是怎么算的？">失败凭单和基础工资还有工资偏差是怎么算的？</a></td>
+            <td class="pl"><span>来自</span><a href="https://www.douban.com/people/51938315/">DonnieDarko</a></td>
+            <td class="pl"><span>1 回应</span></td>
+            <td class="pl"><span>2024-12-10 11:12:20</span></td>
+        </tr>
+        
+        <tr>
+            <td class="pl"><a href="https://book.douban.com/subject/36255848/discussion/637604391/" title="是不是删减版？">是不是删减版？</a></td>
+            <td class="pl"><span>来自</span><a href="https://www.douban.com/people/193758587/">白鸽子</a></td>
+            <td class="pl"><span>1 回应</span></td>
+            <td class="pl"><span>2024-12-10 11:00:04</span></td>
+        </tr>
+        
+        <tr>
+            <td class="pl"><a href="https://book.douban.com/subject/36255848/discussion/637504613/" title="工厂日记">工厂日记</a></td>
+            <td class="pl"><span>来自</span><a href="https://www.douban.com/people/157065721/">Bueno🎺</a></td>
+            <td class="pl"><span></span></td>
+            <td class="pl"><span>2023-07-29 08:52:26</span></td>
+        </tr>
+</tbody></table>
+
+
+            <p class="pl" align="right">&gt;
+                <a href="https://book.douban.com/subject/36255848/discussion/">浏览更多话题</a>
+            </p>
+
+
+</div>
+
+
+
+
+</div>
+
+  
+      
+  <script type="text/javascript" src="https://img1.doubanio.com/f/vendors/e31c5a5084c08e5c74d9189744ce50af80a14484/censor.js"></script>
+  <script>
+    (function (kind, id, api) {
+      if ('_INTERNALS_CENSOR' in window) {
+        _INTERNALS_CENSOR.articleReport(kind, id, api);
+      }
+    })('1001', '36255848', 'https://www.douban.com/j/check_redirect_home');
+  </script>
+
+</div>
+      <div class="aside">
+        
+  
+  
+
+
+
+
+
+
+  <div id="dale_book_subject_top_right" ad-status="appended" data-sell-type="RTB" data-type="GoogleRender" data-version="3.2.46"><div id="dale_book_subject_top_right_frame" style="position: relative; margin: 0px 0px 20px; display: block; overflow: hidden;"><script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4830389020085397" crossorigin="anonymous"></script></div></div>
+
+  
+
+
+
+
+
+  <link rel="stylesheet" href="https://img3.doubanio.com/cuphead/book-static/cart/presale.3f3fa.css">
+  <link rel="stylesheet" href="https://img9.doubanio.com/cuphead/book-static/cart/buyinfo.1e186.css">
+
+  <div class="gray_ad buyinfo" id="buyinfo">
+      <div class="buyinfo-printed" id="buyinfo-printed">
+        
+
+          
+  
+
+  <h2>
+    <span>当前版本有售</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+          
+  <ul class="bs current-version-list">
+      
+      <li>
+        
+
+            
+              <div class="cell price-btn-wrapper">
+                <div class="vendor-name">
+                  <a target="_blank" href="https://read.douban.com/ebook/475633282/?dcs=subject-buylink&amp;dcm=douban&amp;dct=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                    <span>豆瓣阅读</span>
+                  </a>
+                </div>
+
+                <div class="cell impression_track_mod_buyinfo" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject">
+                  <div class="cell price-wrapper">
+                    <a target="_blank" href="https://read.douban.com/ebook/475633282/?dcs=subject-buylink&amp;dcm=douban&amp;dct=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span class="buylink-price ">
+                        
+    27.99元
+
+                        
+                      </span>
+                    </a>
+
+                  </div>
+
+                  <div class="cell">
+                    <a href="https://read.douban.com/ebook/475633282/?dcs=subject-buylink&amp;dcm=douban&amp;dct=36255848" class="buy-book-btn e-book-btn" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span>购买电子书</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+      </li>
+      
+      <li>
+        
+
+            
+              <div class="cell price-btn-wrapper">
+                <div class="vendor-name">
+                  <a target="_blank" href="https://www.dedao.cn/ebook/detail?id=N5lDqb9b47pXZxGn1kBzPlMyQArYv0qvZDLWqe85E2aVKdo9jNgOLRmDJ6nXLm16&amp;source=douban" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                    <span>得到</span>
+                  </a>
+                </div>
+
+                <div class="cell impression_track_mod_buyinfo" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject">
+                  <div class="cell price-wrapper">
+                    <a target="_blank" href="https://www.dedao.cn/ebook/detail?id=N5lDqb9b47pXZxGn1kBzPlMyQArYv0qvZDLWqe85E2aVKdo9jNgOLRmDJ6nXLm16&amp;source=douban" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span class="buylink-price ">
+                        
+                        27.99元
+                      </span>
+                    </a>
+
+                  </div>
+
+                  <div class="cell">
+                    <a href="https://www.dedao.cn/ebook/detail?id=N5lDqb9b47pXZxGn1kBzPlMyQArYv0qvZDLWqe85E2aVKdo9jNgOLRmDJ6nXLm16&amp;source=douban" class="buy-book-btn e-book-btn" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span>购买电子书</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+      </li>
+      
+      <li>
+        
+
+            
+              <div class="cell price-btn-wrapper">
+                <div class="vendor-name">
+                  <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=jingdong&amp;srcpage=subject&amp;price=4160&amp;pos=3&amp;url=https%3A%2F%2Funion-click.jd.com%2Fjdc%3Fe%3Disbn9787208181564uid%26p%3DJF8BARwJK1olWAcDUV1VCEwVCl8IGVMWWw8DXW4ZVxNJXF9RXh5UHw0cSgYYXBcIWDoXSQVJQwYAXF1bAUoeHDZNRwYlPgVDE0ArDh90VT9dWjt-NVl9JiQIaEcbM2gNHF0SVAUFZF5ZCU8TM18IGmtHM9604ob4uVfDqeDdk8wlXwYDVVtdAEwUAl8IHV0SXg8EU19aCEkRM28AH2vM3bHU9syElsHCi_g4K2sWbV5ABwFVDkIRAG4BG1IVWQEHEAYIOHsXM2w4RTUUWlZWUF5aACVLXW5TWVpLC2gHXF9aCE8SBF8KGloXXzYyZDdcbwh3YxsMRSFgWWcBFhdUdU5JcwRBfDUXJH1ALR8eUypJXjJhYgFePkIyVG5dDksVMw&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=jingdong&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                    <span>京东商城</span>
+                  </a>
+                </div>
+
+                <div class="cell impression_track_mod_buyinfo" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=jingdong&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject">
+                  <div class="cell price-wrapper">
+                    <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=jingdong&amp;srcpage=subject&amp;price=4160&amp;pos=1&amp;url=https%3A%2F%2Funion-click.jd.com%2Fjdc%3Fe%3Disbn9787208181564uid%26p%3DJF8BARwJK1olWAcDUV1VCEwVCl8IGVMWWw8DXW4ZVxNJXF9RXh5UHw0cSgYYXBcIWDoXSQVJQwYAXF1bAUoeHDZNRwYlPgVDE0ArDh90VT9dWjt-NVl9JiQIaEcbM2gNHF0SVAUFZF5ZCU8TM18IGmtHM9604ob4uVfDqeDdk8wlXwYDVVtdAEwUAl8IHV0SXg8EU19aCEkRM28AH2vM3bHU9syElsHCi_g4K2sWbV5ABwFVDkIRAG4BG1IVWQEHEAYIOHsXM2w4RTUUWlZWUF5aACVLXW5TWVpLC2gHXF9aCE8SBF8KGloXXzYyZDdcbwh3YxsMRSFgWWcBFhdUdU5JcwRBfDUXJH1ALR8eUypJXjJhYgFePkIyVG5dDksVMw&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=jingdong&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span class="buylink-price ">
+                        
+                        41.60元
+                      </span>
+                    </a>
+
+                  </div>
+
+                  <div class="cell">
+                    <a href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=jingdong&amp;srcpage=subject&amp;price=4160&amp;pos=1&amp;url=https%3A%2F%2Funion-click.jd.com%2Fjdc%3Fe%3Disbn9787208181564uid%26p%3DJF8BARwJK1olWAcDUV1VCEwVCl8IGVMWWw8DXW4ZVxNJXF9RXh5UHw0cSgYYXBcIWDoXSQVJQwYAXF1bAUoeHDZNRwYlPgVDE0ArDh90VT9dWjt-NVl9JiQIaEcbM2gNHF0SVAUFZF5ZCU8TM18IGmtHM9604ob4uVfDqeDdk8wlXwYDVVtdAEwUAl8IHV0SXg8EU19aCEkRM28AH2vM3bHU9syElsHCi_g4K2sWbV5ABwFVDkIRAG4BG1IVWQEHEAYIOHsXM2w4RTUUWlZWUF5aACVLXW5TWVpLC2gHXF9aCE8SBF8KGloXXzYyZDdcbwh3YxsMRSFgWWcBFhdUdU5JcwRBfDUXJH1ALR8eUypJXjJhYgFePkIyVG5dDksVMw&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" class="buy-book-btn paper-book-btn" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=jingdong&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span>购买纸质书</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+                
+  
+
+      </li>
+      
+      <li>
+        
+
+            
+              <div class="cell price-btn-wrapper">
+                <div class="vendor-name">
+                  <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=dangdang&amp;srcpage=subject&amp;price=5510&amp;pos=4&amp;url=https%3A%2F%2Funion.dangdang.com%2Ftransfer.php%3Ffrom%3DP-306226-0-s36255848%26backurl%3Dhttps%3A%2F%2Fproduct.dangdang.com%2Fproduct.aspx%3Fproduct_id%3D29570156&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dangdang&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                    <span>当当网</span>
+                  </a>
+                </div>
+
+                <div class="cell impression_track_mod_buyinfo" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=dangdang&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject">
+                  <div class="cell price-wrapper">
+                    <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=dangdang&amp;srcpage=subject&amp;price=5510&amp;pos=1&amp;url=https%3A%2F%2Funion.dangdang.com%2Ftransfer.php%3Ffrom%3DP-306226-0-s36255848%26backurl%3Dhttps%3A%2F%2Fproduct.dangdang.com%2Fproduct.aspx%3Fproduct_id%3D29570156&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dangdang&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span class="buylink-price ">
+                        
+                        55.10元
+                      </span>
+                    </a>
+
+                  </div>
+
+                  <div class="cell">
+                    <a href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=dangdang&amp;srcpage=subject&amp;price=5510&amp;pos=1&amp;url=https%3A%2F%2Funion.dangdang.com%2Ftransfer.php%3Ffrom%3DP-306226-0-s36255848%26backurl%3Dhttps%3A%2F%2Fproduct.dangdang.com%2Fproduct.aspx%3Fproduct_id%3D29570156&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" class="buy-book-btn paper-book-btn" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dangdang&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span>购买纸质书</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+                
+  
+
+      </li>
+      
+      <li>
+        
+
+            
+              <div class="cell price-btn-wrapper">
+                <div class="vendor-name">
+                  <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=bookschina&amp;srcpage=subject&amp;price=3700&amp;pos=5&amp;url=http%3A%2F%2Fwww.bookschina.com%2Funion%2Fubook.asp%3Fadservice%3D354872%26tourl%3Dhttp%3A%2F%2Fwww.bookschina.com%2F9087148.htm&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=bookschina&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                    <span>中图网</span>
+                  </a>
+                </div>
+
+                <div class="cell impression_track_mod_buyinfo" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=bookschina&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject">
+                  <div class="cell price-wrapper">
+                    <a target="_blank" href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=bookschina&amp;srcpage=subject&amp;price=3700&amp;pos=1&amp;url=http%3A%2F%2Fwww.bookschina.com%2Funion%2Fubook.asp%3Fadservice%3D354872%26tourl%3Dhttp%3A%2F%2Fwww.bookschina.com%2F9087148.htm&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=bookschina&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span class="buylink-price ">
+                        
+                        37.00元
+                      </span>
+                    </a>
+
+                  </div>
+
+                  <div class="cell">
+                    <a href="https://book.douban.com/link2/?lowest=3700&amp;pre=0&amp;vendor=bookschina&amp;srcpage=subject&amp;price=3700&amp;pos=1&amp;url=http%3A%2F%2Fwww.bookschina.com%2Funion%2Fubook.asp%3Fadservice%3D354872%26tourl%3Dhttp%3A%2F%2Fwww.bookschina.com%2F9087148.htm&amp;cntvendor=5&amp;srcsubj=36255848&amp;type=bkbuy&amp;subject=36255848" class="buy-book-btn paper-book-btn" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=bookschina&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vendor_subject')">
+                      
+                      <span>购买纸质书</span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+                
+  
+
+      </li>
+  </ul>
+
+
+      </div>
+      
+  <div class="add2cartContainer no-border">
+    
+  <span class="add2cartWidget ll">
+      <a class="j  add2cart a_show_login" href="https://www.douban.com/accounts/passport/login?source=book" rel="nofollow">
+        <span>+ 加入购书单</span></a>
+  </span>
+  
+
+  </div>
+
+  </div>
+
+<script>
+  $(document).ready(function() {
+    $('.impression_track_mod_buyinfo').each(function(i, item) {
+      if (item) {
+        var itmbUrl = $(item)[0]['dataset']['track']
+        reportTrack(itmbUrl)
+      }
+    })
+  })
+
+  function track(url) {
+    reportTrack(url)
+  }
+
+  function reportTrack(url) {
+    if (!url) { return false }
+    $.ajax({ url: url, dataType: 'text/html' })
+  }
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+      
+
+<link rel="stylesheet" href="https://img2.doubanio.com/cuphead/book-static/other/online-partner.6781e.css">
+
+  <div class="gray_ad online-partner">
+    <div class="online-type">
+      <h2>
+        在线试读
+        ：
+      </h2>
+      <div class="online-read-or-audio">
+        <div class="vendor-info">
+          <img class="vendor-icon" src="https://img1.doubanio.com/f/rohirrim/f6f620132e6d8a02d171f03114bbe2339aa8af97/website/static/pics/icon/icon_douban_read.png">
+          <a class="vendor-name impression_track_mod_buyinfo" target="_blank" href="https://read.douban.com/reader/ebook/475633282?from=book" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text')">
+            豆瓣阅读
+          </a>
+        </div>
+        <a class="vendor-link" target="_blank" href="https://read.douban.com/reader/ebook/475633282?from=book" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=douban_read&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text')">
+          在线阅读
+        </a>
+      </div>
+
+        <div class="online-read-or-audio">
+          <div class="vendor-info">
+            <img class="vendor-icon" src="https://img1.doubanio.com/f/rohirrim/161387ce451872cbf51fcb288cd5ffd1dcd89705/website/static/pics/icon/icon_dedao.png">
+            <a class="vendor-name impression_track_mod_buyinfo" target="_blank" href="https://www.dedao.cn/ebook/reader?id=N5lDqb9b47pXZxGn1kBzPlMyQArYv0qvZDLWqe85E2aVKdo9jNgOLRmDJ6nXLm16&amp;source=douban" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text')">
+              得到
+            </a>
+          </div>
+          <a class="vendor-link" target="_blank" href="https://www.dedao.cn/ebook/reader?id=N5lDqb9b47pXZxGn1kBzPlMyQArYv0qvZDLWqe85E2aVKdo9jNgOLRmDJ6nXLm16&amp;source=douban" data-track="https://frodo.douban.com/rohirrim/tracking/impression?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text" onclick="track('https://frodo.douban.com/rohirrim/tracking/click?subject_id=36255848&amp;isbn=720818156X&amp;source=dedao&amp;user_id=&amp;bid=khkD49G5Aak&amp;platform=pc&amp;location=vender_subject_text')">
+            在线试读
+          </a>
+        </div>
+    </div>
+  </div>
+
+
+  
+    
+
+
+
+
+
+
+  
+
+<link rel="stylesheet" href="https://img1.doubanio.com/cuphead/book-static/subject/works.4fdcb.css">
+
+
+<div class="gray_ad version_works">
+  
+  
+
+  <h2>
+    <span>这本书的其他版本</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+      <span class="pl">&nbsp;(
+          <a href="https://book.douban.com/works/1153615">全部3</a>
+        ) </span>
+
+  </h2>
+
+
+  <ul>
+      
+      <li class="mb8 pl">
+        <div class="meta-wrapper">
+          <div class="meta">
+            <a href="https://book.douban.com/subject/6511983/">Gallimard （2002）</a>
+            <div class="count">
+              <span>暂无评分</span> 2人读过
+            </div>
+          </div>
+
+        </div>
+
+        <ul class="buyinfo" style="display: none;">
+          
+  <ul class="bs current-version-list">
+  </ul>
+
+
+          
+  <ul class="secondhand-books-list bs">
+</ul>
+
+        </ul>
+      </li>
+      
+      <li class="mb8 pl">
+        <div class="meta-wrapper">
+          <div class="meta">
+            <a href="https://book.douban.com/subject/35352030/">Gallimard （1951）</a>
+            <div class="count">
+              <span>暂无评分</span> 2人读过
+            </div>
+          </div>
+
+        </div>
+
+        <ul class="buyinfo" style="display: none;">
+          
+  <ul class="bs current-version-list">
+  </ul>
+
+
+          
+  <ul class="secondhand-books-list bs">
+</ul>
+
+        </ul>
+      </li>
+  </ul>
+</div>
+
+<script>
+  $(document).ready(function() {
+    $('.fold-btn a').click(function() {
+      var $btn = $(this).find('span');
+      var $target = $(this).parents('.meta-wrapper').eq(0).next('.buyinfo');
+      if ($target.is(':visible')) {
+        $target.css('display', 'none');
+        $btn.text('展开');
+      } else {
+        $target.css('display', 'flex');
+        $btn.text('收起');
+
+        // track
+        if (!($target.attr('data-exposed'))) {
+          $target.find('.impression_track_manually').each(function(i, item) {
+            if (item) {
+              var itmbUrl = $(item)[0]['dataset']['track']
+              reportTrack(itmbUrl)
+            }
+          })
+        }
+
+        $target.attr('data-exposed', true);
+      }
+    })
+  })
+</script>
+
+
+  
+
+
+
+
+
+
+  
+    
+
+
+
+  
+  
+
+  <h2>
+    <span>以下书单推荐</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+      <span class="pl">&nbsp;(
+          <a href="https://book.douban.com/subject/36255848/doulists">全部</a>
+        ) </span>
+
+  </h2>
+
+
+  <div id="db-doulist-section" class="indent">
+    <ul class="bs">
+          
+            <li class=""><a class="" href="https://www.douban.com/doulist/39012552/" target="_blank">书海无涯</a>
+                <span class="pl">(佾云)</span>
+            </li>
+          
+            <li class=""><a class="" href="https://www.douban.com/doulist/1876083/" target="_blank">工人与新工人</a>
+                <span class="pl">(猫不许)</span>
+            </li>
+          
+            <li class=""><a class="" href="https://www.douban.com/doulist/46537632/" target="_blank">①这列火车载满了书籍,将在夜晚途经你梦里</a>
+                <span class="pl">(Z)</span>
+            </li>
+          
+            <li class=""><a class="" href="https://www.douban.com/doulist/3266744/" target="_blank">工人、工厂、工业的历史与文化</a>
+                <span class="pl">(麦秸)</span>
+            </li>
+          
+            <li class=""><a class="" href="https://www.douban.com/doulist/3038930/" target="_blank">工人阶级及相关研究（3）</a>
+                <span class="pl">(🦉的瓦涅密)</span>
+            </li>
+    </ul>
+  </div>
+
+  <div id="dale_book_subject_middle_mini" ad-status="loaded"></div>
+  
+    
+
+
+
+
+
+  
+  
+
+  <h2>
+    <span>谁读这本书?</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+<div id="collector">
+  
+
+<div>
+    
+    <div class="ll"><a href="https://www.douban.com/people/lzzzzbw/"><img src="https://img3.doubanio.com/icon/u223456473-2.jpg" alt="zbe599"></a></div>
+    <div style="padding-left:60px"><a href="https://www.douban.com/people/lzzzzbw/">zbe599</a><br>
+      <div class="pl ll">          今天上午          读过      </div>
+
+      <br>
+
+    </div>
+    <div class="clear"></div><br>
+    <div class="ul" style="margin-bottom:12px;"></div>
+</div>
+<div>
+    
+    <div class="ll"><a href="https://www.douban.com/people/131954718/"><img src="https://img1.doubanio.com/icon/u131954718-30.jpg" alt="君山"></a></div>
+    <div style="padding-left:60px"><a href="https://www.douban.com/people/131954718/">君山</a><br>
+      <div class="pl ll">          今天上午          想读      </div>
+
+      <br>
+
+    </div>
+    <div class="clear"></div><br>
+    <div class="ul" style="margin-bottom:12px;"></div>
+</div>
+<div>
+    
+    <div class="ll"><a href="https://www.douban.com/people/249562049/"><img src="https://img3.doubanio.com/icon/u249562049-2.jpg" alt="豆友uMH9H-PQ3g"></a></div>
+    <div style="padding-left:60px"><a href="https://www.douban.com/people/249562049/">豆友uMH9H-PQ3g</a><br>
+      <div class="pl ll">          今天凌晨          想读      </div>
+
+      <br>
+
+    </div>
+    <div class="clear"></div><br>
+    <div class="ul" style="margin-bottom:12px;"></div>
+</div>
+<div>
+    
+    <div class="ll"><a href="https://www.douban.com/people/54740080/"><img src="https://img1.doubanio.com/icon/u54740080-129.jpg" alt="要酸不要甜"></a></div>
+    <div style="padding-left:60px"><a href="https://www.douban.com/people/54740080/">要酸不要甜</a><br>
+      <div class="pl ll">          昨天          在读      </div>
+
+      <br>
+
+    </div>
+    <div class="clear"></div><br>
+    <div class="ul" style="margin-bottom:12px;"></div>
+</div>
+
+
+      <p class="pl">&gt; <a href="https://book.douban.com/subject/36255848/comments?status=N">467人在读</a></p>
+      <p class="pl">&gt; <a href="https://book.douban.com/subject/36255848/comments?status=P">2502人读过</a></p>
+      <p class="pl">&gt; <a href="https://book.douban.com/subject/36255848/comments?status=F">14182人想读</a></p>
+
+</div>
+
+
+
+
+
+  
+<!-- douban ad begin -->
+<div id="dale_book_subject_middle_right" ad-status="appended" data-sell-type="CPD" data-type="AdmaruRender" data-version="3.2.46"><div style="position: relative; margin: 0px 0px 20px; display: block; width: 300px; height: 250px; overflow: hidden;"><iframe src="about:blank" sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" safe-mode="custom" referrerpolicy="no-referrer-when-downgrade" width="300" height="250" frameborder="0" scrolling="no" name="dale_book_subject_middle_right_frame" id="dale_book_subject_middle_right_frame" style="overflow: hidden; display: block;"></iframe><div style="line-height: 1; text-align: center; background-color: rgba(0, 0, 0, 0.3); font-size: 12px; position: absolute; right: 0px; bottom: 0px; padding: 4px; color: rgb(255, 255, 255);">由Admaru提供的广告</div></div></div>
+<script type="text/javascript">
+    (function (global) {
+        if(!document.getElementsByClassName) {
+            document.getElementsByClassName = function(className) {
+                return this.querySelectorAll("." + className);
+            };
+            Element.prototype.getElementsByClassName = document.getElementsByClassName;
+
+        }
+        var articles = global.document.getElementsByClassName('article'),
+            asides = global.document.getElementsByClassName('aside');
+
+        if (articles.length > 0 && asides.length > 0 && articles[0].offsetHeight >= asides[0].offsetHeight) {
+            (global.DoubanAdSlots = global.DoubanAdSlots || []).push('dale_book_subject_middle_right');
+        }
+    })(this);
+</script>
+<!-- douban ad end -->
+
+  
+    
+
+
+
+
+
+
+<h2>
+  
+  
+
+  </h2><h2>
+    <span>二手市场</span>
+      &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
+
+  </h2>
+
+
+
+<div class="indent">
+  <ul class="bs">
+  <li class="">
+        <a class="rr j a_show_login" href="https://www.douban.com/register?reason=secondhand-offer&amp;cat=book"><span>在豆瓣转让</span></a>
+
+      有14182人想读，手里有一本闲着?
+    </li>
+  </ul>
+</div>
+
+  
+<p class="pl">订阅关于工厂日记的评论: <br><span class="feed">
+    <a href="https://book.douban.com/feed/subject/36255848/reviews"> feed: rss 2.0</a></span></p>
+
+
+      </div>
+      <div class="extra">
+        
+  
+<!-- douban ad begin -->
+<div id="dale_book_subject_bottom_super_banner" ad-status="loaded" data-sell-type="RTB" data-type="YoudaoRender" data-version="3.2.46"></div>
+<script type="text/javascript">
+    (function (global) {
+        var body = global.document.body,
+            html = global.document.documentElement;
+
+        var height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
+        if (height >= 2000) {
+            (global.DoubanAdSlots = global.DoubanAdSlots || []).push('dale_book_subject_bottom_super_banner');
+        }
+    })(this);
+</script>
+<!-- douban ad end -->
+
+
+      </div>
+    </div>
+  </div>
+
+        
+<div id="footer">
+
+<span id="icp" class="fleft gray-link">
+    © 2005－2026 douban.com, all rights reserved 北京豆网科技有限公司
+</span>
+
+<a href="https://www.douban.com/hnypt/variformcyst.py" style="display: none;"></a>
+
+<span class="fright">
+    <a href="https://www.douban.com/about">关于豆瓣</a>
+    · <a href="https://www.douban.com/jobs">在豆瓣工作</a>
+    · <a href="https://www.douban.com/about?topic=contactus">联系我们</a>
+    · <a href="https://www.douban.com/about/legal">法律声明</a>
+    
+    · <a href="https://help.douban.com/?app=book" target="_blank">帮助中心</a>
+    · <a href="https://book.douban.com/library_invitation">图书馆合作</a>
+    · <a href="https://www.douban.com/doubanapp/">移动应用</a>
+</span>
+
+</div>
+
+    </div>
+      
+
+    <script type="text/javascript">
+    $(function(){
+      $('.add2cartWidget').each(function() {
+        var add2CartBtn = $(this).find('.add2cart');
+        var inCartHint = $(this).find('.book-in-cart');
+        var deleteBtn = inCartHint.find('.delete-cart-item');
+
+        deleteBtn.click(function(e) {
+          e.preventDefault();
+          $.post_withck('/cart', {remove: this.rel}, function() {
+            add2CartBtn.show();
+            inCartHint.hide();
+          });
+        });
+      });
+    });
+  </script>
+    <!-- mako -->
+    
+  
+
+
+
+
+
+
+
+
+    
+<script type="text/javascript">
+    (function (global) {
+        var newNode = global.document.createElement('script'),
+            existingNode = global.document.getElementsByTagName('script')[0],
+            adSource = '//erebor.douban.com/',
+            userId = '',
+            browserId = 'khkD49G5Aak',
+            criteria = '7:社会学|7:哲学|7:法国|7:社会|7:纪实|7:女性|7:西蒙娜·薇依|7:社科|7:非虚构|7:随笔|3:/subject/36255848/',
+            preview = '',
+            debug = false,
+            adSlots = ['dale_book_subject_top_right', 'dale_book_subject_middle_mini'];
+
+        global.DoubanAdRequest = {src: adSource, uid: userId, bid: browserId, crtr: criteria, prv: preview, debug: debug};
+        global.DoubanAdSlots = (global.DoubanAdSlots || []).concat(adSlots);
+
+        newNode.setAttribute('type', 'text/javascript');
+        newNode.setAttribute('src', '//img1.doubanio.com/ZHdhZ2Y4eC9mL2FkanMvZmE3NGZkMWY5NzhhZmM4NmZhZjMxMTllNTQ5MGIyYWRlNTUwYmI0NS9hZC5yZWxlYXNlLmpz?company_token=kX69T8w1wyOE-dale');
+        newNode.setAttribute('async', true);
+        existingNode.parentNode.insertBefore(newNode, existingNode);
+    })(this);
+</script>
+
+
+
+
+
+
+    
+  
+
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var p=(('https:' == document.location.protocol) ? 'https' : 'http'), u=p+'://fundin.douban.com/';
+    _paq.push(['setTrackerUrl', u+'piwik']);
+    _paq.push(['setSiteId', '100001']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; 
+    g.type='text/javascript';
+    g.defer=true; 
+    g.async=true; 
+    g.src=p+'://s.doubanio.com/dae/fundin/piwik.js';
+    s.parentNode.insertBefore(g,s);
+  })();
+</script>
+
+<script type="text/javascript">
+var setMethodWithNs = function(namespace) {
+  var ns = namespace ? namespace + '.' : ''
+    , fn = function(string) {
+        if(!ns) {return string}
+        return ns + string
+      }
+  return fn
+}
+
+var gaWithNamespace = function(fn, namespace) {
+  var method = setMethodWithNs(namespace)
+  fn.call(this, method)
+}
+
+var _gaq = _gaq || []
+  , accounts = [
+      { id: 'UA-7019765-1', namespace: 'douban' }
+    , { id: 'UA-7019765-16', namespace: '' }
+    ]
+  , gaInit = function(account) {
+      gaWithNamespace(function(method) {
+        gaInitFn.call(this, method, account)
+      }, account.namespace)
+    }
+  , gaInitFn = function(method, account) {
+      _gaq.push([method('_setAccount'), account.id])
+
+      
+  _gaq.push([method('_addOrganic'), 'google', 'q'])
+  _gaq.push([method('_addOrganic'), 'baidu', 'wd'])
+  _gaq.push([method('_addOrganic'), 'soso', 'w'])
+  _gaq.push([method('_addOrganic'), 'youdao', 'q'])
+  _gaq.push([method('_addOrganic'), 'so.360.cn', 'q'])
+  _gaq.push([method('_addOrganic'), 'sogou', 'query'])
+  if (account.namespace) {
+    _gaq.push([method('_addIgnoredOrganic'), '豆瓣'])
+    _gaq.push([method('_addIgnoredOrganic'), 'douban'])
+    _gaq.push([method('_addIgnoredOrganic'), '豆瓣网'])
+    _gaq.push([method('_addIgnoredOrganic'), 'www.douban.com'])
+  }
+
+      if (account.namespace === 'douban') {
+        _gaq.push([method('_setDomainName'), '.douban.com'])
+      }
+
+        _gaq.push([method('_setCustomVar'), 1, 'responsive_view_mode', 'desktop', 3])
+
+        _gaq.push([method('_setCustomVar'), 2, 'login_status', '0', 2]);
+
+      _gaq.push([method('_trackPageview')])
+    }
+
+for(var i = 0, l = accounts.length; i < l; i++) {
+  var account = accounts[i]
+  gaInit(account)
+}
+
+
+;(function() {
+    var ga = document.createElement('script');
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.setAttribute('async', 'true');
+    document.documentElement.firstChild.appendChild(ga);
+})()
+</script>
+
+
+
+
+
+
+
+
+    <!-- dae-web-book--default-6c5fc5d459-nd6sd-->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div id="search_suggest" style="display: none; top: 77.999px; left: 594.906px;"><ul></ul></div><iframe name="google_ads_top_frame" id="google_ads_top_frame" style="display: none; position: fixed; left: -999px; top: -999px; width: 0px; height: 0px;"></iframe></body></html>

--- a/test_data/https___music_douban_com_subject_1401362_
+++ b/test_data/https___music_douban_com_subject_1401362_
@@ -1,119 +1,73 @@
-<!DOCTYPE html>
-<html lang="zh-CN" class="ua-mac ua-webkit">
-<head>
+<!DOCTYPE html><html lang="zh-CN" class="ua-mac ua-webkit"><head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="renderer" content="webkit">
     <meta name="referrer" content="always">
-    <meta name="google-site-verification" content="ok0wCgT20tBBgo9_zat2iAcimtN4Ftf5ccsh092Xeyw" />
+    <meta name="google-site-verification" content="ok0wCgT20tBBgo9_zat2iAcimtN4Ftf5ccsh092Xeyw">
     <title>
     Rubber Soul (豆瓣)
 </title>
-
+    
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="Sun, 6 Mar 2005 01:00:00 GMT">
-
+    
     <meta http-equiv="mobile-agent" content="format=html5; url=https://m.douban.com/music/subject/1401362">
+    
+    
+    <meta property="og:title" content="Rubber Soul">
+    <meta property="og:description" content="Rank 'em how you like, Rubber Soul is an undeniable pivot point in the Fab Four's varied discography...">
+    <meta property="og:site_name" content="豆瓣">
+    <meta property="og:url" content="https://music.douban.com/subject/1401362/">
+    <meta property="og:image" content="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg">
+    <meta property="og:type" content="music.album">
+        <meta property="music:musician" content="The Beatles">
 
 
-    <meta property="og:title" content="Rubber Soul" />
-    <meta property="og:description" content="Rank &#39;em how you like, Rubber Soul is an undeniable pivot point in the Fab Four&#39;s varied discography..." />
-    <meta property="og:site_name" content="豆瓣" />
-    <meta property="og:url" content="https://music.douban.com/subject/1401362/" />
-    <meta property="og:image" content="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg" />
-    <meta property="og:type" content="music.album" />
-        <meta property="music:musician" content="The Beatles" />
-
-
-
-    <script >var _head_start = new Date();</script>
-    <script src="https://img1.doubanio.com/f/music/b66ed708717bf0b4a005a4d0113af8843ef3b8ff/js/music/lib/jquery-1.11.0.min.js"></script>
-    <script src="https://img1.doubanio.com/f/music/dcd7ea79bfc24a0b5d9a280a8ca59acceddd56be/js/music/lib/jquery-migrate-1.2.1.js"></script>
-    <script src="https://img1.doubanio.com/f/shire/4888ee2fda6812f70a064a51c93b84fde8e4a3c2/js/douban.js"></script>
-    <script src="https://img1.doubanio.com/f/shire/2c0c1c6b83f9a457b0f38c38a32fc43a42ec9bad/js/do.js" data-cfg-autoload="false"></script>
-    <link href="https://img1.doubanio.com/f/shire/204847ecc7d679de915c283531d14f16cfbee65e/css/douban.css" rel="stylesheet" type="text/css">
-    <link href="https://img1.doubanio.com/f/music/ea0c776c52fba60e24e92ea802336c1fe9697ff4/css/music/init.css" rel="stylesheet" type="text/css" />
+    <link type="text/css" rel="stylesheet" href="https://img1.doubanio.com/f/vendors/e8a7261937da62636d22ca4c579efc4a4d759b1b/css/ui/dialog.css"><script type="text/javascript" defer="" async="" src="https://img3.doubanio.com/dae/fundin/piwik.js"></script><script async="" src="//www.googletagmanager.com/gtm.js?id=GTM-5WP579"></script><script type="text/javascript" src="//img1.doubanio.com/ZHdhZ2Y4eC9mL2FkanMvZmE3NGZkMWY5NzhhZmM4NmZhZjMxMTllNTQ5MGIyYWRlNTUwYmI0NS9hZC5yZWxlYXNlLmpz?company_token=kX69T8w1wyOE-dale" async="true"></script><script type="text/javascript" src="https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js" async="true"></script><script>var _head_start = new Date();</script>
+    <script src="https://img1.doubanio.com/f/vendors/0511abe9863c2ea7084efa7e24d1d86c5b3974f1/js/jquery-1.10.2.min.js"></script>
+    <script src="https://img1.doubanio.com/f/vendors/e258329ca4b2122b4efe53fddc418967441e0e7f/js/douban.js"></script>
+    <script src="https://img1.doubanio.com/f/vendors/43c21c5607ffe86759538789a60360c06532b4bf/js/do.js" data-cfg-autoload="false"></script>
+    <link href="https://img1.doubanio.com/f/vendors/fae7e145bf16b2f427ba0fe7ef3d47c04af3a6c0/css/douban.css" rel="stylesheet" type="text/css">
+    <link href="https://img3.doubanio.com/cuphead/music-static/css/init.3670a.css" rel="stylesheet" type="text/css">
     <style type="text/css">
-
-        a:link { color: #259; }
-        a:visited { color: #769; }
-        a:hover { color: #fff; }
-        a:active { color: #fff; }
-
+        
     </style>
-
-    <script src="https://img1.doubanio.com/f/shire/2c0c1c6b83f9a457b0f38c38a32fc43a42ec9bad/js/do.js" data-cfg-corelib="false"></script>
+    
+    <script src="https://img1.doubanio.com/f/vendors/43c21c5607ffe86759538789a60360c06532b4bf/js/do.js" data-cfg-corelib="false"></script>
     <script type="text/javascript">
         Do.add('dialog-css', {
-            path: 'https://img1.doubanio.com/f/shire/8377b9498330a2e6f056d863987cc7a37eb4d486/css/ui/dialog.css',
+            path: 'https://img1.doubanio.com/f/vendors/e8a7261937da62636d22ca4c579efc4a4d759b1b/css/ui/dialog.css',
             type: 'css'
         })
         Do.add('dialog', {
-            path: 'https://img1.doubanio.com/f/shire/bc881a837a728ab82aa01d653b1c180190bb5a5d/js/ui/dialog.js',
+            path: 'https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js',
             type: 'js',
             requires: ['dialog-css']
         })
     </script>
-
-  <script type='text/javascript'>
-  var _vwo_code = (function() {
-    var account_id = 249272,
-      settings_tolerance = 0,
-      library_tolerance = 2500,
-      use_existing_jquery = false,
-      // DO NOT EDIT BELOW THIS LINE
-      f=false,d=document;return{use_existing_jquery:function(){return use_existing_jquery;},library_tolerance:function(){return library_tolerance;},finish:function(){if(!f){f=true;var a=d.getElementById('_vis_opt_path_hides');if(a)a.parentNode.removeChild(a);}},finished:function(){return f;},load:function(a){var b=d.createElement('script');b.src=a;b.type='text/javascript';b.innerText;b.onerror=function(){_vwo_code.finish();};d.getElementsByTagName('head')[0].appendChild(b);},init:function(){settings_timer=setTimeout('_vwo_code.finish()',settings_tolerance);var a=d.createElement('style'),b='body{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}',h=d.getElementsByTagName('head')[0];a.setAttribute('id','_vis_opt_path_hides');a.setAttribute('type','text/css');if(a.styleSheet)a.styleSheet.cssText=b;else a.appendChild(d.createTextNode(b));h.appendChild(a);this.load('//dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&r='+Math.random());return settings_timer;}};}());
-
-  +function () {
-    var bindEvent = function (el, type, handler) {
-        var $ = window.jQuery || window.Zepto || window.$
-       if ($ && $.fn && $.fn.on) {
-           $(el).on(type, handler)
-       } else if($ && $.fn && $.fn.bind) {
-           $(el).bind(type, handler)
-       } else if (el.addEventListener){
-         el.addEventListener(type, handler, false);
-       } else if (el.attachEvent){
-         el.attachEvent("on" + type, handler);
-       } else {
-         el["on" + type] = handler;
-       }
-     }
-
-    var _origin_load = _vwo_code.load
-    _vwo_code.load = function () {
-      var args = [].slice.call(arguments)
-      bindEvent(window, 'load', function () {
-        _origin_load.apply(_vwo_code, args)
-      })
-    }
-  }()
-
-  _vwo_settings_timer = _vwo_code.init();
-  </script>
+    <link rel="stylesheet" href="https://img1.doubanio.com/cuphead/music-static/css/new_write_btn.2a37b.css">
 
 
-
-    <link rel="stylesheet" href="https://img1.doubanio.com/misc/mixed_static/4575fc7c79433e5e.css">
+    <link rel="stylesheet" href="https://img1.doubanio.com/misc/mixed_static/229a80419086b25b.css">
     <script></script>
 
     <link rel="shortcut icon" href="https://img1.doubanio.com/favicon.ico" type="image/x-icon">
-</head>
+<style type="text/css" id="css-share-button">.bn-sharing{padding-right:10px;background-image:url(//img3.doubanio.com/pics/a1.png) !important;background-repeat:no-repeat !important;background-position:100% -19px !important;}a.bn-sharing:hover{text-decoration:underline;}.bn-sharing-on{background-position:100% 4px !important;position:relative !important;z-index:1 !important;}#db-div-sharing{position:absolute;width:100px;}#db-div-sharing .bd{border:1px solid #aaa;background:#fff;padding:10px 0 0 10px;}#db-div-sharing .bd li{line-height:20px;margin-bottom:5px;}#db-div-sharing .hd{position:absolute;height:24px;overflow:hidden;right:0;top:-24px;padding:0 5px;border:1px solid #aaa;border-bottom:none;background:#fff;}.rec-ren,.rec-sin,.rec-douban,.rec-tx,.rec-sohu,.rec-qqim,.rec-wechat{padding-left:23px;background:url(//img3.doubanio.com/img/files/file-1395904010.png) no-repeat 0 0;}.rec-wechat{background-position:0 0;}.rec-sin{background-position:0 -20px;}.rec-qqim{background-position:0 -40px;}.rec-tx{background-position:0 -60px;}.rec-ren{background-position:0 -80px;}.rec-douban{background-position:0 -100px;}</style><script src="https://ssl.google-analytics.com/ga.js" async="true"></script></head>
 
-<body>
-
+<body style="">
+  
     <script type="text/javascript">var _body_start = new Date();</script>
+    
+   
 
 
 
-
-
-    <link href="//img3.doubanio.com/dae/accounts/resources/20e516e/shire/bundle.css" rel="stylesheet" type="text/css">
+    <link href="//img3.doubanio.com/dae/accounts/resources/f8b2226/shire/bundle.css" rel="stylesheet" type="text/css">
 
 
 
 <div id="db-global-nav" class="global-nav">
   <div class="bd">
-
+    
 <div class="top-nav-info">
   <a href="https://accounts.douban.com/passport/login?source=music" class="nav-login" rel="nofollow">登录/注册</a>
 </div>
@@ -129,14 +83,14 @@
     <p class="appintro-title">豆瓣</p>
     <p class="qrcode">扫码直接下载</p>
     <div class="download">
-      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&direct_dl=1&download=iOS">iPhone</a>
+      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&amp;direct_dl=1&amp;download=iOS">iPhone</a>
       <span>·</span>
-      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&direct_dl=1&download=Android" class="download-android">Android</a>
+      <a href="https://www.douban.com/doubanapp/redirect?channel=top-nav&amp;direct_dl=1&amp;download=Android" class="download-android">Android</a>
     </div>
   </div>
 </div>
 
-
+    
 
 
 <div class="global-nav-items">
@@ -151,7 +105,10 @@
       <a href="https://movie.douban.com" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-movie&quot;,&quot;uid&quot;:&quot;0&quot;}">电影</a>
     </li>
     <li class="on">
-      <a href="https://music.douban.com"  data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-music&quot;,&quot;uid&quot;:&quot;0&quot;}">音乐</a>
+      <a href="https://music.douban.com" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-music&quot;,&quot;uid&quot;:&quot;0&quot;}">音乐</a>
+    </li>
+    <li class="">
+      <a href="https://www.douban.com/podcast/" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-podcast&quot;,&quot;uid&quot;:&quot;0&quot;}">播客</a>
     </li>
     <li class="">
       <a href="https://www.douban.com/location" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-location&quot;,&quot;uid&quot;:&quot;0&quot;}">同城</a>
@@ -160,16 +117,16 @@
       <a href="https://www.douban.com/group" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-group&quot;,&quot;uid&quot;:&quot;0&quot;}">小组</a>
     </li>
     <li class="">
-      <a href="https://read.douban.com&#47;?dcs=top-nav&amp;dcm=douban" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-read&quot;,&quot;uid&quot;:&quot;0&quot;}">阅读</a>
+      <a href="https://read.douban.com/?dcs=top-nav&amp;dcm=douban" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-read&quot;,&quot;uid&quot;:&quot;0&quot;}">阅读</a>
     </li>
     <li class="">
-      <a href="https://douban.fm&#47;?from_=shire_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-fm&quot;,&quot;uid&quot;:&quot;0&quot;}">FM</a>
+      <a href="https://fm.douban.com/?from_=shire_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-fm&quot;,&quot;uid&quot;:&quot;0&quot;}">FM</a>
     </li>
     <li class="">
-      <a href="https://time.douban.com&#47;?dt_time_source=douban-web_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-time&quot;,&quot;uid&quot;:&quot;0&quot;}">时间</a>
+      <a href="https://time.douban.com/?dt_time_source=douban-web_top_nav" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-time&quot;,&quot;uid&quot;:&quot;0&quot;}">时间</a>
     </li>
     <li class="">
-      <a href="https://market.douban.com&#47;?utm_campaign=douban_top_nav&amp;utm_source=douban&amp;utm_medium=pc_web" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-market&quot;,&quot;uid&quot;:&quot;0&quot;}">豆品</a>
+      <a href="https://market.douban.com/?utm_campaign=douban_top_nav&amp;utm_source=douban&amp;utm_medium=pc_web" target="_blank" data-moreurl-dict="{&quot;from&quot;:&quot;top-nav-click-market&quot;,&quot;uid&quot;:&quot;0&quot;}">豆品</a>
     </li>
   </ul>
 </div>
@@ -186,16 +143,15 @@
 
 
 
-    <script src="//img3.doubanio.com/dae/accounts/resources/20e516e/shire/bundle.js" defer="defer"></script>
+    <script src="//img3.doubanio.com/dae/accounts/resources/f8b2226/shire/bundle.js" defer="defer"></script>
 
 
 
 
+      
 
 
-
-
-    <link href="//img3.doubanio.com/dae/accounts/resources/20e516e/music/bundle.css" rel="stylesheet" type="text/css">
+    <link href="//img3.doubanio.com/dae/accounts/resources/f8b2226/music/bundle.css" rel="stylesheet" type="text/css">
 
 
 
@@ -204,56 +160,45 @@
   <div class="nav-wrap">
   <div class="nav-primary">
     <div class="nav-logo">
-      <a href="https:&#47;&#47;music.douban.com">豆瓣音乐</a>
+      <a href="https://music.douban.com">豆瓣音乐</a>
     </div>
     <div class="nav-search">
-      <form action="https:&#47;&#47;search.douban.com&#47;music/subject_search" method="get">
+      <form action="https://search.douban.com/music/subject_search" method="get">
         <fieldset>
           <legend>搜索：</legend>
           <label for="inp-query">
           </label>
-          <div class="inp"><input id="inp-query" name="search_text" size="22" maxlength="60" placeholder="唱片名、表演者、条码、ISRC" value=""></div>
+          <div class="inp"><input id="inp-query" name="search_text" size="22" maxlength="60" placeholder="唱片名、表演者、条码、ISRC" value="" autocomplete="off"></div>
           <div class="inp-btn"><input type="submit" value="搜索"></div>
-          <input type="hidden" name="cat" value="1003" />
+          <input type="hidden" name="cat" value="1003">
         </fieldset>
       </form>
     </div>
   </div>
   </div>
   <div class="nav-secondary">
-
+    
 
 <div class="nav-items">
   <ul>
-    <li    ><a href="https://music.douban.com/artists/"
-     >音乐人</a>
+    <li><a href="https://music.douban.com/artists/">音乐人</a>
     </li>
-    <li    ><a href="https://music.douban.com/topics/"
-     >专题</a>
+    <li><a href="https://music.douban.com/chart">排行榜</a>
     </li>
-    <li    ><a href="https://music.douban.com/chart"
-     >排行榜</a>
+    <li><a href="https://music.douban.com/tag/">分类浏览</a>
     </li>
-    <li    ><a href="https://music.douban.com/tag/"
-     >分类浏览</a>
+    <li><a href="https://music.douban.com/review/latest/">乐评</a>
     </li>
-    <li    ><a href="https://music.douban.com/review/latest/"
-     >乐评</a>
+    <li><a href="https://fm.douban.com/?from_=music_nav">豆瓣FM</a>
     </li>
-    <li    ><a href="https://douban.fm/?from_=music_nav"
-     >豆瓣FM</a>
+    <li><a href="https://fm.douban.com/explore/songlists/">歌单</a>
     </li>
-    <li    ><a href="https://douban.fm/explore/songlists/"
-     >歌单</a>
-    </li>
-    <li    ><a href="https://music.douban.com/annual/2022?fullscreen=1&source=navigation"
-            target="_blank"
-     >2022年度榜单</a>
+    <li><a href="https://music.douban.com/annual/2025/?fullscreen=1&amp;source=navigation" target="_blank">2025年度榜单</a>
     </li>
   </ul>
 </div>
 
-    <a href="https://music.douban.com/annual/2022?source=music_navigation" class="musicannual"></a>
+    <a href="https://music.douban.com/annual/2025/?source=music_navigation" class="musicannual"></a>
   </div>
 </div>
 
@@ -292,127 +237,107 @@
 
 
 
-    <script src="//img3.doubanio.com/dae/accounts/resources/20e516e/music/bundle.js" defer="defer"></script>
+    <script src="//img3.doubanio.com/dae/accounts/resources/f8b2226/music/bundle.js" defer="defer"></script>
 
 
 
 
-
-
+    
     <div id="wrapper">
-
+        
 
         <h1>
             <span>Rubber Soul</span>
             <div class="clear"></div>
         </h1>
-
+        
 <div id="content">
-
+    
     <div class="grid-16-8 clearfix">
-
-
+        
+        
         <div class="article">
-
-
-
+               
     <div class="indent">
         <div class="subjectwrap clearfix">
-
+            
 
 
 <div class="subject clearfix">
     <div id="mainpic">
         <span class="ckd-collect">
-            <a class="nbg" href="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg"
-            title="点击看大图">
-                <img src="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg"
-                    alt="Rubber Soul" rel="v:photo"/>
+            <a class="nbg" href="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg" title="点击看大图">
+                <img src="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg" alt="Rubber Soul" rel="v:photo">
             </a>
         </span>
-        <br/>
-
-
-
-
-<div class="infobox" style="">
-    <div class="bd">
-        <div class="start_radio">
-                <a target="_fm" href="https://douban.fm/?cid=13669&amp;from_=music_subject">
-                <img height="14" src="https://img1.doubanio.com/f/music/2306dcd67c23f9b28b6657dadef088a7e9ab1357/pics/music/subject/start-fm-logo.png" alt="FM">
-                听相似歌曲
-            </a>
-        </div>
-    </div>
-</div>
-
-
+        <br>
+        
 
     </div>
 
     <div id="info" class="ckd-collect">
+        
 
-
-
-
-
+                
+                    
+    
     <span class="pl">又名:</span>&nbsp;橡胶灵魂
-    <br />
+    <br>
 
-
+                
                     <span>
                         <span class="pl">
                             表演者:
-
+                                    
                                     <a href="/search?q=The+Beatles&amp;sid=1401362">The Beatles</a>
                         </span>
                     </span>
-
-                    <br/>
-
-
-
+                    
+                    <br>
+                
+                    
+    
     <span class="pl">流派:</span>&nbsp;摇滚
-    <br />
+    <br>
 
-
-
-
+                
+                    
+    
     <span class="pl">专辑类型:</span>&nbsp;专辑
-    <br />
+    <br>
 
-
-
-
+                
+                    
+    
     <span class="pl">介质:</span>&nbsp;Audio CD
-    <br />
+    <br>
 
-
-
-
+                
+                    
+    
     <span class="pl">发行时间:</span>&nbsp;1965
-    <br />
+    <br>
 
-
-
-
+                
+                    
+    
     <span class="pl">出版者:</span>&nbsp;Capitol
-    <br />
+    <br>
 
-
-
-
+                
+                    
+    
     <span class="pl">唱片数:</span>&nbsp;1
-    <br />
+    <br>
 
-
-
-
+                
+                        
+    
     <span class="pl">条形码:</span>&nbsp;0077774644020
-    <br />
+    <br>
 
-
-
+        
+            
             <span class="pl">其他版本:</span>&nbsp;
             <a href="https://music.douban.com/subject/6958653/">Rubber Soul</a>
             （<a href="/albums/103752">全部</a>）
@@ -422,10 +347,10 @@
 
 
 
+            
+                
 
-
-
-
+    
     <div id="interest_sectl">
         <div class="rating_wrap clearbox" rel="v:rating">
             <div class="rating_logo">
@@ -437,63 +362,63 @@
                 <div class="rating_right ">
                     <div class="ll bigstar50"></div>
                     <div class="rating_sum">
-                            <a href="comments" class="rating_people"><span property="v:votes">11657</span>人评价</a>
+                            <a href="comments" class="rating_people"><span property="v:votes">15227</span>人评价</a>
                     </div>
                 </div>
             </div>
 
-
-
-
+                
+                    
+                    
     <span class="stars5 starstop" title="力荐">
         5星
     </span>
 
-
+                    
     <div class="power" style="width:64px"></div>
 
-                    <span class="rating_per">82.0%</span>
+                    <span class="rating_per">81.4%</span>
                     <br>
-
-
+                    
+                    
     <span class="stars4 starstop" title="推荐">
         4星
     </span>
 
-
+                    
     <div class="power" style="width:12px"></div>
 
-                    <span class="rating_per">15.4%</span>
+                    <span class="rating_per">15.8%</span>
                     <br>
-
-
+                    
+                    
     <span class="stars3 starstop" title="还行">
         3星
     </span>
 
-
+                    
     <div class="power" style="width:1px"></div>
 
-                    <span class="rating_per">2.3%</span>
+                    <span class="rating_per">2.4%</span>
                     <br>
-
-
+                    
+                    
     <span class="stars2 starstop" title="较差">
         2星
     </span>
 
-
+                    
     <div class="power" style="width:0px"></div>
 
                     <span class="rating_per">0.2%</span>
                     <br>
-
-
+                    
+                    
     <span class="stars1 starstop" title="很差">
         1星
     </span>
 
-
+                    
     <div class="power" style="width:0px"></div>
 
                     <span class="rating_per">0.2%</span>
@@ -506,86 +431,77 @@
 
 
         </div>
-
-
+        
+            
 
 
 
 <div id="interest_sect_level" class="clearfix">
-
-        <a href="https://www.douban.com/register?reason=collectwish&amp;ck="
-           rel="nofollow" class="j a_show_login colbutt ll"
-           name="pbtn-1401362-wish">
+    
+        <a href="https://www.douban.com/register?reason=collectwish&amp;ck=" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-1401362-wish">
             <span>想听</span>
         </a>
-        <a href="https://www.douban.com/register?reason=collectdo&amp;ck="
-           rel="nofollow" class="j a_show_login colbutt ll"
-           name="pbtn-1401362-do">
+        <a href="https://www.douban.com/register?reason=collectdo&amp;ck=" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-1401362-do">
             <span>在听</span>
         </a>
-        <a href="https://www.douban.com/register?reason=collectcollect&amp;ck="
-           rel="nofollow" class="j a_show_login colbutt ll"
-           name="pbtn-1401362-collect">
+        <a href="https://www.douban.com/register?reason=collectcollect&amp;ck=" rel="nofollow" class="j a_show_login colbutt ll" name="pbtn-1401362-collect">
             <span>听过</span>
         </a>
 
         <div class="ll j a_stars">
-
-
+            
+    
     评价:
     <span id="rating">
-        <span id="stars" data-solid="https://img1.doubanio.com/f/shire/5a2327c04c0c231bced131ddf3f4467eb80c1c86/pics/rating_icons/star_onmouseover.png" data-hollow="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" data-solid-2x="https://img1.doubanio.com/f/shire/7258904022439076d57303c3b06ad195bf1dc41a/pics/rating_icons/star_onmouseover@2x.png" data-hollow-2x="https://img1.doubanio.com/f/shire/95cc2fa733221bb8edd28ad56a7145a5ad33383e/pics/rating_icons/star_hollow_hover@2x.png">
+        <span id="stars" data-solid="https://img1.doubanio.com/f/vendors/5a2327c04c0c231bced131ddf3f4467eb80c1c86/pics/rating_icons/star_onmouseover.png" data-hollow="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" data-solid-2x="https://img1.doubanio.com/f/vendors/7258904022439076d57303c3b06ad195bf1dc41a/pics/rating_icons/star_onmouseover@2x.png" data-hollow-2x="https://img1.doubanio.com/f/vendors/95cc2fa733221bb8edd28ad56a7145a5ad33383e/pics/rating_icons/star_hollow_hover@2x.png">
                 <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-1">
 
-            <img src="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star1" width="16" height="16" /></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-2">
+            <img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star1" width="16" height="16"></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-2">
 
-            <img src="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star2" width="16" height="16" /></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-3">
+            <img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star2" width="16" height="16"></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-3">
 
-            <img src="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star3" width="16" height="16" /></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-4">
+            <img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star3" width="16" height="16"></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-4">
 
-            <img src="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star4" width="16" height="16" /></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-5">
+            <img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star4" width="16" height="16"></a>                <a href="https://www.douban.com/register?reason=rate" class="j a_show_login" name="pbtn-1401362-5">
 
-            <img src="https://img1.doubanio.com/f/shire/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star5" width="16" height="16" /></a>        </span>
+            <img src="https://img1.doubanio.com/f/vendors/2520c01967207a1735171056ec588c8c1257e5f8/pics/rating_icons/star_hollow_hover.png" id="star5" width="16" height="16"></a>        </span>
         <span id="rateword" class="pl"></span>
-        <input id="n_rating" type="hidden" value="" />
+        <input id="n_rating" type="hidden" value="">
     </span>
 
         </div>
 
-
-
-
 <style type="text/css">
-    a.colbutt { color: #000000; }
+    a.colbutt { color: #000000 !important; }
 </style>
 </div>
 
 
 
 
-
+        
 
 
 
 <div class="gtleft">
     <ul class="ul_subject_menu bicelink color_gray pt6 clearfix">
             <li>
-                    <img src="https://img1.doubanio.com/f/shire/cc03d0fcf32b7ce3af7b160a0b85e5e66b47cc42/pics/short-comment.gif" />&nbsp;
+                    <img src="https://img1.doubanio.com/f/vendors/cc03d0fcf32b7ce3af7b160a0b85e5e66b47cc42/pics/short-comment.gif">&nbsp;
                     <a class="j a_show_login" href="https://www.douban.com/register?reason=short_comment" rel="nofollow">写短评</a>
             </li>
             <li>
-                    <img src="https://img1.doubanio.com/f/shire/5bbf02b7b5ec12b23e214a580b6f9e481108488c/pics/add-review.gif" />&nbsp;
+                    <img src="https://img1.doubanio.com/f/vendors/5bbf02b7b5ec12b23e214a580b6f9e481108488c/pics/add-review.gif">&nbsp;
                     <a class="j a_show_login" href="https://www.douban.com/register?reason=review" rel="nofollow">写乐评</a>
             </li>
             <li>
-                    <img src="https://img1.doubanio.com/f/shire/61cc48ba7c40e0272d46bb93fe0dc514f3b71ec5/pics/add-doulist.gif" />&nbsp;
+                    <img src="">&nbsp;
                     <a class="j a_show_login" href="https://www.douban.com/register?reason=collect-doulist" rel="nofollow">加入豆列</a>
             </li>
-
-
-
+            
+            
+    
     <li class="rec" id="W-None">
-        <a href= "#" data-type="W" data-url="https://music.douban.com/subject/1401362/" data-desc="" data-title="专辑《Rubber Soul》 (来自豆瓣) " data-pic="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg" class="bn-sharing ">分享到</a> &nbsp;&nbsp;
+        <a href="#" data-type="W" data-url="https://music.douban.com/subject/1401362/" data-desc="" data-title="专辑《Rubber Soul》 (来自豆瓣) " data-pic="https://img1.doubanio.com/view/subject/m/public/s28825668.jpg" class="bn-sharing ">分享到</a> &nbsp;&nbsp;
     </li>
     <script>
     if (!window.DoubanShareMenuList) {
@@ -595,26 +511,26 @@
     (function(u){
         if(__cache_url[u]) return;
         __cache_url[u] = true;
-        window.DoubanShareIcons = 'https://img1.doubanio.com/f/shire/3c8da10d6081bd1b2d13d3733b2ac201535c5d0f/pics/ic_shares2.png';
+        window.DoubanShareIcons = '';
         var initShareButton = function() {
           $.ajax({url:u,dataType:'script',cache:true});
         };
         if (typeof Do == 'function' && 'ready' in Do) {
-          Do('https://img1.doubanio.com/f/shire/8377b9498330a2e6f056d863987cc7a37eb4d486/css/ui/dialog.css',
-            'https://img1.doubanio.com/f/shire/bc881a837a728ab82aa01d653b1c180190bb5a5d/js/ui/dialog.js',
+          Do('https://img1.doubanio.com/f/vendors/e8a7261937da62636d22ca4c579efc4a4d759b1b/css/ui/dialog.css',
+            'https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js',
             initShareButton);
         } else if(typeof Douban == 'object' && 'loader' in Douban) {
           Douban.loader.batch(
-            'https://img1.doubanio.com/f/shire/8377b9498330a2e6f056d863987cc7a37eb4d486/css/ui/dialog.css',
-            'https://img1.doubanio.com/f/shire/bc881a837a728ab82aa01d653b1c180190bb5a5d/js/ui/dialog.js'
+            'https://img1.doubanio.com/f/vendors/e8a7261937da62636d22ca4c579efc4a4d759b1b/css/ui/dialog.css',
+            'https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js'
           ).done(initShareButton);
         }
-    })('https://img1.doubanio.com/f/shire/64044c0cde0c2bbf9c3eb94e57da6070d0340c4b/js/lib/sharebutton.js');
+    })('https://img1.doubanio.com/f/vendors/b6e0770163b1da14217b0f1ca39189d47b95f51f/js/lib/sharebutton.js');
     </script>
 
     </ul>
 </div>
-
+    
 
 
 
@@ -627,49 +543,47 @@
 
     <span class="rec">
 
-<a data-user_id="0" href="https://www.douban.com/accounts/register?reason=collect" share-id="1401362" data-mode="plain" data-name="Rubber Soul" data-type="music" data-desc="The Beatles / 专辑 / 1965 / Capitol / Audio CD" data-href="https://music.douban.com/subject/1401362/" data-image="https://img1.doubanio.com/view/subject/s/public/s28825668.jpg" data-properties="{&#34;rating&#34;:&#34;9.6&#34;}" data-redir="https://music.douban.com/static/dshare_proxy.html" data-text="" data-apikey="" data-curl="" data-count="10" data-object_kind="1003" data-object_id="1401362" data-target_type="rec" data-target_action="0" data-action_props="{&#34;subject_url&#34;:&#34;https:\/\/music.douban.com\/subject\/1401362\/&#34;,&#34;subject_title&#34;:&#34;Rubber Soul&#34;}" data-btn_text="推荐" data-heading="推荐到豆瓣" data-sanity_key="_196fc" class="j a_show_login lnk-sharing lnk-douban-sharing">推荐</a>
+<a data-user_id="0" href="https://www.douban.com/accounts/register?reason=collect" share-id="1401362" data-mode="plain" data-name="Rubber Soul" data-type="music" data-desc="The Beatles / 专辑 / 1965 / Capitol / Audio CD" data-href="https://music.douban.com/subject/1401362/" data-image="https://img1.doubanio.com/view/subject/s/public/s28825668.jpg" data-properties="{&quot;rating&quot;:&quot;9.6&quot;}" data-redir="https://music.douban.com/static/dshare_proxy.html" data-text="" data-apikey="" data-curl="" data-count="10" data-object_kind="1003" data-object_id="1401362" data-target_type="rec" data-target_action="0" data-action_props="{&quot;subject_url&quot;:&quot;https:\/\/music.douban.com\/subject\/1401362\/&quot;,&quot;subject_title&quot;:&quot;Rubber Soul&quot;}" data-btn_text="推荐" data-heading="推荐到豆瓣" data-sanity_key="_196fc" class="j a_show_login lnk-sharing lnk-douban-sharing">推荐</a>
 </span>
 </div>
 
 
     </div>
-    <br clear="all"/>
+    <br clear="all">
 
     <div id="collect_form_1401362"></div>
 
     <div class="related_info">
+        
 
 
 
 
 
-
-
+    
     <h2>
         简介
-            &nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;
+            &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
     </h2>
 
     <div class="indent" id="link-report">
-
+            
                 <span class="short">
                     <span property="v:summary">　　Rank 'em how you like, Rubber Soul is an undeniable pivot point in the Fab Four's varied discography no matter where, or how, you first heard it. The album was softened up in its original 12-song American edition to jibe with the Dylan/Byrds folk-rock sound, as well as squeeze money from the Parlophone catalog. The 14-song U.K. edition--the version now available on compact di...</span>
                     <a href="javascript:void(0)" class="j a_show_full">(展开全部)</a>
                 </span>
-                <span class="all hidden">　　Rank 'em how you like, Rubber Soul is an undeniable pivot point in the Fab Four's varied discography no matter where, or how, you first heard it. The album was softened up in its original 12-song American edition to jibe with the Dylan/Byrds folk-rock sound, as well as squeeze money from the Parlophone catalog. The 14-song U.K. edition--the version now available on compact disc--is a different, more dynamic, and ultimately more accomplished achievement. So many classics: &quot;Drive My Car&quot; and &quot;Nowhere Man&quot; (both omitted from the U.S. edition) merge the early combustible Beatifics to a burgeoning studio consciousness; &quot;The Word&quot; can be read as a pre-psych warning shot; the sitar-laden &quot;Norwegian Wood&quot; and the evocative &quot;Girl&quot; (the latter written on the last night of the sessions) stand as turning points in John Lennon's oeuvre. George finally emerges too, with the McGuinn-ish &quot;If I Needed Someone.&quot; EMI. 2005.</span>
-            <br/>
+                <span class="all hidden">　　Rank 'em how you like, Rubber Soul is an undeniable pivot point in the Fab Four's varied discography no matter where, or how, you first heard it. The album was softened up in its original 12-song American edition to jibe with the Dylan/Byrds folk-rock sound, as well as squeeze money from the Parlophone catalog. The 14-song U.K. edition--the version now available on compact disc--is a different, more dynamic, and ultimately more accomplished achievement. So many classics: "Drive My Car" and "Nowhere Man" (both omitted from the U.S. edition) merge the early combustible Beatifics to a burgeoning studio consciousness; "The Word" can be read as a pre-psych warning shot; the sitar-laden "Norwegian Wood" and the evocative "Girl" (the latter written on the last night of the sessions) stand as turning points in John Lennon's oeuvre. George finally emerges too, with the McGuinn-ish "If I Needed Someone." EMI. 2005.</span>
+            <br>
     </div>
 
 
 
+        
 
 
 
-
-<link rel="stylesheet" href="https://img1.doubanio.com/f/verify/b94df3c30a99176a78709b95ecf1cf80b105beb0/entry_creator/dist/author_subject/style.css">
-<div id="author_subject" class="author-wrapper">
-    <div class="loading"></div>
-</div>
+<link rel="stylesheet" href="https://img1.doubanio.com/f/verify/a5bc0bc0aea4221d751bc4809fd4b0a1075ad25e/entry_creator/dist/author_subject/style.css">
+<div id="author_subject" class="author-wrapper"><div class="author-subject"></div></div>
 <script>
     var answerObj = {
         TYPE: 'music',
@@ -678,8 +592,11 @@
         USER_ID: 'None'
     }
 </script>
-<script src="https://img1.doubanio.com/f/music/61252f2f9b35f08b37f69d17dfe48310dd295347/js/music/lib/react/bundle.js"></script>
-<script type="text/javascript" src="https://img1.doubanio.com/f/verify/6e7e593ba318f1355c70e66e010cf89411c3d937/entry_creator/dist/author_subject/index.js"></script>
+<script src="https://img1.doubanio.com/f/vendors/bd6325a12f40c34cbf2668aafafb4ccd60deab7e/vendors.js"></script>
+<script src="https://img1.doubanio.com/f/vendors/6242a400cfd25992da35ace060e58f160efc9c50/shared_rc.js"></script>
+<script type="text/javascript" src="https://img1.doubanio.com/f/verify/67e13c04cd5519da7657f708714ba1e7eab8d342/entry_creator/dist/author_subject/index.js"></script> 
+
+        
 
 
 
@@ -689,142 +606,162 @@
 
 
 
-
-
-
-            <div class="">
-
+            
+            <div>
+                
     <h2>
         曲目
-            &nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;
+            &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
     </h2>
 
                     <div class="track-list">
-                        <div class="indent">
-                            <div class="">
-                                1. Drive My Car<br/>2. Norwegian Wood (This Bird Has Flown)<br/>3. You Won't See Me<br/>4. Nowhere Man<br/>5. Think For Yourself<br/>6. The Word<br/>7. Michelle<br/>8. What Goes On<br/>9. Girl<br/>10. I'm Looking Through You<br/>11. In My Life<br/>12. Wait<br/>13. If I Needed Someone<br/>14. Run For Your Life
-                            </div>
-                        </div>
+                        
+                        <ul class="track-items indent">
+                            <li class="indent" data-track-order="1.">Drive My Car</li>
+                            <li class="indent" data-track-order="2.">Norwegian Wood (This Bird Has Flown)</li>
+                            <li class="indent" data-track-order="3.">You Won't See Me</li>
+                            <li class="indent" data-track-order="4.">Nowhere Man</li>
+                            <li class="indent" data-track-order="5.">Think For Yourself</li>
+                            <li class="indent" data-track-order="6.">The Word</li>
+                            <li class="indent" data-track-order="7.">Michelle</li>
+                            <li class="indent" data-track-order="8.">What Goes On</li>
+                            <li class="indent" data-track-order="9.">Girl</li>
+                            <li class="indent" data-track-order="10.">I'm Looking Through You</li>
+                            <li class="indent" data-track-order="11.">In My Life</li>
+                            <li class="indent" data-track-order="12.">Wait</li>
+                            <li class="indent" data-track-order="13.">If I Needed Someone</li>
+                            <li class="indent" data-track-order="14.">Run For Your Life</li>
+                        </ul>
                     </div>
                 </div>
-
+                
 
 <br clear="all">
 
+    
+    
+    
 
 
-
-
-
-
-
+    
+        
             <div id="db-rec-section" class="block5 subject_show knnlike">
-
+                
     <h2>
-        喜欢听&#34;Rubber Soul&#34;的人也喜欢的唱片
-            &nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;
+        喜欢听"Rubber Soul"的人也喜欢的唱片
+            &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
     </h2>
 
                 <div class="content clearfix" style="margin-top: 9px;">
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1401364/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s1410145.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1401364/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s1410145.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1401364/" class="">Revolver</a>
+                                <a href="https://music.douban.com/subject/1401364/">Revolver</a>
+                                <span class="subject-rate">9.5</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/2359520/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s3690624.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/2359520/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s3690624.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/2359520/" class="">The Beatles (The White Album)</a>
+                                <a href="https://music.douban.com/subject/2359520/">The Beatles (30th Anniversary Limi...</a>
+                                <span class="subject-rate">9.6</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1394665/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s1445617.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1394665/"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/m/public/s1445617.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1394665/" class="">Sgt. Pepper&#39;s Lonely Hearts Club B...</a>
+                                <a href="https://music.douban.com/subject/1394665/">Sgt. Pepper's Lonely Hearts Club B...</a>
+                                <span class="subject-rate">9.6</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1457725/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s2389040.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1457725/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s2389040.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1457725/" class="">Help!</a>
+                                <a href="https://music.douban.com/subject/1457725/">Help!</a>
+                                <span class="subject-rate">9.4</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px; margin-right:0px">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1401363/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s1410144.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1401361/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s24519989.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1401363/" class="">A Hard Day&#39;s Night</a>
+                                <a href="https://music.douban.com/subject/1401361/">Abbey Road</a>
+                                <span class="subject-rate">9.6</span>
                             </dd>
                         </dl>
                             <dl class="clear"></dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1437026/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s4484960.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1401366/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s2399848.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1437026/" class="">Please Please Me</a>
+                                <a href="https://music.douban.com/subject/1401366/">Magical Mystery Tour</a>
+                                <span class="subject-rate">9.5</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1401366/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s2399848.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1401363/"><img class="m_sub_img" src="https://img9.doubanio.com/view/subject/m/public/s1410144.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1401366/" class="">Magical Mystery Tour</a>
+                                <a href="https://music.douban.com/subject/1401363/">A Hard Day's Night</a>
+                                <span class="subject-rate">9.2</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1401361/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s24519989.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1437026/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s4484960.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1401361/" class="">Abbey Road</a>
+                                <a href="https://music.douban.com/subject/1437026/">Please Please Me</a>
+                                <span class="subject-rate">9.1</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px;">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1433639/"><img class="m_sub_img" src="https://img1.doubanio.com/view/subject/m/public/s1447787.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1433639/"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/m/public/s1447787.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1433639/" class="">With the Beatles</a>
+                                <a href="https://music.douban.com/subject/1433639/">With the Beatles</a>
+                                <span class="subject-rate">9.0</span>
                             </dd>
                         </dl>
-
-
+                        
+                        
                         <dl class="subject-rec-list" style="margin-top:0px; width: 108px; margin-right:0px">
                             <dt style="height: auto; margin-bottom: 5px;">
-                                    <a href="https://music.douban.com/subject/1457726/"><img class="m_sub_img" src="https://img2.doubanio.com/view/subject/m/public/s1474792.jpg" width="115" /></a>
+                                    <a href="https://music.douban.com/subject/1457726/"><img class="m_sub_img" src="https://img3.doubanio.com/view/subject/m/public/s1474792.jpg" width="115"></a>
                             </dt>
                             <dd>
-                                <a href="https://music.douban.com/subject/1457726/" class="">Beatles for Sale</a>
+                                <a href="https://music.douban.com/subject/1457726/">Beatles for Sale</a>
+                                <span class="subject-rate">8.8</span>
                             </dd>
                         </dl>
                             <dl class="clear"></dl>
@@ -838,106 +775,52 @@
 
 
 
+        
+            
 
 
 
 
 
-
-
-<div id='comments-section'>
-    <link rel="stylesheet" href="https://img1.doubanio.com/f/music/d63a579a99fd372b4398731a279a1382e6eac71e/css/music/lib/subject-comments/comments-section.css"/>
-    <link rel="stylesheet" href="https://img1.doubanio.com/f/music/9aae5c6f1a6c1ef339d7c9a37d69641086bd6917/css/music/lib/subject-comments/comments.css"/>
+<div id="comments-section">
+    <link rel="stylesheet" href="https://img1.doubanio.com/f/vendors/d63a579a99fd372b4398731a279a1382e6eac71e/subject-comments/comments-section.css">
+    <link rel="stylesheet" href="https://img1.doubanio.com/f/vendors/9aae5c6f1a6c1ef339d7c9a37d69641086bd6917/subject-comments/comments.css">
     <div class="mod-hd">
-
+        
         <a class="redbutt rr j a_show_login" href="https://www.douban.com/login?reason=collect&amp;ck=" name="pbtn-1401362-collect"><span>我来说两句</span></a>
-
+            
     <h2>
         短评
-            &nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;
+            &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
             <span class="pl">&nbsp;(
-
-                    <a href="https://music.douban.com/subject/1401362/comments/" target="_self">全部 2076 条</a>
+                
+                    <a href="https://music.douban.com/subject/1401362/comments/" target="_self">全部 2866 条</a>
                 ) </span>
     </h2>
 
     </div>
     <div class="nav-tab">
-
+        
     <div class="tabs-wrapper  line">
-                <a class="short-comment-tabs on-tab"
-                    href="https://music.douban.com/subject/1401362/comments?sort=new_score"
-                    data-tab="new_score">热门</a>
+                <a class="short-comment-tabs on-tab" href="https://music.douban.com/subject/1401362/comments?sort=new_score" data-tab="new_score">热门</a>
                 <span>/</span>
-                <a class="short-comment-tabs "
-                    href="https://music.douban.com/subject/1401362/comments?sort=time"
-                    data-tab="time">最新</a>
+                <a class="short-comment-tabs " href="https://music.douban.com/subject/1401362/comments?sort=time" data-tab="time">最新</a>
                 <span>/</span>
-                <a class="j a_show_login "
-                    href="https://music.douban.com/subject/1401362/comments?sort=follows"
-                    data-tab="follows">好友</a>
+                <a class="j a_show_login " href="https://music.douban.com/subject/1401362/comments?sort=follows" data-tab="follows">好友</a>
     </div>
 
     </div>
     <div id="comment-list-wrapper" class="indent">
-
-
+        
+  
   <div class="comment-list new_score show" id="new_score">
       <ul>
-
-  <li class="comment-item" data-cid="164668444">
-    <div class="comment">
-      <h3>
-        <span class="comment-vote">
-          <span id="c-164668444" class="vote-count">3</span>
-            <a href="javascript:;" id="btn-164668444" class="j a_show_login" data-cid="164668444">有用</a>
-        </span>
-        <span class="comment-info">
-          <a href="https://www.douban.com/people/ZeitgeistAmour/">Kreuzberg</a>
-            <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2012-05-17 14:44:39</span>
-          <span class="comment-location"></span>
-        </span>
-      </h3>
-      <p class="comment-content">
-
-        <span class="short">偶像组合转型～</span>
-      </p>
-
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=164668444"></div>
-    </div>
-  </li>
-
-
-  <li class="comment-item" data-cid="711827195">
-    <div class="comment">
-      <h3>
-        <span class="comment-vote">
-          <span id="c-711827195" class="vote-count">16</span>
-            <a href="javascript:;" id="btn-711827195" class="j a_show_login" data-cid="711827195">有用</a>
-        </span>
-        <span class="comment-info">
-          <a href="https://www.douban.com/people/yuyao/">雨摇</a>
-            <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2013-08-04 23:09:39</span>
-          <span class="comment-location"></span>
-        </span>
-      </h3>
-      <p class="comment-content">
-
-        <span class="short">这时期的Beatles我喜欢，介乎早期的清纯和后期的迷幻之间。后期Beatles在麦卡特尼的策划下，做作、玩概念，跟知识界、政客和歌迷，开特别逼真的玩笑。第二首的西塔琴是哈里森弹的，Beatles成员中最迷恋东方文化的那个。后来乐队去了印度修行，摇滚界曾逛起一股东方文化旋风。</span>
-      </p>
-
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=711827195"></div>
-    </div>
-  </li>
-
-
+          
   <li class="comment-item" data-cid="1072117924">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-1072117924" class="vote-count">27</span>
+          <span id="c-1072117924" class="vote-count">46</span>
             <a href="javascript:;" id="btn-1072117924" class="j a_show_login" data-cid="1072117924">有用</a>
         </span>
         <span class="comment-info">
@@ -948,7 +831,7 @@
         </span>
       </h3>
       <p class="comment-content">
-
+      
         <span class="short">一首希腊挽歌，一首法国情歌，一首政府歌曲，一首生活小摘，一首嬉皮士独白和一首滥用关系的歌曲都包含在这张专辑里。</span>
       </p>
 
@@ -956,189 +839,240 @@
     </div>
   </li>
 
-
-  <li class="comment-item" data-cid="394510904">
+          
+  <li class="comment-item" data-cid="419480666">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-394510904" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-394510904" class="j a_show_login" data-cid="394510904">有用</a>
+          <span id="c-419480666" class="vote-count">1</span>
+            <a href="javascript:;" id="btn-419480666" class="j a_show_login" data-cid="419480666">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/enjoyrachel/">Enjoy🌈Rachel</a>
-            <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2011-05-24 16:40:19</span>
+          <a href="https://www.douban.com/people/freedxy/">风撼斜阳</a>
+            <span class="user-stars allstar40 rating" title="推荐"></span>
+          <span class="comment-time">2011-07-29 15:14:23</span>
           <span class="comment-location"></span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">爱情秘籍，早期最美好的一张~~</span>
+      
+        <span class="short"> Norwegian Wood &amp; In My Life</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=394510904"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=419480666"></div>
     </div>
   </li>
 
-
-  <li class="comment-item" data-cid="792590276">
+          
+  <li class="comment-item" data-cid="819250289">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-792590276" class="vote-count">1</span>
-            <a href="javascript:;" id="btn-792590276" class="j a_show_login" data-cid="792590276">有用</a>
+          <span id="c-819250289" class="vote-count">4</span>
+            <a href="javascript:;" id="btn-819250289" class="j a_show_login" data-cid="819250289">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/hzsxd1986/">拾贝壳的猫</a>
-            <span class="user-stars allstar30 rating" title="还行"></span>
-          <span class="comment-time">2014-03-31 20:18:18</span>
+          <a href="https://www.douban.com/people/cmhloveukulele/">爱罗武勇</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <span class="comment-time">2015-03-01 15:07:48</span>
           <span class="comment-location"></span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">吉他敲得不错</span>
+      
+        <span class="short">Paul写完Michelle后交给John，John加上“I love you I love you I love you”后变为截然不同的歌，这就是为何当披头士在1970年4月10日解散时世界都哭了。Michelle,In My Life,Girl,Norwegian Wood</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=792590276"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=819250289"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="432836029">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+          <span id="c-432836029" class="vote-count">3</span>
+            <a href="javascript:;" id="btn-432836029" class="j a_show_login" data-cid="432836029">有用</a>
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/min_1224_child/">树上的女爵</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <span class="comment-time">2011-09-04 11:08:18</span>
+          <span class="comment-location"></span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">五星追忆，老年华不脱节于任何时地</span>
+      </p>
+
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=432836029"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="571606607">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+          <span id="c-571606607" class="vote-count">4</span>
+            <a href="javascript:;" id="btn-571606607" class="j a_show_login" data-cid="571606607">有用</a>
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/biglaitythecure/">海孩等pk14</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <span class="comment-time">2013-01-27 12:30:32</span>
+          <span class="comment-location"></span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">唉 真好听</span>
+      </p>
+
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=571606607"></div>
     </div>
   </li>
 
       </ul>
   </div>
 
-
-
+        
+  
   <div class="comment-list time hide" id="time">
       <ul>
-
-  <li class="comment-item" data-cid="3742050183">
+          
+  <li class="comment-item" data-cid="4807858138">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-3742050183" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-3742050183" class="j a_show_login" data-cid="3742050183">有用</a>
+          <span id="c-4807858138" class="vote-count">0</span>
+            <a href="javascript:;" id="btn-4807858138" class="j a_show_login" data-cid="4807858138">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/zyakabreezy/">还是No.3</a>
+          <a href="https://www.douban.com/people/95024211/">十日总督</a>
             <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2023-04-03 14:59:50</span>
-          <span class="comment-location">山东</span>
-        </span>
-      </h3>
-      <p class="comment-content">
-
-        <span class="short">@2021-07-07 14:31:26 @2022-10-15 22:40:28</span>
-      </p>
-
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=3742050183"></div>
-    </div>
-  </li>
-
-
-  <li class="comment-item" data-cid="3742280701">
-    <div class="comment">
-      <h3>
-        <span class="comment-vote">
-          <span id="c-3742280701" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-3742280701" class="j a_show_login" data-cid="3742280701">有用</a>
-        </span>
-        <span class="comment-info">
-          <a href="https://www.douban.com/people/168409738/">acid</a>
-            <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2023-04-03 19:22:08</span>
+          <span class="comment-time">2026-04-01 01:03:07</span>
           <span class="comment-location">上海</span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">我心中Beatles的第一专辑。前后期风格的交汇结合以及高度主题化的音乐表达；</span>
+      
+        <span class="short">满分专辑</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=3742280701"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=4807858138"></div>
     </div>
   </li>
 
-
-  <li class="comment-item" data-cid="3755514441">
+          
+  <li class="comment-item" data-cid="4808902578">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-3755514441" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-3755514441" class="j a_show_login" data-cid="3755514441">有用</a>
+          <span id="c-4808902578" class="vote-count">0</span>
+            <a href="javascript:;" id="btn-4808902578" class="j a_show_login" data-cid="4808902578">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/avocadoz/">思議自在神通</a>
+          <a href="https://www.douban.com/people/266494132/">混沌</a>
             <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2023-04-15 11:51:47</span>
-          <span class="comment-location">中国台湾</span>
+          <span class="comment-time">2026-04-02 15:09:05</span>
+          <span class="comment-location">上海</span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">因為是完整聽過的第一張（有一張打口CD），所有曲目都很喜歡，最愛Michelle</span>
+      
+        <span class="short">这张和《Revolver》是最早听的披头士的专辑，总是喜欢听整张，在某种意义上是正式的摇滚乐启蒙。
+后来才意识到在此之前摇滚圈是没有整张听专辑的概念的，这张对摇滚乐而言也是一种启蒙。</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=3755514441"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=4808902578"></div>
     </div>
   </li>
 
-
-  <li class="comment-item" data-cid="3755760348">
+          
+  <li class="comment-item" data-cid="4803456301">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-3755760348" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-3755760348" class="j a_show_login" data-cid="3755760348">有用</a>
+          <span id="c-4803456301" class="vote-count">0</span>
+            <a href="javascript:;" id="btn-4803456301" class="j a_show_login" data-cid="4803456301">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/84711037/">卢 垚</a>
-            <span class="user-stars allstar40 rating" title="推荐"></span>
-          <span class="comment-time">2023-04-15 15:33:33</span>
+          <a href="https://www.douban.com/people/287329618/">里昂辣椒油</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <span class="comment-time">2026-03-26 18:15:05</span>
           <span class="comment-location">广东</span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">转型的一张专辑</span>
+      
+        <span class="short">最爱的披头士专辑</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=3755760348"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=4803456301"></div>
     </div>
   </li>
 
-
-  <li class="comment-item" data-cid="3750762749">
+          
+  <li class="comment-item" data-cid="4787371271">
     <div class="comment">
       <h3>
         <span class="comment-vote">
-          <span id="c-3750762749" class="vote-count">0</span>
-            <a href="javascript:;" id="btn-3750762749" class="j a_show_login" data-cid="3750762749">有用</a>
+          <span id="c-4787371271" class="vote-count">0</span>
+            <a href="javascript:;" id="btn-4787371271" class="j a_show_login" data-cid="4787371271">有用</a>
         </span>
         <span class="comment-info">
-          <a href="https://www.douban.com/people/255874554/">Kissability</a>
-            <span class="user-stars allstar50 rating" title="力荐"></span>
-          <span class="comment-time">2023-04-10 21:47:06</span>
-          <span class="comment-location">四川</span>
+          <a href="https://www.douban.com/people/289419050/">三笠</a>
+            <span class="user-stars allstar40 rating" title="推荐"></span>
+          <span class="comment-time">2026-03-06 18:28:06</span>
+          <span class="comment-location">辽宁</span>
         </span>
       </h3>
       <p class="comment-content">
-
-        <span class="short">这张应该算是现代摇滚的起源了吧，很多有启发性的旋律，但感觉没放太开，还没华丽起来</span>
+      
+        <span class="short">有点无聊</span>
       </p>
 
-      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=3750762749"></div>
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=4787371271"></div>
+    </div>
+  </li>
+
+          
+  <li class="comment-item" data-cid="4786796467">
+    <div class="comment">
+      <h3>
+        <span class="comment-vote">
+          <span id="c-4786796467" class="vote-count">0</span>
+            <a href="javascript:;" id="btn-4786796467" class="j a_show_login" data-cid="4786796467">有用</a>
+        </span>
+        <span class="comment-info">
+          <a href="https://www.douban.com/people/262321500/">海雾</a>
+            <span class="user-stars allstar50 rating" title="力荐"></span>
+          <span class="comment-time">2026-03-05 22:08:33</span>
+          <span class="comment-location">陕西</span>
+        </span>
+      </h3>
+      <p class="comment-content">
+      
+        <span class="short">早期风格的集大成者，当我习惯了整轨的叙事性与节奏时，不应该忘记两分多的小歌也可以无比完美，不急不徐的节奏带着天真愉悦的情调。
+最喜欢的几首：The word 因为bass最明显，对我而言很爪耳
+Drive my car、Michelle： 列侬的loveyou使这首歌补全了能够脍炙人口的拼图、run for your life</span>
+      </p>
+
+      <div class="link-report" data-url="https://music.douban.com/subject/1401362/?comment_id=4786796467"></div>
     </div>
   </li>
 
       </ul>
   </div>
 
-
+        
 
     </div>
-        <p>&gt; <a href="https://music.douban.com/subject/1401362/comments/">更多短评 2076 条</a></p>
-    <script src="https://img1.doubanio.com/f/music/6eba6f43fb7592ab783e390f654c0d6a96b1598e/js/music/lib/subject-comments/comments-section.js"></script>
+        <p>&gt; <a href="https://music.douban.com/subject/1401362/comments/">更多短评 2866 条</a></p>
+    <script src="https://img1.doubanio.com/f/vendors/6eba6f43fb7592ab783e390f654c0d6a96b1598e/subject-comments/comments-section.js"></script>
     <script>
         (function () {
             if (window.SUBJECT_COMMENTS_SECTION) {
@@ -1168,30 +1102,27 @@
 </div>
 
 
+          
 
 
-
-<link rel="stylesheet" href="https://img1.doubanio.com/misc/mixed_static/29a12b2380e44526.css">
+<!-- COLLECTED CSS -->
 
     <section id="reviews-wrapper" class="reviews mod music-content">
         <header>
-
-                <a href="new_review" rel="nofollow" class="create-review redbutt rr "
-                    data-isverify="False"
-                    data-verify-url="https://www.douban.com/accounts/phone/verify?redir=https://music.douban.com/subject/1401362/new_review">
+            
+                <a href="new_review" rel="nofollow" class="create-review redbutt rr " data-isverify="False" data-verify-url="https://www.douban.com/accounts/phone/verify?redir=https://music.douban.com/subject/1401362/new_review">
                     <span>我要写乐评</span>
                 </a>
             <h2>
                     Rubber Soul的乐评 · · · · · ·
 
-                    <span class="pl">( <a href="reviews">全部 21 条</a> )</span>
+                    <span class="pl">( <a href="reviews">全部 24 条</a> )</span>
             </h2>
         </header>
 
+            
             <div class="review_filter">
-                            <a href="javascript:;;" class="cur" data-sort="">热门</a> &#047;
-                            <a href="javascript:;;" data-sort="time">最新</a> &#047;
-                            <a href="javascript:;;" data-sort="follow">好友</a>
+                                <span class="link"><a href="javascript:;;" class="cur" data-sort="">热门</a></span>
             </div>
             <script>
                 var cur_sort = '';
@@ -1227,31 +1158,33 @@
             </script>
 
 
+            
 
 
 
+<link rel="stylesheet" href="https://img1.doubanio.com/cuphead/zerkalo-static/review/list.f3448.css">
 
 <div class="review-list  ">
+        
+    
 
-
-
-
-
+            
+    
     <div data-cid="1527408">
         <div class="main review-item" id="1527408">
 
-
-
+            
+    
     <header class="main-hd">
         <a href="https://www.douban.com/people/xiangeliushui/" class="avator">
             <img width="24" height="24" src="https://img1.doubanio.com/icon/u2871287-9.jpg">
         </a>
 
         <a href="https://www.douban.com/people/xiangeliushui/" class="name">流水弦歌</a>
-
             <span class="allstar50 main-title-rating" title="力荐"></span>
 
         <span content="2008-10-17" class="main-meta">2008-10-17 15:25:14</span>
+
 
 
     </header>
@@ -1276,42 +1209,36 @@
 
                 <div class="action">
                     <a href="javascript:;" class="action-btn up" data-rid="1527408" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-1527408">
-                                101
-                        </span>
+                            113
                     </a>
                     <a href="javascript:;" class="action-btn down" data-rid="1527408" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-1527408">
-                                3
-                        </span>
+                            3
                     </a>
                     <a href="https://music.douban.com/review/1527408/#comments" class="reply ">9回应</a>
 
-                    <a href="javascript:;;" class="fold hidden">收起</a>
+                    <a href="javascript:;;" class="fold hidden" data-rid="1527408">收起</a>
                 </div>
             </div>
         </div>
     </div>
 
-
-
+            
+    
     <div data-cid="12591301">
         <div class="main review-item" id="12591301">
 
-
-
+            
+    
     <header class="main-hd">
         <a href="https://www.douban.com/people/159330609/" class="avator">
-            <img width="24" height="24" src="https://img2.doubanio.com/icon/u159330609-3.jpg">
+            <img width="24" height="24" src="https://img9.doubanio.com/icon/u159330609-4.jpg">
         </a>
 
         <a href="https://www.douban.com/people/159330609/" class="name">ScarlettLemon</a>
-
             <span class="allstar50 main-title-rating" title="力荐"></span>
 
         <span content="2020-05-13" class="main-meta">2020-05-13 21:52:53</span>
+
 
 
     </header>
@@ -1336,162 +1263,36 @@
 
                 <div class="action">
                     <a href="javascript:;" class="action-btn up" data-rid="12591301" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-12591301">
-                                10
-                        </span>
+                            19
                     </a>
                     <a href="javascript:;" class="action-btn down" data-rid="12591301" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-12591301">
-                                1
-                        </span>
+                            2
                     </a>
                     <a href="https://music.douban.com/review/12591301/#comments" class="reply ">1回应</a>
 
-                    <a href="javascript:;;" class="fold hidden">收起</a>
+                    <a href="javascript:;;" class="fold hidden" data-rid="12591301">收起</a>
                 </div>
             </div>
         </div>
     </div>
 
-
-
-    <div data-cid="1226250">
-        <div class="main review-item" id="1226250">
-
-
-
-    <header class="main-hd">
-        <a href="https://www.douban.com/people/GaRY.Wing/" class="avator">
-            <img width="24" height="24" src="https://img9.doubanio.com/icon/u1546232-15.jpg">
-        </a>
-
-        <a href="https://www.douban.com/people/GaRY.Wing/" class="name">GaRY</a>
-
-            <span class="allstar50 main-title-rating" title="力荐"></span>
-
-        <span content="2007-10-21" class="main-meta">2007-10-21 01:36:12</span>
-
-
-    </header>
-
-
-            <div class="main-bd">
-
-                <h2><a href="https://music.douban.com/review/1226250/">The Beatles</a></h2>
-
-                <div id="review_1226250_short" class="review-short" data-rid="1226250">
-                    <div class="short-content">
-
-                        Michelle，我的最爱。一首出名却是从未达到榜首的歌曲。在吉尼斯统计的世界最多艺人翻唱曲目中排名第二。 本张专辑虽然没有其后的专辑那么有名，但是Paul等人的才华已经开始逐渐展现，John也处于创作的成熟期，使得专辑总体十分出色。 从《Michelle》青涩，含蓄，温和的风格中...
-
-                        &nbsp;(<a href="javascript:;" id="toggle-1226250-copy" class="unfold" title="展开">展开</a>)
-                    </div>
-                </div>
-
-                <div id="review_1226250_full" class="hidden">
-                    <div id="review_1226250_full_content" class="full-content"></div>
-                </div>
-
-                <div class="action">
-                    <a href="javascript:;" class="action-btn up" data-rid="1226250" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-1226250">
-                                10
-                        </span>
-                    </a>
-                    <a href="javascript:;" class="action-btn down" data-rid="1226250" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-1226250">
-                                4
-                        </span>
-                    </a>
-                    <a href="https://music.douban.com/review/1226250/#comments" class="reply ">8回应</a>
-
-                    <a href="javascript:;;" class="fold hidden">收起</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-
-    <div data-cid="1477899">
-        <div class="main review-item" id="1477899">
-
-
-
-    <header class="main-hd">
-        <a href="https://www.douban.com/people/kingwangone/" class="avator">
-            <img width="24" height="24" src="https://img1.doubanio.com/icon/u2773067-10.jpg">
-        </a>
-
-        <a href="https://www.douban.com/people/kingwangone/" class="name">懵逼小作手</a>
-
-            <span class="allstar50 main-title-rating" title="力荐"></span>
-
-        <span content="2008-08-23" class="main-meta">2008-08-23 18:04:50</span>
-
-
-    </header>
-
-
-            <div class="main-bd">
-
-                <h2><a href="https://music.douban.com/review/1477899/">Norwegian Wood 挪威的森林 Beatles</a></h2>
-
-                <div id="review_1477899_short" class="review-short" data-rid="1477899">
-                    <div class="short-content">
-
-                        I once had a girl, or should I say, she once had me.  我曾经拥有一个女孩 或者我应该说她曾经拥有我...   She showed me her room, isn&#39;t it good, norwegian wood?  她向我展示她的住所！ 很棒吧这&#34;挪威的木屋&#34; （挪威木料做的家具）  She asked me to stay and she told ...
-
-                        &nbsp;(<a href="javascript:;" id="toggle-1477899-copy" class="unfold" title="展开">展开</a>)
-                    </div>
-                </div>
-
-                <div id="review_1477899_full" class="hidden">
-                    <div id="review_1477899_full_content" class="full-content"></div>
-                </div>
-
-                <div class="action">
-                    <a href="javascript:;" class="action-btn up" data-rid="1477899" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-1477899">
-                                11
-                        </span>
-                    </a>
-                    <a href="javascript:;" class="action-btn down" data-rid="1477899" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-1477899">
-                                3
-                        </span>
-                    </a>
-                    <a href="https://music.douban.com/review/1477899/#comments" class="reply ">2回应</a>
-
-                    <a href="javascript:;;" class="fold hidden">收起</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-
+            
+    
     <div data-cid="14092390">
         <div class="main review-item" id="14092390">
 
-
-
+            
+    
     <header class="main-hd">
         <a href="https://www.douban.com/people/MsMojoRisin/" class="avator">
             <img width="24" height="24" src="https://img1.doubanio.com/icon/u174158120-28.jpg">
         </a>
 
         <a href="https://www.douban.com/people/MsMojoRisin/" class="name">WalrusTuTu☮</a>
-
             <span class="allstar50 main-title-rating" title="力荐"></span>
 
         <span content="2021-12-26" class="main-meta">2021-12-26 18:51:09</span>
+
 
 
     </header>
@@ -1516,41 +1317,196 @@
 
                 <div class="action">
                     <a href="javascript:;" class="action-btn up" data-rid="14092390" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-14092390">
-                                6
-                        </span>
+                            10
                     </a>
                     <a href="javascript:;" class="action-btn down" data-rid="14092390" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-14092390">
-                        </span>
                     </a>
                     <a href="https://music.douban.com/review/14092390/#comments" class="reply ">0回应</a>
 
-                    <a href="javascript:;;" class="fold hidden">收起</a>
+                    <a href="javascript:;;" class="fold hidden" data-rid="14092390">收起</a>
                 </div>
             </div>
         </div>
     </div>
 
+            
+    
+    <div data-cid="1477899">
+        <div class="main review-item" id="1477899">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/kingwangone/" class="avator">
+            <img width="24" height="24" src="https://img1.doubanio.com/icon/u2773067-10.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/kingwangone/" class="name">懵逼小作手</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2008-08-23" class="main-meta">2008-08-23 18:04:50</span>
 
 
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://music.douban.com/review/1477899/">Norwegian Wood 挪威的森林 Beatles</a></h2>
+
+                <div id="review_1477899_short" class="review-short" data-rid="1477899">
+                    <div class="short-content">
+
+                        I once had a girl, or should I say, she once had me.  我曾经拥有一个女孩 或者我应该说她曾经拥有我...   She showed me her room, isn't it good, norwegian wood?  她向我展示她的住所！ 很棒吧这"挪威的木屋" （挪威木料做的家具）  She asked me to stay and she told ...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-1477899-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_1477899_full" class="hidden">
+                    <div id="review_1477899_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="1477899" title="有用">
+                            11
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="1477899" title="没用">
+                            3
+                    </a>
+                    <a href="https://music.douban.com/review/1477899/#comments" class="reply ">2回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="1477899">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="1226250">
+        <div class="main review-item" id="1226250">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/GaRY.Wing/" class="avator">
+            <img width="24" height="24" src="https://img9.doubanio.com/icon/u1546232-15.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/GaRY.Wing/" class="name">GaRY</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2007-10-21" class="main-meta">2007-10-21 01:36:12</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://music.douban.com/review/1226250/">The Beatles</a></h2>
+
+                <div id="review_1226250_short" class="review-short" data-rid="1226250">
+                    <div class="short-content">
+
+                        Michelle，我的最爱。一首出名却是从未达到榜首的歌曲。在吉尼斯统计的世界最多艺人翻唱曲目中排名第二。 本张专辑虽然没有其后的专辑那么有名，但是Paul等人的才华已经开始逐渐展现，John也处于创作的成熟期，使得专辑总体十分出色。 从《Michelle》青涩，含蓄，温和的风格中...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-1226250-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_1226250_full" class="hidden">
+                    <div id="review_1226250_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="1226250" title="有用">
+                            11
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="1226250" title="没用">
+                            4
+                    </a>
+                    <a href="https://music.douban.com/review/1226250/#comments" class="reply ">8回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="1226250">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="16024942">
+        <div class="main review-item" id="16024942">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/199994861/" class="avator">
+            <img width="24" height="24" src="https://img2.doubanio.com/icon/u199994861-1.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/199994861/" class="name">Sanctuary</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2024-06-29" class="main-meta">2024-06-29 12:21:49</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://music.douban.com/review/16024942/">Pitchfork满分乐评：首张无可争议的杰作是他们最安静、最民谣化的唱片</a></h2>
+
+                <div id="review_16024942_short" class="review-short" data-rid="16024942">
+                    <div class="short-content">
+
+                        对于现代的听众来说，《Rubber Soul》这张专辑及其所代表的前迷幻时代混搭——六十年代的流行、灵魂和民谣乐，乍一听或许显得克制，甚至有点过时。但可以说，这是披头士职业生涯中最重要的艺术跃进——一个标志着他们开始从“披头士狂热”与青少年流行乐的沉重要求转向更深入、...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-16024942-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_16024942_full" class="hidden">
+                    <div id="review_16024942_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="16024942" title="有用">
+                            4
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="16024942" title="没用">
+                    </a>
+                    <a href="https://music.douban.com/review/16024942/#comments" class="reply ">3回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="16024942">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
     <div data-cid="5104298">
         <div class="main review-item" id="5104298">
 
-
-
+            
+    
     <header class="main-hd">
         <a href="https://www.douban.com/people/hukou/" class="avator">
             <img width="24" height="24" src="https://img9.doubanio.com/icon/u1545412-34.jpg">
         </a>
 
         <a href="https://www.douban.com/people/hukou/" class="name">解惑蠹虫</a>
-
             <span class="allstar50 main-title-rating" title="力荐"></span>
 
         <span content="2011-09-22" class="main-meta">2011-09-22 00:06:26</span>
+
 
 
     </header>
@@ -1563,7 +1519,7 @@
                 <div id="review_5104298_short" class="review-short" data-rid="5104298">
                     <div class="short-content">
 
-                        2011.09.21 23:49  Norwegian Wood  —The beatles  出自专辑Rubber Soul    Rubber Soul  1965-  i once had a girl or should i say she once had me she showed me her room isn&#39;t it good norwegian wood? she asked me to stay and she told me to sit anywhere so i look...
+                        2011.09.21 23:49  Norwegian Wood  —The beatles  出自专辑Rubber Soul    Rubber Soul  1965-  i once had a girl or should i say she once had me she showed me her room isn't it good norwegian wood? she asked me to stay and she told me to sit anywhere so i look...
 
                         &nbsp;(<a href="javascript:;" id="toggle-5104298-copy" class="unfold" title="展开">展开</a>)
                     </div>
@@ -1575,160 +1531,35 @@
 
                 <div class="action">
                     <a href="javascript:;" class="action-btn up" data-rid="5104298" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-5104298">
-                                2
-                        </span>
+                            3
                     </a>
                     <a href="javascript:;" class="action-btn down" data-rid="5104298" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-5104298">
-                        </span>
                     </a>
                     <a href="https://music.douban.com/review/5104298/#comments" class="reply ">0回应</a>
 
-                    <a href="javascript:;;" class="fold hidden">收起</a>
+                    <a href="javascript:;;" class="fold hidden" data-rid="5104298">收起</a>
                 </div>
             </div>
         </div>
     </div>
 
-
-
-    <div data-cid="8160461">
-        <div class="main review-item" id="8160461">
-
-
-
-    <header class="main-hd">
-        <a href="https://www.douban.com/people/141745650/" class="avator">
-            <img width="24" height="24" src="https://img9.doubanio.com/icon/u141745650-6.jpg">
-        </a>
-
-        <a href="https://www.douban.com/people/141745650/" class="name">灰色幽默</a>
-
-            <span class="allstar50 main-title-rating" title="力荐"></span>
-
-        <span content="2016-11-06" class="main-meta">2016-11-06 20:29:40</span>
-
-
-    </header>
-
-
-            <div class="main-bd">
-
-                <h2><a href="https://music.douban.com/review/8160461/">青年视角的爱情感言——rubber soul</a></h2>
-
-                <div id="review_8160461_short" class="review-short" data-rid="8160461">
-                    <div class="short-content">
-
-                        rubber soul是beatles转型的开始，一般被大家视为revlover和sgt的铺垫实验作品。制作这张专辑时，beatles还没有使用后续的各种创新录音技术，印度迷幻元素也没有sgt里那么重，但这些都只是表像，这张专辑的重点在于高度统一的视角。 如果对歌词稍加留意就会发现这张专辑都是青...
-
-                        &nbsp;(<a href="javascript:;" id="toggle-8160461-copy" class="unfold" title="展开">展开</a>)
-                    </div>
-                </div>
-
-                <div id="review_8160461_full" class="hidden">
-                    <div id="review_8160461_full_content" class="full-content"></div>
-                </div>
-
-                <div class="action">
-                    <a href="javascript:;" class="action-btn up" data-rid="8160461" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-8160461">
-                                2
-                        </span>
-                    </a>
-                    <a href="javascript:;" class="action-btn down" data-rid="8160461" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-8160461">
-                        </span>
-                    </a>
-                    <a href="https://music.douban.com/review/8160461/#comments" class="reply ">0回应</a>
-
-                    <a href="javascript:;;" class="fold hidden">收起</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-
-    <div data-cid="1042370">
-        <div class="main review-item" id="1042370">
-
-
-
-    <header class="main-hd">
-        <a href="https://www.douban.com/people/palwoo/" class="avator">
-            <img width="24" height="24" src="https://img2.doubanio.com/icon/u1091456-3.jpg">
-        </a>
-
-        <a href="https://www.douban.com/people/palwoo/" class="name">i</a>
-
-            <span class="allstar40 main-title-rating" title="推荐"></span>
-
-        <span content="2006-05-04" class="main-meta">2006-05-04 10:20:49</span>
-
-
-    </header>
-
-
-            <div class="main-bd">
-
-                <h2><a href="https://music.douban.com/review/1042370/">不是Rubber的Rubber Soul</a></h2>
-
-                <div id="review_1042370_short" class="review-short" data-rid="1042370">
-                    <div class="short-content">
-
-                        虽然还是以情歌为主，但披头士在这张专辑里已开始转型，不再是单纯的大孩子阳光组合了。  喜欢Norwegian Wood淡淡的惆怅和忧郁，喜欢Nowhere Man的情歌不再，喜欢Michelle与Girl和声背景下的“I Love You, I Want You”与“girl,girl”的喃喃倾诉，喜欢In My Life的怀旧情结和...
-
-                        &nbsp;(<a href="javascript:;" id="toggle-1042370-copy" class="unfold" title="展开">展开</a>)
-                    </div>
-                </div>
-
-                <div id="review_1042370_full" class="hidden">
-                    <div id="review_1042370_full_content" class="full-content"></div>
-                </div>
-
-                <div class="action">
-                    <a href="javascript:;" class="action-btn up" data-rid="1042370" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-1042370">
-                                3
-                        </span>
-                    </a>
-                    <a href="javascript:;" class="action-btn down" data-rid="1042370" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-1042370">
-                                1
-                        </span>
-                    </a>
-                    <a href="https://music.douban.com/review/1042370/#comments" class="reply ">0回应</a>
-
-                    <a href="javascript:;;" class="fold hidden">收起</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-
+            
+    
     <div data-cid="13881241">
         <div class="main review-item" id="13881241">
 
-
-
+            
+    
     <header class="main-hd">
         <a href="https://www.douban.com/people/182351657/" class="avator">
             <img width="24" height="24" src="https://img1.doubanio.com/icon/u182351657-9.jpg">
         </a>
 
         <a href="https://www.douban.com/people/182351657/" class="name">Strickland</a>
-
             <span class="allstar50 main-title-rating" title="力荐"></span>
 
         <span content="2021-09-23" class="main-meta">2021-09-23 15:32:34</span>
+
 
 
     </header>
@@ -1753,19 +1584,66 @@
 
                 <div class="action">
                     <a href="javascript:;" class="action-btn up" data-rid="13881241" title="有用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png" />
-                        <span id="r-useful_count-13881241">
-                                1
-                        </span>
+                            2
                     </a>
                     <a href="javascript:;" class="action-btn down" data-rid="13881241" title="没用">
-                        <img src="https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png" />
-                        <span id="r-useless_count-13881241">
-                        </span>
                     </a>
                     <a href="https://music.douban.com/review/13881241/#comments" class="reply ">0回应</a>
 
-                    <a href="javascript:;;" class="fold hidden">收起</a>
+                    <a href="javascript:;;" class="fold hidden" data-rid="13881241">收起</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+            
+    
+    <div data-cid="8160461">
+        <div class="main review-item" id="8160461">
+
+            
+    
+    <header class="main-hd">
+        <a href="https://www.douban.com/people/141745650/" class="avator">
+            <img width="24" height="24" src="https://img9.doubanio.com/icon/u141745650-6.jpg">
+        </a>
+
+        <a href="https://www.douban.com/people/141745650/" class="name">灰色幽默</a>
+            <span class="allstar50 main-title-rating" title="力荐"></span>
+
+        <span content="2016-11-06" class="main-meta">2016-11-06 20:29:40</span>
+
+
+
+    </header>
+
+
+            <div class="main-bd">
+
+                <h2><a href="https://music.douban.com/review/8160461/">青年视角的爱情感言——rubber soul</a></h2>
+
+                <div id="review_8160461_short" class="review-short" data-rid="8160461">
+                    <div class="short-content">
+
+                        rubber soul是beatles转型的开始，一般被大家视为revlover和sgt的铺垫实验作品。制作这张专辑时，beatles还没有使用后续的各种创新录音技术，印度迷幻元素也没有sgt里那么重，但这些都只是表像，这张专辑的重点在于高度统一的视角。 如果对歌词稍加留意就会发现这张专辑都是青...
+
+                        &nbsp;(<a href="javascript:;" id="toggle-8160461-copy" class="unfold" title="展开">展开</a>)
+                    </div>
+                </div>
+
+                <div id="review_8160461_full" class="hidden">
+                    <div id="review_8160461_full_content" class="full-content"></div>
+                </div>
+
+                <div class="action">
+                    <a href="javascript:;" class="action-btn up" data-rid="8160461" title="有用">
+                            2
+                    </a>
+                    <a href="javascript:;" class="action-btn down" data-rid="8160461" title="没用">
+                    </a>
+                    <a href="https://music.douban.com/review/8160461/#comments" class="reply ">0回应</a>
+
+                    <a href="javascript:;;" class="fold hidden" data-rid="8160461">收起</a>
                 </div>
             </div>
         </div>
@@ -1773,32 +1651,13 @@
 
 
 
-
-
-
     <!-- COLLECTED JS -->
     <!-- COLLECTED CSS -->
 </div>
 
-    <script type="text/javascript">
-        (function() {
-            if (window.__init_review_list) return;
-            __init_review_list = true;
-        })();
-        window.useful_icon = "https://img1.doubanio.com/f/zerkalo/536fd337139250b5fb3cf9e79cb65c6193f8b20b/pics/up.png";
-        window.usefuled_icon = "https://img1.doubanio.com/f/zerkalo/635290bb14771c97270037be21ad50514d57acc3/pics/up-full.png";
-        window.useless_icon = "https://img1.doubanio.com/f/zerkalo/68849027911140623cf338c9845893c4566db851/pics/down.png";
-        window.uselessed_icon = "https://img1.doubanio.com/f/zerkalo/23cee7343568ca814238f5ef18bf8aadbe959df2/pics/down-full.png";
-    </script>
+    <script src="https://img1.doubanio.com/cuphead/zerkalo-static/review/list.c3cec.js"></script>
+    <script src="https://img1.doubanio.com/f/vendors/f25ae221544f39046484a823776f3aa01769ee10/js/ui/dialog.js"></script>
 
-    <link rel="stylesheet" href="https://img1.doubanio.com/f/zerkalo/3aeb281ab0e4f2c7050458684acfeb6838441de9/css/review/editor/ng/setting_standalone.css">
-    <script src="https://img1.doubanio.com/f/zerkalo/938cdbe2e223a3117cbbcb4929cae2001b402c20/js/review/editor/ng/manifest.js"></script>
-    <script src="https://img1.doubanio.com/f/zerkalo/296cd5fec472a78add5fee958c58d72f47d91586/js/review/editor/ng/vendor.js"></script>
-    <script src="https://img1.doubanio.com/f/zerkalo/b140a9a8a3a6e73877ab7b1e41078199599a6ae9/js/review/editor/ng/setting_standalone.js"></script>
-    <script src="https://img1.doubanio.com/f/zerkalo/8941af7854ddad9561648b706cdb49f3d1534ff3/js/review/editor/ng/render_gif.js"></script>
-    <script src="https://img1.doubanio.com/f/zerkalo/ad32b4b739a59a90e9e3437fd2fba797dd7c26f2/js/review/actions.js"></script>
-    <script src="https://img1.doubanio.com/f/zerkalo/7196bdec780f03785f55b06fda34999595057f65/js/review/unfold.js"></script>
-    <script src="https://img1.doubanio.com/f/vendors/bc881a837a728ab82aa01d653b1c180190bb5a5d/js/ui/dialog.js"></script>
 
 
 
@@ -1813,32 +1672,30 @@
                     &gt;
                         <a href="reviews">
                             更多乐评
-                                21篇
+                                24篇
                         </a>
                 </p>
     </section>
 <!-- COLLECTED JS -->
 
 
-
-
-        <br/>
-
-
+        <br>
+        
+            
 
 
 
 
     <h2>
-        &#34;Rubber Soul&#34;的论坛
-            &nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;&nbsp;&middot;
+        "Rubber Soul"的论坛
+            &nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·&nbsp;·
     </h2>
 
     <div id="db-discussion-section" class="indent">
-
+        
     <table class="olt">
-        <tr><td><td><td><td></tr>
-
+        <tbody><tr><td></td><td></td><td></td><td></td></tr>
+                
                 <tr>
                     <td class="pl">
                         <a href="https://music.douban.com/subject/1401362/discussion/637186963/" title="1965年10月~11月，录制专辑《Rubber Soul》相册一览">1965年10月~11月，录制专辑《Rubber Soul》相册一览</a></td><td class="pl">来自<a href="https://www.douban.com/people/150652714/">dizzymatter</a>
@@ -1846,7 +1703,7 @@
                     <td class="pl"></td>
                     <td class="pl">2022-03-15 19:01:11</td>
                 </tr>
-
+                
                 <tr>
                     <td class="pl">
                         <a href="https://music.douban.com/subject/1401362/discussion/43606682/" title="我觉得逼头四就是低级趣味">我觉得逼头四就是低级趣味</a></td><td class="pl">来自<a href="https://www.douban.com/people/jason1087/">[已注销]</a>
@@ -1854,7 +1711,7 @@
                     <td class="pl">15 回应</td>
                     <td class="pl">2020-08-21 22:48:41</td>
                 </tr>
-
+                
                 <tr>
                     <td class="pl">
                         <a href="https://music.douban.com/subject/1401362/discussion/22089806/" title="此情可待成追忆">此情可待成追忆</a></td><td class="pl">来自<a href="https://www.douban.com/people/cillayang/">cillayang</a>
@@ -1862,7 +1719,7 @@
                     <td class="pl"></td>
                     <td class="pl">2010-02-19 23:20:49</td>
                 </tr>
-
+                
                 <tr>
                     <td class="pl">
                         <a href="https://music.douban.com/subject/1401362/discussion/16445701/" title="载">载</a></td><td class="pl">来自<a href="https://www.douban.com/people/Icedive/">ice</a>
@@ -1870,7 +1727,7 @@
                     <td class="pl"></td>
                     <td class="pl">2009-05-24 23:09:27</td>
                 </tr>
-
+                
                 <tr>
                     <td class="pl">
                         <a href="https://music.douban.com/subject/1401362/discussion/11703309/" title="美国版少了三首歌">美国版少了三首歌</a></td><td class="pl">来自<a href="https://www.douban.com/people/2385774/">逆风居士</a>
@@ -1878,7 +1735,7 @@
                     <td class="pl"></td>
                     <td class="pl">2009-05-13 14:06:03</td>
                 </tr>
-    </table>
+    </tbody></table>
 
             <p class="pl" align="right">&gt; <a href="https://music.douban.com/subject/1401362/discussion/">浏览更多话题</a></p>
     </div>
@@ -1889,28 +1746,37 @@
 
     </div>
 
+    
+        
+  <script type="text/javascript" src="https://img1.doubanio.com/f/vendors/e31c5a5084c08e5c74d9189744ce50af80a14484/censor.js"></script>
+  <script>
+    (function (kind, id, api) {
+      if ('_INTERNALS_CENSOR' in window) {
+        _INTERNALS_CENSOR.articleReport(kind, id, api);
+      }
+    })('1003', '1401362', 'https://www.douban.com/j/check_redirect_home');
+  </script>
+
+
         </div>
         <div class="aside">
+                
+
+    
+
+
+    <div id="dale_music_subject_top_right" ad-status="appended" data-sell-type="RTB" data-type="IredwhaleRender" data-version="3.2.46"><iframe src="about:blank" sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" safe-mode="custom" referrerpolicy="no-referrer-when-downgrade" width="300" height="250" frameborder="0" scrolling="no" name="dale_music_subject_top_right_frame" id="dale_music_subject_top_right_frame" style="position: relative; margin: 0px 0px 20px; display: block; width: 300px; height: 250px; overflow: hidden;"></iframe></div>
+
+
+    
+        
 
 
 
 
 
-
-    <div id="dale_music_subject_top_right"></div>
-<div id="dale_music_channel_right_mini"></div>
-<div id="dale_music_subject_top_middle"></div>
-
-
-
-
-
-
-
-
-
-
-
+    
+        
 
 
 
@@ -1921,7 +1787,7 @@
          <span class="pl">(<a href="https://music.douban.com/subject/1401362/doulists">全部</a>)</span>
     </h2>
     <div id="db-doulist-section" class="indent">
-
+        
     <ul class="bs">
         <li>
             <a href="https://www.douban.com/doulist/241262/" target="_blank">豆瓣9分音乐专辑</a>
@@ -1950,8 +1816,8 @@
 
 
 
-
-
+    
+        
 
 
 
@@ -1959,83 +1825,81 @@
     谁听这张唱片?
 </h2>
 <div class="indent" id="collector">
-
-
-
-
-
-
+    
+        
+    
+    
+    
+            
                 <div class="ll">
-                    <a href="https://www.douban.com/people/242850400/"><img src="https://img2.doubanio.com/icon/up242850400-2.jpg" class="pil" alt="阿诚会发疯"/></a>
+                    <a href="https://www.douban.com/people/285263278/"><img src="https://img3.doubanio.com/icon/up285263278-2.jpg" class="pil" alt="tra3000"></a>
                 </div>
                 <div style="padding-left:60px;">
-                    <a href="https://www.douban.com/people/242850400/">阿诚会发疯</a>
-                    <br/>
-                    <div class="pl ll">今天凌晨听过</div>
-                    <br/>
+                    <a href="https://www.douban.com/people/285263278/">tra3000</a>
+                    <br>
+                    <div class="pl ll">1小时前听过</div>
+                    <br>
                 </div>
                 <div class="clear"></div>
-                <br/>
+                <br>
                 <div class="ul" style="margin-bottom:12px;"></div>
-
-
+                
+            
                 <div class="ll">
-                    <a href="https://www.douban.com/people/62952105/"><img src="https://img1.doubanio.com/icon/up62952105-8.jpg" class="pil" alt="wjjjjjjjjj"/></a>
+                    <a href="https://www.douban.com/people/cm582698271/"><img src="https://img9.doubanio.com/icon/up203076033-6.jpg" class="pil" alt="KFK的swan"></a>
                 </div>
                 <div style="padding-left:60px;">
-                    <a href="https://www.douban.com/people/62952105/">wjjjjjjjjj</a>
-                    <br/>
+                    <a href="https://www.douban.com/people/cm582698271/">KFK的swan</a>
+                    <br>
                     <div class="pl ll">昨天听过</div>
-                    <br/>
-
-                        <span class="pl">tags:Rock</span>
+                    <br>
                 </div>
                 <div class="clear"></div>
-                <br/>
+                <br>
                 <div class="ul" style="margin-bottom:12px;"></div>
-
-
+                
+            
                 <div class="ll">
-                    <a href="https://www.douban.com/people/156890423/"><img src="https://img9.doubanio.com/icon/up156890423-15.jpg" class="pil" alt="24½"/></a>
+                    <a href="https://www.douban.com/people/250377011/"><img src="https://img3.doubanio.com/icon/up250377011-2.jpg" class="pil" alt="emanon"></a>
                 </div>
                 <div style="padding-left:60px;">
-                    <a href="https://www.douban.com/people/156890423/">24½</a>
-                    <br/>
+                    <a href="https://www.douban.com/people/250377011/">emanon</a>
+                    <br>
                     <div class="pl ll">昨天听过</div>
-                    <span class="allstar40" title="推荐"></span><br/>
+                    <span class="allstar50" title="力荐"></span><br>
                 </div>
                 <div class="clear"></div>
-                <br/>
+                <br>
                 <div class="ul" style="margin-bottom:12px;"></div>
-
-
+                
+            
                 <div class="ll">
-                    <a href="https://www.douban.com/people/223983792/"><img src="https://img2.doubanio.com/icon/up223983792-2.jpg" class="pil" alt="🐙"/></a>
+                    <a href="https://www.douban.com/people/291782678/"><img src="https://img3.doubanio.com/icon/up291782678-2.jpg" class="pil" alt="呼噜呼噜呼噜噜"></a>
                 </div>
                 <div style="padding-left:60px;">
-                    <a href="https://www.douban.com/people/223983792/">🐙</a>
-                    <br/>
-                    <div class="pl ll">昨天想听</div>
-                    <br/>
+                    <a href="https://www.douban.com/people/291782678/">呼噜呼噜呼噜噜</a>
+                    <br>
+                    <div class="pl ll">昨天听过</div>
+                    <span class="allstar50" title="力荐"></span><br>
                 </div>
                 <div class="clear"></div>
-                <br/>
+                <br>
                 <div class="ul" style="margin-bottom:12px;"></div>
+                
 
 
 
-
-
-            <p class="pl">&gt;
-                <a href="https://music.douban.com/subject/1401362/comments?status=N">595人在听</a>
+         
+            <p class="pl">&gt; 
+                <a href="https://music.douban.com/subject/1401362/comments?status=N">628人在听</a>
             </p>
-
-            <p class="pl">&gt;
-                <a href="https://music.douban.com/subject/1401362/comments?status=P">15021人听过</a>
+         
+            <p class="pl">&gt; 
+                <a href="https://music.douban.com/subject/1401362/comments?status=P">19708人听过</a>
             </p>
-
-            <p class="pl">&gt;
-                <a href="https://music.douban.com/subject/1401362/comments?status=F">1886人想听</a>
+         
+            <p class="pl">&gt; 
+                <a href="https://music.douban.com/subject/1401362/comments?status=F">2212人想听</a>
             </p>
 </div>
 
@@ -2046,10 +1910,10 @@
 
 
 
-
+    
 
 <!-- douban ad begin -->
-<div id="dale_music_subject_middle_right"></div>
+<div id="dale_music_subject_middle_right" ad-status="appended" data-sell-type="CPD" data-type="AdmaruRender" data-version="3.2.46"><div style="position: relative; margin: 0px 0px 20px; display: block; width: 300px; height: 250px; overflow: hidden;"><iframe src="about:blank" sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" safe-mode="custom" referrerpolicy="no-referrer-when-downgrade" width="300" height="250" frameborder="0" scrolling="no" name="dale_music_subject_middle_right_frame" id="dale_music_subject_middle_right_frame" style="overflow: hidden; display: block;"></iframe><div style="line-height: 1; text-align: center; background-color: rgba(0, 0, 0, 0.3); font-size: 12px; position: absolute; right: 0px; bottom: 0px; padding: 4px; color: rgb(255, 255, 255);">由Admaru提供的广告</div></div></div>
 <script type="text/javascript">
     (function (global) {
         if(!document.getElementsByClassName) {
@@ -2071,51 +1935,32 @@
 
 
 
+    
+        
 
 
 
 
+    
 
 
-
-
-
-<p class="pl">订阅关于Rubber Soul的评论: <br/><span class="feed">
+<p class="pl">订阅关于Rubber Soul的评论: <br><span class="feed">
     <a href="https://music.douban.com/feed/subject/1401362/reviews"> feed: rss 2.0</a></span></p>
 
 
 
         </div>
         <div class="extra">
-
-
-
-<!-- douban ad begin -->
-<div id="dale_music_subject_bottom_super_banner"></div>
-<script type="text/javascript">
-    (function (global) {
-        var body = global.document.body,
-            html = global.document.documentElement;
-
-        var height = Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight);
-        if (height >= 2000) {
-            (global.DoubanAdSlots = global.DoubanAdSlots || []).push('dale_music_subject_bottom_super_banner');
-        }
-    })(this);
-</script>
-<!-- douban ad end -->
-
-
-
+            
         </div>
     </div>
 </div>
 
-
+        
 <div id="footer">
-
+    
 <span id="icp" class="fleft gray-link">
-    &copy; 2005－2023 douban.com, all rights reserved 北京豆网科技有限公司
+    © 2005－2026 douban.com, all rights reserved 北京豆网科技有限公司
 </span>
 
 <a href="https://www.douban.com/hnypt/variformcyst.py" style="display: none;"></a>
@@ -2125,18 +1970,35 @@
     · <a href="https://www.douban.com/jobs">在豆瓣工作</a>
     · <a href="https://www.douban.com/about?topic=contactus">联系我们</a>
     · <a href="https://www.douban.com/about/legal">法律声明</a>
-
+    
     · <a href="https://help.douban.com/?app=music" target="_blank">帮助中心</a>
-    · <a href="https://douban.fm/app">手机音乐</a>
-    · <a href="https://www.douban.com/partner/">豆瓣广告</a>
+    · <a href="https://fm.douban.com/app">手机音乐</a>
 </span>
 
 </div>
 
     </div>
-    <script type="text/javascript" src="https://img1.doubanio.com/misc/mixed_static/23f807d8ff269601.js"></script>
-
-
+    <script type="text/javascript">
+    Do(function(){
+        $(function(){
+            $('#uncollect-s').click(function(e){
+                e.preventDefault();
+                var r = confirm('真的要删除这个收藏？'),
+                    sid = $(this).data('sid');
+                if (r === true){
+                    $.post_withck('/j/subject/' + sid + '/remove', function(res){
+                        res = $.parseJSON(res);
+                        if (res.r === 'success'){
+                            document.location.reload(true);
+                        }
+                    });
+                }
+            });
+        });
+    });
+</script>
+    
+    
     <script type="text/javascript">
         Do('dialog', function() {
             $('.collect_btn').each(function(){
@@ -2145,6 +2007,7 @@
         });
     </script>
 
+    
 
 
 
@@ -2153,25 +2016,24 @@
 
 
 
-
-
+    
 <script type="text/javascript">
     (function (global) {
         var newNode = global.document.createElement('script'),
             existingNode = global.document.getElementsByTagName('script')[0],
             adSource = '//erebor.douban.com/',
             userId = '',
-            browserId = 'ZX59oiRl9yw',
+            browserId = '_9Y_aod1NWg',
             criteria = '7:TheBeatles|7:beatles|7:Rock|7:英国|7:摇滚|7:经典|7:1965|7:UK|7:欧美|7:Soul|3:/subject/1401362/',
             preview = '',
             debug = false,
-            adSlots = ['dale_music_subject_top_right', 'dale_music_channel_right_mini', 'dale_music_subject_top_middle'];
+            adSlots = ['dale_music_subject_top_right'];
 
         global.DoubanAdRequest = {src: adSource, uid: userId, bid: browserId, crtr: criteria, prv: preview, debug: debug};
         global.DoubanAdSlots = (global.DoubanAdSlots || []).concat(adSlots);
 
         newNode.setAttribute('type', 'text/javascript');
-        newNode.setAttribute('src', '//img1.doubanio.com/MnJwNGlleS9mL2FkanMvY2M1OGQyNTQ2N2I2YmQzOTlmNTliMGJiMjI4MWRhZTlkNTNjYTFkZC9hZC5yZWxlYXNlLmpz');
+        newNode.setAttribute('src', '//img1.doubanio.com/ZHdhZ2Y4eC9mL2FkanMvZmE3NGZkMWY5NzhhZmM4NmZhZjMxMTllNTQ5MGIyYWRlNTUwYmI0NS9hZC5yZWxlYXNlLmpz?company_token=kX69T8w1wyOE-dale');
         newNode.setAttribute('async', true);
         existingNode.parentNode.insertBefore(newNode, existingNode);
     })(this);
@@ -2182,14 +2044,8 @@
 
 
 
-
-
-
-
-
-
-
-
+    
+    
 
 
 
@@ -2266,9 +2122,13 @@ if (window.addEventListener) {
 
 
 
-    <!-- dae-web-music--default-68657c8d67-h5wp7-->
+    <!-- dae-web-music--default-77c496f895-bnjs8-->
 
   <script>_SPLITTEST=''</script>
-</body>
 
-</html>
+
+
+
+
+
+<div id="search_suggest" style="display: none; top: 78.0005px; left: 594.905px;"><ul></ul></div><iframe name="google_ads_top_frame" id="google_ads_top_frame" style="display: none; position: fixed; left: -999px; top: -999px; width: 0px; height: 0px;"></iframe></body></html>

--- a/tests/catalog/test_book.py
+++ b/tests/catalog/test_book.py
@@ -411,6 +411,21 @@ class TestDoubanBook:
         assert site.resource.item.display_title == "1984 Nineteen Eighty-Four"
 
     @use_local_response
+    def test_author_related_resources(self):
+        t_url = "https://book.douban.com/subject/36255848/"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready is True
+        assert site.resource is not None
+        assert site.resource.metadata.get("title") == "工厂日记"
+        related = site.resource.metadata.get("related_resources", [])
+        assert len(related) >= 1
+        # Author link /author/4608425 should be normalized to full URL
+        urls = [r.get("url", "") for r in related]
+        assert "https://book.douban.com/author/4608425/" in urls
+
+    @use_local_response
     def test_publisher(self):
         t_url = "https://book.douban.com/subject/35902899/"
         site = SiteManager.get_site_by_url(t_url)

--- a/tests/catalog/test_people.py
+++ b/tests/catalog/test_people.py
@@ -1262,6 +1262,148 @@ class TestExtractPersonageLinks:
         assert len(resources) == 0
 
 
+class TestExtractPeopleLinksFromAnchors:
+    def test_author_links(self):
+        """Author links should be extracted with their full URL."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="https://book.douban.com/author/4608425">Author One</a>
+          <a href="https://book.douban.com/author/9999999/">Author Two</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 2
+        assert resources[0]["url"] == "https://book.douban.com/author/4608425/"
+        assert resources[1]["url"] == "https://book.douban.com/author/9999999/"
+        # Author links don't have id_type (resolved via redirect)
+        assert "id_type" not in resources[0]
+
+    def test_musician_links(self):
+        """Musician links should be extracted with their full URL."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="https://music.douban.com/musician/104916/">Artist</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 1
+        assert resources[0]["url"] == "https://music.douban.com/musician/104916/"
+
+    def test_personage_links_direct(self):
+        """Personage links should be extracted with id_type and id_value."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="https://www.douban.com/personage/30098574/">Person</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 1
+        assert resources[0]["id_type"] == IdType.DoubanPersonage
+        assert resources[0]["id_value"] == "30098574"
+        assert resources[0]["url"] == "https://www.douban.com/personage/30098574/"
+
+    def test_mixed_link_types(self):
+        """Mix of personage, author, and musician links."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="https://www.douban.com/personage/11111/">Direct Person</a>
+          <a href="https://book.douban.com/author/22222">Book Author</a>
+          <a href="https://music.douban.com/musician/33333/">Musician</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 3
+        assert resources[0]["id_type"] == IdType.DoubanPersonage
+        assert resources[1]["url"] == "https://book.douban.com/author/22222/"
+        assert resources[2]["url"] == "https://music.douban.com/musician/33333/"
+
+    def test_relative_urls(self):
+        """Relative author and musician paths should be normalized to full URLs."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="/author/4608425">Author (relative)</a>
+          <a href="/musician/104916/">Musician (relative)</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 2
+        assert resources[0]["url"] == "https://book.douban.com/author/4608425/"
+        assert resources[1]["url"] == "https://music.douban.com/musician/104916/"
+
+    def test_deduplicates(self):
+        """Same author via relative and absolute URL should not be duplicated."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="/author/4608425">Name 1</a>
+          <a href="https://book.douban.com/author/4608425/">Name 1</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 1
+
+    def test_limit(self):
+        """Should respect the limit parameter."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        anchors_html = "".join(
+            f'<a href="https://www.douban.com/personage/{i}/">P{i}</a>'
+            for i in range(1, 20)
+        )
+        fragment = html.fromstring(f"<div>{anchors_html}</div>")
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors, limit=5)
+        assert len(resources) == 5
+
+    def test_ignores_unrelated_links(self):
+        """Non-person links should be ignored."""
+        from lxml import html
+
+        from catalog.sites.douban import extract_people_links_from_anchors
+
+        fragment = html.fromstring("""
+        <div>
+          <a href="https://book.douban.com/subject/12345/">A Book</a>
+          <a href="https://movie.douban.com/celebrity/99999/">Celebrity</a>
+          <a href="https://example.com/">External</a>
+        </div>
+        """)
+        anchors = fragment.findall(".//a")
+        resources = extract_people_links_from_anchors(anchors)
+        assert len(resources) == 0
+
+
 @pytest.mark.django_db(databases="__all__")
 class TestItemMergeCreditsAdvanced:
     def test_merge_preserves_character_name(self):


### PR DESCRIPTION
## Summary

- Extract author/musician links from Douban book and music pages and add them as `related_resources`, so they are fetched asynchronously as `People` objects via the existing pipeline
- Add shared `extract_people_links_from_anchors()` helper in `douban.py` that handles `personage/N` (direct), `author/N`, and `musician/N` URL patterns (both absolute and relative)
- Refactor movie scraper's `_extract_personage_links` to use the same shared helper

## How it works

When a book page like `https://book.douban.com/subject/36255848/` is scraped, author links (e.g. `/author/4608425`) are extracted from the `<a>` tags and stored in `metadata["related_resources"]`. The existing `fetch_related_resources_task` then calls `SiteManager.get_site_by_url()`, which follows the HTTP 302 redirect (`book.douban.com/author/4608425` -> `www.douban.com/personage/30098574/`), matches `DoubanPersonage`, and creates the linked People object.

Same mechanism applies to `music.douban.com/musician/N` links on music pages.

## Test plan

- [x] Unit tests for `extract_people_links_from_anchors` covering absolute URLs, relative URLs, personage/author/musician patterns, deduplication, limits, and unrelated link filtering (11 tests)
- [x] Integration test verifying book scraper extracts author link from real scraped test data (`subject/36255848`)
- [x] Regression: existing `TestExtractPersonageLinks` tests pass with refactored movie code
- [x] All pre-commit checks pass (ruff, ruff-format, ty, djlint)
- [ ] Full DB integration tests via Docker (`pytest --reuse-db`)