### PR TITLE
add sentry metrics logging

### DIFF
--- a/catalog/common/downloaders.py
+++ b/catalog/common/downloaders.py
@@ -18,6 +18,8 @@ from requests import Response
 from requests.exceptions import RequestException
 
 from common.models import SiteConfig
+from common.sentry import count as sentry_count
+from common.sentry import url_domain
 
 RESPONSE_OK = 0  # response is ready for pasring
 RESPONSE_INVALID_CONTENT = -1  # content not valid but no need to retry
@@ -226,6 +228,18 @@ class BasicDownloader:
         if timeout:
             self.timeout = timeout
 
+    def _record_download_invocation(self) -> None:
+        if getattr(self, "_suppress_download_invocation_metric", False):
+            self._suppress_download_invocation_metric = False
+            return
+        sentry_count(
+            "catalog.download",
+            attributes={"domain": url_domain(self.url)},
+        )
+
+    def _suppress_next_download_invocation_metric(self) -> None:
+        self._suppress_download_invocation_metric = True
+
     def validate_response(self, response) -> int:
         if response is None:
             return RESPONSE_NETWORK_ERROR
@@ -271,6 +285,7 @@ class BasicDownloader:
             return None, RESPONSE_NETWORK_ERROR
 
     def download(self) -> ResponseType:
+        self._record_download_invocation()
         resp, self.response_type = self._download(self.url)
         if self.response_type == RESPONSE_OK and resp:
             return resp
@@ -311,6 +326,7 @@ class BasicDownloader2(BasicDownloader):
             return None, RESPONSE_NETWORK_ERROR
 
     def download(self) -> ResponseType:
+        self._record_download_invocation()
         resp, self.response_type = self._download(self.url)
         if self.response_type == RESPONSE_OK and resp:
             return resp
@@ -336,6 +352,7 @@ class ProxiedDownloader(BasicDownloader):
         )
 
     def download(self):
+        self._record_download_invocation()
         urls = self.get_proxied_urls()
         last_try = False
         url = urls.pop(0) if len(urls) else None
@@ -363,6 +380,7 @@ class ProxiedDownloader(BasicDownloader):
 
 class RetryDownloader(BasicDownloader):
     def download(self):
+        self._record_download_invocation()
         retries = SiteConfig.system.downloader_retries
         total_retries = retries
         while retries:
@@ -380,11 +398,13 @@ class RetryDownloader(BasicDownloader):
 
 class CachedDownloader(BasicDownloader):
     def download(self):
+        self._record_download_invocation()
         cache_key = "dl:" + self.url
         resp = cache.get(cache_key)
         if resp:
             self.response_type = RESPONSE_OK
         else:
