### PR TITLE
perf: fix N+1 queries on /collection and /users profile pages

### DIFF
--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -728,6 +728,23 @@ class Item(PolymorphicModel):
             prefetch_related_objects(performanceproductions, "show")
 
     @staticmethod
+    def prefetch_credits(items: "Iterable[Item]") -> None:
+        """Batch-prefetch credits (with person) for templates that render
+        ``item.role_credits`` per card. Without this, each card fires a
+        ``catalog_itemcredit`` join query.
+        """
+        item_list = [i for i in items if i is not None]
+        if not item_list:
+            return
+        prefetch_related_objects(
+            item_list,
+            models.Prefetch(
+                "credits",
+                queryset=ItemCredit.objects.select_related("person"),
+            ),
+        )
+
+    @staticmethod
     def prefetch_edition_works(items: "Iterable[Item]") -> None:
         """Batch-prefetch Edition.works for ItemSchema/parent_uuid serialization.
 

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -54,6 +54,7 @@ class CollectionMember(ListMember):
 class Collection(List):
     if TYPE_CHECKING:
         members: models.QuerySet[CollectionMember]
+        _stats_cache: dict[int, dict[str, int]]
     url_path = "collection"
     post_when_save = True
     index_when_save = True
@@ -167,6 +168,7 @@ class Collection(List):
                 items = r.items
                 pages = r.pages
                 Item.prefetch_parent_items(items)
+                Item.prefetch_credits(items)
                 Rating.attach_to_items(items)
                 Tag.attach_to_items(items)
                 if viewer:
@@ -205,6 +207,7 @@ class Collection(List):
                 for member in members:
                     member.item = items_map.get(member.item_id)
                 Item.prefetch_parent_items(items)
+                Item.prefetch_credits(items)
                 Rating.attach_to_items(items)
                 Tag.attach_to_items(items)
                 if viewer:
@@ -214,6 +217,9 @@ class Collection(List):
     def get_stats(self, viewer: APIdentity):
         from .shelf import ShelfMember, ShelfType
 
+        cached = getattr(self, "_stats_cache", {}).get(getattr(viewer, "pk", None))
+        if cached is not None:
+            return cached
         items = self.item_ids
         stats: dict[str, int] = {"total": len(items)}
         for st in ShelfType.values:
@@ -229,6 +235,61 @@ class Collection(List):
             round(stats["complete"] * 100 / stats["total"]) if stats["total"] else 0
         )
         return stats
+
+    @classmethod
+    def attach_stats_for_viewer(
+        cls, collections: list["Collection"], viewer: APIdentity
+    ) -> None:
+        """Pre-compute ``get_stats(viewer)`` for many collections in two queries.
+
+        ``_sidebar.html`` iterates ``identity.featured_collections`` and calls
+        ``get_stats`` once per collection; without batching, each call hits
+        ``CollectionMember`` and ``ShelfMember`` separately. This loads all
+        member item_ids and the viewer's shelf placements in a single round
+        trip each, then stores the per-collection stats on the instance for
+        ``get_stats`` to return on cache hit.
+        """
+        from .shelf import ShelfMember, ShelfType
+
+        if not collections or viewer is None:
+            return
+        # Static collections share their item ids via CollectionMember; dynamic
+        # ones compute item_ids from the search index, so we let those fall
+        # through to per-instance get_stats.
+        static = [c for c in collections if not c.is_dynamic]
+        items_by_collection: dict[int, list[int]] = {c.pk: [] for c in static}
+        if static:
+            rows = CollectionMember.objects.filter(
+                parent_id__in=[c.pk for c in static]
+            ).values_list("parent_id", "item_id")
+            for parent_id, item_id in rows:
+                items_by_collection.setdefault(parent_id, []).append(item_id)
+        all_item_ids = {iid for ids in items_by_collection.values() for iid in ids}
+        # One ShelfMember per (owner, item) within standard shelves, so a
+        # single map of item_id -> shelf_type lets us tally per collection.
+        shelf_by_item: dict[int, str] = {}
+        if all_item_ids:
+            for row in ShelfMember.objects.filter(
+                owner=viewer, item_id__in=all_item_ids
+            ).values("item_id", "parent__shelf_type"):
+                shelf_by_item[row["item_id"]] = row["parent__shelf_type"]
+        for c in static:
+            items = items_by_collection.get(c.pk, [])
+            stats: dict[str, int] = {"total": len(items)}
+            for st in ShelfType.values:
+                stats[st] = 0
+            for item_id in items:
+                st = shelf_by_item.get(item_id)
+                if st:
+                    stats[st] = stats.get(st, 0) + 1
+            stats["percentage"] = (
+                round(stats["complete"] * 100 / stats["total"]) if stats["total"] else 0
+            )
+            cache = getattr(c, "_stats_cache", None)
+            if cache is None:
+                cache = {}
+                c._stats_cache = cache
+            cache[viewer.pk] = stats
 
     def get_progress(self, viewer: APIdentity):
         items = self.item_ids

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -283,7 +283,9 @@ class Collection(List):
                 if st:
                     stats[st] = stats.get(st, 0) + 1
             stats["percentage"] = (
-                round(stats["complete"] * 100 / stats["total"]) if stats["total"] else 0
+                round(stats.get("complete", 0) * 100 / stats["total"])
+                if stats["total"]
+                else 0
             )
             cache = getattr(c, "_stats_cache", None)
             if cache is None:

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -189,6 +189,10 @@ def profile(request: AuthedHttpRequest, user_name):
     Takahe.prefetch_takahe_identities(
         [c.owner for c in pinned_collections if c.owner_id] + featured_owners
     )
+    Collection.attach_stats_for_viewer(
+        list(target.featured_collections.all()),  # ty: ignore[unresolved-attribute]
+        target,
+    )
     default_layout[0:0] = [
         {"id": f"collection_{collection.uuid}", "visibility": True}
         for collection in pinned_collections


### PR DESCRIPTION
## Summary

Sentry flagged two recent N+1 issues. Both are in template-render hot paths that loop over a small list and trigger one query per iteration.

- **EGGPLANT-1B5** `/collection/{uuid}` — every item card rendered `item.role_credits`, firing one `catalog_itemcredit JOIN catalog_people` query per card. `Collection.get_members_by_page` now calls `Item.prefetch_credits(items)`, populating the prefetch cache that `_credits_with_person` already checks.
- **EGGPLANT-1AS** `/users/{user_name}/` — `_sidebar.html` iterates `identity.featured_collections` and calls `get_stats` per collection, each running its own `CollectionMember` and `ShelfMember GROUP BY` queries. Added `Collection.attach_stats_for_viewer()` to precompute stats for many collections in two queries, and made `get_stats` short-circuit on the cache. The profile view calls it after the existing identity prefetch.

## Test plan

- [ ] `/collection/{uuid}` page loads with the same content; no per-item `catalog_itemcredit` queries in DB logs (one prefetch query instead).
- [ ] `/users/{user_name}/` profile loads; sidebar "Current Targets" stats render correctly with two combined queries instead of two-per-featured-collection.
- [ ] Existing `tests/journal/test_n_plus_one.py::TestCollectionGetStats` still passes (single-aggregation invariant preserved when stats cache is empty).
- [ ] Sentry events for EGGPLANT-1B5 and EGGPLANT-1AS taper off after deploy.