### PR TITLE
Tidy credits edit UI and filter roles by item class

### DIFF
--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -740,6 +740,21 @@ class Item(PolymorphicModel):
     CREDIT_FIELD_MAPPING: dict[str, str] = {}
 
     @classmethod
+    def credit_role_choices(cls):
+        """CreditRole choices relevant to this item class.
+
+        Derived from the class's `available_roles` (PeopleRole values share
+        string values with CreditRole) plus any role in CREDIT_FIELD_MAPPING.
+        Falls back to all CreditRole choices if neither is set.
+        """
+        allowed: set[str] = {str(r) for r in getattr(cls, "available_roles", [])}
+        allowed.update(cls.CREDIT_FIELD_MAPPING.values())
+        allowed &= set(CreditRole.values)
+        if not allowed:
+            return list(CreditRole.choices)
+        return [(v, label) for v, label in CreditRole.choices if v in allowed]
+
+    @classmethod
     def create_from_external_resource(cls, p: "ExternalResource") -> Self:
         logger.debug(f"creating new item from {p}")
         obj = cls.copy_metadata(p.metadata)

--- a/catalog/templates/_item_credits_list.html
+++ b/catalog/templates/_item_credits_list.html
@@ -1,51 +1,144 @@
 {% load i18n %}
+<style>
+  #credits-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  #credits-list .credit-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.4rem;
+    border-radius: 4px;
+    transition: background-color 0.15s;
+  }
+
+  #credits-list .credit-row:hover {
+    background-color: color-mix(in srgb, var(--pico-color) 8%, transparent);
+  }
+
+  #credits-list .credit-role {
+    color: var(--pico-muted-color);
+    font-size: 0.8em;
+    min-width: 6em;
+    flex-shrink: 0;
+  }
+
+  #credits-list .credit-name {
+    font-weight: 500;
+  }
+
+  #credits-list .credit-person-link {
+    color: var(--pico-muted-color);
+    font-size: 0.75em;
+  }
+
+  #credits-list .credit-character {
+    cursor: pointer;
+    color: var(--pico-muted-color);
+    font-size: 0.9em;
+  }
+
+  #credits-list .credit-character:hover {
+    color: var(--pico-color);
+  }
+
+  #credits-list .credit-character .fa-pen {
+    font-size: 0.7em;
+    opacity: 0.5;
+  }
+
+  #credits-list .credit-character-form {
+    display: none;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  #credits-list .credit-character-form input {
+    margin-bottom: 0;
+    max-width: 14em;
+    font-size: 0.9em;
+    padding: 0.2rem 0.4rem;
+  }
+
+  #credits-list .credit-row.editing .credit-character {
+    display: none;
+  }
+
+  #credits-list .credit-row.editing .credit-character-form {
+    display: flex;
+  }
+
+  #credits-list .credit-actions {
+    margin-left: auto;
+  }
+
+  #credits-list .credit-empty {
+    color: var(--pico-muted-color);
+    padding: 0.5rem 0.4rem;
+  }
+
+  #credits-list .credit-add-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+  }
+
+  #credits-list .credit-add-form select {
+    max-width: 10em;
+    margin-bottom: 0;
+  }
+
+  #credits-list .credit-add-form input {
+    margin-bottom: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  #credits-list .credit-add-form button {
+    white-space: nowrap;
+    margin-bottom: 0;
+    width: auto;
+    flex-shrink: 0;
+  }
+</style>
 <div id="credits-list">
   {% for credit in credits %}
-    <div style="display: flex;
-                align-items: center;
-                gap: 0.5em;
-                padding: 0.2em 0.3em;
-                margin-bottom: 0.1em;
-                border-radius: 4px;
-                transition: background-color 0.15s"
-         onmouseover="this.style.backgroundColor='color-mix(in srgb, var(--pico-color) 8%, transparent)'"
-         onmouseout="this.style.backgroundColor='transparent'">
-      <small>[{{ credit.get_role_display }}]</small>
+    <div class="credit-row" data-credit-row>
+      <small class="credit-role">{{ credit.get_role_display }}</small>
       {% if credit.person %}
