### PR TITLE
Note card UI refresh, unified people search nav, sibling credits N+1 fix

### DIFF
--- a/catalog/models/book.py
+++ b/catalog/models/book.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.db.models import Prefetch
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
 from ninja import Field
@@ -41,6 +42,7 @@ from .item import (
     IdType,
     Item,
     ItemCategory,
+    ItemCredit,
     ItemInSchema,
     ItemType,
     PrimaryLookupIdDescriptor,
@@ -386,6 +388,12 @@ class Edition(Item):
             work.editions.exclude(pk=self.pk)
             .exclude(is_deleted=True)
             .exclude(merged_to_item__isnull=False)
+            .prefetch_related(
+                Prefetch(
+                    "credits",
+                    queryset=ItemCredit.objects.select_related("person"),
+                )
+            )
             .order_by("-metadata__pub_year")
         )
 

--- a/catalog/templates/_item_notes.html
+++ b/catalog/templates/_item_notes.html
@@ -22,7 +22,6 @@
       </span>
       <span class="action inline">
         <span class="timestamp">{{ note.created_time|date }}</span>
-        {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
         <span class="timestamp"></span>
       </span>
       {% if note.item != item %}
@@ -30,10 +29,14 @@
       {% endif %}
       <div class="note-card{% if note.sensitive %} spoiler{% endif %}"
            {% if note.sensitive %}_="on click toggle .revealed on me"{% endif %}>
-        <div class="note-card-quote-mark">&ldquo;</div>
+        {% if note.title or note.progress_value %}
+          <div class="note-card-title">
+            {% if note.title %}<strong>{{ note.title }}</strong>{% endif %}
+            {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
+          </div>
+        {% endif %}
         <div class="note-card-content{% if not note.sensitive %} tldr{% endif %}"
              {% if not note.sensitive %}_="on click toggle .tldr on me"{% endif %}>
-          {% if note.title %}<strong>{{ note.title|default:'' }}</strong> -{% endif %}
           {{ note.content|linebreaksbr }}
           <div class="attachments">
             {% for attachment in note.attachments %}

--- a/catalog/templates/_item_user_pieces.html
+++ b/catalog/templates/_item_user_pieces.html
@@ -63,18 +63,16 @@
 <section>
   <h5>
     {% trans "my notes" %}
-    {% if mark.shelf %}
-      <small>
-        <span class="action inline">
-          <a href="#"
-             hx-get="{% url 'journal:note' item.uuid %}"
-             hx-target="body"
-             hx-swap="beforeend">
-            <i class="fa-regular fa-square-plus"></i>
-          </a>
-        </span>
-      </small>
-    {% endif %}
+    <small>
+      <span class="action inline">
+        <a href="#"
+           hx-get="{% url 'journal:note' item.uuid %}"
+           hx-target="body"
+           hx-swap="beforeend">
+          <i class="fa-regular fa-square-plus"></i>
+        </a>
+      </span>
+    </small>
   </h5>
   {% for note in mark.notes %}
     <span class="note-card-actionbar action inline">

--- a/catalog/templates/_item_user_pieces.html
+++ b/catalog/templates/_item_user_pieces.html
@@ -77,12 +77,13 @@
     {% endif %}
   </h5>
   {% for note in mark.notes %}
-    <span class="action">
+    <span class="note-card-actionbar action inline">
       <span>
         <a href="#"
            hx-get="{% url 'journal:note' note.item.uuid note.uuid %}"
            hx-target="body"
-           hx-swap="beforeend"><i class="fa-regular fa-pen-to-square"></i></a>
+           hx-swap="beforeend"
+           title="{% trans 'Edit' %}"><i class="fa-regular fa-pen-to-square"></i></a>
       </span>
       {% if note.latest_post %}
         {% include "action_like_post.html" with post=note.latest_post %}
@@ -91,10 +92,13 @@
       {% endif %}
     </span>
     <div class="note-card">
-      <div class="note-card-quote-mark">&ldquo;</div>
+      {% if note.title or note.progress_value %}
+        <div class="note-card-title">
+          {% if note.title %}<strong>{{ note.title }}</strong>{% endif %}
+          {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
+        </div>
+      {% endif %}
       <div class="note-card-content tldr" _="on click toggle .tldr on me">
-        {% if note.title %}<strong>{{ note.title|default:'' }}</strong> -{% endif %}
-        {% if note.progress_value %}<span class="tag-list"><span><a>{{ note.progress_display }}</a></span></span>{% endif %}
         {{ note.content|linebreaksbr }}
         <div class="attachments">
           {% for attachment in note.attachments %}

--- a/catalog/templates/search_results_people.html
+++ b/catalog/templates/search_results_people.html
@@ -18,28 +18,7 @@
       <div class="grid__main">
         <div>
           {% if request.GET.q %}
-            <hgroup>
-              <h5>&ldquo;{{ request.GET.q }}&rdquo;</h5>
-              <div class="search-category-picker">
-                {% if request.GET.type %}
-                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people">{% trans 'all' %}</a>
-                {% else %}
-                  {% trans 'all' %}
-                {% endif %}
-                |
-                {% if request.GET.type != 'person' %}
-                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people&amp;type=person">{% trans 'Person' %}</a>
-                {% else %}
-                  {% trans 'Person' %}
-                {% endif %}
-                |
-                {% if request.GET.type != 'organization' %}
-                  <a href="?q={{ request.GET.q|urlencode }}&amp;c=people&amp;type=organization">{% trans 'Organization' %}</a>
-                {% else %}
-                  {% trans 'Organization' %}
-                {% endif %}
-              </div>
-            </hgroup>
+            {% include "search_header.html" %}
           {% endif %}
           {% if search_error %}
             <p class="caveat">{% trans "Search is temporarily unavailable. Please try again later." %}</p>

--- a/common/static/scss/_mark.scss
+++ b/common/static/scss/_mark.scss
@@ -6,6 +6,22 @@
   }
 }
 
+.note-edit-buttons {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+
+  [type=submit] {
+    flex: 1;
+    margin: 0;
+  }
+
+  > a.button {
+    width: auto;
+    margin: 0;
+  }
+}
+
 #mark_date {
   width: unset !important;
 }

