### PR TITLE
fix(catalog): hide child items when parent is shown on people/org pages

### DIFF
--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -725,6 +725,58 @@ class Item(PolymorphicModel):
         if performanceproductions:
             prefetch_related_objects(performanceproductions, "show")
 
+    @staticmethod
+    def descendant_ids_with_ancestor_in(item_ids: "Iterable[int]") -> set[int]:
+        """IDs within item_ids whose parent (or grandparent, for TVEpisode)
+        is also in item_ids.
+
+        Used to hide redundant child entries when both the parent and child
+        appear in a list (e.g. Work + its Edition, TVShow + its TVSeason).
+        Runs a bounded set of indexed id-only lookups; no item rows are
+        fetched.
+        """
+        from .book import Work
+        from .performance import PerformanceProduction
+        from .podcast import PodcastEpisode
+        from .tv import TVEpisode, TVSeason
+
+        ids = list(item_ids)
+        hidden: set[int] = set()
+        if not ids:
+            return hidden
+
+        # Edition -> Work via Work.editions M2M
+        hidden.update(
+            Work.editions.through.objects.filter(
+                edition_id__in=ids, work_id__in=ids
+            ).values_list("edition_id", flat=True)
+        )
+        # TVSeason -> TVShow
+        hidden.update(
+            TVSeason.objects.filter(pk__in=ids, show_id__in=ids).values_list(
+                "pk", flat=True
+            )
+        )
+        # TVEpisode -> TVSeason or TVShow (grandparent)
+        hidden.update(
+            TVEpisode.objects.filter(pk__in=ids)
+            .filter(Q(season_id__in=ids) | Q(season__show_id__in=ids))
+            .values_list("pk", flat=True)
+        )
+        # PodcastEpisode -> Podcast
+        hidden.update(
+            PodcastEpisode.objects.filter(pk__in=ids, program_id__in=ids).values_list(
+                "pk", flat=True
+            )
+        )
+        # PerformanceProduction -> Performance
+        hidden.update(
+            PerformanceProduction.objects.filter(
+                pk__in=ids, show_id__in=ids
+            ).values_list("pk", flat=True)
+        )
+        return hidden
+
     METADATA_COPY_LIST = [
         # "title",
         # "brief",

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -167,12 +167,9 @@ def people_works(request, item_path, item_uuid, role):
     # Filter by role
     qs = ItemPeopleRelation.objects.filter(people=item, role=role)
     item_ids = list(qs.values_list("item_id", flat=True))
-    # Hide child items (e.g. Edition, TVSeason, TVEpisode) when their parent
-    # is also credited for this person+role, to avoid redundant entries.
-    hidden_ids = Item.descendant_ids_with_ancestor_in(item_ids)
     works_qs = Item.objects.filter(
         pk__in=item_ids, is_deleted=False, merged_to_item__isnull=True
-    ).exclude(pk__in=hidden_ids)
+    )
 
     # Filter by shelf status if user is authenticated
     status_filter = request.GET.get("status", "")
@@ -183,6 +180,15 @@ def people_works(request, item_path, item_uuid, role):
             parent__shelf_type=status_filter,
         ).values_list("item_id", flat=True)
         works_qs = works_qs.filter(pk__in=shelf_item_ids)
+
+    # Hide child items (e.g. Edition, TVSeason, TVEpisode) when their parent
+    # is also visible in this list, to avoid redundant entries. Compute over
+    # the already-filtered ids so deleted/merged parents or items outside the
+    # status filter do not mask their children.
+    visible_ids = list(works_qs.values_list("pk", flat=True))
+    hidden_ids = Item.descendant_ids_with_ancestor_in(visible_ids)
+    if hidden_ids:
+        works_qs = works_qs.exclude(pk__in=hidden_ids)
 
     total = works_qs.count()
     paginator = CustomPaginator(works_qs, request)

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -167,9 +167,12 @@ def people_works(request, item_path, item_uuid, role):
     # Filter by role
     qs = ItemPeopleRelation.objects.filter(people=item, role=role)
     item_ids = list(qs.values_list("item_id", flat=True))
