### PR TITLE
fix(search): add People & Organizations link to search results

### DIFF
--- a/catalog/templates/search_header.html
+++ b/catalog/templates/search_header.html
@@ -70,6 +70,12 @@
       {% endif %}
       {% if by_category.performance %}<small>({{ by_category.performance }})</small>{% endif %}
     {% endif %}
+    |
+    {% if request.GET.c != 'people' %}
+      <a href="?q={{ request.GET.q }}&amp;c=people">{% trans "People & Organizations" %}</a>
+    {% else %}
+      {% trans "People & Organizations" %}
+    {% endif %}
     {% if user.is_authenticated %}
       |
       {% if request.GET.c != 'journal' %}

--- a/catalog/templates/search_header.html
+++ b/catalog/templates/search_header.html
@@ -10,14 +10,14 @@
   <div class="search-category-picker">
     {% visible_categories as cats %}
     {% if request.GET.c and request.GET.c != 'all' %}
-      <a href="?q={{ request.GET.q }}&amp;c=all">{% trans "all" %}</a>
+      <a href="?q={{ request.GET.q|urlencode }}&amp;c=all">{% trans "all" %}</a>
     {% else %}
       {% trans "all" %}
     {% endif %}
     {% if 'book' in cats %}
       |
       {% if request.GET.c != 'book' %}
