### PR TITLE
Polish people search UI and rename org URL path

### DIFF
--- a/catalog/models/people.py
+++ b/catalog/models/people.py
@@ -117,7 +117,7 @@ class People(Item):
     category = ItemCategory.People
     url_path = "people"
     url_path_person = "person"
-    url_path_organization = "company"
+    url_path_organization = "organization"
     type = ItemType.People
 
     # People can have any role

--- a/catalog/templates/_sidebar_search.html
+++ b/catalog/templates/_sidebar_search.html
@@ -65,10 +65,7 @@
       <a href="{% url 'catalog:create' 'Performance' %}?title={{ request.GET.q | default:'' | urlencode }}">{% trans 'Add performance or theater pieces' %}</a>
     </li>
     <li>
-      <a href="{% url 'catalog:create' 'People' %}?title={{ request.GET.q | default:'' | urlencode }}&people_type=person">{% trans 'Add a person' %}</a>
-    </li>
-    <li>
-      <a href="{% url 'catalog:create' 'People' %}?title={{ request.GET.q | default:'' | urlencode }}&people_type=organization">{% trans 'Add an organization' %}</a>
+      <a href="{% url 'catalog:create' 'People' %}?title={{ request.GET.q | default:'' | urlencode }}">{% trans 'Add a person or organization' %}</a>
     </li>
   </ul>
 </details>

--- a/catalog/templates/search_results_people.html
+++ b/catalog/templates/search_results_people.html
@@ -58,6 +58,7 @@
         {% include "_pagination.html" %}
       </div>
       <aside class="grid__aside bottom">
+        {% include "_sidebar_search.html" %}
       </aside>
     </main>
     {% include '_footer.html' %}

--- a/common/templates/_header.html
+++ b/common/templates/_header.html
@@ -44,8 +44,8 @@
               <option {% if request.GET.c == 'performance' or '/performance/' in request.path %}selected{% endif %}
                       value="performance">{% trans 'Performance' %}</option>
             {% endif %}
-            <option {% if request.GET.c == 'people' or '/person/' in request.path or '/company/' in request.path %}selected{% endif %}
-                    value="people">{% trans 'People' %}</option>
+            <option {% if request.GET.c == 'people' or '/person/' in request.path or '/organization/' in request.path %}selected{% endif %}
+                    value="people">{% trans 'Person / Org' %}</option>
             <option {% if request.GET.c == 'journal' %}selected{% endif %}
                     value="journal">{% trans 'Journal' %}</option>
             <option {% if request.GET.c == 'timeline' %}selected{% endif %}

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 00:59-0400\n"
+"POT-Creation-Date: 2026-04-17 09:08-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -710,7 +710,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:135
+#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
@@ -732,27 +732,27 @@ msgstr ""
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:973
+#: catalog/models/item.py:988
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:975
+#: catalog/models/item.py:990
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:977
+#: catalog/models/item.py:992
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:993
+#: catalog/models/item.py:1008
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:999
+#: catalog/models/item.py:1014
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1002
+#: catalog/models/item.py:1017
 msgid "url to the resource"
 msgstr ""
 
@@ -1082,31 +1082,31 @@ msgstr ""
 msgid "comment this episode"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:114
+#: catalog/templates/_item_credits_list.html:117
 msgid "linked to a person page"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:120
+#: catalog/templates/_item_credits_list.html:123
 msgid "click to edit character name"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:142
+#: catalog/templates/_item_credits_list.html:145
 msgid "Remove this credit?"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:143
+#: catalog/templates/_item_credits_list.html:146
 msgid "remove"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:149
+#: catalog/templates/_item_credits_list.html:152
 msgid "No credits yet."
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:161
+#: catalog/templates/_item_credits_list.html:164
 msgid "Name or /people/... URL"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:165
+#: catalog/templates/_item_credits_list.html:168
 msgid "Add"
 msgstr ""
 