+            self._suppress_next_download_invocation_metric()
             resp = super().download()
             if self.response_type == RESPONSE_OK:
                 cache.set(
@@ -816,6 +836,10 @@ class ScrapDownloader(BasicDownloader):
 
     def _scrape_with_provider(self, provider: str) -> Tuple[ResponseType | None, int]:
         """Scrape using the specified provider."""
+        sentry_count(
+            "catalog.scraper",
+            attributes={"domain": url_domain(self.url), "provider": provider},
+        )
         logger.debug(f"Fetching {self.url} with {provider}...")
         if provider == "scrapfly":
             api_key = SiteConfig.system.downloader_scrapfly_key
@@ -880,6 +904,7 @@ class ScrapDownloader(BasicDownloader):
             logger.debug("No scraping providers configured, using basic download")
             return super().download()
 
+        self._record_download_invocation()
         resp = None
         resp_type = None
 

--- a/catalog/search/utils.py
+++ b/catalog/search/utils.py
@@ -13,6 +13,8 @@ from catalog.common import (
     DownloadError,
     SiteManager,
 )
+from common.sentry import count as sentry_count
+from common.sentry import url_domain
 from takahe.search import search_by_ap_url
 from users.models import User
 
@@ -133,6 +135,13 @@ def enqueue_fetch(url, is_refetch, user=None):
     return job_id
 
 
+def _record_fetch_failure(url: str) -> None:
+    sentry_count(
+        "catalog.fetch.failure",
+        attributes={"domain": url_domain(url)},
+    )
+
+
 def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
     user = User.objects.get(pk=user_pk) if user_pk else None
     with set_actor(user):
@@ -145,6 +154,7 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
                     logger.info(f"fetched {url} {item_url}")
                     return item_url
                 logger.warning(f"Site not found for {url}")
+                _record_fetch_failure(url)
                 return "-"
             res = site.get_resource_ready(ignore_existing_content=is_refetch)
             item = res.item if res else None
@@ -153,9 +163,12 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
                 return item.url
             else:
                 logger.error(f"fetch {url} failed")
+                _record_fetch_failure(url)
         except DownloadError as e:
             if e.response_type != RESPONSE_CENSORSHIP:
                 logger.error(f"fetch {url} error", extra={"exception": e})
+            _record_fetch_failure(url)
         except Exception as e:
             logger.error(f"parse {url} error {e}", extra={"exception": e})
+            _record_fetch_failure(url)
         return "-"

--- a/common/sentry.py
+++ b/common/sentry.py
@@ -1,0 +1,44 @@
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlparse
+
+MetricAttributes = Mapping[str, str | int | float | bool | None]
+
+
+def url_domain(url: str | None) -> str:
+    if not url:
+        return "unknown"
+    parsed = urlparse(url if "://" in url else f"//{url}")
+    return (parsed.hostname or "unknown").lower()
+
+
+def _clean_attributes(attributes: MetricAttributes | None) -> dict[str, Any]:
+    if not attributes:
+        return {}
+    return {key: value for key, value in attributes.items() if value is not None}
+
+
+def count(
+    key: str,
+    value: int | float = 1,
+    attributes: MetricAttributes | None = None,
+) -> None:
+    """Emit a Sentry counter metric when Sentry is configured."""
+    try:
+        import sentry_sdk
+    except ImportError:
+        return
+
+    is_initialized = getattr(sentry_sdk, "is_initialized", None)
+    if not callable(is_initialized) or not is_initialized():
+        return
+
+    metrics = getattr(sentry_sdk, "metrics", None)
+    metrics_count = getattr(metrics, "count", None)
+    if not callable(metrics_count):
+        return
+
+    try:
+        metrics_count(key, value, attributes=_clean_attributes(attributes))
+    except Exception:
+        return

--- a/mastodon/views/bluesky.py
+++ b/mastodon/views/bluesky.py
@@ -3,6 +3,7 @@ from django.http import HttpRequest
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import count as sentry_count
 from common.views import render_error
 
 from ..models import Bluesky
@@ -11,6 +12,7 @@ from .common import disconnect_identity, process_verified_account
 
 @require_http_methods(["POST"])
 def bluesky_login(request: HttpRequest):
+    sentry_count("login.attempt", attributes={"type": "bluesky"})
     username = request.POST.get("username", "").strip().lstrip("@")
     password = request.POST.get("password", "").strip()
     if not username or not password:

--- a/mastodon/views/email.py
+++ b/mastodon/views/email.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import count as sentry_count
 from common.views import render_error
 
 from ..forms import EmailLoginForm
@@ -25,6 +26,7 @@ def email_login_state(request):
 
 @require_http_methods(["POST"])
 def email_login(request: HttpRequest):
+    sentry_count("login.attempt", attributes={"type": "email"})
     form = EmailLoginForm(request.POST)
     if not form.is_valid():
         return render_error(request, _("Invalid captcha"))

--- a/mastodon/views/mastodon.py
+++ b/mastodon/views/mastodon.py
@@ -4,6 +4,7 @@ from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import count as sentry_count
 from common.views import render_error
 from mastodon.models import Mastodon
 from mastodon.views.common import disconnect_identity, process_verified_account
@@ -17,6 +18,10 @@ def mastodon_login(request):
         return render_error(request, _("Missing instance domain"))
     login_domain = (
         login_domain.strip().lower().split("//")[-1].split("/")[0].split("@")[-1]
+    )
+    sentry_count(
+        "login.attempt",
+        attributes={"type": "mastodon", "domain": login_domain or "unknown"},
     )
     try:
         login_url = Mastodon.generate_auth_url(login_domain, request)

--- a/mastodon/views/threads.py
+++ b/mastodon/views/threads.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import count as sentry_count
 from common.views import render_error
 
 from ..models import Threads
@@ -14,6 +15,7 @@ from .common import disconnect_identity, process_verified_account
 @require_http_methods(["POST"])
 def threads_login(request: HttpRequest):
     """start login process via threads"""
+    sentry_count("login.attempt", attributes={"type": "threads"})
     return redirect(Threads.generate_auth_url(request))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "podcastparser>=0.6.10",
     "psycopg2-binary",
     "requests>=2.32.3",
-    "sentry-sdk>=2.17.0",
+    "sentry-sdk>=2.44.0",
     "setproctitle>=1.3.3",
     "tqdm>=4.66.6",
     "typesense>=0.21.0",

--- a/takahe/ap_handlers.py
+++ b/takahe/ap_handlers.py
@@ -6,6 +6,8 @@ from loguru import logger
 from catalog.common import SiteManager
 from catalog.models import Item
 from catalog.sites.fedi import FediverseInstance
+from common.sentry import count as sentry_count
+from common.sentry import url_domain
 from common.utils import discord_send
 from journal.models import (
     Comment,
@@ -117,6 +119,24 @@ def post_fetched(pk, post_data):
     return _post_fetched(pk, False, post_data, True)
 
 
+def _remote_post_domain(post: Any) -> str:
+    author = getattr(post, "author", None)
+    if not author:
+        return "unknown"
+    try:
+        domain = getattr(author, "uri_domain", None)
+    except Exception:
+        domain = None
+    return domain or url_domain(getattr(author, "actor_uri", None))
+
+
+def _record_remote_post_fetched(post: Any) -> None:
+    sentry_count(
+        "post.fetched",
+        attributes={"domain": _remote_post_domain(post)},
+    )
+
+
 def _post_fetched(pk, local, post_data, create: bool | None = None):
     retry = 1
     while True:
@@ -158,6 +178,7 @@ def _post_fetched(pk, local, post_data, create: bool | None = None):
             JournalIndex.instance().replace_posts([post])
             return
     else:
+        _record_remote_post_fetched(post)
         if not post.type_data and not post_data:
             logger.warning(f"Remote post {post} has no type_data")
             return

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+import sentry_sdk
+
+from common import sentry
+from takahe import ap_handlers
+
+
+def test_url_domain_extracts_hostname():
+    assert sentry.url_domain("https://Example.com/path") == "example.com"
+    assert sentry.url_domain("mastodon.social") == "mastodon.social"
+    assert sentry.url_domain("") == "unknown"
+
+
+def test_count_noops_when_sentry_is_not_initialized(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sentry_sdk, "is_initialized", lambda: False)
+    monkeypatch.setattr(
+        sentry_sdk.metrics,
+        "count",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    sentry.count("neodb.test", attributes={"domain": "example.com"})
+
+    assert calls == []
+
+
+def test_count_emits_when_sentry_is_initialized(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sentry_sdk, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        sentry_sdk.metrics,
+        "count",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    sentry.count(
+        "neodb.test",
+        2,
+        attributes={"domain": "example.com", "empty": None},
+    )
+
+    assert calls == [(("neodb.test", 2), {"attributes": {"domain": "example.com"}})]
+
+
+def test_remote_post_domain_uses_author_uri_domain():
+    post = SimpleNamespace(
+        author=SimpleNamespace(
+            uri_domain="remote.example",
+            actor_uri="https://fallback.example/@user",
+        )
+    )
+
+    assert ap_handlers._remote_post_domain(post) == "remote.example"
+
+
+def test_record_remote_post_fetched_logs_domain(monkeypatch):
+    calls = []
+    post = SimpleNamespace(
+        author=SimpleNamespace(
+            uri_domain=None,
+            actor_uri="https://remote.example/@user",
+        )
+    )
+    monkeypatch.setattr(
+        ap_handlers,
+        "sentry_count",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    ap_handlers._record_remote_post_fetched(post)
+
+    assert calls == [
+        (
+            ("post.fetched",),
+            {"attributes": {"domain": "remote.example"}},
+        )
+    ]

--- a/users/views/webauthn.py
+++ b/users/views/webauthn.py
@@ -24,6 +24,7 @@ from webauthn.helpers.structs import (
     UserVerificationRequirement,
 )
 
+from common.sentry import count as sentry_count
 from common.validators import get_safe_redirect_url
 
 from ..models import WebAuthnCredential
@@ -139,6 +140,7 @@ def passkey_login_options(request):
 
 @require_http_methods(["POST"])
 def passkey_login_verify(request):
+    sentry_count("login.attempt", attributes={"type": "passkey"})
     entry = request.session.pop("webauthn_login_challenge", None)
     if not entry:
         return HttpResponseBadRequest("No login challenge in session")

--- a/uv.lock
+++ b/uv.lock
@@ -1807,7 +1807,7 @@ requires-dist = [
     { name = "podcastparser", specifier = ">=0.6.10" },
     { name = "psycopg2-binary" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "sentry-sdk", specifier = ">=2.17.0" },
+    { name = "sentry-sdk", specifier = ">=2.44.0" },
     { name = "setproctitle", specifier = ">=1.3.3" },
     { name = "tqdm", specifier = ">=4.66.6" },
     { name = "typesense", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary

Adds a small `common.sentry` utility for Sentry counter metrics that no-ops when Sentry is not configured or the SDK metrics API is unavailable.

Instruments counters for:

- downloader invocations by domain
- scraper provider invocations by domain and provider
- login attempts by type, with Mastodon domain when applicable
- fetch failures by domain
- remote post fetches using the existing `post.fetched` event name by remote domain

The Sentry SDK floor is raised to a metrics-capable version and focused tests cover the no-op behavior, attribute cleanup, domain extraction, and remote post metric emission.

## Validation

- `uv run ruff check takahe/ap_handlers.py tests/core/test_sentry.py`
- `uv run ty check takahe/ap_handlers.py tests/core/test_sentry.py`
- `uv run pytest tests/core/test_sentry.py tests/core/test_downloaders.py`
- commit hooks passed during amend
