### PR TITLE
feat(journal): federate Collections across servers

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -226,6 +226,29 @@ existing catalog fetch path.
 makes the field nullable). Remote mirrors don't get stub catalog
 entries.
 
+### Known limitation: followers-only inbound list sync
+
+The page-walking inbound sync signs every fetch as the local Takahe
+SystemActor (`takahe.auth.sign_get`). On the receiving (origin) side,
+`is_visible_to_identity` is given that signing actor and asks "is this
+actor a follower of the owner?" — for a SystemActor, the answer is
+always **no**, so the origin returns 404. This means
+**followers-only Shelf / Collection items endpoints cannot be synced
+between peers in this PR**. Only public lists round-trip correctly.
+
+Public lists work because `is_visible_to_identity(visibility=0)`
+returns True regardless of the signer (`anonymous_viewable` path).
+
+Fixing this requires either signing as a local follower of the remote
+owner (we'd need to pick one and use their key — Takahe stores keys
+in `takahe.Identity.private_key`) or relaxing the receiver-side check
+to accept "instance SystemActor of an instance with at least one
+follower" (Mastodon's per-instance trust model). Both are non-trivial
+auth-model changes; they're left out of this PR. The announcement
+Note still delivers the lightweight envelope to followers, so a
+follower's local mirror is created with `visibility` set; only the
+member list lags.
+
 ### Out of scope (deferred)
 
 - **`Tag` federation** — column provisioned (`Tag.remote_id` via the

--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -226,6 +226,19 @@ existing catalog fetch path.
 makes the field nullable). Remote mirrors don't get stub catalog
 entries.
 
+### AP endpoints refuse mirrors
+
+`_list_ap_object_view` and `_list_items_view`
+(`journal/views/collection.py`) gate on `_is_locally_owned(instance)`
+and 404 otherwise. The origin server is authoritative for their own
+users' lists; we hold a possibly-stale snapshot. The check requires
+both `instance.local` AND `instance.owner.local` because
+`ShelfManager` auto-initializes a `Shelf` row per `shelf_type` for any
+APIdentity it touches (local OR remote, with `local=True` from the
+model default), so a remote owner's auto-initialized shelf row would
+otherwise sneak through. Peers chasing a federated link should follow
+the original `id` URL on the origin instead.
+
 ### Known limitation: followers-only inbound list sync
 
 The page-walking inbound sync signs every fetch as the local Takahe

--- a/journal/jobs/list_sync.py
+++ b/journal/jobs/list_sync.py
@@ -117,8 +117,17 @@ def fetch_remote_list_members(class_path: str, pk: int, attempts: int = 0) -> No
         logger.warning(
             f"list_sync: hit MAX_PAGES walking {inst.remote_id}; partial sync"
         )
+    if failed_page:
+        # A page in the chain failed to fetch. ``_sync_members_from_ap``
+        # treats omitted entries as stale and would *delete* them, so a
+        # transient failure on page 1 would empty the mirror and a
+        # later-page failure would drop subsequent members. Retry without
+        # mutating local state; the next attempt either succeeds or we
+        # exhaust ``MAX_FETCH_ATTEMPTS`` and bail.
+        _maybe_retry(class_path, pk, attempts)
+        return
     pending = cls._sync_members_from_ap(inst, flat_items)
-    if pending or failed_page:
+    if pending:
         # Items pending catalog fetch — retry so the next pass picks them
         # up after the catalog cache primes.
         _maybe_retry(class_path, pk, attempts)

--- a/journal/migrations/0010_collectionmember_unique_collection_member.py
+++ b/journal/migrations/0010_collectionmember_unique_collection_member.py
@@ -1,6 +1,48 @@
 from django.db import migrations, models
 
 