-        <a href="{{ credit.person.url }}">{{ credit.name }}</a>
-        <i class="fa-solid fa-link" style="font-size: 0.7em; opacity: 0.5;"></i>
+        <a class="credit-name" href="{{ credit.person.url }}">{{ credit.name }}</a>
+        <i class="fa-solid fa-link credit-person-link"
+           title="{% trans 'linked to a person page' %}"></i>
       {% else %}
-        <span>{{ credit.name }}</span>
+        <span class="credit-name">{{ credit.name }}</span>
       {% endif %}
-      <small style="cursor: pointer;
-                    opacity: 0.7"
-             title="{% trans 'click to edit character name' %}"
-             onclick="var s=this;var f=s.nextElementSibling;s.style.display='none';f.style.display='flex';f.querySelector('input').focus();">
+      <span class="credit-character"
+            data-edit-character
+            title="{% trans 'click to edit character name' %}">
         {% if credit.character_name %}
           ({{ credit.character_name }})
         {% else %}
-          <i class="fa-solid fa-pen" style="font-size: 0.6em; opacity: 0.4;"></i>
+          <i class="fa-solid fa-pen"></i>
         {% endif %}
-      </small>
-      <form hx-post="{% url 'catalog:update_credit' item.url_path item.uuid credit.pk %}"
+      </span>
+      <form class="credit-character-form"
+            hx-post="{% url 'catalog:update_credit' item.url_path item.uuid credit.pk %}"
             hx-target="#credits-section"
-            hx-swap="innerHTML"
-            style="display: none;
-                   align-items: center;
-                   gap: 0.3em">
+            hx-swap="innerHTML">
         {% csrf_token %}
         <input type="text"
                name="character_name"
                value="{{ credit.character_name }}"
                placeholder="{% trans 'character name' %}"
-               style="margin-bottom: 0;
-                      max-width: 12em;
-                      font-size: 0.85em;
-                      padding: 0.2em 0.4em"
-               onblur="this.form.requestSubmit()"
-               onkeydown="if(event.key==='Enter'){event.preventDefault();this.form.requestSubmit();}if(event.key==='Escape'){this.form.style.display='none';this.form.previousElementSibling.style.display='';}">
+               data-character-input>
       </form>
-      <span class="action inline" style="margin-left: auto;">
+      <span class="action inline credit-actions">
         <a hx-post="{% url 'catalog:remove_credit' item.url_path item.uuid credit.pk %}"
            hx-target="#credits-section"
            hx-swap="innerHTML"
@@ -56,29 +149,62 @@
       </span>
     </div>
   {% empty %}
-    <p class="empty">{% trans 'No credits yet.' %}</p>
+    <p class="credit-empty">{% trans 'No credits yet.' %}</p>
   {% endfor %}
-  <form hx-post="{% url 'catalog:add_credit' item.url_path item.uuid %}"
+  <form class="credit-add-form"
+        hx-post="{% url 'catalog:add_credit' item.url_path item.uuid %}"
         hx-target="#credits-section"
-        hx-swap="innerHTML"
-        style="display: flex;
-               gap: 0.5em;
-               margin-top: 0.5em;
-               align-items: center">
+        hx-swap="innerHTML">
     {% csrf_token %}
-    <select name="role" required style="max-width: 10em; margin-bottom: 0;">
+    <select name="role" required>
       {% for value, label in credit_roles %}<option value="{{ value }}">{{ label }}</option>{% endfor %}
     </select>
     <input type="text"
            name="name"
            placeholder="{% trans 'Name or /people/... URL' %}"
