### PR TITLE
feat(tmdb): fetch people for TV seasons; add producer role

### DIFF
--- a/catalog/migrations/0022_alter_itemcredit_role.py
+++ b/catalog/migrations/0022_alter_itemcredit_role.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("catalog", "0021_reindex_people"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="itemcredit",
+            name="role",
+            field=models.CharField(
+                choices=[
+                    ("author", "author"),
+                    ("translator", "translator"),
+                    ("director", "director"),
+                    ("playwright", "playwright"),
+                    ("actor", "actor"),
+                    ("producer", "producer"),
+                    ("artist", "artist"),
+                    ("designer", "designer"),
+                    ("composer", "composer"),
+                    ("choreographer", "choreographer"),
+                    ("performer", "performer"),
+                    ("host", "host"),
+                    ("original_creator", "original creator"),
+                    ("crew", "crew"),
+                    ("publisher", "publisher"),
+                    ("developer", "developer"),
+                    ("production_company", "production company"),
+                    ("record_label", "record label"),
+                    ("distributor", "distributor"),
+                    ("studio", "studio"),
+                    ("troupe", "troupe"),
+                ],
+                max_length=100,
+                verbose_name="role",
+            ),
+        ),
+    ]

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -95,6 +95,7 @@ class CreditRole(models.TextChoices):
     Director = "director", _("director")
     Playwright = "playwright", _("playwright")
     Actor = "actor", _("actor")
+    Producer = "producer", _("producer")
     Artist = "artist", _("artist")
     Designer = "designer", _("designer")
     Composer = "composer", _("composer")

--- a/catalog/models/movie.py
+++ b/catalog/models/movie.py
@@ -26,6 +26,7 @@ class MovieInSchema(ItemInSchema):
     director: list[str]
     playwright: list[str]
     actor: list[str]
+    producer: list[str]
     genre: list[str]
     language: list[str]
     area: list[str]
@@ -44,6 +45,10 @@ class MovieInSchema(ItemInSchema):
     @staticmethod
     def resolve_actor(obj: "Movie") -> list[str]:
         return obj.credit_names_by_role("actor")
+
+    @staticmethod
+    def resolve_producer(obj: "Movie") -> list[str]:
+        return obj.credit_names_by_role("producer")
 
 
 class MovieSchema(MovieInSchema, BaseSchema):
@@ -73,6 +78,7 @@ class Movie(Item):
         "director": "director",
         "playwright": "playwright",
         "actor": "actor",
+        "producer": "producer",
     }
 
     METADATA_COPY_LIST = [
@@ -81,6 +87,7 @@ class Movie(Item):
         "director",
         "playwright",
         "actor",
+        "producer",
         "genre",
         "showtime",
         "site",
@@ -109,6 +116,13 @@ class Movie(Item):
     )
     actor = jsondata.JSONField(
         verbose_name=_("actor"),
+        null=False,
+        blank=True,
+        default=list,
+        schema=LIST_OF_STR_SCHEMA,
+    )
+    producer = jsondata.JSONField(
+        verbose_name=_("producer"),
         null=False,
         blank=True,
         default=list,

--- a/catalog/models/people.py
+++ b/catalog/models/people.py
@@ -294,6 +294,7 @@ class People(Item):
             "director": PeopleRole.DIRECTOR,
             "playwright": PeopleRole.PLAYWRIGHT,
             "actor": PeopleRole.ACTOR,
+            "producer": PeopleRole.PRODUCER,
             "artist": PeopleRole.ARTIST,
             "designer": PeopleRole.DESIGNER,
             "composer": PeopleRole.COMPOSER,

--- a/catalog/models/tv.py
+++ b/catalog/models/tv.py
@@ -68,6 +68,10 @@ class _TVCreditResolverMixin:
     def resolve_actor(obj: "TVShow | TVSeason") -> list[str]:
         return obj.credit_names_by_role("actor")
 
+    @staticmethod
+    def resolve_producer(obj: "TVShow | TVSeason") -> list[str]:
+        return obj.credit_names_by_role("producer")
+
 
 class TVShowInSchema(_TVCreditResolverMixin, ItemInSchema):
     season_count: int | None = None
@@ -75,6 +79,7 @@ class TVShowInSchema(_TVCreditResolverMixin, ItemInSchema):
     director: list[str]
     playwright: list[str]
     actor: list[str]
+    producer: list[str]
     genre: list[str]
     language: list[str]
     area: list[str]
@@ -96,6 +101,7 @@ class TVSeasonInSchema(_TVCreditResolverMixin, ItemInSchema):
     director: list[str]
     playwright: list[str]
     actor: list[str]
+    producer: list[str]
     genre: list[str]
     language: list[str]
     area: list[str]
@@ -134,6 +140,7 @@ class TVShow(Item):
         "director": "director",
         "playwright": "playwright",
         "actor": "actor",
+        "producer": "producer",
     }
     imdb = PrimaryLookupIdDescriptor(IdType.IMDB)
     tmdb_tv = PrimaryLookupIdDescriptor(IdType.TMDB_TV)
