### PR TITLE
feat(openlibrary): add Author site and link authors on Edition/Work

### DIFF
--- a/catalog/sites/openlibrary.py
+++ b/catalog/sites/openlibrary.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from urllib.parse import quote_plus
 
 import httpx
@@ -10,6 +11,23 @@ from catalog.models.utils import detect_isbn_asin, isbn_10_to_13
 from catalog.search import *
 from common.models import detect_language
 from common.models.lang import normalize_language
+
+
+def _author_id_from_key(key: str) -> str | None:
+    """Extract `OL...A` author id from a key like `/authors/OL34184A`."""
+    if not key:
+        return None
+    m = re.search(r"/authors/(OL\d+A)", key)
+    return m.group(1) if m else None
+
+
+def _build_author_resource(author_id: str) -> dict:
+    return {
+        "model": "People",
+        "id_type": IdType.OpenLibrary_Author,
+        "id_value": author_id,
+        "url": f"https://openlibrary.org/authors/{author_id}",
+    }
 
 
 @SiteManager.register
@@ -47,11 +65,17 @@ class OpenLibrary(AbstractSite):
         title = book_data.get("title", "")
         subtitle = book_data.get("subtitle")
         authors = []
+        author_resources: list[dict] = []
+        seen_author_ids: set[str] = set()
         if "authors" in book_data:
             for a in book_data["authors"]:
                 author_url = "https://openlibrary.org" + a["key"] + ".json"
                 author_json = BasicDownloader(author_url).download().json()
                 authors.append(author_json.get("name", ""))
+                author_id = _author_id_from_key(a.get("key", ""))
+                if author_id and author_id not in seen_author_ids:
+                    seen_author_ids.add(author_id)
+                    author_resources.append(_build_author_resource(author_id))
         publishers = book_data.get("publishers", [])
         pub_house = publishers[0] if publishers else None
         pub_year = None
@@ -142,6 +166,8 @@ class OpenLibrary(AbstractSite):
 
         if work_info:
             metadata["required_resources"] = [work_info]
