### PR TITLE
perf: fix recent Sentry N+1 issues

### DIFF
--- a/catalog/models/performance.py
+++ b/catalog/models/performance.py
@@ -18,6 +18,7 @@ from .item import (
     IdType,
     Item,
     ItemCategory,
+    ItemCredit,
     ItemSchema,
     ItemType,
 )
@@ -292,6 +293,12 @@ class Performance(Item):
             self.productions.all()
             .order_by("metadata__opening_date", "title")
             .filter(is_deleted=False, merged_to_item=None)
+            .prefetch_related(
+                models.Prefetch(
+                    "credits",
+                    queryset=ItemCredit.objects.select_related("person"),
+                )
+            )
         )
 
     @property

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -184,15 +184,21 @@ def search(request):
     items, num_pages, __, by_cat, q = query_index(
         keywords, categories, p, exclude_categories=excl, per_page=per_page
     )
-    Item.prefetch_parent_items(items)
+    # Include duplicates attached as `dupe_to`: the template renders them
+    # via a nested {% include '_list_item.html' %} loop, so they need the
+    # same prefetches/attachments to avoid N+1 in templates.
+    all_items = list(items)
+    for i in items:
+        all_items.extend(getattr(i, "dupe_to", []) or [])
+    Item.prefetch_parent_items(all_items)
     prefetch_related_objects(
-        items,
+        all_items,
         Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
     )
-    Rating.attach_to_items(items)
-    Tag.attach_to_items(items)
+    Rating.attach_to_items(all_items)
+    Tag.attach_to_items(all_items)
     if request.user.is_authenticated:
-        Mark.attach_to_items(request.user.identity, items, request.user)
+        Mark.attach_to_items(request.user.identity, all_items, request.user)
     return render(
         request,
         "search_results.html",

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils import timezone
 
 from catalog.models import Item, ItemCategory
+from catalog.models.item import item_content_types
 from users.models import APIdentity
 
 from .common import Piece, VisibilityType
@@ -63,8 +64,19 @@ class List(Piece):
 
     def get_summary(self) -> dict[str, int]:
         summary = {k: 0 for k in ItemCategory.values}
-        for c in self.recent_items:
-            summary[c.category] += 1
+        ctype_to_category = {
+            ctype_id: getattr(cls, "category", None)
+            for cls, ctype_id in item_content_types().items()
+        }
+        rows = (
+            self.items.all()
+            .values("polymorphic_ctype_id")
+            .annotate(count=models.Count("id"))
+        )
+        for row in rows:
+            category = ctype_to_category.get(row["polymorphic_ctype_id"])
+            if category in summary:
+                summary[category] += row["count"]
         return summary
 
     def append_item(self, item, **params):


### PR DESCRIPTION
## Summary

Fixes three unresolved N+1 query issues from the last 7 days in Sentry:

- **NEODB-EGGPLANT-1AC** (`/performance/{uuid}`) — `Performance.all_productions` returned a queryset without prefetching `credits`, so `performance.html` iterating productions and reading `prod.role_credits.{role}` triggered one `catalog_itemcredit` query per production. Added `Prefetch("credits", ItemCredit.objects.select_related("person"))` to the queryset.
- **NEODB-SOCIAL-4CC** (`/collection/{uuid}`) — `List.get_summary` looped `recent_items` and read `c.category`, forcing django-polymorphic to resolve each subclass row. Replaced with a single aggregated query grouped by `polymorphic_ctype_id`, mapped to `ItemCategory` via the existing `item_content_types()` helper.
- **NEODB-SOCIAL-4JZ** (`/search`) — `search_results.html` recursively renders `item.dupe_to` items via a nested `{% include '_list_item.html' %}`, but `query_index` excludes those duplicates from the returned list. They therefore bypassed `prefetch_related_objects`, `Rating.attach_to_items`, `Tag.attach_to_items`, and `Mark.attach_to_items`, causing per-duplicate `journal_rating`, `journal_tag`, and `catalog_itemcredit` queries during template render. The view now collects `dupe_to` items into the set passed to those helpers.

## Out of scope
The 3 stator hashtag/post-stats N+1 issues from the same period (`EGGPLANT-2T`, `NEODB-SOCIAL-3FC`, `NEODB-SOCIAL-3KD`) live in `neodb-takahe` and are already triaged as `ignored` in Sentry; not addressed here.

## Test plan
- [x] `uv run pre-commit run -a` (ruff, djLint, ty) clean
- [x] Smoke import of edited modules under Django setup
- [ ] Manual verification of `/search`, `/performance/{uuid}`, `/collection/{uuid}` rendering on a populated dataset
- [ ] Confirm the affected Sentry issues stop reproducing on next release