@@ -152,6 +159,7 @@ class TVShow(Item):
         "director",
         "playwright",
         "actor",
+        "producer",
         "localized_description",
         "genre",
         "showtime",
@@ -182,6 +190,13 @@ class TVShow(Item):
     )
     actor = jsondata.JSONField(
         verbose_name=_("actor"),
+        null=False,
+        blank=True,
+        default=list,
+        schema=LIST_OF_STR_SCHEMA,
+    )
+    producer = jsondata.JSONField(
+        verbose_name=_("producer"),
         null=False,
         blank=True,
         default=list,
@@ -364,6 +379,7 @@ class TVSeason(Item):
         "director": "director",
         "playwright": "playwright",
         "actor": "actor",
+        "producer": "producer",
     }
     douban_movie = PrimaryLookupIdDescriptor(IdType.DoubanMovie)
     imdb = PrimaryLookupIdDescriptor(IdType.IMDB)
@@ -386,6 +402,7 @@ class TVSeason(Item):
         "director",
         "playwright",
         "actor",
+        "producer",
         "genre",
         "showtime",
         "site",
@@ -415,6 +432,13 @@ class TVSeason(Item):
     )
     actor = jsondata.JSONField(
         verbose_name=_("actor"),
+        null=False,
+        blank=True,
+        default=list,
+        schema=LIST_OF_STR_SCHEMA,
+    )
+    producer = jsondata.JSONField(
+        verbose_name=_("producer"),
         null=False,
         blank=True,
         default=list,

--- a/catalog/sites/tmdb.py
+++ b/catalog/sites/tmdb.py
@@ -82,27 +82,33 @@ _PRODUCER_JOBS = {"Producer", "Executive Producer"}
 def _extract_tmdb_credits(credits_data: dict, cast_limit: int = 10) -> dict:
     """Pull directors, writers, producers, and cast out of a TMDB credits block.
 
-    Returns a dict with name lists plus a deduplicated list of related People
-    resources (top cast + all pulled crew) ready for related_resources.
+    Crew roles are deduplicated by person id (a person may be credited under
+    multiple jobs within the same role, e.g. "Screenplay" + "Story" or
+    "Producer" + "Executive Producer"). Returns a dict with name lists plus a
+    deduplicated list of related People resources ready for related_resources.
     """
     crew = credits_data.get("crew") or []
     cast = credits_data.get("cast") or []
-    directors = [c for c in crew if c.get("job") == "Director"]
-    writers = [c for c in crew if c.get("job") in _WRITER_JOBS]
-    producers = [c for c in crew if c.get("job") in _PRODUCER_JOBS]
-    # Deduplicate producers by person id (a person may be credited under both
-    # "Producer" and "Executive Producer" or similar)
-    seen_producer_ids = set()
-    unique_producers = []
-    for p in producers:
-        pid = p.get("id")
-        if pid is None or pid not in seen_producer_ids:
-            if pid is not None:
-                seen_producer_ids.add(pid)
-            unique_producers.append(p)
+
+    def select_unique(jobs: set[str]) -> list[dict]:
+        seen_ids: set = set()
+        out: list[dict] = []
+        for c in crew:
+            if c.get("job") not in jobs:
+                continue
+            pid = c.get("id")
+            if pid is None or pid not in seen_ids:
+                out.append(c)
+                if pid is not None:
+                    seen_ids.add(pid)
+        return out
+
+    directors = select_unique({"Director"})
+    writers = select_unique(_WRITER_JOBS)
+    producers = select_unique(_PRODUCER_JOBS)
     related: list[dict] = []
     seen: set = set()
-    for person in directors + writers + unique_producers + cast[:cast_limit]:
+    for person in directors + writers + producers + cast[:cast_limit]:
         pid = person.get("id")
         if pid and pid not in seen:
             seen.add(pid)
@@ -117,7 +123,7 @@ def _extract_tmdb_credits(credits_data: dict, cast_limit: int = 10) -> dict:
     return {
         "directors": directors,
         "writers": writers,
-        "producers": unique_producers,
+        "producers": producers,
         "cast": cast,
         "related_people": related,
     }

--- a/catalog/sites/tmdb.py
+++ b/catalog/sites/tmdb.py
@@ -73,6 +73,56 @@ def _copy_dict(s, key_map):
     return d
 
 
+# TMDB writing department job titles we treat as playwright
+_WRITER_JOBS = {"Screenplay", "Writer", "Teleplay", "Story"}
+# TMDB production department job titles we treat as producer
+_PRODUCER_JOBS = {"Producer", "Executive Producer"}
+
+
+def _extract_tmdb_credits(credits_data: dict, cast_limit: int = 10) -> dict:
+    """Pull directors, writers, producers, and cast out of a TMDB credits block.
+
+    Returns a dict with name lists plus a deduplicated list of related People
+    resources (top cast + all pulled crew) ready for related_resources.
+    """
+    crew = credits_data.get("crew") or []
+    cast = credits_data.get("cast") or []
+    directors = [c for c in crew if c.get("job") == "Director"]
+    writers = [c for c in crew if c.get("job") in _WRITER_JOBS]
+    producers = [c for c in crew if c.get("job") in _PRODUCER_JOBS]
+    # Deduplicate producers by person id (a person may be credited under both
+    # "Producer" and "Executive Producer" or similar)
+    seen_producer_ids = set()
+    unique_producers = []
+    for p in producers:
+        pid = p.get("id")
+        if pid is None or pid not in seen_producer_ids:
+            if pid is not None:
+                seen_producer_ids.add(pid)
+            unique_producers.append(p)
+    related: list[dict] = []
+    seen: set = set()
+    for person in directors + writers + unique_producers + cast[:cast_limit]:
+        pid = person.get("id")
+        if pid and pid not in seen:
+            seen.add(pid)
+            related.append(
+                {
+                    "model": "People",
+                    "id_type": IdType.TMDB_Person,
+                    "id_value": str(pid),
+                    "url": f"https://www.themoviedb.org/person/{pid}",
+                }
+            )
+    return {
+        "directors": directors,
+        "writers": writers,
+        "producers": unique_producers,
+        "cast": cast,
+        "related_people": related,
+    }
+
+
 @SiteManager.register
 class TMDB_Movie(AbstractSite):
     SITE_NAME = SiteName.TMDB
@@ -126,31 +176,13 @@ class TMDB_Movie(AbstractSite):
         language = list(map(lambda x: x["name"], res_data["spoken_languages"]))
         brief = res_data["overview"]
 
-        directors = [c for c in res_data["credits"]["crew"] if c["job"] == "Director"]
-        screenwriters = [
-            c for c in res_data["credits"]["crew"] if c["job"] == "Screenplay"
-        ]
-        cast = res_data["credits"]["cast"]
-        director = [c["name"] for c in directors]
-        playwright = [c["name"] for c in screenwriters]
-        actor = [c["name"] for c in cast]
+        credits = _extract_tmdb_credits(res_data.get("credits") or {})
+        director = [c["name"] for c in credits["directors"]]
+        playwright = [c["name"] for c in credits["writers"]]
+        producer = [c["name"] for c in credits["producers"]]
+        actor = [c["name"] for c in credits["cast"]]
+        related_people = credits["related_people"]
         area = []
-
-        # Collect key people as related_resources for auto-fetch
-        related_people = []
-        seen_ids = set()
-        for person in directors + screenwriters + cast[:10]:
-            pid = person.get("id")
-            if pid and pid not in seen_ids:
-                seen_ids.add(pid)
-                related_people.append(
-                    {
-                        "model": "People",
-                        "id_type": IdType.TMDB_Person,
-                        "id_value": str(pid),
-                        "url": f"https://www.themoviedb.org/person/{pid}",
-                    }
-                )
 
         # other_info = {}
         # other_info['TMDB评分'] = res_data['vote_average']
@@ -180,6 +212,7 @@ class TMDB_Movie(AbstractSite):
                 "director": director,
                 "playwright": playwright,
                 "actor": actor,
+                "producer": producer,
                 "genre": genre,
                 "showtime": showtime,
                 "site": None,
@@ -307,19 +340,21 @@ class TMDB_TV(AbstractSite):
         genre = [x["name"] for x in res_data["genres"]]
         language = list(map(lambda x: x["name"], res_data["spoken_languages"]))
         brief = res_data["overview"]
-        creators = res_data.get("created_by", [])
-        screenwriters = [
-            c for c in res_data["credits"]["crew"] if c["job"] == "Screenplay"
-        ]
-        cast = res_data["credits"]["cast"]
-        director = [c["name"] for c in creators]
-        playwright = [c["name"] for c in screenwriters]
-        actor = [c["name"] for c in cast]
+        creators = res_data.get("created_by") or []
+        credits = _extract_tmdb_credits(res_data.get("credits") or {})
+        # TV shows rarely list a single series-level director; fall back to
+        # "created_by" when crew Director entries are empty so the field stays
+        # meaningful for Douban compatibility.
+        director_people = credits["directors"] or creators
+        director = [c["name"] for c in director_people]
+        playwright = [c["name"] for c in credits["writers"]]
+        producer = [c["name"] for c in credits["producers"]]
+        actor = [c["name"] for c in credits["cast"]]
         area = []
 
-        related_people = []
-        seen_ids = set()
-        for person in creators + screenwriters + cast[:10]:
+        related_people = credits["related_people"]
+        seen_ids = {int(r["id_value"]) for r in related_people}
+        for person in creators:
             pid = person.get("id")
             if pid and pid not in seen_ids:
                 seen_ids.add(pid)
@@ -363,6 +398,7 @@ class TMDB_TV(AbstractSite):
                 "director": director,
                 "playwright": playwright,
                 "actor": actor,
+                "producer": producer,
                 "genre": genre,
                 "showtime": showtime,
                 "site": None,
@@ -460,6 +496,12 @@ class TMDB_TVSeason(AbstractSite):
                 "url": f"https://www.themoviedb.org/tv/{show_id}",
             }
         ]