@@ -1176,13 +1176,13 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:21 catalog/views/edit.py:131
-#: catalog/views/edit.py:165 catalog/views/edit.py:203
-#: catalog/views/edit.py:262 catalog/views/edit.py:266
-#: catalog/views/edit.py:284 catalog/views/edit.py:330
-#: catalog/views/edit.py:345 catalog/views/edit.py:383
-#: catalog/views/edit.py:393 catalog/views/edit.py:419
-#: catalog/views/search.py:254
+#: catalog/templates/_sidebar_edit.html:21 catalog/views/edit.py:130
+#: catalog/views/edit.py:164 catalog/views/edit.py:202
+#: catalog/views/edit.py:261 catalog/views/edit.py:265
+#: catalog/views/edit.py:283 catalog/views/edit.py:329
+#: catalog/views/edit.py:344 catalog/views/edit.py:382
+#: catalog/views/edit.py:392 catalog/views/edit.py:418
+#: catalog/views/search.py:256
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1461,11 +1461,7 @@ msgid "Add performance or theater pieces"
 msgstr ""
 
 #: catalog/templates/_sidebar_search.html:68
-msgid "Add a person"
-msgstr ""
-
-#: catalog/templates/_sidebar_search.html:71
-msgid "Add an organization"
+msgid "Add a person or organization"
 msgstr ""
 
 #: catalog/templates/_wikipedia_pages.html:10
@@ -1902,7 +1898,6 @@ msgid "Logged in user may see search results from other sites."
 msgstr ""
 
 #: catalog/templates/search_results_people.html:12
-#: common/templates/_header.html:48
 msgid "People"
 msgstr ""
 
@@ -1922,17 +1917,17 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:167
+#: catalog/views/edit.py:166
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:169
+#: catalog/views/edit.py:168
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:192 catalog/views/edit.py:246
-#: catalog/views/edit.py:332 catalog/views/edit.py:421
-#: catalog/views/edit.py:453 journal/views/collection.py:96
+#: catalog/views/edit.py:191 catalog/views/edit.py:245
+#: catalog/views/edit.py:331 catalog/views/edit.py:420
+#: catalog/views/edit.py:452 journal/views/collection.py:96
 #: journal/views/collection.py:156 journal/views/collection.py:168
 #: journal/views/collection.py:185 journal/views/collection.py:251
 #: journal/views/collection.py:287 journal/views/collection.py:322
@@ -1947,7 +1942,7 @@ msgstr ""
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:249 catalog/views/edit.py:252
+#: catalog/views/edit.py:248 catalog/views/edit.py:251
 #: journal/views/collection.py:58 journal/views/collection.py:83
 #: journal/views/collection.py:339 journal/views/collection.py:429
 #: journal/views/common.py:128 journal/views/mark.py:141
@@ -1959,31 +1954,31 @@ msgstr ""
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:306
+#: catalog/views/edit.py:305
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:311
+#: catalog/views/edit.py:310
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:343
+#: catalog/views/edit.py:342
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:348
+#: catalog/views/edit.py:347
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:352
+#: catalog/views/edit.py:351
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:391
+#: catalog/views/edit.py:390
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:395
+#: catalog/views/edit.py:394
 msgid "Cannot link items other than editions"
 msgstr ""
 
@@ -1991,11 +1986,11 @@ msgstr ""
 msgid "the internet"
 msgstr ""
 
-#: catalog/views/search.py:243
+#: catalog/views/search.py:245
 msgid "Invalid URL"
 msgstr ""
 
-#: catalog/views/search.py:246
+#: catalog/views/search.py:248
 msgid "Unsupported URL"
 msgstr ""
 
@@ -3196,6 +3191,10 @@ msgstr ""
 
 #: common/templates/_header.html:29
 msgid "Movie & TV"
+msgstr ""
+
+#: common/templates/_header.html:48
+msgid "Person / Org"
 msgstr ""
 
 #: common/templates/_header.html:50

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 00:59-0400\n"
+"POT-Creation-Date: 2026-04-17 09:08-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -513,7 +513,7 @@ msgstr "收藏单"
 
 #: catalog/models/common.py:148 catalog/models/common.py:161
 msgid "Person / Organization"
-msgstr "个人 / 组织"
+msgstr "个人 / 团体"
 
 #: catalog/models/common.py:152 catalog/models/common.py:166
 #: common/templates/_header.html:25
@@ -709,7 +709,7 @@ msgstr "角色"
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:135
+#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "角色名"
 
@@ -731,27 +731,27 @@ msgstr "元数据"
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:973
+#: catalog/models/item.py:988
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:975
+#: catalog/models/item.py:990
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:977
+#: catalog/models/item.py:992
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:993
+#: catalog/models/item.py:1008
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:999
+#: catalog/models/item.py:1014
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1002
+#: catalog/models/item.py:1017
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
@@ -826,7 +826,7 @@ msgstr "个人"
 #: catalog/models/people.py:32 catalog/templates/search_results_people.html:37
 #: catalog/templates/search_results_people.html:39
 msgid "Organization"
