### PR TITLE
bug fix

### DIFF
--- a/takahe/models.py
+++ b/takahe/models.py
@@ -1996,7 +1996,7 @@ class Emoji(models.Model):
             "shortcode": self.shortcode,
             "url": url,
             "static_url": self.remote_url or url,
-            "visible_in_picker": self.public,
+            "visible_in_picker": True if self.public is None else self.public,
             "category": self.category or "",
         }
         return data


### PR DESCRIPTION
## Summary

Fixes two Sentry issues surfaced from production:

- **EGGPLANT-16S** — Bumps `neodb-takahe` submodule with a fix that routes Create+Note ActivityPub messages that have an attachment (but no text content) through `Post.handle_create_ap`. Previously such messages (e.g. image-only posts from `bsky.brid.gy`) fell through to `PostInteraction.handle_ap`, which only understands like/announce/poll-vote and raised `ValueError: Cannot handle AP type Create`. Bare Notes (no content, no attachment) still route to the PostInteraction path for poll votes.
- **EGGPLANT-146** — `Emoji.public` is a nullable `BooleanField` (null = unreviewed), but `takahe/models.Emoji.to_mastodon_json` emitted it as-is. The `CustomEmoji.visible_in_picker: bool` schema at `journal/apis/post.py:24` rejected `None`, breaking `/api/item/{uuid}/posts/` response validation. Now defaults to `True` when `public is None`, matching the "unreviewed are public" pattern already stubbed for `EmojiQuerySet.usable` in the same file.

## Test plan

- [ ] Hit `/api/item/{uuid}/posts/` for an item whose authors have unreviewed custom emojis; response validates.
- [ ] Deliver a Create+Note with attachment-only (no content) into a local inbox; verifies it lands as a Post, not an errored PostInteraction.
- [ ] Existing poll vote path still works (Note with `name`, no content, no attachment).