-           required
-           style="margin-bottom: 0">
-    <button type="submit"
-            class="outline"
-            style="white-space: nowrap;
-                   margin-bottom: 0">
+           required>
+    <button type="submit" class="outline">
       <i class="fa-solid fa-plus"></i>
+      {% trans 'Add' %}
     </button>
   </form>
 </div>
+<script>
+  (function () {
+    var list = document.getElementById('credits-list');
+    if (!list) return;
+    list.addEventListener('click', function (e) {
+      var trigger = e.target.closest('[data-edit-character]');
+      if (!trigger) return;
+      var row = trigger.closest('[data-credit-row]');
+      if (!row) return;
+      row.classList.add('editing');
+      var input = row.querySelector('[data-character-input]');
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    });
+    list.addEventListener('keydown', function (e) {
+      var input = e.target.closest('[data-character-input]');
+      if (!input) return;
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        input.form.requestSubmit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        input.closest('[data-credit-row]').classList.remove('editing');
+      }
+    });
+    list.addEventListener('focusout', function (e) {
+      var input = e.target.closest('[data-character-input]');
+      if (!input) return;
+      setTimeout(function () {
+        var row = input.closest('[data-credit-row]');
+        if (row && !row.contains(document.activeElement)) {
+          input.form.requestSubmit();
+        }
+      }, 0);
+    });
+  })();
+</script>