-msgstr "组织"
+msgstr "团体"
 
 #: catalog/models/people.py:37
 msgid "Author"
@@ -1081,31 +1081,31 @@ msgstr "添加短评"
 msgid "comment this episode"
 msgstr "写该集短评"
 
-#: catalog/templates/_item_credits_list.html:114
+#: catalog/templates/_item_credits_list.html:117
 msgid "linked to a person page"
 msgstr "已关联人物页面"
 
-#: catalog/templates/_item_credits_list.html:120
+#: catalog/templates/_item_credits_list.html:123
 msgid "click to edit character name"
 msgstr "点击编辑角色名"
 
-#: catalog/templates/_item_credits_list.html:142
+#: catalog/templates/_item_credits_list.html:145
 msgid "Remove this credit?"
 msgstr ""
 
-#: catalog/templates/_item_credits_list.html:143
+#: catalog/templates/_item_credits_list.html:146
 msgid "remove"
 msgstr "移除"
 
-#: catalog/templates/_item_credits_list.html:149
+#: catalog/templates/_item_credits_list.html:152
 msgid "No credits yet."
 msgstr "暂无演职员信息。"
 
-#: catalog/templates/_item_credits_list.html:161
+#: catalog/templates/_item_credits_list.html:164
 msgid "Name or /people/... URL"
 msgstr "姓名或 /people/... 链接"
 
-#: catalog/templates/_item_credits_list.html:165
+#: catalog/templates/_item_credits_list.html:168
 msgid "Add"
 msgstr "添加"
 
@@ -1175,13 +1175,13 @@ msgstr "回到条目"
 msgid "Edit Options"
 msgstr "编辑选项"
 
-#: catalog/templates/_sidebar_edit.html:21 catalog/views/edit.py:131
-#: catalog/views/edit.py:165 catalog/views/edit.py:203
-#: catalog/views/edit.py:262 catalog/views/edit.py:266
-#: catalog/views/edit.py:284 catalog/views/edit.py:330
-#: catalog/views/edit.py:345 catalog/views/edit.py:383
-#: catalog/views/edit.py:393 catalog/views/edit.py:419
-#: catalog/views/search.py:254
+#: catalog/templates/_sidebar_edit.html:21 catalog/views/edit.py:130
+#: catalog/views/edit.py:164 catalog/views/edit.py:202
+#: catalog/views/edit.py:261 catalog/views/edit.py:265
+#: catalog/views/edit.py:283 catalog/views/edit.py:329
+#: catalog/views/edit.py:344 catalog/views/edit.py:382
+#: catalog/views/edit.py:392 catalog/views/edit.py:418
+#: catalog/views/search.py:256
 msgid "Editing this item is restricted."
 msgstr "这个条目仅管理员可编辑。"
 
@@ -1460,16 +1460,8 @@ msgid "Add performance or theater pieces"
 msgstr "添加戏剧演出"
 
 #: catalog/templates/_sidebar_search.html:68
-#, fuzzy
-#| msgid "Add games"
-msgid "Add a person"
-msgstr "添加游戏"
-
-#: catalog/templates/_sidebar_search.html:71
-#, fuzzy
-#| msgid "Organization"
-msgid "Add an organization"
-msgstr "组织"
+msgid "Add a person or organization"
+msgstr "添加人物或团体"
 
 #: catalog/templates/_wikipedia_pages.html:10
 msgid "Wikipedia Pages"
@@ -1907,7 +1899,6 @@ msgid "Logged in user may see search results from other sites."
 msgstr "登录用户可看到来自其它网站的搜索结果。"
 
 #: catalog/templates/search_results_people.html:12
-#: common/templates/_header.html:48
 msgid "People"
 msgstr "人物"
 
@@ -1927,17 +1918,17 @@ msgstr "本剧所有季"
 msgid "Editions"
 msgstr "版本"
 
-#: catalog/views/edit.py:167
+#: catalog/views/edit.py:166
 msgid "Item in use."
 msgstr "条目已被引用或标记。"
 
-#: catalog/views/edit.py:169
+#: catalog/views/edit.py:168
 msgid "Item cannot be deleted."
 msgstr "条目不可被删除。"
 