+        credits = _extract_tmdb_credits(d.get("credits") or {})
+        pd.metadata["director"] = [c["name"] for c in credits["directors"]]
+        pd.metadata["playwright"] = [c["name"] for c in credits["writers"]]
+        pd.metadata["producer"] = [c["name"] for c in credits["producers"]]
+        pd.metadata["actor"] = [c["name"] for c in credits["cast"]]
+        pd.metadata["related_resources"] = credits["related_people"]
         # Add external IDs to lookup_ids
         if d["external_ids"].get("imdb_id"):
             pd.lookup_ids[IdType.IMDB] = d["external_ids"].get("imdb_id")

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 09:08-0400\n"
+"POT-Creation-Date: 2026-04-17 15:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,11 +59,11 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:30 catalog/models/item.py:223
+#: catalog/forms.py:30 catalog/models/item.py:224
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:226
+#: catalog/forms.py:35 catalog/models/item.py:227
 msgid "Primary ID Value"
 msgstr ""
 
@@ -105,9 +105,9 @@ msgstr ""
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:197 catalog/models/movie.py:94
-#: catalog/models/performance.py:384 catalog/models/tv.py:167
-#: catalog/models/tv.py:400
+#: catalog/models/book.py:197 catalog/models/movie.py:101
+#: catalog/models/performance.py:384 catalog/models/tv.py:175
+#: catalog/models/tv.py:417
 msgid "original title"
 msgstr ""
 
