### PR TITLE
catalog: tidy Wikidata PIDs and link People to Wikidata

### DIFF
--- a/catalog/sites/ao3.py
+++ b/catalog/sites/ao3.py
@@ -15,7 +15,7 @@ class ArchiveOfOurOwn(AbstractSite):
     URL_PATTERNS = [
         r"\w+://archiveofourown\.org/works/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = ""
     DEFAULT_MODEL = Edition
 
     @classmethod

--- a/catalog/sites/apple_music.py
+++ b/catalog/sites/apple_music.py
@@ -34,7 +34,7 @@ class AppleMusic(AbstractSite):
         r"https://music\.apple\.com/[a-z]{2}/album/(\d+)",
         r"https://music\.apple\.com/album/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P2281"
     DEFAULT_MODEL = Album
     headers = {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0",

--- a/catalog/sites/bgg.py
+++ b/catalog/sites/bgg.py
@@ -20,7 +20,7 @@ class BoardGameGeek(AbstractSite):
         r"^\w+://boardgamegeek\.com/boardgame/(\d+)",
         r"^\w+://boardgamegeek\.com/boardgameexpansion/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P2339"
     DEFAULT_MODEL = Game
 
     @classmethod

--- a/catalog/sites/bookstw.py
+++ b/catalog/sites/bookstw.py
@@ -10,7 +10,7 @@ class BooksTW(AbstractSite):
     URL_PATTERNS = [
         r"\w+://www\.books\.com\.tw/products/(\w+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = ""
     DEFAULT_MODEL = Edition
 
     @classmethod

--- a/catalog/sites/discogs.py
+++ b/catalog/sites/discogs.py
@@ -18,7 +18,7 @@ class DiscogsRelease(AbstractSite):
         r"https://www\.discogs\.com/[a-z]{2}/release/(\d+)[^\d]*",
         r"https://www\.discogs\.com/[a-z]{2}_[A-Z]{2}/release/(\d+)[^\d]*",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P2206"
     DEFAULT_MODEL = Album
 
     @classmethod
@@ -79,7 +79,7 @@ class DiscogsMaster(AbstractSite):
         r"^https://www\.discogs\.com/master/(\d+)[^\d]*",
         r"^https://www\.discogs\.com/[\w\-]+/master/(\d+)[^\d]*",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P1954"
     DEFAULT_MODEL = Album
 
     @classmethod

--- a/catalog/sites/douban_book.py
+++ b/catalog/sites/douban_book.py
@@ -22,7 +22,7 @@ class DoubanBook(AbstractSite):
         r"\w+://www.douban.com/doubanapp/dispatch\?uri=/book/(\d+)/",
         r"\w+://www.douban.com/doubanapp/dispatch/book/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P6442"
     DEFAULT_MODEL = Edition
 
     @classmethod
@@ -296,7 +296,7 @@ class DoubanBook_Work(AbstractSite):
     SITE_NAME = SiteName.Douban
     ID_TYPE = IdType.DoubanBook_Work
     URL_PATTERNS = [r"\w+://book\.douban\.com/works/(\d+)"]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P10319"
     DEFAULT_MODEL = Work
 
     @classmethod

--- a/catalog/sites/douban_drama.py
+++ b/catalog/sites/douban_drama.py
@@ -29,7 +29,7 @@ class DoubanDramaVersion(AbstractSite):
         r"\w+://www.douban.com/location/drama/(\d+)/#(\d+)$",
     ]
 
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = ""
     DEFAULT_MODEL = PerformanceProduction
 
     @classmethod

--- a/catalog/sites/douban_movie.py
+++ b/catalog/sites/douban_movie.py
@@ -22,7 +22,7 @@ class DoubanMovie(AbstractSite):
         r"\w+://www.douban.com/doubanapp/dispatch\?uri=/movie/(\d+)/",
         r"\w+://www.douban.com/doubanapp/dispatch/movie/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P4529"
     MATCHABLE_MODELS = [Movie, TVSeason]
 
     @classmethod

--- a/catalog/sites/douban_personage.py
+++ b/catalog/sites/douban_personage.py
@@ -14,7 +14,7 @@ class DoubanPersonage(AbstractSite):
     URL_PATTERNS = [
         r"\w+://www\.douban\.com/personage/(\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P12836"
     DEFAULT_MODEL = People
 
     @classmethod

--- a/catalog/sites/goodreads.py
+++ b/catalog/sites/goodreads.py
@@ -46,7 +46,7 @@ class GoodreadsDownloader(RetryDownloader):
 class Goodreads(AbstractSite):
     SITE_NAME = SiteName.Goodreads
     ID_TYPE = IdType.Goodreads
-    WIKI_PROPERTY_ID = "P2968"
+    WIKI_PROPERTY_ID = "P2969"
     DEFAULT_MODEL = Edition
     URL_PATTERNS = [
         r".+goodreads\.com/.*book/show/(\d+)",

--- a/catalog/sites/igdb.py
+++ b/catalog/sites/igdb.py
@@ -61,7 +61,7 @@ class IGDB(AbstractSite):
         r"\w+://www\.igdb\.com/games/([a-zA-Z0-9\-_]+)",
         r"\w+://m\.igdb\.com/games/([a-zA-Z0-9\-_]+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P5794"
     DEFAULT_MODEL = Game
 
     @classmethod
@@ -249,7 +249,7 @@ class IGDB_Company(AbstractSite):
     URL_PATTERNS = [
         r"\w+://www\.igdb\.com/companies/([a-zA-Z0-9\-_]+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P9650"
     DEFAULT_MODEL = People
 
     @classmethod

--- a/catalog/sites/imdb.py
+++ b/catalog/sites/imdb.py
@@ -45,7 +45,7 @@ class IMDB(AbstractSite):
         r"\w+://www.imdb.com/name/(nm\d+)",
         r"\w+://m.imdb.com/name/(nm\d+)",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P345"
     MATCHABLE_MODELS = [Movie, TVShow, TVEpisode, People]
 
     @classmethod

--- a/catalog/sites/musicbrainz.py
+++ b/catalog/sites/musicbrainz.py
@@ -314,7 +314,7 @@ class MusicBrainzRelease(AbstractSite):
     URL_PATTERNS = [
         r"^\w+://musicbrainz\.org/release/([a-f0-9\-]{36}).*",
     ]
-    WIKI_PROPERTY_ID = "P437"  # MusicBrainz release ID
+    WIKI_PROPERTY_ID = "P5813"  # MusicBrainz release ID
     DEFAULT_MODEL = Album
 
     @classmethod

--- a/catalog/sites/spotify.py
+++ b/catalog/sites/spotify.py
@@ -34,7 +34,7 @@ class Spotify(AbstractSite):
         r"^\w+://open\.spotify\.com/album/([a-zA-Z0-9]+).*",
         r"^\w+://open\.spotify\.com/[\w\-]+/album/([a-zA-Z0-9]+).*",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P2205"
     DEFAULT_MODEL = Album
 
     @classmethod
@@ -179,6 +179,45 @@ class Spotify(AbstractSite):
             except Exception as e:
                 logger.error("Spotify search error", extra={"query": q, "exception": e})
         return results
+
+
+@SiteManager.register
+class Spotify_Artist(AbstractSite):
+    SITE_NAME = SiteName.Spotify
+    ID_TYPE = IdType.Spotify_Artist
+    URL_PATTERNS = [
+        r"^\w+://open\.spotify\.com/artist/([a-zA-Z0-9]+).*",
+        r"^\w+://open\.spotify\.com/[\w\-]+/artist/([a-zA-Z0-9]+).*",
+    ]
+    WIKI_PROPERTY_ID = "P1902"
+    DEFAULT_MODEL = People
+
+    @classmethod
+    def id_to_url(cls, id_value):
+        return f"https://open.spotify.com/artist/{id_value}"
+
+    def scrape(self):
+        if not SiteConfig.system.spotify_api_key:
+            raise ParseError(self, "no Spotify API key")
+        api_url = f"https://api.spotify.com/v1/artists/{self.id_value}"
+        headers = {
+            "Authorization": f"Bearer {get_spotify_token()}",
+            "User-Agent": settings.NEODB_USER_AGENT,
+        }
+        res_data = BasicDownloader(api_url, headers=headers).download().json()
+        name = res_data.get("name", "")
+        if not name:
+            raise ParseError(self, "name")
+        lang = detect_language(name)
+        image_url = res_data["images"][0]["url"] if res_data.get("images") else None
+        return ResourceContent(
+            metadata={
+                "title": name,
+                "localized_name": [{"lang": lang, "text": name}],
+                "localized_bio": [],
+                "cover_image_url": image_url,
+            }
+        )
 
 
 def get_spotify_token():

--- a/catalog/sites/steam.py
+++ b/catalog/sites/steam.py
@@ -32,7 +32,7 @@ class Steam(AbstractSite):
     SITE_NAME = SiteName.Steam
     ID_TYPE = IdType.Steam
     URL_PATTERNS = [r"\w+://store\.steampowered\.com/app/(\d+)"]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P1733"
     DEFAULT_MODEL = Game
     api_key: str = ""
 

--- a/catalog/sites/tmdb.py
+++ b/catalog/sites/tmdb.py
@@ -135,7 +135,7 @@ class TMDB_Movie(AbstractSite):
     SITE_NAME = SiteName.TMDB
     ID_TYPE = IdType.TMDB_Movie
     URL_PATTERNS = [r"^\w+://www.themoviedb.org/movie/(\d+)"]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P4947"
     DEFAULT_MODEL = Movie
 
     @classmethod
@@ -303,7 +303,7 @@ class TMDB_TV(AbstractSite):
         r"^\w+://www.themoviedb.org/tv/(\d+)[^/]*/?$",
         r"^\w+://www.themoviedb.org/tv/(\d+)[^/]*/seasons$",
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P4983"
     DEFAULT_MODEL = TVShow
 
     @classmethod
@@ -440,7 +440,7 @@ class TMDB_TVSeason(AbstractSite):
     SITE_NAME = SiteName.TMDB
     ID_TYPE = IdType.TMDB_TVSeason
     URL_PATTERNS = [r"^\w+://www.themoviedb.org/tv/(\d+)[^/]*/season/(\d+)[^/]*/?$"]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = ""
     DEFAULT_MODEL = TVSeason
     ID_PATTERN = r"^(\d+)-(\d+)$"
 
@@ -572,7 +572,7 @@ class TMDB_TVEpisode(AbstractSite):
     URL_PATTERNS = [
         r"\w+://www.themoviedb.org/tv/(\d+)[^/]*/season/(\d+)/episode/(\d+)[^/]*$"
     ]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P12559"
     DEFAULT_MODEL = TVEpisode
     ID_PATTERN = r"^(\d+)-(\d+)-(\d+)$"
 
@@ -650,7 +650,7 @@ class TMDB_Person(AbstractSite):
     SITE_NAME = SiteName.TMDB
     ID_TYPE = IdType.TMDB_Person
     URL_PATTERNS = [r"^\w+://www.themoviedb.org/person/(\d+)"]
-    WIKI_PROPERTY_ID = "?"
+    WIKI_PROPERTY_ID = "P4985"
     DEFAULT_MODEL = People
 
     @classmethod

--- a/catalog/sites/wikidata.py
+++ b/catalog/sites/wikidata.py
@@ -201,6 +201,8 @@ class WikidataProperties:
     P4985 = "P4985"  # TMDb person ID
     P2963 = "P2963"  # Goodreads author ID
     P1902 = "P1902"  # Spotify artist ID
+    P9650 = "P9650"  # IGDB company ID
+    P12836 = "P12836"  # Douban personage ID
 
     IdTypeMapping = {
         "P345": IdType.IMDB,
@@ -233,6 +235,8 @@ class WikidataProperties:
         "P4985": IdType.TMDB_Person,
         "P2963": IdType.Goodreads_Author,
         "P1902": IdType.Spotify_Artist,
+        "P9650": IdType.IGDB_Company,
+        "P12836": IdType.DoubanPersonage,
     }
 
 

--- a/tests/catalog/test_musicbrainz.py
+++ b/tests/catalog/test_musicbrainz.py
@@ -380,7 +380,7 @@ class TestMusicBrainzIntegration:
         assert (
             MusicBrainzReleaseGroup.WIKI_PROPERTY_ID == "P436"
         )  # MusicBrainz release group ID
-        assert MusicBrainzRelease.WIKI_PROPERTY_ID == "P437"  # MusicBrainz release ID
+        assert MusicBrainzRelease.WIKI_PROPERTY_ID == "P5813"  # MusicBrainz release ID
         assert (
             MusicBrainzReleaseGroup.WIKI_PROPERTY_ID
             != MusicBrainzRelease.WIKI_PROPERTY_ID

--- a/tests/catalog/test_people.py
+++ b/tests/catalog/test_people.py
@@ -965,6 +965,18 @@ class TestGoodreadsAuthor:
         assert site is not None
         assert site.id_value == "874602"
 
+    @use_local_response
+    def test_scrape(self):
+        t_url = "https://www.goodreads.com/author/show/874602"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.resource is not None
+        assert site.resource.item is not None
+        item = site.resource.item
+        assert isinstance(item, People)
+        assert "Ursula" in item.display_name or "Le Guin" in item.display_name
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestSpotifyArtist:
@@ -1002,18 +1014,6 @@ class TestIGDBCompany:
         site = SiteManager.get_site_by_url(t_url)
         assert site is not None
         assert site.id_value == t_id_value
-
-    @use_local_response
-    def test_scrape(self):
-        t_url = "https://www.goodreads.com/author/show/874602"
-        site = SiteManager.get_site_by_url(t_url)
-        assert site is not None
-        site.get_resource_ready()
-        assert site.resource is not None
-        assert site.resource.item is not None
-        item = site.resource.item
-        assert isinstance(item, People)
-        assert "Ursula" in item.display_name or "Le Guin" in item.display_name
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/catalog/test_people.py
+++ b/tests/catalog/test_people.py
@@ -381,6 +381,8 @@ class TestPeople:
         assert IdType.Goodreads_Author.value in id_types
         assert IdType.Spotify_Artist.value in id_types
         assert IdType.OpenLibrary_Author.value in id_types
+        assert IdType.IGDB_Company.value in id_types
+        assert IdType.DoubanPersonage.value in id_types
         # Should not include movie-specific types
         assert IdType.TMDB_Movie.value not in id_types
 
@@ -962,6 +964,44 @@ class TestGoodreadsAuthor:
         site = SiteManager.get_site_by_url(t_url)
         assert site is not None
         assert site.id_value == "874602"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSpotifyArtist:
+    def test_parse(self):
+        t_id_value = "4Z8W4fKeB5YxbusRsdQVPb"
+        t_url = f"https://open.spotify.com/artist/{t_id_value}"
+        p = SiteManager.get_site_cls_by_id_type(IdType.Spotify_Artist)
+        assert p is not None
+        assert p.validate_url(t_url)
+        assert p.DEFAULT_MODEL == People
+        assert p.WIKI_PROPERTY_ID == "P1902"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        assert site.id_value == t_id_value
+
+    def test_parse_regional_url(self):
+        """intl-xx regional prefix should still parse."""
+        t_id_value = "4Z8W4fKeB5YxbusRsdQVPb"
+        t_url = f"https://open.spotify.com/intl-ja/artist/{t_id_value}"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        assert site.id_value == t_id_value
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestIGDBCompany:
+    def test_parse(self):
+        t_id_value = "valve"
+        t_url = f"https://www.igdb.com/companies/{t_id_value}"
+        p = SiteManager.get_site_cls_by_id_type(IdType.IGDB_Company)
+        assert p is not None
+        assert p.validate_url(t_url)
+        assert p.DEFAULT_MODEL == People
+        assert p.WIKI_PROPERTY_ID == "P9650"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        assert site.id_value == t_id_value
 
     @use_local_response
     def test_scrape(self):

--- a/tests/catalog/test_wikidata.py
+++ b/tests/catalog/test_wikidata.py
@@ -810,6 +810,8 @@ def test_wikidata_person_id_type_mappings():
     assert mapping.get("P4985") == IdType.TMDB_Person
     assert mapping.get("P2963") == IdType.Goodreads_Author
     assert mapping.get("P1902") == IdType.Spotify_Artist
+    assert mapping.get("P9650") == IdType.IGDB_Company
+    assert mapping.get("P12836") == IdType.DoubanPersonage
 
 
 class TestWikiDataPerson:


### PR DESCRIPTION
## Summary

- Add `Spotify_Artist` site class (`open.spotify.com/artist/<id>`, `DEFAULT_MODEL = People`). The `IdType.Spotify_Artist` already existed in `People.lookup_id_type_choices` and Wikidata's `P1902` already mapped to it, but there was no scraper — so Wikidata pre-matches became orphaned lookup_ids. Now they produce a real child People resource.
- Add `P9650` → `IGDB_Company` and `P12836` → `DoubanPersonage` to `WikidataProperties.IdTypeMapping`. Neither was mapped before, so Wikidata entities carrying those claims never produced a child People resource, and `lookup_qid_by_external_id()` couldn't walk the other direction either.
- Resolve placeholder `WIKI_PROPERTY_ID = "?"` markers across site classes: set the real Wikidata property where one exists, empty string where none does. Two pre-existing wrong values were also corrected while sweeping:
  - `Goodreads.WIKI_PROPERTY_ID`: `P2968` (which is actually "QUDT unit ID" — completely unrelated) → `P2969` ("Goodreads edition ID", matching `IdType.Goodreads`).
  - `MusicBrainzRelease.WIKI_PROPERTY_ID`: `P437` (which is "distribution format") → `P5813` ("MusicBrainz release ID", matching `IdType.MusicBrainz_Release`). The `tests/catalog/test_musicbrainz.py` assertion was similarly wrong and is updated.

Per `docs/internals/catalog.md`, `WIKI_PROPERTY_ID` is documented as "not used now" — the active cross-link machinery lives in `WikidataProperties.IdTypeMapping`. The sweep is therefore cosmetic for most classes, but keeps the two flavors in sync and removes a footgun for any future feature that wires the class attribute in.

All PIDs were verified against wikidata.org before use.

## Tests

- `tests/catalog/test_wikidata.py::test_wikidata_person_id_type_mappings` — now also asserts `P9650` → `IGDB_Company` and `P12836` → `DoubanPersonage`.
- `tests/catalog/test_people.py::TestPeople::test_lookup_id_type_choices` — extended with `IGDB_Company` and `DoubanPersonage`.
- `tests/catalog/test_people.py::TestSpotifyArtist` — URL parse (plain + `intl-xx` regional prefix) and class-attribute assertions (`DEFAULT_MODEL == People`, `WIKI_PROPERTY_ID == "P1902"`).
- `tests/catalog/test_people.py::TestIGDBCompany` — URL parse and class-attribute assertions.
- `tests/catalog/test_musicbrainz.py::TestMusicBrainzIntegration::test_different_wiki_properties` — updated to assert `P5813` instead of `P437`.

## Test plan

- [x] `uv run pre-commit run --files <changed>` — ruff, ruff format, ty all pass
- [x] `docker compose --profile dev run --rm dev-shell /neodb-venv/bin/pytest --reuse-db tests/catalog/` — 431 passed
- [x] Live smoke: `manage.py cat https://www.igdb.com/companies/cd-projekt --save` creates `People` (organization) with correct name, bio, logo, `people_type=organization`
- [x] Live smoke: `manage.py cat https://open.spotify.com/artist/06HL4z0CvFAxyc27GXpf02 --save` creates `People` (person) for Taylor Swift with correct name and cover image