### PR TITLE
perf(catalog): prefetch credits/resources on item list pages

### DIFF
--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -898,10 +898,19 @@ class Item(PolymorphicModel):
     def get_credits_by_role(self, role: str) -> "QuerySet[ItemCredit]":
         return self.credits.filter(role=role).select_related("person")
 
+    def _credits_with_person(self) -> list["ItemCredit"]:
+        # Use the prefetch cache when callers have prefetched
+        # `credits` (ideally with `credits__person`). Applying
+        # `.select_related("person")` here would bypass that cache
+        # and re-query once per item.
+        if "credits" in getattr(self, "_prefetched_objects_cache", {}):
+            return list(self.credits.all())
+        return list(self.credits.select_related("person").all())
+
     @cached_property
     def api_credits(self) -> list["ItemCredit"]:
         """Credits for API serialization."""
-        return list(self.credits.select_related("person").all())
+        return self._credits_with_person()
 
     def credit_names_by_role(self, role: str) -> list[str]:
         """Return credit names as list[str] from the credits table."""
@@ -911,7 +920,7 @@ class Item(PolymorphicModel):
     def role_credits(self) -> dict[str, list["ItemCredit"]]:
         """All credits grouped by role, for template access."""
         result: dict[str, list[ItemCredit]] = {}
-        for credit in self.credits.select_related("person").all():
+        for credit in self._credits_with_person():
             result.setdefault(credit.role, []).append(credit)
         return result
 

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.db.models import Count, F, Window, prefetch_related_objects
+from django.db.models import Count, F, Prefetch, Window, prefetch_related_objects
 from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -22,15 +22,17 @@ from journal.models import (
     Comment,
     Mark,
     Note,
+    Rating,
     Review,
     ShelfManager,
     ShelfMember,
+    Tag,
     q_piece_in_home_feed_of_user,
     q_piece_visible_to_user,
 )
 from takahe.utils import Takahe
 
-from ..models import ExternalResource, IdType, Item, Podcast, TVEpisode
+from ..models import ExternalResource, IdType, Item, ItemCredit, Podcast, TVEpisode
 from ..models.people import ItemPeopleRelation, People, PeopleRole
 from ..sites import WikiData
 
@@ -89,8 +91,12 @@ def retrieve(request, item_path, item_uuid):
         return JsonResponse(item.ap_object, content_type="application/activity+json")
     if request.method == "HEAD":
         return HttpResponse()