-        <a href="?q={{ request.GET.q }}&amp;c=book">{% trans "books" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=book">{% trans "books" %}</a>
       {% else %}
         {% trans "books" %}
       {% endif %}
@@ -26,7 +26,7 @@
     {% if 'movie' in cats or 'tv' in cats %}
       |
       {% if request.GET.c != 'movietv' %}
-        <a href="?q={{ request.GET.q }}&amp;c=movietv">{% trans "movie & tv" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=movietv">{% trans "movie & tv" %}</a>
       {% else %}
         {% trans "movie & tv" %}
       {% endif %}
@@ -37,7 +37,7 @@
     {% if 'podcast' in cats %}
       |
       {% if request.GET.c != 'podcast' %}
-        <a href="?q={{ request.GET.q }}&amp;c=podcast">{% trans "podcasts" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=podcast">{% trans "podcasts" %}</a>
       {% else %}
         {% trans "podcasts" %}
       {% endif %}
@@ -46,7 +46,7 @@
     {% if 'music' in cats %}
       |
       {% if request.GET.c != 'music' %}
-        <a href="?q={{ request.GET.q }}&amp;c=music">{% trans "music" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=music">{% trans "music" %}</a>
       {% else %}
         {% trans "music" %}
       {% endif %}
@@ -55,7 +55,7 @@
     {% if 'game' in cats %}
       |
       {% if request.GET.c != 'game' %}
-        <a href="?q={{ request.GET.q }}&amp;c=game">{% trans "games" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=game">{% trans "games" %}</a>
       {% else %}
         {% trans "games" %}
       {% endif %}
@@ -64,7 +64,7 @@
     {% if 'performance' in cats %}
       |
       {% if request.GET.c != 'performance' %}
-        <a href="?q={{ request.GET.q }}&amp;c=performance">{% trans "performances" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=performance">{% trans "performances" %}</a>
       {% else %}
         {% trans "performances" %}
       {% endif %}
@@ -72,20 +72,20 @@
     {% endif %}
     |
     {% if request.GET.c != 'people' %}
-      <a href="?q={{ request.GET.q }}&amp;c=people">{% trans "People & Organizations" %}</a>
+      <a href="?q={{ request.GET.q|urlencode }}&amp;c=people">{% trans "people & organizations" %}</a>
     {% else %}
-      {% trans "People & Organizations" %}
+      {% trans "people & organizations" %}
     {% endif %}
     {% if user.is_authenticated %}
       |
       {% if request.GET.c != 'journal' %}
-        <a href="?q={{ request.GET.q }}&amp;c=journal">{% trans "your journal" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=journal">{% trans "your journal" %}</a>
       {% else %}
         {% trans "your journal" %}
       {% endif %}
       |
       {% if request.GET.c != 'timeline' %}
-        <a href="?q={{ request.GET.q }}&amp;c=timeline">{% trans "your timeline" %}</a>
+        <a href="?q={{ request.GET.q|urlencode }}&amp;c=timeline">{% trans "your timeline" %}</a>
       {% else %}
         {% trans "your timeline" %}
       {% endif %}

--- a/catalog/templates/search_results_people.html
+++ b/catalog/templates/search_results_people.html
@@ -22,19 +22,19 @@
               <h5>&ldquo;{{ request.GET.q }}&rdquo;</h5>
               <div class="search-category-picker">
                 {% if request.GET.type %}
-                  <a href="?q={{ request.GET.q }}&amp;c=people">{% trans 'all' %}</a>
+                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people">{% trans 'all' %}</a>
                 {% else %}
                   {% trans 'all' %}
                 {% endif %}
                 |
                 {% if request.GET.type != 'person' %}
-                  <a href="?q={{ request.GET.q }}&amp;c=people&amp;type=person">{% trans 'Person' %}</a>
+                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people&amp;type=person">{% trans 'Person' %}</a>
                 {% else %}
                   {% trans 'Person' %}
                 {% endif %}
                 |
                 {% if request.GET.type != 'organization' %}
-                  <a href="?q={{ request.GET.q }}&amp;c=people&amp;type=organization">{% trans 'Organization' %}</a>
+                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people&amp;type=organization">{% trans 'Organization' %}</a>
                 {% else %}
                   {% trans 'Organization' %}
                 {% endif %}

--- a/common/templates/_header.html
+++ b/common/templates/_header.html
@@ -45,7 +45,7 @@
                       value="performance">{% trans 'Performance' %}</option>
             {% endif %}
             <option {% if request.GET.c == 'people' or '/person/' in request.path or '/organization/' in request.path %}selected{% endif %}
-                    value="people">{% trans 'Person / Org' %}</option>
+                    value="people">{% trans 'People & Organizations' %}</option>
             <option {% if request.GET.c == 'journal' %}selected{% endif %}
                     value="journal">{% trans 'Journal' %}</option>
             <option {% if request.GET.c == 'timeline' %}selected{% endif %}

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 19:40-0400\n"
+"POT-Creation-Date: 2026-04-17 19:51-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1863,8 +1863,8 @@ msgid "performances"
 msgstr ""
 
 #: catalog/templates/search_header.html:75
-#: catalog/templates/search_header.html:77 common/templates/_header.html:48
-msgid "People & Organizations"
+#: catalog/templates/search_header.html:77
+msgid "people & organizations"
 msgstr ""
 
 #: catalog/templates/search_header.html:82
@@ -3202,6 +3202,10 @@ msgstr ""
 
 #: common/templates/_header.html:29
 msgid "Movie & TV"
+msgstr ""
+
+#: common/templates/_header.html:48
+msgid "People & Organizations"
 msgstr ""
 
 #: common/templates/_header.html:50

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 18:45-0400\n"
+"POT-Creation-Date: 2026-04-17 19:40-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1634,7 +1634,7 @@ msgstr ""
 #: catalog/templates/people_works.html:28 common/templates/_sidebar.html:114
 #: common/templates/_sidebar_anonymous.html:46
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
-#: journal/templates/profile_following.html:29
+#: journal/templates/profile_following.html:30
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_collection_list.html:52
@@ -1862,17 +1862,22 @@ msgstr ""
 msgid "performances"
 msgstr ""
 
-#: catalog/templates/search_header.html:76
-#: catalog/templates/search_header.html:78
-msgid "your journal"
+#: catalog/templates/search_header.html:75
+#: catalog/templates/search_header.html:77 common/templates/_header.html:48
+msgid "People & Organizations"
 msgstr ""
 
 #: catalog/templates/search_header.html:82
 #: catalog/templates/search_header.html:84
+msgid "your journal"
+msgstr ""
+
+#: catalog/templates/search_header.html:88
+#: catalog/templates/search_header.html:90
 msgid "your timeline"
 msgstr ""
 
-#: catalog/templates/search_header.html:91
+#: catalog/templates/search_header.html:97
 #: journal/templates/add_to_collection.html:14
 msgid "Save as dynamic collection"
 msgstr ""
@@ -3197,10 +3202,6 @@ msgstr ""
 
 #: common/templates/_header.html:29
 msgid "Movie & TV"
-msgstr ""
-
-#: common/templates/_header.html:48
-msgid "Person / Org"
 msgstr ""
 
 #: common/templates/_header.html:50

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 18:45-0400\n"
+"POT-Creation-Date: 2026-04-17 19:40-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -513,7 +513,7 @@ msgstr "收藏单"
 
 #: catalog/models/common.py:148 catalog/models/common.py:161
 msgid "Person / Organization"
-msgstr "个人 / 团体"
+msgstr "人物 / 团体"
 
 #: catalog/models/common.py:152 catalog/models/common.py:166
 #: common/templates/_header.html:25
@@ -826,7 +826,7 @@ msgstr "碟片数"
 #: catalog/models/people.py:31 catalog/templates/search_results_people.html:31
 #: catalog/templates/search_results_people.html:33
 msgid "Person"
-msgstr "个人"
+msgstr "人物"
 
 #: catalog/models/people.py:32 catalog/templates/search_results_people.html:37
 #: catalog/templates/search_results_people.html:39
@@ -1635,7 +1635,7 @@ msgstr "热门标签"
 #: catalog/templates/people_works.html:28 common/templates/_sidebar.html:114
 #: common/templates/_sidebar_anonymous.html:46
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
-#: journal/templates/profile_following.html:29
+#: journal/templates/profile_following.html:30
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_collection_list.html:52
@@ -1863,17 +1863,22 @@ msgstr "游戏"
 msgid "performances"
 msgstr "演出"
 
-#: catalog/templates/search_header.html:76
-#: catalog/templates/search_header.html:78
-msgid "your journal"
-msgstr "你的记录"
+#: catalog/templates/search_header.html:75
+#: catalog/templates/search_header.html:77 common/templates/_header.html:48
+msgid "People & Organizations"
+msgstr "人物与团体"
 
 #: catalog/templates/search_header.html:82
 #: catalog/templates/search_header.html:84
+msgid "your journal"
+msgstr "你的记录"
+
+#: catalog/templates/search_header.html:88
+#: catalog/templates/search_header.html:90
 msgid "your timeline"
 msgstr "你的帖文"
 
-#: catalog/templates/search_header.html:91
+#: catalog/templates/search_header.html:97
 #: journal/templates/add_to_collection.html:14
 msgid "Save as dynamic collection"
 msgstr "保存为动态收藏单"
@@ -3265,10 +3270,6 @@ msgstr "全部"
 #: common/templates/_header.html:29
 msgid "Movie & TV"
 msgstr "影视"
-
-#: common/templates/_header.html:48
-msgid "Person / Org"
-msgstr "人物 / 团体"
 
 #: common/templates/_header.html:50
 msgid "Journal"

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-17 19:40-0400\n"
+"POT-Creation-Date: 2026-04-17 19:51-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1864,8 +1864,8 @@ msgid "performances"
 msgstr "演出"
 
 #: catalog/templates/search_header.html:75
-#: catalog/templates/search_header.html:77 common/templates/_header.html:48
-msgid "People & Organizations"
+#: catalog/templates/search_header.html:77
+msgid "people & organizations"
 msgstr "人物与团体"
 
 #: catalog/templates/search_header.html:82
@@ -3270,6 +3270,10 @@ msgstr "全部"
 #: common/templates/_header.html:29
 msgid "Movie & TV"
 msgstr "影视"
+
+#: common/templates/_header.html:48
+msgid "People & Organizations"
+msgstr "人物与团体"
 
 #: common/templates/_header.html:50
 msgid "Journal"


### PR DESCRIPTION
## Summary

- Add a "People & Organizations" category link in the main search results header so users can navigate from regular search results to the people search (previously only reachable via the header dropdown).
- Rename the header dropdown option from "Person / Org" to "People & Organizations" for consistency with the new link.
- Regenerate gettext catalogs and standardize zh-Hans translations on 人物 / 团体 (previously mixed 个人 / 人物).

## Test plan

- [ ] Search for a term on the main search page; confirm "People & Organizations" appears in the category picker and links to `?c=people`.
- [ ] Confirm the renamed header dropdown still routes to the people search.
- [ ] Verify zh-Hans renders as "人物与团体" on both surfaces.