--- a/common/static/scss/_post.scss
+++ b/common/static/scss/_post.scss
@@ -107,25 +107,18 @@ section.activity.post>section.replies {
 	position: relative;
 	background: var(--pico-card-background-color);
 
-	.note-card-quote-mark {
-		font-size: 3em;
-		line-height: 1;
-		color: var(--pico-muted-color);
-		opacity: 0.3;
-		font-family: Georgia, "Times New Roman", serif;
-		margin-bottom: -0.25em;
-		user-select: none;
+	.note-card-title {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.5em;
+		margin-bottom: 0.5em;
 	}
 
 	.note-card-content {
 		font-size: 0.95em;
 		line-height: 1.6;
 		word-break: break-word;
-
-		strong {
-			display: block;
-			margin-bottom: 0.25em;
-		}
 
 		.attachments {
 			margin-top: 0.5em;
@@ -139,14 +132,29 @@ section.activity.post>section.replies {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		gap: 0.5em;
+
+		> span {
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
 	}
 
 	.note-card-avatar {
 		width: 2em;
 		height: 2em;
+		flex-shrink: 0;
 		border-radius: 50%;
 		object-fit: cover;
 	}
+}
+
+.note-card-actionbar {
+	display: block;
+	width: auto;
+	text-align: right;
 }
 
 .quote-post {

--- a/journal/templates/note.html
+++ b/journal/templates/note.html
@@ -35,8 +35,15 @@
             </label>
           </div>
         </div>
-        <div>
-          <input type="submit" class="button float-right" value="{% trans "Save" %}">
+        <div class="note-edit-buttons">
+          <input type="submit" value="{% trans "Save" %}">
+          {% if note %}
+            <a hx-post="{% url 'journal:note_delete' note.uuid %}?return_url={{ request.META.HTTP_REFERER|default:'/' }}"
+               hx-confirm="{% trans 'Are you sure to delete this note?' %}"
+               class="button secondary outline"
+               role="button"
+               title="{% trans 'Delete' %}"><i class="fa-regular fa-trash-can"></i></a>
+          {% endif %}
         </div>
       </form>
     </div>

--- a/journal/urls.py
+++ b/journal/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     ),
     path("item/<str:item_uuid>/note", note_edit, name="note"),
     path("item/<str:item_uuid>/note/<str:note_uuid>", note_edit, name="note"),
+    path("note/delete/<str:piece_uuid>", piece_delete, name="note_delete"),
     path("piece/<str:piece_uuid>/replies", piece_replies, name="piece_replies"),
     path("@<str:handle>/posts/<int:post_pk>/", post_view, name="post_view"),
     path("post/<int:post_id>/translate", post_translate, name="post_translate"),

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -7,7 +7,7 @@ from django.core.exceptions import BadRequest, PermissionDenied
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db.models import F, Min, OuterRef, Subquery
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -195,6 +195,9 @@ def piece_delete(request, piece_uuid):
         return render(
             request, "piece_delete.html", {"piece": piece, "return_url": return_url}
         )
-    else:
-        piece.delete()
-        return redirect(return_url)
+    piece.delete()
+    if request.headers.get("HX-Request"):
+        response = HttpResponse(status=204)
+        response["HX-Redirect"] = return_url
+        return response
+    return redirect(return_url)

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -15,6 +15,7 @@ from catalog.models import (
     People,
     PeopleRole,
     PeopleType,
+    Work,
 )
 from catalog.models.people import ItemPeopleRelation
 from journal.models import Collection, Mark, ShelfType, Tag
@@ -1073,6 +1074,37 @@ class TestItemRetrieveCreditsPrefetch:
         ]
         # One prefetch query is allowed; should never scale with access count.
         assert len(credit_queries) <= 1
+
+    def test_sibling_editions_credits_prefetched(self):
+        """edition.html shows publisher_name per sibling edition; must not N+1."""
+        work = Work.objects.create(title="IR Work")
+        work.editions.add(self.book)
+        publisher = People.objects.create(
+            title="IR Publisher",
+            people_type=PeopleType.ORGANIZATION,
+            metadata={"localized_name": [{"lang": "en", "text": "IR Publisher"}]},
+        )
+        for i in range(3):
+            sibling = Edition.objects.create(title=f"IR Sibling {i}")
+            work.editions.add(sibling)
+            ItemCredit.objects.create(
+                item=sibling,
+                person=publisher,
+                role=CreditRole.Publisher,
+                name=publisher.display_name,
+            )
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(self.book.url)
+        assert response.status_code == 200
+        credit_queries = [
+            q
+            for q in ctx.captured_queries
+            if "catalog_itemcredit" in q["sql"] and "SELECT" in q["sql"].upper()
+        ]
+        # One for the main item + one prefetch batch for siblings = at most 2.
+        assert len(credit_queries) <= 2
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Summary
- Fix N+1 `catalog_itemcredit` queries on the Edition detail page (Sentry EGGPLANT-19W) by prefetching credits on `Edition.sibling_items`, plus a regression test.
- Refresh the note card UI: drop the decorative quote mark; move title and progress into a `.note-card-title` row above the content; keep sidebar note owner actions (edit, like, boost, open) aligned on one row above the card; add a trash-icon delete button on the note edit dialog (JS confirm, htmx-aware piece_delete); prevent the footer avatar from being squeezed by long item titles.
- People search results now use the shared `search_header.html` category nav so users can switch back to books / movies / etc. without re-running the query.

## Test plan
- [ ] `uv run pre-commit run -a`
- [ ] `pytest tests/journal/test_n_plus_one.py::TestItemRetrieveCreditsPrefetch` (new `test_sibling_editions_credits_prefetched` passes)
- [ ] Load an Edition page that has siblings: confirm ≤2 credit queries fire.
- [ ] Item detail right sidebar "my notes": edit + like/boost/open icons render on one row above the card; edit dialog delete button shows JS confirm and navigates back on confirm.
- [ ] `/search?q=<term>&c=people`: unified category nav (all | books | movie & tv | ... | people & organizations | ...) is displayed.