+        if author_resources:
+            metadata["related_resources"] = author_resources
 
         return ResourceContent(
             metadata=metadata,
@@ -293,13 +319,18 @@ class OpenLibrary_Work(AbstractSite):
         title = work_data.get("title", "")
 
         authors = []
+        author_resources: list[dict] = []
+        seen_author_ids: set[str] = set()
         if "authors" in work_data:
             for author_ref in work_data["authors"]:
-                author_url = (
-                    "https://openlibrary.org" + author_ref["author"]["key"] + ".json"
-                )
+                author_key = author_ref.get("author", {}).get("key", "")
+                author_url = "https://openlibrary.org" + author_key + ".json"
                 author_json = BasicDownloader(author_url).download().json()
                 authors.append(author_json.get("name", ""))
+                author_id = _author_id_from_key(author_key)
+                if author_id and author_id not in seen_author_ids:
+                    seen_author_ids.add(author_id)
+                    author_resources.append(_build_author_resource(author_id))
 
         description = ""
         if "description" in work_data:
@@ -314,8 +345,9 @@ class OpenLibrary_Work(AbstractSite):
 
         lang = detect_language(title + " " + description)
 
-        # Fetch related editions
+        # Fetch related editions and merge with author People resources
         related_resources = self.fetch_editions()
+        related_resources.extend(author_resources)
 
         metadata = {
             "title": title,
@@ -329,3 +361,128 @@ class OpenLibrary_Work(AbstractSite):
         }
 
         return ResourceContent(metadata=metadata)
+
+
+@SiteManager.register
+class OpenLibrary_Author(AbstractSite):
+    SITE_NAME = SiteName.OpenLibrary
+    ID_TYPE = IdType.OpenLibrary_Author
+    WIKI_PROPERTY_ID = "P648"
+    DEFAULT_MODEL = People
+    URL_PATTERNS = [
+        r"https://openlibrary\.org/authors/(OL\d+A)",
+        r"https://www\.openlibrary\.org/authors/(OL\d+A)",
+    ]
+
+    @classmethod
+    def id_to_url(cls, id_value):
+        return f"https://openlibrary.org/authors/{id_value}"
+
+    @staticmethod
+    def _parse_date(date_str: str) -> str | None:
+        """Parse OpenLibrary date strings into ISO format where possible.
+
+        Handles variants like '13 September 1916', 'September 1916', '1916',
+        and already-ISO values.
+        """
+        if not date_str:
+            return None
+        s = date_str.strip()
+        if not s:
+            return None
+        for fmt, out in (
+            ("%d %B %Y", "%Y-%m-%d"),
+            ("%B %d, %Y", "%Y-%m-%d"),
+            ("%B %Y", "%Y-%m"),
+            ("%Y-%m-%d", "%Y-%m-%d"),
+            ("%Y-%m", "%Y-%m"),
+            ("%Y", "%Y"),
+        ):
+            try:
+                return datetime.strptime(s, fmt).strftime(out)
+            except ValueError:
+                continue
+        return s
+
+    @staticmethod
+    def _text_value(value) -> str:
+        if isinstance(value, dict):
+            return str(value.get("value") or "").strip()
+        return str(value or "").strip()
+
+    def scrape(self):
+        api_url = f"https://openlibrary.org/authors/{self.id_value}.json"
+        response = BasicDownloader(api_url).download()
+        data = response.json()
+        if not data:
+            raise ParseError(self, "no author data")
+
+        name = (data.get("name") or "").strip()
+        if not name:
+            raise ParseError(self, "author name")
+        lang = detect_language(name)
+
+        localized_name = [{"lang": lang, "text": name}]
+        seen_names = {name}
+        for alt in data.get("alternate_names", []) or []:
+            alt = (alt or "").strip()
+            if alt and alt not in seen_names:
+                seen_names.add(alt)
+                localized_name.append({"lang": detect_language(alt), "text": alt})
+
+        bio = self._text_value(data.get("bio"))
+        localized_bio = [{"lang": lang, "text": bio}] if bio else []
+
+        birth_date = self._parse_date(data.get("birth_date", ""))
+        death_date = self._parse_date(data.get("death_date", ""))
+
+        cover_image_url = None
+        photos = data.get("photos") or []
+        photo_id = next((p for p in photos if isinstance(p, int) and p > 0), None)
+        if photo_id:
+            cover_image_url = f"https://covers.openlibrary.org/a/id/{photo_id}-L.jpg"
+
+        official_site = None
+        for link in data.get("links", []) or []:
+            url = (link or {}).get("url")
+            if url and url.startswith("http"):
+                official_site = url
+                break
+
+        remote_ids = data.get("remote_ids") or {}
+        lookup_ids: dict = {}
+        wikidata_qid = remote_ids.get("wikidata")
+        if wikidata_qid:
+            lookup_ids[IdType.WikiData] = wikidata_qid
+        goodreads_author = remote_ids.get("goodreads")
+        if goodreads_author:
+            lookup_ids[IdType.Goodreads_Author] = str(goodreads_author)
+        imdb_id = remote_ids.get("imdb")
+        if imdb_id and str(imdb_id).startswith("nm"):
+            lookup_ids[IdType.IMDB] = imdb_id
+
+        raw_img, ext = (None, None)
+        if cover_image_url:
+            try:
+                raw_img, ext = BasicImageDownloader.download_image(
+                    cover_image_url, None, headers={}
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to download author photo for {self.id_value}: {e}"
+                )
+
+        return ResourceContent(
+            metadata={
+                "title": name,
+                "localized_name": localized_name,
+                "localized_bio": localized_bio,
+                "birth_date": birth_date,
+                "death_date": death_date,
+                "official_site": official_site,
+                "cover_image_url": cover_image_url,
+            },
+            cover_image=raw_img,
+            cover_image_extention=ext,
+            lookup_ids=lookup_ids,
+        )

--- a/catalog/sites/openlibrary.py
+++ b/catalog/sites/openlibrary.py
@@ -69,10 +69,13 @@ class OpenLibrary(AbstractSite):
         seen_author_ids: set[str] = set()
         if "authors" in book_data:
             for a in book_data["authors"]:
-                author_url = "https://openlibrary.org" + a["key"] + ".json"
+                author_key = a.get("key", "")
+                if not author_key:
+                    continue
+                author_url = "https://openlibrary.org" + author_key + ".json"
                 author_json = BasicDownloader(author_url).download().json()
                 authors.append(author_json.get("name", ""))
-                author_id = _author_id_from_key(a.get("key", ""))
+                author_id = _author_id_from_key(author_key)
                 if author_id and author_id not in seen_author_ids:
                     seen_author_ids.add(author_id)
                     author_resources.append(_build_author_resource(author_id))
@@ -324,6 +327,8 @@ class OpenLibrary_Work(AbstractSite):
         if "authors" in work_data:
             for author_ref in work_data["authors"]:
                 author_key = author_ref.get("author", {}).get("key", "")
+                if not author_key:
+                    continue
                 author_url = "https://openlibrary.org" + author_key + ".json"
                 author_json = BasicDownloader(author_url).download().json()
                 authors.append(author_json.get("name", ""))
@@ -419,10 +424,10 @@ class OpenLibrary_Author(AbstractSite):
 
         name = (data.get("name") or "").strip()
         if not name:
-            raise ParseError(self, "author name")
-        lang = detect_language(name)
+            raise ParseError(self, "missing author name")
+        name_lang = detect_language(name)
 
-        localized_name = [{"lang": lang, "text": name}]
+        localized_name = [{"lang": name_lang, "text": name}]
         seen_names = {name}
         for alt in data.get("alternate_names", []) or []:
             alt = (alt or "").strip()
@@ -431,7 +436,7 @@ class OpenLibrary_Author(AbstractSite):
                 localized_name.append({"lang": detect_language(alt), "text": alt})
 
         bio = self._text_value(data.get("bio"))
-        localized_bio = [{"lang": lang, "text": bio}] if bio else []
+        localized_bio = [{"lang": detect_language(bio), "text": bio}] if bio else []
 
         birth_date = self._parse_date(data.get("birth_date", ""))
         death_date = self._parse_date(data.get("death_date", ""))
@@ -443,11 +448,21 @@ class OpenLibrary_Author(AbstractSite):
             cover_image_url = f"https://covers.openlibrary.org/a/id/{photo_id}-L.jpg"
 
         official_site = None
+        fallback_site = None
         for link in data.get("links", []) or []:
-            url = (link or {}).get("url")
-            if url and url.startswith("http"):
+            if not isinstance(link, dict):
+                continue
+            url = link.get("url")
+            if not url or not url.startswith("http"):
+                continue
+            title = (link.get("title") or "").lower()
+            if "official" in title or "website" in title:
                 official_site = url
                 break
+            if fallback_site is None:
+                fallback_site = url
+        if official_site is None:
+            official_site = fallback_site
 
         remote_ids = data.get("remote_ids") or {}
         lookup_ids: dict = {}
@@ -465,7 +480,7 @@ class OpenLibrary_Author(AbstractSite):
         if cover_image_url:
             try:
                 raw_img, ext = BasicImageDownloader.download_image(
-                    cover_image_url, None, headers={}
+                    cover_image_url, self.url, headers={}
                 )
             except Exception as e:
                 logger.warning(

--- a/catalog/sites/wikidata.py
+++ b/catalog/sites/wikidata.py
@@ -1217,10 +1217,18 @@ class WikiData(AbstractSite):
         """
         # Find the Wikidata property ID for this ID type
         property_id = None
-        for prop_id, mapped_type in WikidataProperties.IdTypeMapping.items():
-            if mapped_type == id_type:
-                property_id = prop_id
-                break
+        # OpenLibrary Edition / Work / Author all share property P648
+        if id_type in (
+            IdType.OpenLibrary,
+            IdType.OpenLibrary_Work,
+            IdType.OpenLibrary_Author,
+        ):
+            property_id = "P648"
+        else:
+            for prop_id, mapped_type in WikidataProperties.IdTypeMapping.items():
+                if mapped_type == id_type:
+                    property_id = prop_id
+                    break
 
         if not property_id:
             logger.warning(f"No Wikidata property mapping found for {id_type}")

--- a/tests/catalog/test_openlibrary.py
+++ b/tests/catalog/test_openlibrary.py
@@ -1,7 +1,7 @@
 import pytest
 
 from catalog.common import SiteManager, use_local_response
-from catalog.models import Edition, IdType, SiteName, Work
+from catalog.models import Edition, IdType, People, SiteName, Work
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -53,6 +53,14 @@ class TestOpenLibrary:
             {"lang": "en", "text": "Fantastic Mr. Fox"}
         ]
         assert metadata["author"] == ["Roald Dahl"]
+        related = metadata.get("related_resources") or []
+        author_refs = [
+            r for r in related if r.get("id_type") == IdType.OpenLibrary_Author
+        ]
+        assert author_refs
+        assert author_refs[0]["model"] == "People"
+        assert author_refs[0]["id_value"] == "OL34184A"
+        assert author_refs[0]["url"] == "https://openlibrary.org/authors/OL34184A"
 
     @use_local_response
     def test_work_relationship(self):
@@ -116,13 +124,30 @@ class TestOpenLibraryWork:
         assert len(metadata["related_resources"]) > 0
 
         # Verify structure of related edition resources
-        first_edition = metadata["related_resources"][0]
+        editions_only = [
+            r
+            for r in metadata["related_resources"]
+            if r.get("id_type") == IdType.OpenLibrary
+        ]
+        assert editions_only
+        first_edition = editions_only[0]
         assert first_edition["model"] == "Edition"
         assert first_edition["id_type"] == IdType.OpenLibrary
         assert "id_value" in first_edition
         assert first_edition["id_value"].endswith("M")  # OpenLibrary edition format
         assert "url" in first_edition
         assert first_edition["url"].startswith("https://openlibrary.org/books/")
+
+        # Verify author People resource is present
+        author_refs = [
+            r
+            for r in metadata["related_resources"]
+            if r.get("id_type") == IdType.OpenLibrary_Author
+        ]
+        assert author_refs
+        assert author_refs[0]["model"] == "People"
+        assert author_refs[0]["id_value"] == "OL34184A"
+        assert author_refs[0]["url"] == "https://openlibrary.org/authors/OL34184A"
 
     @use_local_response
     def test_fetch_editions(self):
@@ -142,6 +167,50 @@ class TestOpenLibraryWork:
             assert edition["id_value"].endswith("M")
             assert edition["url"].startswith("https://openlibrary.org/books/")
             assert "title" in edition
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestOpenLibraryAuthor:
+    def test_parse(self):
+        t_type = IdType.OpenLibrary_Author
+        t_id = "OL34184A"
+        t_url = "https://openlibrary.org/authors/OL34184A"
+        p1 = SiteManager.get_site_cls_by_id_type(t_type)
+        p2 = SiteManager.get_site_by_url(t_url)
+        assert p1 is not None
+        assert p1.id_to_url(t_id) == t_url
+        assert p2 is not None
+        assert p2.url_to_id(t_url) == t_id
+        assert p2.ID_TYPE == t_type
+        assert p2.id_value == t_id
+
+    @use_local_response
+    def test_scrape_author(self):
+        t_url = "https://openlibrary.org/authors/OL34184A"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.resource is not None
+        assert site.resource.site_name == SiteName.OpenLibrary
+        assert site.resource.id_type == IdType.OpenLibrary_Author
+        assert site.resource.id_value == "OL34184A"
+        assert isinstance(site.resource.item, People)
+
+        metadata = site.resource.metadata
+        assert metadata["title"] == "Roald Dahl"
+        assert metadata["birth_date"] == "1916-09-13"
+        assert metadata["death_date"] == "1990-11-23"
+        assert metadata["official_site"] == "http://www.roalddahl.com/"
+        names = {n["text"] for n in metadata["localized_name"]}
+        assert "Roald Dahl" in names
+        assert (metadata.get("cover_image_url") or "").startswith(
+            "https://covers.openlibrary.org/a/id/"
+        )
+
+        lookup = site.resource.other_lookup_ids
+        assert lookup.get(IdType.WikiData) == "Q25161"
+        assert lookup.get(IdType.Goodreads_Author) == "4273"
+        assert lookup.get(IdType.IMDB) == "nm0001094"
 
 
 def test_openlibrary_search_categories_sync():

--- a/uv.lock
+++ b/uv.lock
@@ -1766,7 +1766,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.2.25" },
     { name = "dateparser", specifier = ">=1.2.0" },
     { name = "deepl", specifier = ">=1.22.0" },
-    { name = "deepmerge", specifier = ">=1.1.1" },
+    { name = "deepmerge", specifier = ">=2.0" },
     { name = "discord-py", specifier = ">=2.4.0" },
     { name = "django", specifier = ">=5.2,<5.3" },
     { name = "django-anymail", extras = ["mailgun", "amazon-ses", "sendgrid", "mailjet", "postal", "mandrill", "mailersend", "brevo"], specifier = ">=13.0" },
@@ -1779,7 +1779,7 @@ requires-dist = [
     { name = "django-jsonform", git = "https://github.com/alphatownsman/django-jsonform" },
     { name = "django-maintenance-mode" },
     { name = "django-ninja", specifier = ">=1.3.0" },
-    { name = "django-polymorphic", specifier = ">=4.1.0" },
+    { name = "django-polymorphic", specifier = ">=4.11.2" },
     { name = "django-redis" },
     { name = "django-rq", specifier = ">=3.1" },
     { name = "django-sass-processor", specifier = ">=1.4.1" },
@@ -1799,7 +1799,7 @@ requires-dist = [
     { name = "libsass", specifier = ">=0.23.0" },
     { name = "listparser", specifier = ">=0.20" },
     { name = "loguru", specifier = ">=0.7.2" },
-    { name = "lxml", specifier = ">=5.3.0" },
+    { name = "lxml", specifier = ">=6.0.4" },
     { name = "markdownify", specifier = ">=0.13.1" },
     { name = "mistune", specifier = ">=3.0.2" },
     { name = "nh3", specifier = ">=0.2.21" },
@@ -1818,7 +1818,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coverage", specifier = ">=7.6.10" },
+    { name = "coverage", specifier = ">=7.13.5" },
     { name = "django-stubs", specifier = ">=5.1.2" },
     { name = "djlint", specifier = ">=1.36.4" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },


### PR DESCRIPTION
## Summary

- Add `OpenLibrary_Author` site class that matches `/authors/OL...A` URLs and scrapes the author JSON for name, alternate names, bio, birth/death dates (parsed to ISO where possible), photo, official site, and external IDs (WikiData, Goodreads author, IMDb) from `remote_ids`.
- Update `OpenLibrary` (Edition) and `OpenLibrary_Work` scrapers to emit `People` entries in `related_resources` so fetching an edition or work triggers author resolution via the new site, mirroring the existing Goodreads pattern.

## Test plan

- [x] `uv run pre-commit run -a` (ruff/format/djlint/ty)
- [x] `pytest tests/catalog/test_openlibrary.py` - 9 passed (new + existing)
- [x] `pytest tests/catalog/test_people.py tests/catalog/test_wikidata.py` - 124 passed, no regressions