@@ -580,20 +580,20 @@ msgstr ""
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:99 catalog/models/item.py:99
+#: catalog/models/game.py:99 catalog/models/item.py:100
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:107 catalog/models/item.py:98
+#: catalog/models/game.py:107 catalog/models/item.py:99
 #: catalog/models/music.py:87
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:115 catalog/models/item.py:108
+#: catalog/models/game.py:115 catalog/models/item.py:109
 msgid "developer"
 msgstr ""
 
-#: catalog/models/game.py:123 catalog/models/item.py:107
+#: catalog/models/game.py:123 catalog/models/item.py:108
 #: catalog/models/music.py:95
 msgid "publisher"
 msgstr ""
@@ -607,7 +607,7 @@ msgid "date of publication"
 msgstr ""
 
 #: catalog/models/game.py:140 catalog/models/music.py:81
-#: catalog/models/tv.py:205
+#: catalog/models/tv.py:220
 msgid "YYYY-MM-DD"
 msgstr ""
 
@@ -619,10 +619,10 @@ msgstr ""
 msgid "platform"
 msgstr ""
 
-#: catalog/models/game.py:159 catalog/models/movie.py:146
+#: catalog/models/game.py:159 catalog/models/movie.py:160
 #: catalog/models/people.py:159 catalog/models/performance.py:258
 #: catalog/models/performance.py:464 catalog/models/podcast.py:87
-#: catalog/models/tv.py:219 catalog/models/tv.py:453
+#: catalog/models/tv.py:234 catalog/models/tv.py:477
 #: catalog/templates/game.html:34 catalog/templates/movie.html:58
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -631,132 +631,137 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:95 catalog/models/movie.py:97
+#: catalog/models/item.py:95 catalog/models/movie.py:104
 #: catalog/models/performance.py:182 catalog/models/performance.py:388
-#: catalog/models/tv.py:170 catalog/models/tv.py:403
+#: catalog/models/tv.py:178 catalog/models/tv.py:420
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:96 catalog/models/movie.py:104
+#: catalog/models/item.py:96 catalog/models/movie.py:111
 #: catalog/models/performance.py:189 catalog/models/performance.py:395
-#: catalog/models/tv.py:177 catalog/models/tv.py:410
+#: catalog/models/tv.py:185 catalog/models/tv.py:427
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:97 catalog/models/movie.py:111
+#: catalog/models/item.py:97 catalog/models/movie.py:118
 #: catalog/models/performance.py:217 catalog/models/performance.py:423
