### PR TITLE
feat(admin): gate django-rq dashboard to superusers

### DIFF
--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -659,7 +659,9 @@ THUMBNAIL_DEBUG = DEBUG
 
 DJANGO_REDIS_IGNORE_EXCEPTIONS = not DEBUG
 
-RQ_SHOW_ADMIN_LINK = DEBUG
+# Show the django-rq dashboard link in the Django admin index.
+# URL access is already gated to superusers in `boofilsic/urls.py`.
+RQ_SHOW_ADMIN_LINK = True
 
 SEARCH_INDEX_NEW_ONLY = False
 

--- a/boofilsic/urls.py
+++ b/boofilsic/urls.py
@@ -14,13 +14,76 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from functools import wraps
+
 from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
+from django.core.exceptions import PermissionDenied
+from django.urls import URLPattern, URLResolver, include, path
 from django.views.generic import RedirectView
 
 from common.api import api
 from users.views import login
+
+
+def _superuser_required(view_func):
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        if not (request.user.is_authenticated and request.user.is_superuser):
+            raise PermissionDenied
+        return view_func(request, *args, **kwargs)
+
+    return wrapper
+
+
+def _gate_urlpatterns(patterns, decorator):
+    for p in patterns:
+        if isinstance(p, URLPattern):
+            p.callback = decorator(p.callback)
+        elif isinstance(p, URLResolver):
+            _gate_urlpatterns(p.url_patterns, decorator)
+
+
+# Restrict django-rq to superusers:
+#   * the standalone `/admin-rq/` include (below) has every view wrapped
+#   * the Django-admin Dashboard entry (auto-registered when
+#     RQ_SHOW_ADMIN_LINK is True) is re-registered with a superuser-only
+#     QueueAdmin so it shows up for supers but 403s everyone else
+import django_rq.admin as _django_rq_admin  # noqa: E402
+import django_rq.urls as _django_rq_urls  # noqa: E402
+from django_rq.models import Dashboard as _RQDashboard  # noqa: E402
+
+_gate_urlpatterns(_django_rq_urls.urlpatterns, _superuser_required)
+
+
+class _SuperuserQueueAdmin(_django_rq_admin.QueueAdmin):
+    def has_module_permission(self, request):
+        return bool(
+            getattr(request, "user", None)
+            and request.user.is_active
+            and request.user.is_superuser
+        )
+
+    def has_view_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def has_change_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def get_urls(self):
+        patterns = super().get_urls()
+        _gate_urlpatterns(patterns, _superuser_required)
+        return patterns
+
+
+from django.contrib.admin.exceptions import NotRegistered  # noqa: E402
+
+try:
+    admin.site.unregister(_RQDashboard)
+except NotRegistered:
+    pass
+
+admin.site.register(_RQDashboard, _SuperuserQueueAdmin)
 
 urlpatterns = [
     path("api/", api.urls),


### PR DESCRIPTION
## Summary
- Surface the django-rq dashboard link in the Django admin index (`RQ_SHOW_ADMIN_LINK = True`), but re-register the Dashboard app under a superuser-only `QueueAdmin` subclass so staff-but-not-super accounts see neither the link nor the pages.
- Wrap both URL surfaces with a superuser check:
  - `/<ADMIN_URL>-rq/` (the standalone include)
  - `/<ADMIN_URL>/django_rq/dashboard/...` (the admin-mounted views via `get_urls`)
- Non-super staff now hit 403 on any direct URL; everyone else falls through to django-rq's existing `@staff_member_required`.

## Test plan
- [ ] `uv run pre-commit run -a`
- [ ] Log in as a superuser: Django admin index shows the RQ dashboard link and clicking it loads the queue list.
- [ ] Log in as a staff user (non-superuser): admin index does NOT show the RQ entry; requesting `/<ADMIN_URL>-rq/queues/` or `/<ADMIN_URL>/django_rq/dashboard/queues/` returns 403.
- [ ] Anonymous request to `/<ADMIN_URL>-rq/` returns 403 (previously redirected to admin login).