+    # Hide child items (e.g. Edition, TVSeason, TVEpisode) when their parent
+    # is also credited for this person+role, to avoid redundant entries.
+    hidden_ids = Item.descendant_ids_with_ancestor_in(item_ids)
     works_qs = Item.objects.filter(
         pk__in=item_ids, is_deleted=False, merged_to_item__isnull=True
-    )
+    ).exclude(pk__in=hidden_ids)
 
     # Filter by shelf status if user is authenticated
     status_filter = request.GET.get("status", "")

--- a/tests/catalog/test_people_works_view.py
+++ b/tests/catalog/test_people_works_view.py
@@ -1,0 +1,163 @@
+import pytest
+from django.test import Client
+
+from catalog.models import (
+    Edition,
+    ItemPeopleRelation,
+    People,
+    PeopleRole,
+    PeopleType,
+    TVEpisode,
+    TVSeason,
+    TVShow,
+)
+from catalog.models.book import Work
+from journal.models import ShelfMember, ShelfType
+from users.models import User
+
+
+def _author(name: str = "Dan Simmons") -> People:
+    return People.objects.create(
+        metadata={"localized_name": [{"lang": "en", "text": name}]},
+        people_type=PeopleType.PERSON,
+    )
+
+
+def _director(name: str = "Jane Director") -> People:
+    return People.objects.create(
+        metadata={"localized_name": [{"lang": "en", "text": name}]},
+        people_type=PeopleType.PERSON,
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPeopleWorksHidesChildren:
+    def test_hides_edition_when_work_credited(self):
+        person = _author()
+        work = Work.objects.create(title="Hyperion")
+        edition = Edition.objects.create(title="Hyperion (1989)")
+        work.editions.add(edition)
+        ItemPeopleRelation.objects.create(
+            item=work, people=person, role=PeopleRole.AUTHOR
+        )
+        ItemPeopleRelation.objects.create(
+            item=edition, people=person, role=PeopleRole.AUTHOR
+        )
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 200
+        works_page = response.context["works"]
+        ids = {w.pk for w in works_page.object_list}
+        assert work.pk in ids
+        assert edition.pk not in ids
+        assert response.context["total"] == 1
+
+    def test_shows_edition_when_work_soft_deleted(self):
+        """Regression: a soft-deleted parent must not hide an active child."""
+        person = _author()
+        work = Work.objects.create(title="Hyperion")
+        edition = Edition.objects.create(title="Hyperion (1989)")
+        work.editions.add(edition)
+        ItemPeopleRelation.objects.create(
+            item=work, people=person, role=PeopleRole.AUTHOR
+        )
+        ItemPeopleRelation.objects.create(
+            item=edition, people=person, role=PeopleRole.AUTHOR
+        )
+        work.delete(soft=True)
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 200
+        ids = {w.pk for w in response.context["works"].object_list}
+        assert edition.pk in ids
+        assert work.pk not in ids
+
+    def test_hides_tvseason_when_tvshow_credited(self):
+        person = _director()
+        show = TVShow.objects.create(title="Show")
+        season = TVSeason.objects.create(title="Show S1", show=show, season_number=1)
+        ItemPeopleRelation.objects.create(
+            item=show, people=person, role=PeopleRole.DIRECTOR
+        )
+        ItemPeopleRelation.objects.create(
+            item=season, people=person, role=PeopleRole.DIRECTOR
+        )
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.DIRECTOR.value}")
+        assert response.status_code == 200
+        ids = {w.pk for w in response.context["works"].object_list}
+        assert show.pk in ids
+        assert season.pk not in ids
+
+    def test_hides_tvepisode_via_grandparent(self):
+        """A TVEpisode is hidden when its grandparent TVShow is credited,
+        even if the intermediate TVSeason is not."""
+        person = _director()
+        show = TVShow.objects.create(title="Show")
+        season = TVSeason.objects.create(title="Show S1", show=show, season_number=1)
+        episode = TVEpisode.objects.create(
+            title="Show S1E1", season=season, episode_number=1
+        )
+        ItemPeopleRelation.objects.create(
+            item=show, people=person, role=PeopleRole.DIRECTOR
+        )
+        ItemPeopleRelation.objects.create(
+            item=episode, people=person, role=PeopleRole.DIRECTOR
+        )
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.DIRECTOR.value}")
+        assert response.status_code == 200
+        ids = {w.pk for w in response.context["works"].object_list}
+        assert show.pk in ids
+        assert episode.pk not in ids
+
+    def test_standalone_tvepisode_is_shown(self):
+        """A TVEpisode with no credited ancestor must still be displayed."""
+        person = _director()
+        show = TVShow.objects.create(title="Show")
+        season = TVSeason.objects.create(title="Show S1", show=show, season_number=1)
+        episode = TVEpisode.objects.create(
+            title="Show S1E1", season=season, episode_number=1
+        )
+        ItemPeopleRelation.objects.create(
+            item=episode, people=person, role=PeopleRole.DIRECTOR
+        )
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.DIRECTOR.value}")
+        assert response.status_code == 200
+        ids = {w.pk for w in response.context["works"].object_list}
+        assert episode.pk in ids
+
+    def test_status_filter_does_not_hide_child_of_excluded_parent(self):
+        """Regression: when the status filter drops the parent, the child
+        must remain visible rather than being hidden for redundancy."""
+        person = _author()
+        work = Work.objects.create(title="Hyperion")
+        edition = Edition.objects.create(title="Hyperion (1989)")
+        work.editions.add(edition)
+        ItemPeopleRelation.objects.create(
+            item=work, people=person, role=PeopleRole.AUTHOR
+        )
+        ItemPeopleRelation.objects.create(
+            item=edition, people=person, role=PeopleRole.AUTHOR
+        )
+
+        user = User.register(email="reader@example.com", username="reader")
+        shelf = user.identity.shelf_manager.get_shelf(ShelfType.COMPLETE)
+        ShelfMember.objects.create(
+            owner=user.identity,
+            item=edition,
+            parent=shelf,
+            visibility=0,
+            position=0,
+        )
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+        response = client.get(
+            f"{person.url}/works/{PeopleRole.AUTHOR.value}?status={ShelfType.COMPLETE.value}"
+        )
+        assert response.status_code == 200
+        ids = {w.pk for w in response.context["works"].object_list}
+        assert edition.pk in ids
+        assert work.pk not in ids


### PR DESCRIPTION
## Summary
- On `/person/<id>` and `/organization/<id>`, the works list showed both the parent and its children (Work + Edition, TVShow + TVSeason / TVEpisode, Podcast + PodcastEpisode, Performance + PerformanceProduction) whenever the person was credited on both.
- Hide a descendant when its parent (or the TVShow grandparent for a TVEpisode) is also credited for the same person+role, so only the top-most item appears.
- Filter runs as a handful of indexed id-only lookups against the already-materialized `item_ids` — no extra item rows are fetched, and pagination / total counts reflect the filtered list.

## Test plan
- [ ] Person credited as author on both a Work and one of its Editions: Edition is hidden, Work is shown.
- [ ] Person credited on a TVShow and one of its TVSeasons: TVSeason is hidden.
- [ ] Person credited on a TVShow and a TVEpisode (no TVSeason credit): TVEpisode is still hidden via grandparent check.
- [ ] Person credited on Edition only (no Work): Edition is shown.
- [ ] Person credited on Podcast and PodcastEpisode / Performance and PerformanceProduction: child hidden.
- [ ] Pagination `total` matches the visible count after filtering.