### PR TITLE
fix: credit-field schema resolvers and Collection empty brief

### DIFF
--- a/catalog/models/performance.py
+++ b/catalog/models/performance.py
@@ -29,7 +29,7 @@ class CrewMemberSchema(Schema):
     role: str | None
 
 
-class _PerformanceCreditResolverMixin:
+class _PerformanceCreditResolverMixin(Schema):
     @staticmethod
     def resolve_director(obj: "Performance | PerformanceProduction") -> list[str]:
         return obj.credit_names_by_role("director")

--- a/catalog/models/tv.py
+++ b/catalog/models/tv.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
+from ninja import Schema
 
 from common.models.lang import RE_LOCALIZED_SEASON_NUMBERS, localize_number
 from common.models.misc import int_, uniq
@@ -55,7 +56,7 @@ from .item import (
 from .people import PeopleRole
 
 
-class _TVCreditResolverMixin:
+class _TVCreditResolverMixin(Schema):
     @staticmethod
     def resolve_director(obj: "TVShow | TVSeason") -> list[str]:
         return obj.credit_names_by_role("director")

--- a/journal/forms.py
+++ b/journal/forms.py
@@ -47,6 +47,7 @@ class CollectionForm(forms.ModelForm):
     brief = forms.CharField(
         label=_("Content (Markdown)"),
         strip=False,
+        required=False,
         widget=forms.Textarea(attrs={"class": "easymde-editor"}),
     )
     # share_to_mastodon = forms.BooleanField(label=_("Crosspost to timeline"), initial=True, required=False)

--- a/tests/catalog/test_model.py
+++ b/tests/catalog/test_model.py
@@ -1,6 +1,16 @@
 import pytest
 
-from catalog.models import CreditRole, Edition, Item, ItemCredit, Movie
+from catalog.models import (
+    CreditRole,
+    Edition,
+    Item,
+    ItemCredit,
+    Movie,
+    Performance,
+    PerformanceProduction,
+    TVSeason,
+    TVShow,
+)
 from catalog.models.people import People
 from common.models.jsondata import decrypt_str, encrypt_str
 
@@ -161,3 +171,56 @@ class TestSyncCreditsFromMetadata:
         m.save()
         m.sync_credits_from_metadata()
         assert m.credits.filter(role=CreditRole.Composer).count() == 1
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSchemaCreditResolvers:
+    """Schemas must source credit fields from ItemCredit via resolve_*.
+
+    Regression for NEODB-SOCIAL-4MQ: resolver methods defined on a plain mixin
+    (not a Schema subclass) were silently dropped by ninja's ResolverMetaclass,
+    so ap_object fell back to the raw jsondata field. When that field held
+    corrupted scalar data (string instead of list) Pydantic raised
+    `Input should be a valid list`.
+    """
+
+    def _seed_credit(self, item: Item, role: str, name: str) -> None:
+        ItemCredit.objects.create(item=item, role=role, name=name, order=0)
+
+    def _assert_director_resolved(self, item: Item, expected: list[str]) -> None:
+        # Stash a corrupted scalar in the legacy jsondata field; the resolver
+        # must ignore it and read from credits instead.
+        setattr(item, "director", "corrupt-string")
+        item.save()
+        self._seed_credit(item, CreditRole.Director, expected[0])
+        # Bust the cached_property since we just inserted a credit.
+        item.__dict__.pop("role_credits", None)
+        assert item.ap_object["director"] == expected
+
+    def test_tvseason_resolves_director_from_credits(self):
+        season = TVSeason.objects.create(title="Season")
+        season.localized_title = [{"lang": "en", "text": "Season"}]
+        self._assert_director_resolved(season, ["Real Director"])
+
+    def test_tvshow_resolves_director_from_credits(self):
+        show = TVShow.objects.create(title="Show")
+        show.localized_title = [{"lang": "en", "text": "Show"}]
+        self._assert_director_resolved(show, ["Real Director"])
+
+    def test_performance_resolves_director_from_credits(self):
+        perf = Performance.objects.create(title="Play")
+        perf.localized_title = [{"lang": "en", "text": "Play"}]
+        self._assert_director_resolved(perf, ["Real Director"])
+
+    def test_performance_production_resolves_director_from_credits(self):
+        perf = Performance.objects.create(title="Play")
+        perf.localized_title = [{"lang": "en", "text": "Play"}]
+        perf.save()
+        prod = PerformanceProduction.objects.create(title="Run", show=perf)
+        prod.localized_title = [{"lang": "en", "text": "Run"}]
+        self._assert_director_resolved(prod, ["Real Director"])
+
+    def test_movie_resolves_director_from_credits(self):
+        m = Movie.objects.create(title="Film")
+        m.localized_title = [{"lang": "en", "text": "Film"}]
+        self._assert_director_resolved(m, ["Real Director"])


### PR DESCRIPTION
## Summary

Two unrelated bug fixes:

- **`fix(catalog)`** — `_TVCreditResolverMixin` and `_PerformanceCreditResolverMixin` were plain classes, so ninja's `ResolverMetaclass` never registered their `resolve_*` methods (it only inspects the schema class's own namespace plus base classes that already expose `_ninja_resolvers`). Schema serialization silently fell back to the legacy jsondata fields, and `item.ap_object` validation raised `Input should be a valid list` when those fields held corrupted scalar data (Sentry NEODB-SOCIAL-4MQ, fetching https://bgm.tv/subject/3626). Making both mixins inherit from `ninja.Schema` lets the metaclass pick up the resolvers as the original commit (b9e0090d) intended. Adds regression tests for TVSeason, TVShow, Performance, PerformanceProduction, and Movie.
- **`fix(journal)`** — `CollectionForm.brief` defaulted to `required=True`, so saving a collection with an empty description raised `BadRequest("Invalid parameter")` even though `Collection.brief` is `TextField(blank=True, default="")` and the rest of the save path handles an empty string.

Fixes NEODB-SOCIAL-4MQ.

## Test plan

- [ ] `pytest tests/catalog/test_model.py::TestSchemaCreditResolvers` passes (the four mixin-based cases fail without the resolver fix)
- [ ] Edit a Collection, clear the description field, save — succeeds and persists empty brief
- [ ] Refetch a Bangumi TV subject (e.g. `https://bgm.tv/subject/3626`) — no validation error