-#: catalog/models/tv.py:184 catalog/models/tv.py:417
+#: catalog/models/tv.py:192 catalog/models/tv.py:434
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:100 catalog/models/performance.py:203
+#: catalog/models/item.py:98 catalog/models/movie.py:125
+#: catalog/models/tv.py:199 catalog/models/tv.py:441
+msgid "producer"
+msgstr ""
+
+#: catalog/models/item.py:101 catalog/models/performance.py:203
 #: catalog/models/performance.py:409
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:101 catalog/models/performance.py:210
+#: catalog/models/item.py:102 catalog/models/performance.py:210
 #: catalog/models/performance.py:416
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:102 catalog/models/performance.py:224
+#: catalog/models/item.py:103 catalog/models/performance.py:224
 #: catalog/models/performance.py:430
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:103 catalog/models/podcast.py:78
+#: catalog/models/item.py:104 catalog/models/podcast.py:78
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:104 catalog/models/performance.py:196
+#: catalog/models/item.py:105 catalog/models/performance.py:196
 #: catalog/models/performance.py:402
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:105 catalog/models/performance.py:238
+#: catalog/models/item.py:106 catalog/models/performance.py:238
 #: catalog/models/performance.py:444
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:109
+#: catalog/models/item.py:110
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:110
+#: catalog/models/item.py:111
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:111
+#: catalog/models/item.py:112
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:112
+#: catalog/models/item.py:113
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:113 catalog/models/performance.py:231
+#: catalog/models/item.py:114 catalog/models/performance.py:231
 #: catalog/models/performance.py:437
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:128 catalog/models/people.py:472
+#: catalog/models/item.py:129 catalog/models/people.py:473
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:129 catalog/models/people.py:136
+#: catalog/models/item.py:130 catalog/models/people.py:136
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:132 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:220 catalog/models/item.py:252
+#: catalog/models/item.py:221 catalog/models/item.py:253
 #: journal/models/collection.py:64
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:221 catalog/models/item.py:260
+#: catalog/models/item.py:222 catalog/models/item.py:261
 #: journal/models/collection.py:65
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:232 catalog/models/people.py:480
+#: catalog/models/item.py:233 catalog/models/people.py:481
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:234 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:235 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:988
+#: catalog/models/item.py:998
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:990
+#: catalog/models/item.py:1000
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:992
+#: catalog/models/item.py:1002
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1008
+#: catalog/models/item.py:1018
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1014
+#: catalog/models/item.py:1024
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1017
+#: catalog/models/item.py:1027
 msgid "url to the resource"
 msgstr ""
 
-#: catalog/models/movie.py:119 catalog/models/music.py:81
+#: catalog/models/movie.py:133 catalog/models/music.py:81
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
@@ -764,36 +769,36 @@ msgstr ""
 msgid "release date"
 msgstr ""
 
-#: catalog/models/movie.py:131 catalog/models/tv.py:437
+#: catalog/models/movie.py:145 catalog/models/tv.py:461
 #: journal/templates/_sidebar_user_mark_list.html:60
 msgid "date"
 msgstr ""
 
-#: catalog/models/movie.py:132 catalog/models/performance.py:130
-#: catalog/models/tv.py:438
+#: catalog/models/movie.py:146 catalog/models/performance.py:130
+#: catalog/models/tv.py:462
 msgid "required"
 msgstr ""
 
-#: catalog/models/movie.py:136 catalog/models/tv.py:442
+#: catalog/models/movie.py:150 catalog/models/tv.py:466
 msgid "region or event"
 msgstr ""
 
-#: catalog/models/movie.py:138 catalog/models/tv.py:211
-#: catalog/models/tv.py:444
+#: catalog/models/movie.py:152 catalog/models/tv.py:226
+#: catalog/models/tv.py:468
 msgid "Germany or Toronto International Film Festival"
 msgstr ""
 
-#: catalog/models/movie.py:148 catalog/models/tv.py:221
-#: catalog/models/tv.py:456
+#: catalog/models/movie.py:162 catalog/models/tv.py:236
+#: catalog/models/tv.py:480
 msgid "region"
 msgstr ""
 
-#: catalog/models/movie.py:159 catalog/models/tv.py:233
-#: catalog/models/tv.py:467
+#: catalog/models/movie.py:173 catalog/models/tv.py:248
+#: catalog/models/tv.py:491
 msgid "year"
 msgstr ""
 
-#: catalog/models/movie.py:160 catalog/models/music.py:84
+#: catalog/models/movie.py:174 catalog/models/music.py:84
 #: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
 #: catalog/templates/tvshow.html:47
 msgid "length"
@@ -941,11 +946,11 @@ msgstr ""
 msgid "date of death"
 msgstr ""
 
-#: catalog/models/people.py:474
+#: catalog/models/people.py:475
 msgid "character"
 msgstr ""
 
-#: catalog/models/people.py:478
+#: catalog/models/people.py:479
 msgid "Character name for actor roles"
 msgstr ""
 
@@ -971,42 +976,42 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:142 catalog/templates/tvseason.html:37
+#: catalog/models/tv.py:149 catalog/templates/tvseason.html:37
 #: catalog/templates/tvshow.html:32
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:145 catalog/models/tv.py:378
+#: catalog/models/tv.py:152 catalog/models/tv.py:394
 #: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:192 catalog/models/tv.py:425
+#: catalog/models/tv.py:207 catalog/models/tv.py:449
 msgid "show time"
 msgstr ""
 
-#: catalog/models/tv.py:204
+#: catalog/models/tv.py:219
 msgid "Date"
 msgstr ""
 