+def _dedupe_collection_members(apps, schema_editor):
+    """Remove duplicate ``(parent, item)`` ``CollectionMember`` rows so the
+    new ``unique_collection_member`` constraint can be added.
+
+    Existing NeoDB deployments may have duplicate rows from past data
+    paths that pre-dated the per-list dedup logic — most commonly when
+    two catalog items were merged together and both ended up on the
+    same collection. ``Collection.append_item`` short-circuits on the
+    happy path, but the merge path bypassed it. Without this dedup the
+    ``AddConstraint`` step below would abort the migration on those
+    deployments.
+
+    Strategy: keep the lowest-pk row per ``(parent_id, item_id)`` and
+    delete the rest via raw SQL — fast and avoids loading every member
+    through the ORM, which can be heavy on large collections.
+    """
+    CollectionMember = apps.get_model("journal", "CollectionMember")
+    db_alias = schema_editor.connection.alias
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            """
+            DELETE FROM journal_collectionmember
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY parent_id, item_id
+                            ORDER BY id
+                        ) AS rn
+                    FROM journal_collectionmember
+                ) ranked
+                WHERE rn > 1
+            )
+            """
+        )
+    # Touch CollectionMember to silence "unused import" warnings in
+    # test discovery; also lets us assert the dedup ran in the unit
+    # tests via ``apps.get_model`` reflection.
+    _ = CollectionMember.objects.using(db_alias).count()
+
+
 class Migration(migrations.Migration):
     """Enforce ``UniqueConstraint(parent, item)`` on ``CollectionMember``.
 
@@ -11,9 +53,12 @@ class Migration(migrations.Migration):
     enforced at the ORM level because constraint violations fail the
     transaction rather than silently dedup.
 
-    Existing data already satisfies this invariant — ``Collection.append_item``
-    short-circuits when the item is already a member — so the constraint
-    can be added without a data migration.
+    Pre-existing data may not satisfy this invariant if a deployment
+    has previously merged catalog items that were both members of the
+    same collection. ``_dedupe_collection_members`` runs first to keep
+    the lowest-pk row per ``(parent, item)`` so ``AddConstraint`` can
+    succeed; ``RunPython.noop`` is the inverse because the constraint
+    add itself is what re-locks the data.
     """
 
     dependencies = [
@@ -21,6 +66,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            _dedupe_collection_members, reverse_code=migrations.RunPython.noop
+        ),
         migrations.AddConstraint(
             model_name="collectionmember",
             constraint=models.UniqueConstraint(

--- a/journal/migrations/0010_collectionmember_unique_collection_member.py
+++ b/journal/migrations/0010_collectionmember_unique_collection_member.py
@@ -2,44 +2,74 @@ from django.db import migrations, models
 
 
 def _dedupe_collection_members(apps, schema_editor):
-    """Remove duplicate ``(parent, item)`` ``CollectionMember`` rows so the
-    new ``unique_collection_member`` constraint can be added.
+    """Collapse duplicate ``(parent, item)`` ``CollectionMember`` rows so
+    the new ``unique_collection_member`` constraint can be added.
 
     Existing NeoDB deployments may have duplicate rows from past data
     paths that pre-dated the per-list dedup logic — most commonly when
     two catalog items were merged together and both ended up on the
     same collection. ``Collection.append_item`` short-circuits on the
     happy path, but the merge path bypassed it. Without this dedup the
-    ``AddConstraint`` step below would abort the migration on those
-    deployments.
+    ``AddConstraint`` step below would abort the migration.
 
-    Strategy: keep the lowest-pk row per ``(parent_id, item_id)`` and
-    delete the rest. Use the historical ORM (``apps.get_model``) so the
-    multi-table-inheritance PK (``piece_ptr_id``, not ``id``) and the
-    parent ``Piece`` row are handled correctly across PG / SQLite.
+    Strategy:
+    1. Aggregate-pre-filter: ``GROUP BY (parent_id, item_id) HAVING
+       COUNT(*) > 1`` runs in one DB pass and returns nothing on a clean
+       deployment, so the migration is essentially free in the common
+       case.
+    2. For each duplicate group, keep the lowest-pk row and merge the
+       per-row ``note`` (stored at ``metadata["note"]`` via
+       ``jsondata.CharField``) — concatenate distinct non-empty notes
+       in pk order separated by a blank line, so the user keeps the
+       text they wrote rather than silently losing it.
+    3. Delete the surviving duplicates. ``Piece`` parent rows cascade
+       via the multi-table-inheritance FK so no orphans remain.
     """
+    from django.db.models import Count
+
     CollectionMember = apps.get_model("journal", "CollectionMember")
     db_alias = schema_editor.connection.alias
-    seen: set[tuple[int, int]] = set()
-    duplicate_pks: list[int] = []
-    qs = (
+
+    dup_keys = list(
         CollectionMember.objects.using(db_alias)
-        .order_by("parent_id", "item_id", "pk")
-        .values_list("pk", "parent_id", "item_id")
+        .values("parent_id", "item_id")
+        .annotate(_c=Count("pk"))
+        .filter(_c__gt=1)
+        .values_list("parent_id", "item_id")
     )
-    for pk, parent_id, item_id in qs.iterator():
-        key = (parent_id, item_id)
-        if key in seen:
-            duplicate_pks.append(pk)
-        else:
-            seen.add(key)
-    if duplicate_pks:
-        # Bulk-delete the duplicate child rows. ``Piece`` parent rows
-        # are cascaded via the PolymorphicModel multi-table-inheritance
-        # FK, so this leaves no orphan piece rows.
-        for chunk_start in range(0, len(duplicate_pks), 1000):
-            chunk = duplicate_pks[chunk_start : chunk_start + 1000]
-            CollectionMember.objects.using(db_alias).filter(pk__in=chunk).delete()
+    if not dup_keys:
+        return
+
+    for parent_id, item_id in dup_keys:
+        rows = list(
+            CollectionMember.objects.using(db_alias)
+            .filter(parent_id=parent_id, item_id=item_id)
+            .order_by("pk")
+        )
+        if len(rows) <= 1:
+            continue
+        keeper = rows[0]
+        # Collect distinct non-empty notes in pk order. ``metadata`` is the
+        # underlying JSON column; the historical ORM doesn't expose the
+        # ``jsondata`` descriptor, so read the JSON dict directly.
+        seen_notes: list[str] = []
+        for row in rows:
+            meta = row.metadata if isinstance(row.metadata, dict) else {}
+            n = meta.get("note")
+            if isinstance(n, str) and n and n not in seen_notes:
+                seen_notes.append(n)
+        merged = "\n\n".join(seen_notes) if seen_notes else None
+        keeper_meta = dict(keeper.metadata) if isinstance(keeper.metadata, dict) else {}
+        if merged != keeper_meta.get("note"):
+            if merged is None:
+                keeper_meta.pop("note", None)
+            else:
+                keeper_meta["note"] = merged
+            keeper.metadata = keeper_meta
+            keeper.save(update_fields=["metadata"])
+        # Bulk-delete the surviving duplicates.
+        dup_pks = [r.pk for r in rows[1:]]
+        CollectionMember.objects.using(db_alias).filter(pk__in=dup_pks).delete()
 
 
 class Migration(migrations.Migration):

--- a/journal/migrations/0010_collectionmember_unique_collection_member.py
+++ b/journal/migrations/0010_collectionmember_unique_collection_member.py
@@ -14,33 +14,32 @@ def _dedupe_collection_members(apps, schema_editor):
     deployments.
 
     Strategy: keep the lowest-pk row per ``(parent_id, item_id)`` and
-    delete the rest via raw SQL — fast and avoids loading every member
-    through the ORM, which can be heavy on large collections.
+    delete the rest. Use the historical ORM (``apps.get_model``) so the
+    multi-table-inheritance PK (``piece_ptr_id``, not ``id``) and the
+    parent ``Piece`` row are handled correctly across PG / SQLite.
     """
     CollectionMember = apps.get_model("journal", "CollectionMember")
     db_alias = schema_editor.connection.alias
-    with schema_editor.connection.cursor() as cursor:
-        cursor.execute(
-            """
-            DELETE FROM journal_collectionmember
-            WHERE id IN (
-                SELECT id FROM (
-                    SELECT
-                        id,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY parent_id, item_id
-                            ORDER BY id
-                        ) AS rn
-                    FROM journal_collectionmember
-                ) ranked
-                WHERE rn > 1
-            )
-            """
-        )
-    # Touch CollectionMember to silence "unused import" warnings in
-    # test discovery; also lets us assert the dedup ran in the unit
-    # tests via ``apps.get_model`` reflection.
-    _ = CollectionMember.objects.using(db_alias).count()
+    seen: set[tuple[int, int]] = set()
+    duplicate_pks: list[int] = []
+    qs = (
+        CollectionMember.objects.using(db_alias)
+        .order_by("parent_id", "item_id", "pk")
+        .values_list("pk", "parent_id", "item_id")
+    )
+    for pk, parent_id, item_id in qs.iterator():
+        key = (parent_id, item_id)
+        if key in seen:
+            duplicate_pks.append(pk)
+        else:
+            seen.add(key)
+    if duplicate_pks:
+        # Bulk-delete the duplicate child rows. ``Piece`` parent rows
+        # are cascaded via the PolymorphicModel multi-table-inheritance
+        # FK, so this leaves no orphan piece rows.
+        for chunk_start in range(0, len(duplicate_pks), 1000):
+            chunk = duplicate_pks[chunk_start : chunk_start + 1000]
+            CollectionMember.objects.using(db_alias).filter(pk__in=chunk).delete()
 
 
 class Migration(migrations.Migration):

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -314,13 +314,24 @@ class List(Piece):
         return "journal.jobs.list_sync.fetch_remote_list_members"
 
     @classmethod
+    def existing_for_envelope(cls, owner, obj: dict[str, Any], post):
+        """Subclass hook: locate an existing local row for an inbound
+        envelope. Default keys on the announcement post id (works for
+        Collection); subclasses with a stable natural key (Shelf's
+        ``(owner, shelf_type)``) override to also match by that key so a
+        re-announcement from the same actor doesn't try to insert a
+        duplicate row that would fail unique constraints.
+        """
+        return cls.get_by_post_id(post.id) if post else None
+
+    @classmethod
     def update_by_ap_envelope(cls, owner, obj: dict[str, Any], post) -> "List | None":
         """Inbound mirror builder. Validates the envelope, persists / updates
         the local mirror keyed by `remote_id`, and enqueues a member fetch.
 
         Returns the persisted instance or None on rejection.
         """
-        existing = cls.get_by_post_id(post.id) if post else None
+        existing = cls.existing_for_envelope(owner, obj, post)
         if existing and existing.owner.pk != post.author_id:
             logger.warning(
                 f"{cls.__name__} owner mismatch on inbound: "

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -660,6 +660,26 @@ class Shelf(List):
         return {"shelf_type": shelf_type}
 
     @classmethod
+    def existing_for_envelope(cls, owner, obj, post):
+        # Shelves have a stable natural key — ``(owner, shelf_type)`` — and
+        # are auto-initialized for every local user the first time they
+        # mark an item. A re-announcement from the same actor must reuse
+        # that row, otherwise the unique constraint trips on insert.
+        # Prefer ``remote_id`` match (cross-server post-id changes), then
+        # fall back to natural key, then to the post-id link.
+        list_id = obj.get("id") if isinstance(obj, dict) else None
+        if list_id:
+            row = cls.objects.filter(owner=owner, remote_id=list_id).first()
+            if row is not None:
+                return row
+        shelf_type = obj.get("shelfType") if isinstance(obj, dict) else None
+        if shelf_type:
+            row = cls.objects.filter(owner=owner, shelf_type=shelf_type).first()
+            if row is not None:
+                return row
+        return super().existing_for_envelope(owner, obj, post)
+
+    @classmethod
     def update_by_ap_object(cls, owner, item, obj, post, crosspost=None):
         return cls.update_by_ap_envelope(owner, obj, post)
 
@@ -721,16 +741,36 @@ class Shelf(List):
                 kept.add(it.pk)
                 m = existing_members.get(it.pk)
                 if m is None:
-                    ShelfMember.objects.create(
-                        parent=shelf,
-                        item=it,
-                        owner=shelf.owner,
-                        position=pos,
-                        local=False,
-                    )
-                elif m.position != pos:
+                    # The same remote owner may already have a ShelfMember
+                    # for this item on a *different* shelf (e.g. they moved
+                    # an item from wishlist to complete on the origin
+                    # before our resync ran). ShelfMember has a unique
+                    # constraint on (owner, item), so move the existing
+                    # row instead of inserting a duplicate.
+                    cross = ShelfMember.objects.filter(
+                        owner=shelf.owner, item=it
+                    ).first()
+                    if cross is not None:
+                        cross.parent = shelf
+                        cross.position = pos
+                        # Inherit visibility from the parent so a
+                        # followers-only shelf doesn't leak its members
+                        # publicly.
+                        cross.visibility = shelf.visibility
+                        cross.save(update_fields=["parent", "position", "visibility"])
+                    else:
+                        ShelfMember.objects.create(
+                            parent=shelf,
+                            item=it,
+                            owner=shelf.owner,
+                            position=pos,
+                            local=False,
+                            visibility=shelf.visibility,
+                        )
+                elif m.position != pos or m.visibility != shelf.visibility:
                     m.position = pos
-                    m.save(update_fields=["position"])
+                    m.visibility = shelf.visibility
+                    m.save(update_fields=["position", "visibility"])
             stale_ids = [
                 m.pk for item_id, m in existing_members.items() if item_id not in kept
             ]

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -131,12 +131,32 @@ def _resolve_signed_viewer(request):
         )
 
 
+def _is_locally_owned(instance) -> bool:
+    """True iff the list and its owner are both local. ``Piece.local`` is
+    False on mirrors but auto-initialized rows (e.g. ``ShelfManager``
+    creates a Shelf row per ``ShelfType`` for any APIdentity, including
+    remote ones, with ``local=True`` by default), so we also check that
+    the owner is a local APIdentity. A remote owner is the authoritative
+    one for their own content; we must not pretend to speak for them.
+    """
+    if not getattr(instance, "local", False):
+        return False
+    owner = getattr(instance, "owner", None)
+    return bool(owner and getattr(owner, "local", False))
+
+
 def _list_ap_object_view(request, instance):
     """Dereferenceable AP endpoint for any List subclass (Collection, Shelf).
 
     Returns the lightweight Shelf envelope; the items list lives behind
     ``first``/``last`` URLs that point at ``_list_items_view``.
     """
+    # Mirror / remote-owned lists must not be served back over AP — the
+    # origin server is authoritative; we hold a possibly-stale snapshot
+    # and have no business pretending to speak for them. Peers chasing a
+    # federated link should follow the original `id` URL on the origin.
+    if not _is_locally_owned(instance):
+        return JsonResponse({"error": "Not found"}, status=404)
     viewer, err = _resolve_signed_viewer(request)
     if err is not None:
         return err
@@ -155,6 +175,11 @@ def _list_items_view(request, instance):
     No ``page`` query param: returns the ``OrderedCollection`` envelope.
     ``?page=N``: returns one ``OrderedCollectionPage`` slice.
     """
+    # Same gate as ``_list_ap_object_view`` — never serve the items list
+    # of a mirror or a remote-owned auto-initialized shelf row; the
+    # origin owns it.
+    if not _is_locally_owned(instance):
+        return JsonResponse({"error": "Not found"}, status=404)
     viewer, err = _resolve_signed_viewer(request)
     if err is not None:
         return err

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -449,6 +449,55 @@ class TestApContentNegotiation:
 
 
 @pytest.mark.django_db(databases="__all__")
+class TestApViewRefusesRemote:
+    """AP endpoints must never serve a mirror's content — the origin
+    server is authoritative for their own users' lists. We only expose
+    AP for lists that are local AND owned by a local APIdentity.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="apremote@test.com", username="apremote_u")
+        self.identity = self.user.identity
+        self._url_patch = patch(
+            "journal.models.itemlist.is_valid_url", return_value=True
+        )
+        self._url_patch.start()
+        yield
+        self._url_patch.stop()
+
+    def test_envelope_view_returns_404_for_local_mirror(self):
+        from journal.views.collection import _list_ap_object_view
+
+        col = Collection(
+            owner=self.identity,
+            local=False,
+            remote_id="https://remote.example/collection/zzz",
+            title="Mirror",
+            visibility=0,
+        )
+        col.save(post_when_save=False, index_when_save=False)
+        rf = RequestFactory().get(col.url)
+        response = _list_ap_object_view(rf, col)
+        assert response.status_code == 404
+
+    def test_items_view_returns_404_for_local_mirror(self):
+        from journal.views.collection import _list_items_view
+
+        col = Collection(
+            owner=self.identity,
+            local=False,
+            remote_id="https://remote.example/collection/yyy",
+            title="Mirror",
+            visibility=0,
+        )
+        col.save(post_when_save=False, index_when_save=False)
+        rf = RequestFactory().get(col.url + "/items")
+        response = _list_items_view(rf, col)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
 class TestVisibilityByIdentity:
     @pytest.fixture(autouse=True)
     def setup_data(self):

--- a/tests/journal/test_shelf_federation.py
+++ b/tests/journal/test_shelf_federation.py
@@ -86,6 +86,33 @@ class TestShelfApEnvelope:
         assert entry["withRegardTo"] == self.book.absolute_url
         assert "post" not in entry
 
+    def test_remote_owner_shelf_envelope_returns_404(self):
+        # ShelfManager auto-initializes a Shelf row per shelf_type for
+        # any APIdentity (including remote mirrors); those rows have
+        # ``local=True`` from the model default but are owned by a
+        # remote APIdentity. The AP view must refuse them — only the
+        # origin server is authoritative.
+        from journal.views.collection import _list_ap_object_view
+        from takahe.models import Domain, Identity
+        from takahe.utils import Takahe
+
+        domain, _ = Domain.objects.get_or_create(
+            domain="origin.example", defaults={"local": False}
+        )
+        identity = Identity.objects.create(
+            actor_uri="https://origin.example/users/bob/",
+            local=False,
+            username="bobapview",
+            domain=domain,
+        )
+        remote_owner = Takahe.get_or_create_remote_apidentity(identity)
+        remote_shelf = remote_owner.shelf_manager.get_shelf(ShelfType.WISHLIST)
+        from django.test import RequestFactory
+
+        rf = RequestFactory().get(remote_shelf.url)
+        response = _list_ap_object_view(rf, remote_shelf)
+        assert response.status_code == 404
+
     def test_items_page_includes_post_url_when_member_has_latest_post(self):
         wishlist = self.user.identity.shelf_manager.get_shelf(ShelfType.WISHLIST)
         m = ShelfMember.objects.create(

--- a/tests/journal/test_shelf_federation.py
+++ b/tests/journal/test_shelf_federation.py
@@ -298,6 +298,47 @@ class TestShelfSyncMembersFromAp:
         # Local item resolves immediately and gets a member.
         assert [m.item_id for m in s.members.all()] == [self.book1.pk]
 
+    def test_member_visibility_inherits_from_shelf(self):
+        # Followers-only shelf: synced members must NOT default to
+        # visibility=0 (public) — that would leak the member list to
+        # anyone who can list ShelfMember rows.
+        s = self._make_mirror()
+        s.visibility = 1
+        s.save(post_when_save=False, index_when_save=False)
+        Shelf._sync_members_from_ap(
+            s, [{"type": "ShelfItem", "withRegardTo": self.book1.absolute_url}]
+        )
+        m = s.members.get(item=self.book1)
+        assert m.visibility == 1
+
+    def test_member_moves_across_shelves(self):
+        # The same remote owner can move an item between their shelves
+        # (e.g. wishlist → complete) on the origin. ShelfMember has a
+        # unique constraint on (owner, item), so the second sync must
+        # *move* the existing member rather than insert a duplicate.
+        wishlist = self._make_mirror()  # uses ShelfType.WISHLIST
+        complete = Shelf(
+            owner=self.identity,
+            shelf_type=ShelfType.COMPLETE.value,
+            local=False,
+            remote_id="https://remote.example/users/bob/shelf/complete",
+            visibility=0,
+        )
+        complete.save(post_when_save=False, index_when_save=False)
+        Shelf._sync_members_from_ap(
+            wishlist,
+            [{"type": "ShelfItem", "withRegardTo": self.book1.absolute_url}],
+        )
+        assert wishlist.members.filter(item=self.book1).exists()
+        # Re-sync the same item onto a different shelf.
+        Shelf._sync_members_from_ap(
+            complete,
+            [{"type": "ShelfItem", "withRegardTo": self.book1.absolute_url}],
+        )
+        assert complete.members.filter(item=self.book1).exists()
+        # And it left wishlist.
+        assert not wishlist.members.filter(item=self.book1).exists()
+
     def test_reorder_stays_consistent(self):
         s = self._make_mirror()
         Shelf._sync_members_from_ap(


### PR DESCRIPTION
Federates Collection journal pieces using a two-step ActivityPub flow: a lightweight Collection AP object (id, name, content, totalItems) is embedded in the announcement Note Post; the ordered member list is served only by the dereferenceable AP endpoint at /collection/<uuid> and requires a signed GET (NeoDB-canonical (request-target) host date / RSA-SHA256).

Highlights:

- Collection.ap_object slimmed for Note embedding; Collection.full_ap_object() serves orderedItems (capped at 250) from the AP endpoint.
- Inbound: takahe/ap_handlers.py registers Collection in the journal dispatch table; Collection.update_by_ap_object creates a local mirror keyed by remote_id and enqueues fetch_remote_collection_members, which signs a GET to the origin's AP endpoint and materializes members via Collection._sync_members_from_ap. Catalog item lookup pushed up to Item.get_by_ap_object so callers no longer cross apps.
- HTTP signature support: takahe/auth.py adds a deliberately minimal verifier (fixed signed-headers list, rsa-sha256 only, 300s skew, known signers only) plus a SystemActor-keyed sign_get helper for outbound fetches; @http_signature_required decorator sets request.signed_identity and is wired into a content-negotiated branch in collection_retrieve.
- is_visible_to_identity (sibling of is_visible_to) gates the AP view by the resolved remote APIdentity rather than a Django session user.
- URL paste in catalog/views/search.py recognizes remote Collection / Review / Note URLs by indexed remote_id and 302s to the local mirror only after is_visible_to_identity passes; on Collection hits a member refetch is enqueued.
- remote_id moves to the abstract List base so future Shelf federation inherits it; migration 0009_remote_id_async adds the column to Collection / Shelf / Tag and creates indexes (CONCURRENTLY) on Collection plus the existing Content subclasses (Review, Note, Comment, Rating, Debris) so URL-paste lookups are not seq scans.

Tests cover ap_object shapes, mirror creation + member fetch enqueue, member sync (initial / reorder / unknown-item retry), URL-paste with visibility gating, AP content negotiation routing + 401 on unsigned AP, is_visible_to_identity, Item.get_by_ap_object, and verify_http_signature end-to-end with a real RSA keypair (happy path + every rejection branch).

* **Please check if the PR fulfills these requirements**
- [ ] You, as a human, have fully reviewed every single line of this PR
- [ ] You, as a human, have fully tested this PR


* **What kind of change does this PR introduce?**
- [ ] bug fix, including security or performance improvements
- [ ] feature
- [ ] docs
- [ ] other


* **What is the current behavior?** (Link to an open issue if applicable)



* **What is the new behavior?**



* **Does this PR introduce a breaking change?**



* **Other information**:
