### PR TITLE
feat(catalog): support URL paste on people/org search

### DIFF
--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -91,6 +91,29 @@ def fetch(request, url, site: AbstractSite | None, is_refetch: bool = False):
     )
 
 
+def resolve_url_query(request, keywords):
+    """If `keywords` looks like a URL, resolve it to a redirect or fetch
+    response and return it; otherwise return None.
+
+    Shared by the generic and people/org search views so paste-URL
+    behavior stays consistent.
+    """
+    if keywords.find("://") <= 0:
+        return None
+    host = urlparse(keywords).hostname
+    if host and host in settings.SITE_DOMAINS:
+        return redirect(keywords)
+    # skip detecting redirection to avoid timeout
+    site = SiteManager.get_site_by_url(
+        keywords, detect_redirection=False, detect_fallback=False
+    )
+    if site:
+        return fetch(request, keywords, site, False)
+    if request.GET.get("r") and is_safe_url(keywords):
+        return redirect(keywords)
+    return fetch(request, keywords, None, False)
+
+
 def visible_categories(request):
     if not request or not hasattr(request, "user") or not request.user.is_authenticated:
         return default_visible_categories()
@@ -137,19 +160,9 @@ def search(request):
             },
         )
 
-    if keywords.find("://") > 0:
-        host = urlparse(keywords).hostname
-        if host and host in settings.SITE_DOMAINS:
-            return redirect(keywords)
-        # skip detecting redirection to avoid timeout
-        site = SiteManager.get_site_by_url(
-            keywords, detect_redirection=False, detect_fallback=False
-        )
-        if site:
-            return fetch(request, keywords, site, False)
-        if request.GET.get("r") and is_safe_url(keywords):
-            return redirect(keywords)
-        return fetch(request, keywords, None, False)
+    url_response = resolve_url_query(request, keywords)
+    if url_response is not None:
+        return url_response
 
     if tag:
         redir = reverse("common:search") + f'?q=tag:"{tag}"'
@@ -195,18 +208,9 @@ def people_search(request):
             "search_results_people.html",
             {"items": None, "sites": sites},
         )
-    if keywords.find("://") > 0:
-        host = urlparse(keywords).hostname
-        if host and host in settings.SITE_DOMAINS:
-            return redirect(keywords)
-        site = SiteManager.get_site_by_url(
-            keywords, detect_redirection=False, detect_fallback=False
-        )
-        if site:
-            return fetch(request, keywords, site, False)
-        if request.GET.get("r") and is_safe_url(keywords):
-            return redirect(keywords)
-        return fetch(request, keywords, None, False)
+    url_response = resolve_url_query(request, keywords)
+    if url_response is not None:
+        return url_response
     parser = PeopleQueryParser(
         keywords, page=p, page_size=per_page, people_type=people_type
     )

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -195,6 +195,18 @@ def people_search(request):
             "search_results_people.html",
             {"items": None, "sites": sites},
         )
+    if keywords.find("://") > 0:
+        host = urlparse(keywords).hostname
+        if host and host in settings.SITE_DOMAINS:
+            return redirect(keywords)
+        site = SiteManager.get_site_by_url(
+            keywords, detect_redirection=False, detect_fallback=False
+        )
+        if site:
+            return fetch(request, keywords, site, False)
+        if request.GET.get("r") and is_safe_url(keywords):
+            return redirect(keywords)
+        return fetch(request, keywords, None, False)
     parser = PeopleQueryParser(
         keywords, page=p, page_size=per_page, people_type=people_type
     )


### PR DESCRIPTION
## Summary
- People/org search (`?c=people`) now handles a pasted URL the same way the generic search does: local-domain redirect, known external site fetch-and-redirect, safe external redirect on `r=1`, or fallback internet-wide fetch.
- Fixes the UX gap where pasting e.g. a TMDB person / Douban personage / IMDb URL into the people search box just ran a keyword search instead of resolving the item.

## Test plan
- [ ] Paste a local people/org URL into the people search box -> redirects to it.
- [ ] Paste a supported external person URL (TMDB person, Douban personage, IMDb) -> resolves and redirects to the item page.
- [ ] Paste an unsupported URL -> falls through to the generic "fetching from the internet" flow.
- [ ] Plain keyword query still hits PeopleIndex as before.