### PR TITLE
fix: stop DEFERRED sentinel leaking into jsondata form initial

### DIFF
--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -191,10 +191,10 @@ class JSONFieldMixin(object):
 
     def formfield(self: "fields.Field", **kwargs):
         # Field.formfield() seeds initial from get_default(), which we override
-        # to DEFERRED for model init. Supply the real default for forms instead.
+        # to DEFERRED for model init. Pass the raw default so form rendering
+        # invokes any callable (e.g. timezone.now) lazily.
         if self.has_default() and "initial" not in kwargs:
-            default = self.default
-            kwargs["initial"] = default() if callable(default) else default
+            kwargs["initial"] = self.default
         return super().formfield(**kwargs)  # type: ignore
 
 

--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -189,6 +189,14 @@ class JSONFieldMixin(object):
         # deferred during obj initialization so it don't overwrite json with default value
         return DEFERRED
 
+    def formfield(self: "fields.Field", **kwargs):
+        # Field.formfield() seeds initial from get_default(), which we override
+        # to DEFERRED for model init. Supply the real default for forms instead.
+        if self.has_default() and "initial" not in kwargs:
+            default = self.default
+            kwargs["initial"] = default() if callable(default) else default
+        return super().formfield(**kwargs)  # type: ignore
+
 
 class BooleanField(JSONFieldMixin, fields.BooleanField):
     pass

--- a/tests/catalog/test_people.py
+++ b/tests/catalog/test_people.py
@@ -454,6 +454,19 @@ class TestPeopleCreateView:
         assert response.status_code == 200
         assert "people_type" not in response.context["form"].initial
 
+    def test_create_form_jsondata_fields_have_no_deferred_initial(self):
+        """jsondata fields must not surface Django's DEFERRED sentinel as form initial."""
+        client = self._login()
+        response = client.get("/catalog/create/People")
+        assert response.status_code == 200
+        form = response.context["form"]
+        for name in ("birth_date", "death_date", "official_site"):
+            initial = form[name].value()
+            assert initial in (None, "", [], {}), (
+                f"{name} initial leaked non-empty value: {initial!r}"
+            )
+            assert "Deferred" not in str(initial)
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestItemCredit:


### PR DESCRIPTION
## Summary
- On the new Person / Organization form, `birth_date`, `death_date`, and `official_site` rendered with the literal string `<Deferred field>` as their default value.
- Root cause: `JSONFieldMixin.get_default()` returns Django's `DEFERRED` sentinel so model `__init__` won't overwrite the JSON metadata column. `Field.formfield()` also calls `get_default()` to seed the form field's `initial`, so the sentinel leaked through on create forms (no instance).
- Fix: override `formfield()` in `JSONFieldMixin` to supply the real default as `initial`, bypassing the `get_default()` override.

## Test plan
- [x] New regression test `test_create_form_jsondata_fields_have_no_deferred_initial` guarding initial values of all three fields on the create form.
- [x] Full `tests/catalog/test_people.py` suite passes (97 tests).
- [x] `pre-commit run` clean on changed files.