### PR TITLE
fix(profile): load duration tags in following shelf template

### DIFF
--- a/journal/templates/profile_following.html
+++ b/journal/templates/profile_following.html
@@ -1,6 +1,7 @@
 {% load thumb %}
 {% load i18n %}
 {% load mastodon %}
+{% load duration %}
 <span class="action">
   <span>
     <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>


### PR DESCRIPTION
## Summary
- `journal/templates/profile_following.html` uses the `|relative_uri` filter but never loaded the `duration` template tag library, so rendering the template raised `TemplateSyntaxError: Invalid filter: 'relative_uri'` whenever the following shelf was fetched.
- Added `{% load duration %}` alongside the existing loads.

Fixes EGGPLANT-1A2

## Test plan
- [x] `uv run pre-commit run --files journal/templates/profile_following.html`
- [ ] Visit `/users/<user>/profile/following` as a non-owner without the mutual-follow relationship; confirm the empty-state response renders without a template error.