### PR TITLE
feat: scan barcode from top-right dropdown

### DIFF
--- a/common/templates/_header.html
+++ b/common/templates/_header.html
@@ -105,6 +105,9 @@
             </span>
           </summary>
           <ul role="listbox" style="min-width:-webkit-max-content;" dir="rtl">
+            <li>
+              <a href="{% url 'common:scan' %}">{% trans 'Scan Barcode' %}</a>
+            </li>
             {% if request.user.is_authenticated %}
               <li>
                 <a href="{% url 'social:notification' %}">{% trans 'Notification' %}</a>

--- a/common/templates/common/scan.html
+++ b/common/templates/common/scan.html
@@ -1,0 +1,164 @@
+{% load static %}
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}" class="classic-page">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% translate "Scan Barcode" %} - {{ site_name }}</title>
+    {% include "common_libs.html" %}
+    <style>
+      .scan-wrap {
+        max-width: 560px;
+        margin: 1rem auto;
+      }
+      .scan-wrap video {
+        width: 100%;
+        aspect-ratio: 4 / 3;
+        background: #000;
+        border-radius: var(--pico-border-radius);
+        object-fit: cover;
+      }
+      .scan-status {
+        text-align: center;
+        margin: 0.5rem 0;
+        min-height: 1.4em;
+      }
+      .scan-manual {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .scan-manual input {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body>
+    {% include "_header.html" %}
+    <main>
+      <div class="grid__main">
+        <section class="scan-wrap">
+          <h1>{% translate "Scan Barcode" %}</h1>
+          <p>
+            <small>
+              {% blocktranslate %}Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected.{% endblocktranslate %}
+            </small>
+          </p>
+          <video id="scan-video" autoplay playsinline muted>
+          </video>
+          <div class="scan-status" id="scan-status">{% translate "Requesting camera access..." %}</div>
+          <form class="scan-manual"
+                id="scan-manual"
+                method="get"
+                action="{% url 'common:search' %}">
+            <input type="search"
+                   name="q"
+                   placeholder="{% translate 'Or type barcode / ISBN manually' %}"
+                   autocomplete="off" />
+            <input type="hidden" name="c" value="book" />
+            <button type="submit">{% translate "Search" %}</button>
+          </form>
+        </section>
+      </div>
+    </main>
+    {% include "_footer.html" %}
+    <script>
+      (function () {
+        var video = document.getElementById("scan-video");
+        var statusEl = document.getElementById("scan-status");
+        var searchUrl = "{% url 'common:search' %}";
+        var formats = ["ean_13", "ean_8", "upc_a", "upc_e", "code_128", "code_39", "itf", "qr_code"];
+        var stream = null;
+        var stopped = false;
+
+        function setStatus(msg) { statusEl.textContent = msg; }
+
+        function redirect(code) {
+          if (stopped) return;
+          stopped = true;
+          stopStream();
+          var url = searchUrl + "?q=" + encodeURIComponent(code) + "&c=book";
+          window.location.href = url;
+        }
+
+        function stopStream() {
+          if (stream) {
+            stream.getTracks().forEach(function (t) { t.stop(); });
+            stream = null;
+          }
+        }
+
+        function startCamera() {
+          if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            setStatus("{% translate 'Camera not supported on this device. Use manual entry below.' %}");
+            return Promise.reject(new Error("no getUserMedia"));
+          }
+          return navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: "environment" } },
+            audio: false
+          }).then(function (s) {
+            stream = s;
+            video.srcObject = s;
+            return video.play();
+          });
+        }
+
+        function runNativeDetector() {
+          if (!("BarcodeDetector" in window)) return false;
+          var detector;
+          try {
+            detector = new window.BarcodeDetector({ formats: formats });
+          } catch (e) {
+            return false;
+          }
+          setStatus("{% translate 'Scanning...' %}");
+          var loop = function () {
+            if (stopped) return;
+            detector.detect(video).then(function (codes) {
+              if (codes && codes.length > 0) {
+                redirect(codes[0].rawValue);
+              } else {
+                requestAnimationFrame(loop);
+              }
+            }).catch(function () {
+              requestAnimationFrame(loop);
+            });
+          };
+          requestAnimationFrame(loop);
+          return true;
+        }
+
+        function runZxing() {
+          setStatus("{% translate 'Loading scanner library...' %}");
+          return import("{{ cdn_url }}/npm/@zxing/browser@0.1.5/+esm").then(function (mod) {
+            var reader = new mod.BrowserMultiFormatReader();
+            setStatus("{% translate 'Scanning...' %}");
+            return reader.decodeFromVideoElement(video, function (result, err, controls) {
+              if (result) {
+                if (controls) controls.stop();
+                redirect(result.getText());
+              }
+            });
+          }).catch(function () {
+            setStatus("{% translate 'Could not load scanner. Use manual entry below.' %}");
+          });
+        }
+
+        startCamera().then(function () {
+          if (!runNativeDetector()) runZxing();
+        }).catch(function (err) {
+          if (err && (err.name === "NotAllowedError" || err.name === "SecurityError")) {
+            setStatus("{% translate 'Camera permission denied. Use manual entry below.' %}");
+          } else if (err && err.name === "NotFoundError") {
+            setStatus("{% translate 'No camera found. Use manual entry below.' %}");
+          } else {
+            setStatus("{% translate 'Camera unavailable. Use manual entry below.' %}");
+          }
+        });
+
+        window.addEventListener("pagehide", stopStream);
+      })();
+    </script>
+  </body>
+</html>