-#: catalog/models/tv.py:209
+#: catalog/models/tv.py:224
 msgid "Region or Event"
 msgstr ""
 
-#: catalog/models/tv.py:235 catalog/models/tv.py:469
+#: catalog/models/tv.py:250 catalog/models/tv.py:493
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:375 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:391 catalog/templates/tvseason.html:32
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:502
+#: catalog/models/tv.py:526
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:655
+#: catalog/models/tv.py:679
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr ""
@@ -1994,15 +1999,15 @@ msgstr ""
 msgid "Unsupported URL"
 msgstr ""
 
-#: catalog/views/view.py:54 catalog/views/view.py:79
+#: catalog/views/view.py:56 catalog/views/view.py:81
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:58 catalog/views/view.py:87
+#: catalog/views/view.py:60 catalog/views/view.py:89
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:150
+#: catalog/views/view.py:156
 msgid "Invalid role"
 msgstr ""
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 09:08-0400\n"
+"POT-Creation-Date: 2026-04-17 15:43-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -58,11 +58,11 @@ msgstr "简体中文"
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: catalog/forms.py:30 catalog/models/item.py:223
+#: catalog/forms.py:30 catalog/models/item.py:224
 msgid "Primary ID Type"
 msgstr "主要标识类型"
 
-#: catalog/forms.py:35 catalog/models/item.py:226
+#: catalog/forms.py:35 catalog/models/item.py:227
 msgid "Primary ID Value"
 msgstr "主要标识数据"
 
@@ -104,9 +104,9 @@ msgstr "其它"
 msgid "subtitle"
 msgstr "副标题"
 
-#: catalog/models/book.py:197 catalog/models/movie.py:94
-#: catalog/models/performance.py:384 catalog/models/tv.py:167
-#: catalog/models/tv.py:400
+#: catalog/models/book.py:197 catalog/models/movie.py:101
+#: catalog/models/performance.py:384 catalog/models/tv.py:175
+#: catalog/models/tv.py:417
 msgid "original title"
 msgstr "原名"
 
@@ -579,20 +579,20 @@ msgstr "重制"
 msgid "Special Edition"
 msgstr "特别版"
 
-#: catalog/models/game.py:99 catalog/models/item.py:99
+#: catalog/models/game.py:99 catalog/models/item.py:100
 msgid "designer"
 msgstr "设计者"
 
-#: catalog/models/game.py:107 catalog/models/item.py:98
+#: catalog/models/game.py:107 catalog/models/item.py:99
 #: catalog/models/music.py:87
 msgid "artist"
 msgstr "艺术家"
 
-#: catalog/models/game.py:115 catalog/models/item.py:108
+#: catalog/models/game.py:115 catalog/models/item.py:109
 msgid "developer"
 msgstr "开发者"
 
-#: catalog/models/game.py:123 catalog/models/item.py:107
+#: catalog/models/game.py:123 catalog/models/item.py:108
 #: catalog/models/music.py:95
 msgid "publisher"
 msgstr "出版发行"
@@ -606,7 +606,7 @@ msgid "date of publication"
 msgstr "发行日期"
 
 #: catalog/models/game.py:140 catalog/models/music.py:81
-#: catalog/models/tv.py:205
+#: catalog/models/tv.py:220
 msgid "YYYY-MM-DD"
 msgstr "YYYY-MM-DD"
 
@@ -618,10 +618,10 @@ msgstr "发布类型"
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/game.py:159 catalog/models/movie.py:146
+#: catalog/models/game.py:159 catalog/models/movie.py:160
 #: catalog/models/people.py:159 catalog/models/performance.py:258
 #: catalog/models/performance.py:464 catalog/models/podcast.py:87
-#: catalog/models/tv.py:219 catalog/models/tv.py:453
+#: catalog/models/tv.py:234 catalog/models/tv.py:477
 #: catalog/templates/game.html:34 catalog/templates/movie.html:58
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -630,132 +630,137 @@ msgstr "平台"
 msgid "website"
 msgstr "网站"
 
-#: catalog/models/item.py:95 catalog/models/movie.py:97
+#: catalog/models/item.py:95 catalog/models/movie.py:104
 #: catalog/models/performance.py:182 catalog/models/performance.py:388
-#: catalog/models/tv.py:170 catalog/models/tv.py:403
+#: catalog/models/tv.py:178 catalog/models/tv.py:420
 msgid "director"
 msgstr "导演"
 
-#: catalog/models/item.py:96 catalog/models/movie.py:104
+#: catalog/models/item.py:96 catalog/models/movie.py:111
 #: catalog/models/performance.py:189 catalog/models/performance.py:395
-#: catalog/models/tv.py:177 catalog/models/tv.py:410
+#: catalog/models/tv.py:185 catalog/models/tv.py:427
 msgid "playwright"
 msgstr "编剧"
 
-#: catalog/models/item.py:97 catalog/models/movie.py:111
+#: catalog/models/item.py:97 catalog/models/movie.py:118
 #: catalog/models/performance.py:217 catalog/models/performance.py:423
