### PR TITLE
perf: address recent N+1 issues reported in Sentry

### DIFF
--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import List
 
 from django.core.cache import cache
+from django.db.models import Prefetch, prefetch_related_objects
 from django.http import HttpResponse
 from django.utils import timezone
 from ninja import Schema, Status
@@ -21,6 +22,7 @@ from .models import (
     Game,
     GameSchema,
     Item,
+    ItemCredit,
     ItemSchema,
     Movie,
     MovieSchema,
@@ -119,6 +121,11 @@ def search_item(
         exclude_categories=exclude_categories,
     )
     Item.prefetch_parent_items(items)
+    Item.prefetch_edition_works(items)
+    prefetch_related_objects(
+        items,
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     if request.user.is_authenticated:

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -695,7 +695,9 @@ class Item(PolymorphicModel):
         Call this on a list of polymorphic Item instances before rendering
         templates that access item.parent_item (e.g. _item_card_metadata_base).
         Note: Edition is excluded because the template short-circuits
-        parent_item access for editions (type.value == 'edition').
+        parent_item access for editions (type.value == 'edition'). Callers
+        that serialize through ItemSchema (which reads parent_uuid
+        unconditionally) should additionally call ``Item.prefetch_edition_works``.
         """
         from .performance import PerformanceProduction
         from .podcast import PodcastEpisode
@@ -724,6 +726,21 @@ class Item(PolymorphicModel):
             prefetch_related_objects(podcastepisodes, "program")
         if performanceproductions:
             prefetch_related_objects(performanceproductions, "show")
+
+    @staticmethod
+    def prefetch_edition_works(items: "Iterable[Item]") -> None:
+        """Batch-prefetch Edition.works for ItemSchema/parent_uuid serialization.
+
+        Edition.parent_item calls Edition.get_work() -> self.works.all()[0],
+        which would fire one ORDER-BY-pk-LIMIT-1 query per edition when the
+        schema reads parent_uuid. Templates that short-circuit parent_item for
+        editions don't need this.
+        """
+        from .book import Edition
+
+        editions = [i for i in items if isinstance(i, Edition)]
+        if editions:
+            prefetch_related_objects(editions, "works")
 
     @staticmethod
     def descendant_ids_with_ancestor_in(item_ids: "Iterable[int]") -> set[int]:

--- a/catalog/search/utils.py
+++ b/catalog/search/utils.py
@@ -60,9 +60,11 @@ def query_index(
         key = getattr(i, "isbn", getattr(i, "imdb_code", getattr(i, "barcode", None)))
         my_key = {key: i} if key else {}
         if isinstance(i, Edition):
-            work = i.works.first()
-            if work:
-                my_key[work.id] = i
+            # Iterate the prefetched cache rather than .first(), which would
+            # ignore it and emit a per-edition `ORDER BY pk LIMIT 1` query.
+            works = list(i.works.all())
+            if works:
+                my_key[works[0].pk] = i
         if my_key:
             dup_by = None
             for k in my_key:

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -5,6 +5,7 @@ import django_rq
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
+from django.db.models import Prefetch, prefetch_related_objects
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -25,7 +26,14 @@ from journal.models.rating import Rating
 from users.views import query_identity
 
 from ..common.sites import AbstractSite, SiteManager
-from ..models import ExternalResource, Item, ItemCategory, SiteName, item_categories
+from ..models import (
+    ExternalResource,
+    Item,
+    ItemCategory,
+    ItemCredit,
+    SiteName,
+    item_categories,
+)
 from ..search import (
     ExternalSources,
     PeopleIndex,
@@ -177,6 +185,10 @@ def search(request):
         keywords, categories, p, exclude_categories=excl, per_page=per_page
     )
     Item.prefetch_parent_items(items)
+    prefetch_related_objects(
+        items,
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     if request.user.is_authenticated:

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -342,7 +342,10 @@ def _prefetch_comments(comments_list: list["Comment"]):
     from journal.models import Rating
     from journal.models.common import PiecePost
 
-    # Batch-fetch ShelfMembers for all (owner, item) pairs
+    # Batch-fetch ShelfMembers for all (owner, item) pairs.
+    # select_related("parent") eagerly loads the owning Shelf, so mark.action_label
+    # (which reads shelfmember.parent.shelf_type) does not trigger a Piece->Shelf
+    # polymorphic downcast per comment.
     pairs = {(c.owner_id, c.item_id) for c in comments_list}
     shelfmembers: dict[tuple[int, int], ShelfMember] = {}
     ratings: dict[tuple[int, int], int | None] = {}
@@ -352,10 +355,14 @@ def _prefetch_comments(comments_list: list["Comment"]):
         q = Q()
         for owner_id, item_id in pairs:
             q |= Q(owner_id=owner_id, item_id=item_id)
-        for sm in ShelfMember.objects.filter(q):
+        for sm in ShelfMember.objects.filter(q).select_related("parent"):
             shelfmembers[(sm.owner_id, sm.item_id)] = sm
         for r in Rating.objects.filter(q):
             ratings[(r.owner_id, r.item_id)] = r.grade
+
+    # Batch-fetch Takahe identities so comment.owner.display_name (which reads
+    # APIdentity.takahe_identity.name) does not trigger a per-comment lookup.
+    Takahe.prefetch_takahe_identities([c.owner for c in comments_list if c.owner_id])
 
     # Batch-fetch latest post IDs for all comments
     piece_ids = [c.pk for c in comments_list]
@@ -384,6 +391,30 @@ def _prefetch_comments(comments_list: list["Comment"]):
         post_id = piece_to_latest.get(c.pk)
         c.__dict__["latest_post_id"] = post_id
         c.__dict__["latest_post"] = posts_by_id.get(post_id) if post_id else None
+
+
+def _prefetch_reviews(reviews_list: list["Review"]):
+    """Batch-fetch ratings and latest posts for a list of reviews to avoid N+1."""
+    if not reviews_list:
+        return
+    from journal.models.common import prefetch_latest_posts
+
+    # Batch-fetch reviewer's own rating on the reviewed item
+    pairs = {(r.owner_id, r.item_id) for r in reviews_list}
+    ratings: dict[tuple[int, int], int | None] = {}
+    if pairs:
+        from django.db.models import Q
+
+        q = Q()
+        for owner_id, item_id in pairs:
+            q |= Q(owner_id=owner_id, item_id=item_id)
+        for rg in Rating.objects.filter(q):
+            ratings[(rg.owner_id, rg.item_id)] = rg.grade
+
+    prefetch_latest_posts(reviews_list)
+    Takahe.prefetch_takahe_identities([r.owner for r in reviews_list if r.owner_id])
+    for r in reviews_list:
+        r.__dict__["rating_grade"] = ratings.get((r.owner_id, r.item_id))
 
 
 def comments(request, item_path, item_uuid):
@@ -441,17 +472,24 @@ def comments_by_episode(request, item_path, item_uuid):
 def reviews(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     ids = item.child_item_ids + [item.pk] + item.sibling_item_ids
-    queryset = Review.objects.filter(item_id__in=ids).order_by("-created_time")
+    queryset = (
+        Review.objects.filter(item_id__in=ids)
+        .order_by("-created_time")
+        .select_related("owner", "owner__user")
+        .prefetch_related("item")
+    )
     queryset = queryset.filter(q_piece_visible_to_user(request.user))
     before_time = request.GET.get("last")
     if before_time:
         queryset = queryset.filter(created_time__lte=before_time)
+    reviews_list = list(queryset[: NUM_COMMENTS_ON_ITEM_PAGE + 1])
+    _prefetch_reviews(reviews_list)
     return render(
         request,
         "_item_reviews.html",
         {
             "item": item,
-            "reviews": queryset[: NUM_COMMENTS_ON_ITEM_PAGE + 1],
+            "reviews": reviews_list,
         },
     )
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -47,6 +47,7 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
         Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
     )
     Item.prefetch_parent_items(items)
+    Item.prefetch_edition_works(items)
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
     # Batch-fetch latest_post_id for all members to avoid N+1 queries

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -195,6 +195,11 @@ class Collection(List):
                     "external_resources"
                 )
             )
+            # All members share this Collection as their parent. Setting it on
+            # each instance avoids a per-member parent FK load (and consequent
+            # owner/identity/domain dereferences) in collection_items.html.
+            for member in members:
+                member.parent = self
             if items:
                 items_map = {i.pk: i for i in items}
                 for member in members:

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -4,6 +4,7 @@ from urllib.parse import quote_plus
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
+from django.db.models import Prefetch, prefetch_related_objects
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
@@ -161,12 +162,32 @@ def profile(request: AuthedHttpRequest, user_name):
     default_layout.append({"id": "collection_marked", "visibility": True})
     default_layout.append({"id": "people_person_following", "visibility": True})
     default_layout.append({"id": "people_organization_following", "visibility": True})
-    pinned_collections = (
+    pinned_collections = list(
         Collection.objects.filter(
             interactions__interaction_type="pin", interactions__identity=target
         )
         .order_by("-interactions__created_time")
-        .filter(qv)[:10]
+        .filter(qv)
+        .select_related("owner", "owner__user")[:10]
+    )
+    # _sidebar.html iterates identity.featured_collections, calls is_visible_to
+    # (hits owner, owner.user, owner.takahe_identity) and get_stats
+    # (hits collection_members + shelf counts) for each one. Prefetch eagerly
+    # so those derefs reuse cached rows.
+    prefetch_related_objects(
+        [target],
+        Prefetch(
+            "featured_collections",
+            queryset=Collection.objects.select_related("owner", "owner__user"),
+        ),
+    )
+    featured_owners = [
+        c.owner
+        for c in target.featured_collections.all()  # ty: ignore[unresolved-attribute]
+        if getattr(c, "owner_id", None)
+    ]
+    Takahe.prefetch_takahe_identities(
+        [c.owner for c in pinned_collections if c.owner_id] + featured_owners
     )
     default_layout[0:0] = [
         {"id": f"collection_{collection.uuid}", "visibility": True}

--- a/takahe/utils.py
+++ b/takahe/utils.py
@@ -39,9 +39,20 @@ class Takahe:
 
     @staticmethod
     def get_node_name_for_domain(d: str):
+        # ExternalResource.site_label calls this per rendered Fediverse
+        # resource; caching keeps a page of 40 linked items from firing 40
+        # identical domain lookups. Sentinel "" means "known to have no name".
+        cache_key = f"takahe:node_name:{d}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached or None
+        name = ""
         domain = Domain.objects.filter(domain=d).first()
         if domain and domain.nodeinfo:
-            return domain.nodeinfo.get("metadata", {}).get("nodeName")
+            name = domain.nodeinfo.get("metadata", {}).get("nodeName") or ""
+        cache.set(cache_key, name, 600)
+        if name:
+            return name
 
     @staticmethod
     def sync_password(u: "NeoUser"):
@@ -153,6 +164,33 @@ class Takahe:
     @staticmethod
     def get_identity(pk: int):
         return Identity.objects.get(pk=pk)
+
+    @staticmethod
+    def prefetch_takahe_identities(owners):
+        """Populate ``APIdentity.takahe_identity`` on each APIdentity in ``owners``.
+
+        Without this, the first access of ``apidentity.takahe_identity`` (used by
+        display_name, avatar, restricted, etc.) fires a single-row lookup on
+        users_identity — one per unique APIdentity in the list.
+        """
+        seen: dict[int, object] = {}
+        to_load: set[int] = set()
+        for owner in owners:
+            if owner is None or owner.pk in seen:
+                continue
+            seen[owner.pk] = owner
+            if "takahe_identity" not in owner.__dict__:
+                to_load.add(owner.pk)
+        if not to_load:
+            return
+        identities = {
+            i.pk: i
+            for i in Identity.objects.filter(pk__in=to_load).select_related("domain")
+        }
+        for pk, owner in seen.items():
+            identity = identities.get(pk)
+            if identity is not None:
+                owner.__dict__["takahe_identity"] = identity
 
     @staticmethod
     def get_identity_by_local_user(u: "NeoUser"):

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -1149,3 +1149,133 @@ class TestShelfAPICreditsPrefetch:
             )
         assert response.status_code == 200
         assert _per_item_credit_queries(ctx.captured_queries) == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfAPIEditionWorksPrefetch:
+    """Shelf API must prefetch Edition.works so ItemSchema.parent_uuid doesn't N+1."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="saw@example.com", username="sawuser")
+        self.work = Work.objects.create(title="Shelf Work")
+        self.editions = []
+        for i in range(4):
+            e = Edition.objects.create(title=f"SAW Edition {i}")
+            self.work.editions.add(e)
+            Mark(self.user.identity, e).update(
+                ShelfType.WISHLIST, f"n{i}", i + 5, [], 0
+            )
+            self.editions.append(e)
+        self.app = Takahe.get_or_create_app(
+            "Test",
+            "https://example.org",
+            "https://example.org/cb",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(self.app, self.user.identity.pk, self.user.pk)
+
+    def test_shelf_api_no_per_edition_work_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                "/api/me/shelf/wishlist",
+                HTTP_AUTHORIZATION=f"Bearer {self.token}",
+            )
+        assert response.status_code == 200
+        work_queries = [
+            q
+            for q in ctx.captured_queries
+            if "catalog_work_editions" in q["sql"]
+            and '"catalog_work_editions"."edition_id" =' in q["sql"]
+        ]
+        assert work_queries == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReviewsPrefetch:
+    """/item/.../reviews should batch rating, latest_post, and identity lookups."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.book = Edition.objects.create(title="Review Book")
+        self.reviewers = [
+            User.register(email=f"rv{i}@example.com", username=f"rvuser{i}")
+            for i in range(3)
+        ]
+        for i, u in enumerate(self.reviewers):
+            Mark(u.identity, self.book).update(ShelfType.COMPLETE, None, i + 5, [], 0)
+            u.identity.shelf_manager  # ensure manager exists
+            from journal.models import Review
+
+            Review.objects.create(
+                owner=u.identity,
+                item=self.book,
+                title=f"Title {i}",
+                body=f"Body {i}",
+            )
+
+    def test_reviews_page_renders(self):
+        client = Client()
+        response = client.get(f"/book/{self.book.uuid}/reviews")
+        assert response.status_code == 200
+
+    def test_reviews_no_per_review_rating_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/book/{self.book.uuid}/reviews")
+        assert response.status_code == 200
+        # Per-review rating_grade lookups would match this pattern
+        rating_queries = [
+            q
+            for q in ctx.captured_queries
+            if "journal_rating" in q["sql"]
+            and '"journal_rating"."owner_id" =' in q["sql"]
+            and '"journal_rating"."item_id" =' in q["sql"]
+            and "IN" not in q["sql"].upper()
+        ]
+        assert rating_queries == []
+
+    def test_reviews_no_per_review_identity_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/book/{self.book.uuid}/reviews")
+        assert response.status_code == 200
+        identity_queries = [
+            q
+            for q in ctx.captured_queries
+            if "users_identity" in q["sql"]
+            and 'WHERE "users_identity"."id" =' in q["sql"]
+        ]
+        assert identity_queries == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionMemberParent:
+    """Collection page must not dereference member.parent per collection member."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="cmp@example.com", username="cmpuser")
+        self.collection = Collection.objects.create(
+            title="CMP Collection", owner=self.user.identity
+        )
+        for i in range(5):
+            self.collection.append_item(Edition.objects.create(title=f"CMP Book {i}"))
+
+    def test_no_per_member_collection_polymorphic_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/collection/{self.collection.uuid}")
+        assert response.status_code == 200
+        # A per-member parent dereference would polymorphically fetch
+        # journal_collection joined with journal_piece by piece_ptr_id.
+        parent_queries = [
+            q
+            for q in ctx.captured_queries
+            if "journal_collection" in q["sql"]
+            and "journal_piece" in q["sql"]
+            and '"journal_collection"."piece_ptr_id" =' in q["sql"]
+        ]
+        # One top-level collection fetch is expected; members should not add more.
+        assert len(parent_queries) <= 1


### PR DESCRIPTION
## Summary

Addresses 10 unresolved N+1 issues flagged in Sentry over the last ~2 weeks across search, shelf API, item detail, profile, and collection pages. Changes are targeted prefetches / cache usage — no behavioral changes.

| Sentry issue | Route | Fix |
| --- | --- | --- |
| NEODB-SOCIAL-4BR | `/search` | `Edition.works.first()` → iterate prefetched `.all()` in `catalog/search/utils.py` |
| NEODB-SOCIAL-4HT | `/api/me/shelf/{type}` | new `Item.prefetch_edition_works()` called from shelf API |
| NEODB-SOCIAL-4JX | `/search` | batch `prefetch_related_objects(items, Prefetch("credits", …select_related("person")))` |
| EGGPLANT-1AA | `/api/catalog/search` | same credits prefetch + `prefetch_edition_works` |
| NEODB-SOCIAL-4HM | `/{item}/reviews` | new `_prefetch_reviews()` batches rating, latest post, takahe identities |
| NEODB-SOCIAL-4HE | `/{item}/comments` | batch takahe identities so `comment.owner.display_name` stops firing `users_identity` per comment |
| NEODB-SOCIAL-4JW | `/{item}/comments` | `ShelfMember.objects.filter(…).select_related("parent")` so `mark.action_label` stops polymorphic-loading Shelf per comment |
| NEODB-SOCIAL-476 | `/users/{name}/` | prefetch pinned + featured collection owners with user chain; pre-batch takahe identities |
| NEODB-SOCIAL-4CC | `/collection/{uuid}` | `member.parent = self` in `get_members_by_page` avoids per-member Collection polymorphic lookup |
| EGGPLANT-17A | `/collection/{uuid}` | Django cache TTL (10 min) for `Takahe.get_node_name_for_domain` so Fediverse-linked items stop firing `users_domain` per item |

New helpers are narrowly scoped and reusable:
- `Item.prefetch_edition_works(items)` — kept separate from `prefetch_parent_items` so collection-page templates (which short-circuit `edition.parent_item`) don't pay for wasted prefetches.
- `Takahe.prefetch_takahe_identities(owners)` — populates the `takahe_identity` cached_property on a list of `APIdentity`s in one query (with `select_related("domain")`).
- `_prefetch_reviews()` — parallels existing `_prefetch_comments()`; minimal duplication.

## Test plan

- [x] `uv run pre-commit run -a` passes (ruff, ruff format, djlint, ty).
- [x] `pytest tests/journal/ tests/catalog/` — 801 passed.
- [x] `pytest tests/users/ tests/core/ tests/social/ tests/mastodon/` — 341 passed.
- [x] `pytest tests/journal/test_n_plus_one.py` — 53 passed (48 existing + 5 new).
- [x] New regression tests added: `TestShelfAPIEditionWorksPrefetch`, `TestReviewsPrefetch`, `TestCollectionMemberParent`.
- [ ] Spot-check in Sentry after deploy: the 10 listed issues should stop regressing.