-#: catalog/views/edit.py:192 catalog/views/edit.py:246
-#: catalog/views/edit.py:332 catalog/views/edit.py:421
-#: catalog/views/edit.py:453 journal/views/collection.py:96
+#: catalog/views/edit.py:191 catalog/views/edit.py:245
+#: catalog/views/edit.py:331 catalog/views/edit.py:420
+#: catalog/views/edit.py:452 journal/views/collection.py:96
 #: journal/views/collection.py:156 journal/views/collection.py:168
 #: journal/views/collection.py:185 journal/views/collection.py:251
 #: journal/views/collection.py:287 journal/views/collection.py:322
@@ -1952,7 +1943,7 @@ msgstr "条目不可被删除。"
 msgid "Insufficient permission"
 msgstr "权限不足"
 
-#: catalog/views/edit.py:249 catalog/views/edit.py:252
+#: catalog/views/edit.py:248 catalog/views/edit.py:251
 #: journal/views/collection.py:58 journal/views/collection.py:83
 #: journal/views/collection.py:339 journal/views/collection.py:429
 #: journal/views/common.py:128 journal/views/mark.py:141
@@ -1964,31 +1955,31 @@ msgstr "权限不足"
 msgid "Invalid parameter"
 msgstr "无效参数"
 
-#: catalog/views/edit.py:306
+#: catalog/views/edit.py:305
 msgid "TV Season with IMDB id and season number required."
 msgstr "必须是电视剧分季，且包含IMDB id和分季序号。"
 
-#: catalog/views/edit.py:311
+#: catalog/views/edit.py:310
 msgid "Updating episodes"
 msgstr "正在更新单集列表"
 
-#: catalog/views/edit.py:343
+#: catalog/views/edit.py:342
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "无法合并到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:348
+#: catalog/views/edit.py:347
 msgid "Cannot merge items in different categories"
 msgstr "无法合并不同类型的条目"
 
-#: catalog/views/edit.py:352
+#: catalog/views/edit.py:351
 msgid "Cannot merge an item to itself"
 msgstr "无法合并条目和它自己"
 
-#: catalog/views/edit.py:391
+#: catalog/views/edit.py:390
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "无法关联到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:395
+#: catalog/views/edit.py:394
 msgid "Cannot link items other than editions"
 msgstr "无法关联到非图书类的条目"
 
@@ -1996,11 +1987,11 @@ msgstr "无法关联到非图书类的条目"
 msgid "the internet"
 msgstr "互联网"
 
-#: catalog/views/search.py:243
+#: catalog/views/search.py:245
 msgid "Invalid URL"
 msgstr "无效网址"
 
-#: catalog/views/search.py:246
+#: catalog/views/search.py:248
 msgid "Unsupported URL"
 msgstr "尚未支持的网址"
 
@@ -3268,6 +3259,10 @@ msgstr "全部"
 #: common/templates/_header.html:29
 msgid "Movie & TV"
 msgstr "影视"
+
+#: common/templates/_header.html:48
+msgid "Person / Org"
+msgstr "人物 / 团体"
 
 #: common/templates/_header.html:50
 msgid "Journal"

--- a/tests/catalog/test_people.py
+++ b/tests/catalog/test_people.py
@@ -59,7 +59,7 @@ class TestPeople:
         assert not org.is_person
         assert org.is_organization
         assert org.display_name == "Bantam Books"
-        assert org.url == f"/company/{org.uuid}"
+        assert org.url == f"/organization/{org.uuid}"
 
     def test_localized_names(self):
         person = People.objects.create(


### PR DESCRIPTION
## Summary
- Render the catalog search sidebar on the people search results page for parity with catalog search
- Collapse the sidebar's two create links into a single "Add a person or organization"
- Label the header search dropdown "Person / Org" instead of "People"
- Rename `url_path_organization` from `"company"` to `"organization"` so org URLs live under `/organization/<uuid>`
- zh_Hans: translate "Organization" / "Org" as "团体" instead of "组织"

## Test plan
- [ ] `/search?q=...&c=people` shows the filter/create sidebar on the right
- [ ] Sidebar's "Add a person or organization" opens the People create form with no `people_type` preset
- [ ] Header dropdown reads "Person / Org" (zh_Hans: "人物 / 团体") and stays selected on `/person/<uuid>` and `/organization/<uuid>`
- [ ] Organization detail pages resolve at `/organization/<uuid>`
- [ ] `pytest tests/catalog/test_people.py` passes