-#: catalog/models/tv.py:184 catalog/models/tv.py:417
+#: catalog/models/tv.py:192 catalog/models/tv.py:434
 msgid "actor"
 msgstr "演员"
 
-#: catalog/models/item.py:100 catalog/models/performance.py:203
+#: catalog/models/item.py:98 catalog/models/movie.py:125
+#: catalog/models/tv.py:199 catalog/models/tv.py:441
+msgid "producer"
+msgstr "制片人"
+
+#: catalog/models/item.py:101 catalog/models/performance.py:203
 #: catalog/models/performance.py:409
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/item.py:101 catalog/models/performance.py:210
+#: catalog/models/item.py:102 catalog/models/performance.py:210
 #: catalog/models/performance.py:416
 msgid "choreographer"
 msgstr "编舞"
 
-#: catalog/models/item.py:102 catalog/models/performance.py:224
+#: catalog/models/item.py:103 catalog/models/performance.py:224
 #: catalog/models/performance.py:430
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:103 catalog/models/podcast.py:78
+#: catalog/models/item.py:104 catalog/models/podcast.py:78
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/item.py:104 catalog/models/performance.py:196
+#: catalog/models/item.py:105 catalog/models/performance.py:196
 #: catalog/models/performance.py:402
 msgid "original creator"
 msgstr "原始创作者"
 
-#: catalog/models/item.py:105 catalog/models/performance.py:238
+#: catalog/models/item.py:106 catalog/models/performance.py:238
 #: catalog/models/performance.py:444
 msgid "crew"
 msgstr "工作人员"
 
-#: catalog/models/item.py:109
+#: catalog/models/item.py:110
 msgid "production company"
 msgstr "制作公司"
 
-#: catalog/models/item.py:110
+#: catalog/models/item.py:111
 msgid "record label"
 msgstr "唱片公司"
 
-#: catalog/models/item.py:111
+#: catalog/models/item.py:112
 msgid "distributor"
 msgstr "发行商"
 
-#: catalog/models/item.py:112
+#: catalog/models/item.py:113
 msgid "studio"
 msgstr "工作室"
 
-#: catalog/models/item.py:113 catalog/models/performance.py:231
+#: catalog/models/item.py:114 catalog/models/performance.py:231
 #: catalog/models/performance.py:437
 msgid "troupe"
 msgstr "剧团"
 
-#: catalog/models/item.py:128 catalog/models/people.py:472
+#: catalog/models/item.py:129 catalog/models/people.py:473
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:129 catalog/models/people.py:136
+#: catalog/models/item.py:130 catalog/models/people.py:136
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:131 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:132 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "角色名"
 
-#: catalog/models/item.py:220 catalog/models/item.py:252
+#: catalog/models/item.py:221 catalog/models/item.py:253
 #: journal/models/collection.py:64
 msgid "title"
 msgstr "标题"
 
-#: catalog/models/item.py:221 catalog/models/item.py:260
+#: catalog/models/item.py:222 catalog/models/item.py:261
 #: journal/models/collection.py:65
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:232 catalog/models/people.py:480
+#: catalog/models/item.py:233 catalog/models/people.py:481
 msgid "metadata"
 msgstr "元数据"
 
-#: catalog/models/item.py:234 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:235 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:988
+#: catalog/models/item.py:998
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:990
+#: catalog/models/item.py:1000
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:992
+#: catalog/models/item.py:1002
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1008
+#: catalog/models/item.py:1018
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1014
+#: catalog/models/item.py:1024
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1017
+#: catalog/models/item.py:1027
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
-#: catalog/models/movie.py:119 catalog/models/music.py:81
+#: catalog/models/movie.py:133 catalog/models/music.py:81
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
@@ -763,36 +768,36 @@ msgstr "指向外部资源的网址"
 msgid "release date"
 msgstr "发布日期"
 
-#: catalog/models/movie.py:131 catalog/models/tv.py:437
+#: catalog/models/movie.py:145 catalog/models/tv.py:461
 #: journal/templates/_sidebar_user_mark_list.html:60
 msgid "date"
 msgstr "日期"
 
-#: catalog/models/movie.py:132 catalog/models/performance.py:130
-#: catalog/models/tv.py:438
+#: catalog/models/movie.py:146 catalog/models/performance.py:130
+#: catalog/models/tv.py:462
 msgid "required"
 msgstr "必填"
 
-#: catalog/models/movie.py:136 catalog/models/tv.py:442
+#: catalog/models/movie.py:150 catalog/models/tv.py:466
 msgid "region or event"
 msgstr "地区或类型"
 
-#: catalog/models/movie.py:138 catalog/models/tv.py:211
-#: catalog/models/tv.py:444
+#: catalog/models/movie.py:152 catalog/models/tv.py:226
+#: catalog/models/tv.py:468
 msgid "Germany or Toronto International Film Festival"
 msgstr "德国或多伦多国际电影节"
 
