### PR TITLE
fix: scan barcode reliability

### DIFF
--- a/common/templates/common/scan.html
+++ b/common/templates/common/scan.html
@@ -129,11 +129,10 @@
             detector.detect(video).then(function (codes) {
               if (codes && codes.length > 0) {
                 redirect(codes[0].rawValue);
-              } else {
-                requestAnimationFrame(loop);
               }
+              if (!stopped) requestAnimationFrame(loop);
             }).catch(function () {
-              requestAnimationFrame(loop);
+              if (!stopped) requestAnimationFrame(loop);
             });
           };
           requestAnimationFrame(loop);

--- a/common/templates/common/scan.html
+++ b/common/templates/common/scan.html
@@ -68,14 +68,25 @@
         var video = document.getElementById("scan-video");
         var statusEl = document.getElementById("scan-status");
         var searchUrl = "{% url 'common:search' %}";
-        var formats = ["ean_13", "ean_8", "upc_a", "upc_e", "code_128", "code_39", "itf", "qr_code"];
+        var formats = ["ean_13", "ean_8", "upc_a", "upc_e"];
         var stream = null;
         var stopped = false;
 
         function setStatus(msg) { statusEl.textContent = msg; }
 
+        function isValidBookCode(code) {
+          if (!code) return false;
+          var digits = code.replace(/[-\s]/g, "");
+          // EAN-13 / ISBN-13, UPC-A (12), ISBN-10 (allow trailing X), EAN-8 / UPC-E (8)
+          return /^\d{13}$/.test(digits)
+            || /^\d{12}$/.test(digits)
+            || /^\d{9}[\dX]$/i.test(digits)
+            || /^\d{8}$/.test(digits);
+        }
+
         function redirect(code) {
           if (stopped) return;
+          if (!isValidBookCode(code)) return;
           stopped = true;
           stopStream();
           var url = searchUrl + "?q=" + encodeURIComponent(code) + "&c=book";
@@ -131,13 +142,16 @@
 
         function runZxing() {
           setStatus("{% translate 'Loading scanner library...' %}");
-          return import("{{ cdn_url }}/npm/@zxing/browser@0.1.5/+esm").then(function (mod) {
+          return import("https://cdn.jsdelivr.net/npm/@zxing/browser@0.1.5/+esm").then(function (mod) {
             var reader = new mod.BrowserMultiFormatReader();
             setStatus("{% translate 'Scanning...' %}");
             return reader.decodeFromVideoElement(video, function (result, err, controls) {
               if (result) {
-                if (controls) controls.stop();
-                redirect(result.getText());
+                var text = result.getText();
+                if (isValidBookCode(text)) {
+                  if (controls) controls.stop();
+                  redirect(text);
+                }
               }
             });
           }).catch(function () {


### PR DESCRIPTION
## Summary
- Load `@zxing/browser` ESM directly from `cdn.jsdelivr.net`. The bundle has root-relative imports for its transitive deps (`@zxing/library`), so going through the site's `/jsdelivr` proxy prefix caused those inner fetches to resolve against the site origin and 404.
- Narrow the native `BarcodeDetector` formats to EAN/UPC and validate the decoded text (8/10/12/13-digit, ISBN-10 trailing `X` allowed) before redirecting. Prevents stray QR / Code-128 / Code-39 detections from firing a search with non-barcode text.
- Zxing callback only stops the scanner and redirects when the decoded text validates, so the scanner keeps looping on bogus hits.

## Test plan
- [ ] Open `/scan` in Safari/Chrome on a phone; verify the zxing fallback loads (no console error about `eggplant.place/npm/@zxing/library...`).
- [ ] Point camera at a book ISBN (EAN-13 starting 978/979); confirm redirect to search.
- [ ] Point camera at a UPC product barcode; confirm redirect to search.
- [ ] Point camera at a QR code with arbitrary text; confirm it does NOT redirect and continues scanning.