--- a/common/urls.py
+++ b/common/urls.py
@@ -16,6 +16,7 @@ app_name = "common"
 urlpatterns = [
     path("", home),
     path("search", search, name="search"),
+    path("scan/", scan, name="scan"),
     path("home/", home, name="home"),
     path("site/share", share, name="share"),
     path("site/manifest.json", manifest, name="manifest"),

--- a/common/views.py
+++ b/common/views.py
@@ -58,6 +58,10 @@ def search(request):
             return catalog_search(request)
 
 
+def scan(request):
+    return render(request, "common/scan.html")
+
+
 def home(request):
     if request.user.is_authenticated:
         home = request.user.preference.classic_homepage

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-16 22:00-0400\n"
+"POT-Creation-Date: 2026-04-16 22:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3161,7 +3161,7 @@ msgstr ""
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:17 common/templates/_header.html:150
+#: common/templates/_header.html:17 common/templates/_header.html:153
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
@@ -3194,55 +3194,60 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:110 social/templates/notification.html:12
+#: common/templates/_header.html:109 common/templates/common/scan.html:9
+#: common/templates/common/scan.html:42
+msgid "Scan Barcode"
+msgstr ""
+
+#: common/templates/_header.html:113 social/templates/notification.html:12
 #: social/templates/notification.html:60
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:114
+#: common/templates/_header.html:117
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:117 common/templates/_header.html:135
+#: common/templates/_header.html:120 common/templates/_header.html:138
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:120
+#: common/templates/_header.html:123
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:124
+#: common/templates/_header.html:127
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:128
+#: common/templates/_header.html:131
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:132
+#: common/templates/_header.html:135
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:148
+#: common/templates/_header.html:151
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:165
+#: common/templates/_header.html:168
 msgid "Open"
 msgstr ""
 
-#: common/templates/_header.html:180
+#: common/templates/_header.html:183
 msgid "Secure your account with a passkey for quick sign-in."
 msgstr ""
 
-#: common/templates/_header.html:181
+#: common/templates/_header.html:184
 msgid "Set up"
 msgstr ""
 
-#: common/templates/_header.html:183
+#: common/templates/_header.html:186
 msgid "Dismiss"
 msgstr ""
 
@@ -3403,6 +3408,50 @@ msgstr ""
 
 #: common/templates/common/error.html:12
 msgid "Error"
+msgstr ""
+
+#: common/templates/common/scan.html:45
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
+msgstr ""
+
+#: common/templates/common/scan.html:50
+msgid "Requesting camera access..."
+msgstr ""
+
+#: common/templates/common/scan.html:57
+msgid "Or type barcode / ISBN manually"
+msgstr ""
+
+#: common/templates/common/scan.html:60 common/views_manage.py:443
+msgid "Search"
+msgstr ""
+
+#: common/templates/common/scan.html:94
+msgid "Camera not supported on this device. Use manual entry below."
+msgstr ""
+
+#: common/templates/common/scan.html:115 common/templates/common/scan.html:136
+msgid "Scanning..."
+msgstr ""
+
+#: common/templates/common/scan.html:133
+msgid "Loading scanner library..."
+msgstr ""
+
+#: common/templates/common/scan.html:144
+msgid "Could not load scanner. Use manual entry below."
+msgstr ""
+
+#: common/templates/common/scan.html:152
+msgid "Camera permission denied. Use manual entry below."
+msgstr ""
+
+#: common/templates/common/scan.html:154
+msgid "No camera found. Use manual entry below."
+msgstr ""
+
+#: common/templates/common/scan.html:156
+msgid "Camera unavailable. Use manual entry below."
 msgstr ""
 
 #: common/templates/manage/settings.html:9
@@ -3711,10 +3760,6 @@ msgstr ""
 
 #: common/views_manage.py:434
 msgid "Category values to hide from the catalog, one per line."
-msgstr ""
-
-#: common/views_manage.py:443
-msgid "Search"
 msgstr ""
 
 #: common/views_manage.py:455

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-16 22:00-0400\n"
+"POT-Creation-Date: 2026-04-16 22:10-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -3232,7 +3232,7 @@ msgstr "关于"
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr "这是%(site_name)s的临时镜像，请尽可能使用<a href=\"%(site_url)s%(request.get_full_path)s\">原始站点</a>。"
 
-#: common/templates/_header.html:17 common/templates/_header.html:150
+#: common/templates/_header.html:17 common/templates/_header.html:153
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "标题、创作者、ISBN、站外条目链接、@用户名、@用户名@实例"
 
@@ -3265,55 +3265,60 @@ msgstr "动态"
 msgid "Home"
 msgstr "主页"
 
-#: common/templates/_header.html:110 social/templates/notification.html:12
+#: common/templates/_header.html:109 common/templates/common/scan.html:9
+#: common/templates/common/scan.html:42
+msgid "Scan Barcode"
+msgstr "扫描条形码"
+
+#: common/templates/_header.html:113 social/templates/notification.html:12
 #: social/templates/notification.html:60
 msgid "Notification"
 msgstr "通知"
 
-#: common/templates/_header.html:114
+#: common/templates/_header.html:117
 msgid "Data"
 msgstr "数据"
 
-#: common/templates/_header.html:117 common/templates/_header.html:135
+#: common/templates/_header.html:120 common/templates/_header.html:138
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "设置"
 
-#: common/templates/_header.html:120
+#: common/templates/_header.html:123
 msgid "Account"
 msgstr "账号"
 
-#: common/templates/_header.html:124
+#: common/templates/_header.html:127
 msgid "Manage"
 msgstr "管理"
 
-#: common/templates/_header.html:128
+#: common/templates/_header.html:131
 msgid "Logout"
 msgstr "登出"
 
-#: common/templates/_header.html:132
+#: common/templates/_header.html:135
 msgid "Sign up or Login"
 msgstr "注册或登录"
 
-#: common/templates/_header.html:148
+#: common/templates/_header.html:151
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr "搜索你的评论或条目，可加过滤条件如 category:tv status:complete rating:8..10 date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:165
+#: common/templates/_header.html:168
 msgid "Open"
 msgstr "打开"
 
-#: common/templates/_header.html:180
+#: common/templates/_header.html:183
 msgid "Secure your account with a passkey for quick sign-in."
 msgstr "设置通行密钥，快速安全地登录。"
 
-#: common/templates/_header.html:181
+#: common/templates/_header.html:184
 msgid "Set up"
 msgstr "去设置"
 
-#: common/templates/_header.html:183
+#: common/templates/_header.html:186
 msgid "Dismiss"
 msgstr "忽略"
 
@@ -3496,6 +3501,50 @@ msgstr "条目管理员"
 #: common/templates/common/error.html:12
 msgid "Error"
 msgstr "错误"
+
+#: common/templates/common/scan.html:45
+msgid "Point the camera at a book ISBN or product barcode (EAN / UPC). You will be redirected to the search once a code is detected."
+msgstr "将摄像头对准图书 ISBN 或商品条形码（EAN / UPC），检测到编码后将自动跳转到搜索。"
+
+#: common/templates/common/scan.html:50
+msgid "Requesting camera access..."
+msgstr "正在请求摄像头权限…"
+
+#: common/templates/common/scan.html:57
+msgid "Or type barcode / ISBN manually"
+msgstr "或手动输入条形码 / ISBN"
+
+#: common/templates/common/scan.html:60 common/views_manage.py:443
+msgid "Search"
+msgstr "搜索"
+
+#: common/templates/common/scan.html:94
+msgid "Camera not supported on this device. Use manual entry below."
+msgstr "当前设备不支持摄像头，请使用下方手动输入。"
+
+#: common/templates/common/scan.html:115 common/templates/common/scan.html:136
+msgid "Scanning..."
+msgstr "扫描中…"
+
+#: common/templates/common/scan.html:133
+msgid "Loading scanner library..."
+msgstr "正在加载扫描器…"
+
+#: common/templates/common/scan.html:144
+msgid "Could not load scanner. Use manual entry below."
+msgstr "无法加载扫描器，请使用下方手动输入。"
+
+#: common/templates/common/scan.html:152
+msgid "Camera permission denied. Use manual entry below."
+msgstr "摄像头权限被拒绝，请使用下方手动输入。"
+
+#: common/templates/common/scan.html:154
+msgid "No camera found. Use manual entry below."
+msgstr "未找到摄像头，请使用下方手动输入。"
+
+#: common/templates/common/scan.html:156
+msgid "Camera unavailable. Use manual entry below."
+msgstr "摄像头不可用，请使用下方手动输入。"
 
 #: common/templates/manage/settings.html:9
 #, fuzzy
@@ -3842,12 +3891,6 @@ msgstr "添加电视剧集"
 #: common/views_manage.py:434
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
-
-#: common/views_manage.py:443
-#, fuzzy
-#| msgid "Search filters"
-msgid "Search"
-msgstr "筛选搜索结果"
 
 #: common/views_manage.py:455
 #, fuzzy


### PR DESCRIPTION
## Summary
- Adds a "Scan Barcode" item to the top-right dropdown menu that opens a new scanner page.
- The scanner uses the native `BarcodeDetector` API when available and falls back to `@zxing/browser` (loaded via the existing `cdn_url`) for Safari/iOS.
- Once a code is detected, the user is redirected to the existing catalog search with `c=book`, so ISBN/EAN/UPC lookups flow through the current search path without any backend changes.
- Works for both anonymous and authenticated visitors; manual entry is offered on devices without a working camera, or when camera permission is denied.
- Locale strings added and `zh_Hans` translations filled in.

## Test plan
- [ ] Load the app on a mobile device with the rear camera, open the top-right dropdown, tap "Scan Barcode", scan a book back-cover ISBN; verify redirect to `/search?q=<isbn>&c=book` and that the matching edition is found.
- [ ] Repeat on an iOS Safari device to exercise the ZXing fallback.
- [ ] Visit the scan page on a laptop without a camera and verify the page degrades gracefully to manual entry.
- [ ] Deny camera permission and verify the "Camera permission denied" message appears.
- [ ] Run `uv run pre-commit run -a`.