-    # Prefetch parent item and external resources to avoid N+1 in templates
-    prefetch_related_objects([item], "external_resources")
+    # Prefetch parent item, external resources, and credits to avoid N+1 in templates
+    prefetch_related_objects(
+        [item],
+        "external_resources",
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
     Item.prefetch_parent_items([item])
     focus_item = None
     if request.GET.get("focus"):
@@ -180,6 +186,17 @@ def people_works(request, item_path, item_uuid, role):
     page_number = request.GET.get("page", default=1)
     works_page = paginator.get_page(page_number)
     pagination = PageLinksGenerator(page_number, paginator.num_pages, request.GET)
+    # Batch-prefetch per-item data used by _item_card_* partials to avoid N+1
+    works_items = list(works_page.object_list)
+    if works_items:
+        prefetch_related_objects(
+            works_items,
+            "external_resources",
+            Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        )
+        Item.prefetch_parent_items(works_items)
+        Rating.attach_to_items(works_items)
+        Tag.attach_to_items(works_items)
     return render(
         request,
         "people_works.html",

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Any, List
 
 from django.core.cache import cache
-from django.db.models import Prefetch, QuerySet
+from django.db.models import Prefetch, QuerySet, prefetch_related_objects
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
@@ -41,6 +41,11 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
         return
     items = [m.item for m in members]
     # Batch-fetch parent items and item-level data to avoid N+1 queries
+    prefetch_related_objects(
+        items,
+        "external_resources",
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
     Item.prefetch_parent_items(items)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
@@ -167,14 +172,7 @@ def list_marks_on_user_shelf(
         )
         .filter(qv)
         .select_related("owner")
-        .prefetch_related(
-            "item",
-            "item__external_resources",
-            Prefetch(
-                "item__credits",
-                queryset=ItemCredit.objects.select_related("person"),
-            ),
-        )
+        .prefetch_related("item")
     )
     return queryset
 
@@ -197,14 +195,7 @@ def list_marks_on_shelf(
     queryset = (
         request.user.shelf_manager.get_latest_members(type, category)
         .select_related("owner")
-        .prefetch_related(
-            "item",
-            "item__external_resources",
-            Prefetch(
-                "item__credits",
-                queryset=ItemCredit.objects.select_related("person"),
-            ),
-        )
+        .prefetch_related("item")
     )
     return queryset
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -2,13 +2,19 @@ import datetime
 from typing import Any, List
 
 from django.core.cache import cache
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
-from catalog.models import AvailableItemCategory, Item, ItemCategory, ItemSchema
+from catalog.models import (
+    AvailableItemCategory,
+    Item,
+    ItemCategory,
+    ItemCredit,
+    ItemSchema,
+)
 from common.api import PageNumberPagination, Result, api
 from common.utils import get_uuid_or_404
 from journal.models.common import (
@@ -161,7 +167,14 @@ def list_marks_on_user_shelf(
         )
         .filter(qv)
         .select_related("owner")
-        .prefetch_related("item", "item__external_resources")
+        .prefetch_related(
+            "item",
+            "item__external_resources",
+            Prefetch(
+                "item__credits",
+                queryset=ItemCredit.objects.select_related("person"),
+            ),
+        )
     )
     return queryset
 
@@ -184,7 +197,14 @@ def list_marks_on_shelf(
     queryset = (
         request.user.shelf_manager.get_latest_members(type, category)
         .select_related("owner")
-        .prefetch_related("item", "item__external_resources")
+        .prefetch_related(
+            "item",
+            "item__external_resources",
+            Prefetch(
+                "item__credits",
+                queryset=ItemCredit.objects.select_related("person"),
+            ),
+        )
     )
     return queryset
 

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -5,7 +5,18 @@ from django.db import connection
 from django.test import Client
 from django.test.utils import CaptureQueriesContext
 
-from catalog.models import Edition, ExternalResource, IdType, Movie
+from catalog.models import (
+    CreditRole,
+    Edition,
+    ExternalResource,
+    IdType,
+    ItemCredit,
+    Movie,
+    People,
+    PeopleRole,
+    PeopleType,
+)
+from catalog.models.people import ItemPeopleRelation
 from journal.models import Collection, Mark, ShelfType, Tag
 from journal.models.common import prefetch_pieces_for_posts
 from journal.models.shelf import ShelfMember
@@ -900,3 +911,209 @@ class TestMarkBatchFetchNoFKResolution:
             if "catalog_item" in q["sql"] and 'WHERE "catalog_item"."id" =' in q["sql"]
         ]
         assert len(individual_item_queries) == 0
+
+
+def _per_item_credit_queries(captured_queries):
+    return [
+        q
+        for q in captured_queries
+        if "catalog_itemcredit" in q["sql"]
+        and '"catalog_itemcredit"."item_id" =' in q["sql"]
+    ]
+
+
+def _per_item_external_resource_queries(captured_queries):
+    return [
+        q
+        for q in captured_queries
+        if "catalog_externalresource" in q["sql"]
+        and '"catalog_externalresource"."item_id" =' in q["sql"]
+    ]
+
+
+def _per_item_rating_group_queries(captured_queries):
+    return [
+        q
+        for q in captured_queries
+        if "journal_rating" in q["sql"]
+        and "GROUP BY" in q["sql"]
+        and '"journal_rating"."item_id" =' in q["sql"]
+    ]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPeopleWorksPrefetch:
+    """people_works view should batch-fetch credits, external_resources, and ratings."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="pw@example.com", username="pwuser")
+        self.author = People.objects.create(
+            title="PW Author",
+            people_type=PeopleType.PERSON,
+            metadata={"localized_name": [{"lang": "en", "text": "PW Author"}]},
+        )
+        self.books = []
+        for i in range(4):
+            book = Edition.objects.create(title=f"PW Book {i}")
+            ItemCredit.objects.create(
+                item=book,
+                person=self.author,
+                role=CreditRole.Author,
+                name=self.author.display_name,
+            )
+            ItemPeopleRelation.objects.create(
+                item=book, people=self.author, role=PeopleRole.AUTHOR
+            )
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.ISBN,
+                id_value=f"978222200000{i}",
+                url=f"https://example.com/pwbook/{i}",
+            )
+            self.books.append(book)
+
+    def _fetch(self):
+        client = Client()
+        url = f"/people/{self.author.uuid}/works/{PeopleRole.AUTHOR.value}"
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(url)
+        return response, ctx
+
+    def test_page_renders(self):
+        response, _ = self._fetch()
+        assert response.status_code == 200
+        body = response.content.decode()
+        for book in self.books:
+            assert book.display_title in body
+
+    def _queries_for_book_ids(self, queries):
+        """Keep only queries whose item_id = <book_pk> for one of the listed works.
+
+        The People sidebar item triggers its own single-item lookups that are
+        not N+1, so we scope assertions to the per-work page items.
+        """
+        book_ids = {b.pk for b in self.books}
+        return [
+            q for q in queries if any(f'item_id" = {pk}' in q["sql"] for pk in book_ids)
+        ]
+
+    def test_no_per_item_credits_queries(self):
+        """Credits should be prefetched, not queried per work."""
+        response, ctx = self._fetch()
+        assert response.status_code == 200
+        assert (
+            self._queries_for_book_ids(_per_item_credit_queries(ctx.captured_queries))
+            == []
+        )
+
+    def test_no_per_item_external_resource_queries(self):
+        response, ctx = self._fetch()
+        assert response.status_code == 200
+        assert (
+            self._queries_for_book_ids(
+                _per_item_external_resource_queries(ctx.captured_queries)
+            )
+            == []
+        )
+
+    def test_no_per_item_rating_queries(self):
+        response, ctx = self._fetch()
+        assert response.status_code == 200
+        assert (
+            self._queries_for_book_ids(
+                _per_item_rating_group_queries(ctx.captured_queries)
+            )
+            == []
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestItemRetrieveCreditsPrefetch:
+    """catalog.retrieve (edition detail page) should only query credits once."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="ir@example.com", username="iruser")
+        self.author = People.objects.create(
+            title="IR Author",
+            people_type=PeopleType.PERSON,
+            metadata={"localized_name": [{"lang": "en", "text": "IR Author"}]},
+        )
+        self.translator = People.objects.create(
+            title="IR Translator",
+            people_type=PeopleType.PERSON,
+            metadata={"localized_name": [{"lang": "en", "text": "IR Translator"}]},
+        )
+        self.book = Edition.objects.create(title="IR Book")
+        ItemCredit.objects.create(
+            item=self.book,
+            person=self.author,
+            role=CreditRole.Author,
+            name=self.author.display_name,
+        )
+        ItemCredit.objects.create(
+            item=self.book,
+            person=self.translator,
+            role=CreditRole.Translator,
+            name=self.translator.display_name,
+        )
+
+    def test_credits_queried_at_most_once(self):
+        """edition.html reads role_credits multiple times; prefetch means 1 DB hit."""
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(self.book.url)
+        assert response.status_code == 200
+        credit_queries = [
+            q
+            for q in ctx.captured_queries
+            if "catalog_itemcredit" in q["sql"] and "SELECT" in q["sql"].upper()
+        ]
+        # One prefetch query is allowed; should never scale with access count.
+        assert len(credit_queries) <= 1
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfAPICreditsPrefetch:
+    """Shelf API must prefetch item credits across paginated marks."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="sac@example.com", username="sacuser")
+        self.author = People.objects.create(
+            title="SAC Author",
+            people_type=PeopleType.PERSON,
+            metadata={"localized_name": [{"lang": "en", "text": "SAC Author"}]},
+        )
+        self.books = []
+        for i in range(3):
+            book = Edition.objects.create(title=f"SAC Book {i}")
+            ItemCredit.objects.create(
+                item=book,
+                person=self.author,
+                role=CreditRole.Author,
+                name=self.author.display_name,
+            )
+            Mark(self.user.identity, book).update(
+                ShelfType.WISHLIST, f"n{i}", i + 5, [], 0
+            )
+            self.books.append(book)
+        self.app = Takahe.get_or_create_app(
+            "Test",
+            "https://example.org",
+            "https://example.org/cb",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(self.app, self.user.identity.pk, self.user.pk)
+
+    def test_shelf_api_no_per_item_credit_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                "/api/me/shelf/wishlist",
+                HTTP_AUTHORIZATION=f"Bearer {self.token}",
+            )
+        assert response.status_code == 200
+        assert _per_item_credit_queries(ctx.captured_queries) == []


### PR DESCRIPTION
## Summary
- Fixes 5 N+1 Sentry issues on item-list pages (EGGPLANT-19V/19W/19X/19Y/1A0) by prefetching `credits` (with `person`), `external_resources`, ratings, tags, and parent items at the view level.
- Makes `Item.role_credits` / `Item.api_credits` reuse the `credits` prefetch cache instead of bypassing it via `select_related("person")` — the main reason existing prefetches didn't help.
- Adds prefetches in three entry points: `catalog.views.retrieve` (single-item page), `catalog.views.people_works` (paginated works), and the `/api/me/shelf/*` / `/api/user/{handle}/shelf/*` endpoints.

## Test plan
- [x] `uv run pre-commit run` on changed files — clean.
- [x] New regression tests in `tests/journal/test_n_plus_one.py` (3 classes, 6 tests) asserting no per-item `catalog_itemcredit`, `catalog_externalresource`, or `journal_rating` GROUP BY queries for the works list, edition detail, and shelf API.
- [x] Full run of `tests/journal/test_n_plus_one.py`, `tests/catalog/test_people.py`, `tests/catalog/test_pages.py`, `tests/journal/test_shelf.py`, `tests/journal/test_collection.py`, `tests/journal/test_rating.py` — 179 tests pass.

## Scope note
Sentry also flagged EGGPLANT-17A (collection page `users_domain` lookups) and EGGPLANT-188 (search polymorphic TVShow downcast); those root causes differ and are deferred to a follow-up.