--- a/catalog/templates/_item_credits_list.html
+++ b/catalog/templates/_item_credits_list.html
@@ -201,7 +201,7 @@
       if (!input) return;
       setTimeout(function () {
         var row = input.closest('[data-credit-row]');
-        if (row && !row.contains(document.activeElement)) {
+        if (row && row.classList.contains('editing') && !row.contains(document.activeElement)) {
           input.form.requestSubmit();
         }
       }, 0);

--- a/catalog/views/edit.py
+++ b/catalog/views/edit.py
@@ -17,7 +17,6 @@ from journal.models import update_journal_for_merged_item_task
 
 from ..forms import CatalogForms
 from ..models import (
-    CreditRole,
     Edition,
     ExternalResource,
     IdealIdTypes,
@@ -465,7 +464,11 @@ def item_credits(request, item_path, item_uuid):
     return render(
         request,
         "_item_credits_list.html",
-        {"item": item, "credits": credits, "credit_roles": CreditRole.choices},
+        {
+            "item": item,
+            "credits": credits,
+            "credit_roles": type(item).credit_role_choices(),
+        },
     )
 
 
@@ -478,7 +481,8 @@ def add_credit(request, item_path, item_uuid):
     name_input = request.POST.get("name", "").strip()
     if not role or not name_input:
         raise BadRequest("role and name are required")
-    if role not in CreditRole.values:
+    allowed_roles = {v for v, _ in type(item).credit_role_choices()}
+    if role not in allowed_roles:
         raise BadRequest("invalid role")
 
     person = None
@@ -512,7 +516,11 @@ def add_credit(request, item_path, item_uuid):
     return render(
         request,
         "_item_credits_list.html",
-        {"item": item, "credits": credits, "credit_roles": CreditRole.choices},
+        {
+            "item": item,
+            "credits": credits,
+            "credit_roles": type(item).credit_role_choices(),
+        },
     )
 
 
@@ -527,7 +535,11 @@ def remove_credit(request, item_path, item_uuid, credit_id):
     return render(
         request,
         "_item_credits_list.html",
-        {"item": item, "credits": credits, "credit_roles": CreditRole.choices},
+        {
+            "item": item,
+            "credits": credits,
+            "credit_roles": type(item).credit_role_choices(),
+        },
     )
 
 
@@ -544,7 +556,11 @@ def update_credit(request, item_path, item_uuid, credit_id):
     return render(
         request,
         "_item_credits_list.html",
-        {"item": item, "credits": credits, "credit_roles": CreditRole.choices},
+        {
+            "item": item,
+            "credits": credits,
+            "credit_roles": type(item).credit_role_choices(),
+        },
     )
 
 

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 01:33-0400\n"
+"POT-Creation-Date: 2026-04-17 00:59-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -710,7 +710,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:40
+#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:135
 msgid "character name"
 msgstr ""
 
@@ -1082,24 +1082,32 @@ msgstr ""
 msgid "comment this episode"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:22
+#: catalog/templates/_item_credits_list.html:114
+msgid "linked to a person page"
+msgstr ""
+
+#: catalog/templates/_item_credits_list.html:120
 msgid "click to edit character name"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:52
+#: catalog/templates/_item_credits_list.html:142
 msgid "Remove this credit?"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:53
+#: catalog/templates/_item_credits_list.html:143
 msgid "remove"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:59
+#: catalog/templates/_item_credits_list.html:149
 msgid "No credits yet."
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:74
+#: catalog/templates/_item_credits_list.html:161
 msgid "Name or /people/... URL"
+msgstr ""
+
+#: catalog/templates/_item_credits_list.html:165
+msgid "Add"
 msgstr ""
 
 #: catalog/templates/_item_notes.html:68 catalog/templates/_item_notes.html:79

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 01:33-0400\n"
+"POT-Creation-Date: 2026-04-17 00:59-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -709,7 +709,7 @@ msgstr "角色"
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:40
+#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:135
 msgid "character name"
 msgstr "角色名"
 
@@ -1081,25 +1081,33 @@ msgstr "添加短评"
 msgid "comment this episode"
 msgstr "写该集短评"
 
-#: catalog/templates/_item_credits_list.html:22
+#: catalog/templates/_item_credits_list.html:114
+msgid "linked to a person page"
+msgstr "已关联人物页面"
+
+#: catalog/templates/_item_credits_list.html:120
 msgid "click to edit character name"
 msgstr "点击编辑角色名"
 
-#: catalog/templates/_item_credits_list.html:52
+#: catalog/templates/_item_credits_list.html:142
 msgid "Remove this credit?"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:53
+#: catalog/templates/_item_credits_list.html:143
 msgid "remove"
 msgstr "移除"
 
-#: catalog/templates/_item_credits_list.html:59
+#: catalog/templates/_item_credits_list.html:149
 msgid "No credits yet."
 msgstr "暂无演职员信息。"
 
-#: catalog/templates/_item_credits_list.html:74
+#: catalog/templates/_item_credits_list.html:161
 msgid "Name or /people/... URL"
 msgstr "姓名或 /people/... 链接"
+
+#: catalog/templates/_item_credits_list.html:165
+msgid "Add"
+msgstr "添加"
 
 #: catalog/templates/_item_notes.html:68 catalog/templates/_item_notes.html:79
 msgid "more notes from them"


### PR DESCRIPTION
## Summary

- Rewrite the `_item_credits_list.html` partial: inline styles and inline event handlers are replaced with a scoped `<style>` block and a single delegated script. Override pico's default full-width form button so the add-row lays out as select + stretchy input + compact Add button.
- New `Item.credit_role_choices()` intersects `CreditRole` with each class's `available_roles` + `CREDIT_FIELD_MAPPING` values. The credits views pass this per-class list and `add_credit` validates against it, so the dropdown only offers roles that make sense for the item type.

Per-class result:
- Edition: author, translator, publisher
- Movie / TVShow: director, playwright, actor, production_company, distributor
- Album: artist, composer, performer, record_label
- Game: artist, designer, publisher, developer
- Podcast: host
- Performance: director, playwright, actor, composer, choreographer, performer, original_creator, crew, troupe

## Test plan

- [x] `uv run pre-commit run -a`
- [x] Manual: add a credit, edit its character name, remove it on a Movie's credits tab
- [x] Manual: confirm the role dropdown is narrowed to movie-relevant roles
- [ ] Sanity-check visually on Book / Album / Game / Podcast items