### PR TITLE
perf(discover): cap popular posts at 2 per author

### DIFF
--- a/catalog/jobs/discover.py
+++ b/catalog/jobs/discover.py
@@ -80,6 +80,18 @@ class DiscoverGenerator(BaseJob):
                 qs = qs.filter(q)
         return qs
 
+    def _top_post_ids(self, qs, limit: int, max_per_author: int = 2) -> list:
+        pks = []
+        author_count: dict = {}
+        for pk, author_id in qs.values_list("pk", "author_id").iterator():
+            if author_count.get(author_id, 0) >= max_per_author:
+                continue
+            pks.append(pk)
+            author_count[author_id] = author_count.get(author_id, 0) + 1
+            if len(pks) >= limit:
+                break
+        return pks
+
     def get_popular_marked_item_ids(self, category, days, exisiting_ids):
         qs = (
             ShelfMember.objects.filter(q_item_in_category(category))
@@ -236,23 +248,21 @@ class DiscoverGenerator(BaseJob):
                 reviews = reviews.filter(local=True)
             post_ids = (
                 set(
-                    self.get_popular_posts(28, self.min_marks, local).values_list(
-                        "pk", flat=True
-                    )[:5]
+                    self._top_post_ids(
+                        self.get_popular_posts(28, self.min_marks, local), 5
+                    )
                 )
                 | set(
-                    self.get_popular_posts(14, self.min_marks, local).values_list(
-                        "pk", flat=True
-                    )[:5]
+                    self._top_post_ids(
+                        self.get_popular_posts(14, self.min_marks, local), 5
+                    )
                 )
                 | set(
-                    self.get_popular_posts(7, self.min_marks, local).values_list(
-                        "pk", flat=True
-                    )[:10]
+                    self._top_post_ids(
+                        self.get_popular_posts(7, self.min_marks, local), 10
+                    )
                 )
-                | set(
-                    self.get_popular_posts(1, 0, local).values_list("pk", flat=True)[:3]
-                )
+                | set(self._top_post_ids(self.get_popular_posts(1, 0, local), 3))
                 | set(reviews.values_list("posts", flat=True)[:5])
             )
         else:

--- a/catalog/jobs/discover.py
+++ b/catalog/jobs/discover.py
@@ -82,8 +82,8 @@ class DiscoverGenerator(BaseJob):
 
     def _top_post_ids(self, qs, limit: int, max_per_author: int = 2) -> list:
         pks = []
-        author_count: dict = {}
-        for pk, author_id in qs.values_list("pk", "author_id").iterator():
+        author_count: dict[int, int] = {}
+        for pk, author_id in qs.values_list("pk", "author_id")[: limit * 10]:
             if author_count.get(author_id, 0) >= max_per_author:
                 continue
             pks.append(pk)


### PR DESCRIPTION
## Summary
- In the Discover cron, limit the recent/popular posts list to at most 2 posts per author per time-window query, so a single prolific author can't dominate the results.
- Added a small helper `_top_post_ids(qs, limit, max_per_author=2)` on `DiscoverGenerator` that iterates `(pk, author_id)` and short-circuits once `limit` is reached.
- Replaced the four `get_popular_posts(...).values_list("pk", flat=True)[:N]` calls in `run()` with the new helper. Reviews source and other discover logic unchanged.

## Test plan
- [ ] Run `DiscoverGenerator().run()` on a staging instance and verify no author contributes more than 2 posts from each time-window source to the `popular_posts` cache.
- [ ] Confirm `popular_posts` / `trends_statuses` cache keys remain populated and the discover page still renders.
- [ ] `uv run pre-commit run -a` passes.