-#: catalog/models/movie.py:148 catalog/models/tv.py:221
-#: catalog/models/tv.py:456
+#: catalog/models/movie.py:162 catalog/models/tv.py:236
+#: catalog/models/tv.py:480
 msgid "region"
 msgstr "地区"
 
-#: catalog/models/movie.py:159 catalog/models/tv.py:233
-#: catalog/models/tv.py:467
+#: catalog/models/movie.py:173 catalog/models/tv.py:248
+#: catalog/models/tv.py:491
 msgid "year"
 msgstr "年份"
 
-#: catalog/models/movie.py:160 catalog/models/music.py:84
+#: catalog/models/movie.py:174 catalog/models/music.py:84
 #: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
 #: catalog/templates/tvshow.html:47
 msgid "length"
@@ -940,11 +945,11 @@ msgstr "出生日期"
 msgid "date of death"
 msgstr "死亡日期"
 
-#: catalog/models/people.py:474
+#: catalog/models/people.py:475
 msgid "character"
 msgstr ""
 
-#: catalog/models/people.py:478
+#: catalog/models/people.py:479
 msgid "Character name for actor roles"
 msgstr ""
 
@@ -970,42 +975,42 @@ msgstr "上演日期"
 msgid "closing date"
 msgstr "结束日期"
 
-#: catalog/models/tv.py:142 catalog/templates/tvseason.html:37
+#: catalog/models/tv.py:149 catalog/templates/tvseason.html:37
 #: catalog/templates/tvshow.html:32
 msgid "number of seasons"
 msgstr "季数"
 
-#: catalog/models/tv.py:145 catalog/models/tv.py:378
+#: catalog/models/tv.py:152 catalog/models/tv.py:394
 #: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
 msgid "number of episodes"
 msgstr "集数"
 
-#: catalog/models/tv.py:192 catalog/models/tv.py:425
+#: catalog/models/tv.py:207 catalog/models/tv.py:449
 msgid "show time"
 msgstr "上映时间"
 
-#: catalog/models/tv.py:204
+#: catalog/models/tv.py:219
 msgid "Date"
 msgstr "日期"
 
-#: catalog/models/tv.py:209
+#: catalog/models/tv.py:224
 msgid "Region or Event"
 msgstr "地区或场合"
 
-#: catalog/models/tv.py:235 catalog/models/tv.py:469
+#: catalog/models/tv.py:250 catalog/models/tv.py:493
 msgid "episode length"
 msgstr "单集长度"
 
-#: catalog/models/tv.py:375 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:391 catalog/templates/tvseason.html:32
 msgid "season number"
 msgstr "本季序号"
 
-#: catalog/models/tv.py:502
+#: catalog/models/tv.py:526
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:655
+#: catalog/models/tv.py:679
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
@@ -1995,15 +2000,15 @@ msgstr "无效网址"
 msgid "Unsupported URL"
 msgstr "尚未支持的网址"
 
-#: catalog/views/view.py:54 catalog/views/view.py:79
+#: catalog/views/view.py:56 catalog/views/view.py:81
 msgid "Item not found"
 msgstr "条目不存在"
 
-#: catalog/views/view.py:58 catalog/views/view.py:87
+#: catalog/views/view.py:60 catalog/views/view.py:89
 msgid "Item no longer exists"
 msgstr "条目已不存在"
 
-#: catalog/views/view.py:150
+#: catalog/views/view.py:156
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"


### PR DESCRIPTION
## Summary
- `TMDB_TVSeason` now populates `director` / `playwright` / `actor` / `producer` metadata and emits `related_resources` entries for cast + key crew, so People are auto-fetched just like `TMDB_Movie` and `TMDB_TV` already do.
- Broadens writer detection in Movie/TV/TVSeason scrapers to include job in `{Screenplay, Writer, Teleplay, Story}` (previously only `Screenplay`, which misses almost all TV writers).
- Adds a new `Producer` credit role: `CreditRole.Producer`, `producer` jsondata field and schema/resolver on `Movie` / `TVShow` / `TVSeason`, and extraction of job in `{Producer, Executive Producer}` from TMDB crew, deduped by person id.
- Refactors shared credit extraction into `_extract_tmdb_credits`.

## Notes
- Migration `catalog/0022_alter_itemcredit_role.py` adds `producer` to `ItemCredit.role` choices (choices already had it in `ItemPeopleRelation` from migration 0004).
- TVShow still falls back to `created_by` when TMDB's crew list has no `Director` entry, preserving Douban-compatible behavior.

## Test plan
- [x] `pytest tests/catalog/test_tv.py tests/catalog/test_movie.py` (27 passed)
- [x] `pytest tests/catalog/test_people.py tests/catalog/test_wikidata.py` (124 passed)
- [x] `pre-commit` (ruff, ruff format, ty, end-of-files, etc.)
- [x] i18n: `makemessages -l zh_Hans`, producer fuzzy resolved
- [ ] Manual scrape of a real TMDB TV season URL