### PR TITLE
fix(catalog): expose edition_normalize_publisher_imprint migration

### DIFF
--- a/catalog/management/commands/catalog.py
+++ b/catalog/management/commands/catalog.py
@@ -200,6 +200,12 @@ class Command(SiteCommand):
                 from catalog.common.migrations import populate_credits_extra_20260415
 
                 populate_credits_extra_20260415(batch_size=batch_size)
+            case "edition_normalize_publisher_imprint":
+                from catalog.common.migrations import (
+                    edition_normalize_publisher_imprint_20260428,
+                )
+
+                edition_normalize_publisher_imprint_20260428(batch_size=batch_size)
             case _:
                 self.stdout.write(self.style.ERROR("Unknown migration."))
 


### PR DESCRIPTION
## Summary

`edition_normalize_publisher_imprint_20260428` was added to `catalog/common/migrations.py` but never wired into the `catalog migrate` dispatcher, so there was no way to invoke it from the CLI.

This adds the missing `case "edition_normalize_publisher_imprint"` branch in `catalog/management/commands/catalog.py`, mirroring the existing `populate_credits` / `populate_credits_extra` wiring.

## Usage

```sh
./manage.py catalog migrate --name edition_normalize_publisher_imprint [--batch-size 1000]
```

## Notes

- One-line dispatcher addition; no behavior change to the migration itself.
- `--batch-size` is already cast to `int` upstream and forwarded through.