### PR TITLE
fix(search): guard against non-enum source_site when filtering

### DIFF
--- a/catalog/search/external.py
+++ b/catalog/search/external.py
@@ -92,5 +92,9 @@ class ExternalSources:
         results = [i for i in results if i.source_url not in dedupe_urls]
         if disabled_sources:
             ds = set(disabled_sources)
-            results = [r for r in results if r.source_site.value not in ds]
+            results = [
+                r
+                for r in results
+                if getattr(r.source_site, "value", r.source_site) not in ds
+            ]
         return results

--- a/catalog/search/external.py
+++ b/catalog/search/external.py
@@ -95,6 +95,11 @@ class ExternalSources:
             results = [
                 r
                 for r in results
-                if getattr(r.source_site, "value", r.source_site) not in ds
+                if (
+                    r.source_site.value
+                    if isinstance(r.source_site, SiteName)
+                    else r.source_site
+                )
+                not in ds
             ]
         return results


### PR DESCRIPTION
## Summary
- Fediverse search results set `source_site` to the peer hostname (a plain `str`), so `r.source_site.value` at `catalog/search/external.py:95` raised `AttributeError` whenever the user had any disabled source.
- Fall back to the raw value via `getattr(..., "value", ...)` so both `SiteName` enum members and plain strings are compared correctly.

Fixes EGGPLANT-1A1

## Test plan
- [ ] Run `/search/external` with at least one disabled source and a query that hits fediverse peers; confirm no 500.