### PR TITLE
perf: reuse prefetched item.mark in /search list rendering (NEODB-SOCIAL-4EA)

### DIFF
--- a/journal/templatetags/user_actions.py
+++ b/journal/templatetags/user_actions.py
@@ -9,9 +9,12 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def get_mark_for_item(context, item):
     user = context["request"].user
-    return (
-        Mark(user.identity, item) if user and user.is_authenticated and item else None
-    )
+    if not (user and user.is_authenticated and item):
+        return None
+    cached = getattr(item, "mark", None)
+    if cached is not None and cached.owner.pk == user.identity.pk:
+        return cached
+    return Mark(user.identity, item)
 
 
 @register.simple_tag(takes_context=True)

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -1251,6 +1251,51 @@ class TestReviewsPrefetch:
 
 
 @pytest.mark.django_db(databases="__all__")
+class TestGetMarkForItemUsesPrefetched:
+    """get_mark_for_item template tag must reuse Mark.attach_to_items output."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="gmf@example.com", username="gmfuser")
+        self.books = [Edition.objects.create(title=f"GMF Book {i}") for i in range(3)]
+        for i, book in enumerate(self.books):
+            Mark(self.user.identity, book).update(
+                ShelfType.COMPLETE, f"comment {i}", i + 5, [f"tag{i}"], 0
+            )
+
+    def test_returns_prefetched_mark_without_queries(self):
+        from journal.templatetags.user_actions import get_mark_for_item
+
+        Mark.attach_to_items(self.user.identity, self.books, self.user)
+
+        class _Req:
+            user = self.user
+
+        context = {"request": _Req()}
+        with CaptureQueriesContext(connection) as ctx:
+            for book in self.books:
+                m = get_mark_for_item(context, book)
+                assert m is book.mark
+                assert m.shelf_type == ShelfType.COMPLETE
+                assert m.rating_grade is not None
+                assert m.comment is not None
+                assert m.tags
+        assert ctx.captured_queries == []
+
+    def test_falls_back_when_no_prefetch(self):
+        from journal.templatetags.user_actions import get_mark_for_item
+
+        class _Req:
+            user = self.user
+
+        context = {"request": _Req()}
+        m = get_mark_for_item(context, self.books[0])
+        # No item.mark attached, so a fresh Mark is created (will query lazily).
+        assert m is not None
+        assert m.shelf_type == ShelfType.COMPLETE
+
+
+@pytest.mark.django_db(databases="__all__")
 class TestCollectionMemberParent:
     """Collection page must not dereference member.parent per collection member."""
 


### PR DESCRIPTION
## Summary
- `catalog/views/search.py` already calls `Mark.attach_to_items(...)` so every search-result item gets a fully populated `item.mark` (shelfmember + comment + rating + review + tags batched). `_list_item.html` resolved each row's mark via `{% get_mark_for_item item as mark %}`, which always built a fresh `Mark(user.identity, item)` and ignored the prefetched copy. Each subsequent `mark.shelfmember` / `rating_grade` / `comment` / `review` / `tags` access fired its own per-row query — Sentry's `NEODB-SOCIAL-4EA` shows the same `journal_shelfmember`/`journal_review`/`journal_tagmember` lookups repeating 60 times per `/search` render.
- Update `get_mark_for_item` to reuse `item.mark` when it has been attached for the viewing identity and only fall back to constructing a new `Mark` when nothing was prefetched. Other callers that pass `mark=` explicitly (`user_item_list_base.html`, `collection_items.html`, etc.) keep their existing behavior.

## Test plan
- [x] `pytest tests/journal/test_n_plus_one.py` — all 55 perf regression tests pass, including the two new cases asserting (a) zero queries when the prefetched `item.mark` is reused and (b) the lazy fallback when nothing was attached.
- [x] `pytest tests/journal/` — 357 passed.
- [x] `pytest tests/catalog/` — 455 passed.
- [x] `pre-commit run` on the touched files.

Fixes NEODB-SOCIAL-4EA