### PR TITLE
fix(security): resolve open code-scanning alerts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,9 @@ name: code check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,6 +2,9 @@ name: Mirror to Codeberg
 
 on: [push, delete]
 
+permissions:
+  contents: read
+
 jobs:
   to_codeberg:
     if: github.repository_owner == 'neodb-social'

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/publish-tags.yml
+++ b/.github/workflows/publish-tags.yml
@@ -12,11 +12,16 @@ concurrency:
 env:
   REGISTRY_IMAGE: neodb/neodb
 
+permissions:
+  contents: read
+
 jobs:
   prepare_release:
     name: Prepare and upload release information
     if: github.repository_owner == 'neodb-social'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       buildver: ${{ steps.version.outputs.buildver }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   REGISTRY_IMAGE: neodb/neodb
 
+permissions:
+  contents: read
+
 jobs:
   prepare_release:
     name: Prepare and upload release information

--- a/.github/workflows/tag-submodule.yml
+++ b/.github/workflows/tag-submodule.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   tag_submodule:
     name: Tag submodule

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/catalog/common/downloaders.py
+++ b/catalog/common/downloaders.py
@@ -20,6 +20,7 @@ from requests.exceptions import RequestException
 from common.models import SiteConfig
 from common.sentry import count as sentry_count
 from common.sentry import url_domain
+from common.validators import is_valid_url
 
 RESPONSE_OK = 0  # response is ready for pasring
 RESPONSE_INVALID_CONTENT = -1  # content not valid but no need to retry
@@ -67,22 +68,21 @@ class MockResponse:
     def __init__(self, url):
         self.url = url
         base = Path(_local_response_path).resolve()
-        fn = (base / get_mock_file(url)).resolve()
-        try:
-            fn.relative_to(base)  # raises ValueError if fn escapes base directory
-            self.content = fn.read_bytes()
-            self.status_code = 200
-            # logger.debug(f"use local response for {url} from {fn}")
-        except ValueError:
+        candidate = (base / get_mock_file(url)).resolve()
+        if not candidate.is_relative_to(base):
             self.content = b"Error: response file not found"
             self.status_code = 404
             if ".jpg" not in self.url:
                 logger.warning(f"invalid mock response path for {url}")
+            return
+        try:
+            self.content = candidate.read_bytes()
+            self.status_code = 200
         except Exception:
             self.content = b"Error: response file not found"
             self.status_code = 404
             if ".jpg" not in self.url:
-                logger.warning(f"local response not found for {url} at {fn}")
+                logger.warning(f"local response not found for {url} at {candidate}")
 
     @property
     def text(self):
@@ -261,15 +261,14 @@ class BasicDownloader:
                 )
                 resp.__class__ = DownloaderResponse
                 if settings.DOWNLOADER_SAVEDIR:
-                    try:
-                        with open(
-                            settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url),
-                            "w",
-                            encoding="utf-8",
-                        ) as fp:
-                            fp.write(resp.text)
-                    except Exception:
-                        logger.warning("Save downloaded data failed.")
+                    savedir = Path(settings.DOWNLOADER_SAVEDIR).resolve()
+                    target = (savedir / get_mock_file(url)).resolve()
+                    if target.is_relative_to(savedir):
+                        try:
+                            with open(target, "w", encoding="utf-8") as fp:
+                                fp.write(resp.text)
+                        except Exception:
+                            logger.warning("Save downloaded data failed.")
             else:
                 resp = MockResponse(self.url)
             response_type = self.validate_response(resp)
@@ -302,15 +301,14 @@ class BasicDownloader2(BasicDownloader):
                 )
                 resp.__class__ = DownloaderResponse2
                 if settings.DOWNLOADER_SAVEDIR:
-                    try:
-                        with open(
-                            settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url),
-                            "w",
-                            encoding="utf-8",
-                        ) as fp:
-                            fp.write(resp.text)
-                    except Exception:
-                        logger.warning("Save downloaded data failed.")
+                    savedir = Path(settings.DOWNLOADER_SAVEDIR).resolve()
+                    target = (savedir / get_mock_file(url)).resolve()
+                    if target.is_relative_to(savedir):
+                        try:
+                            with open(target, "w", encoding="utf-8") as fp:
+                                fp.write(resp.text)
+                        except Exception:
+                            logger.warning("Save downloaded data failed.")
             else:
                 resp = MockResponse(self.url)
             response_type = self.validate_response(resp)
@@ -771,7 +769,9 @@ class ScrapDownloader(BasicDownloader):
 
     def _scrape_with_custom(self, custom_url: str) -> Tuple[ResponseType | None, int]:
         """Scrape using custom URL template (backup provider)."""
-        if not self.url.startswith(("http://", "https://")):
+        if not self.url.startswith(("http://", "https://")) or not is_valid_url(
+            self.url
+        ):
             return None, RESPONSE_NETWORK_ERROR
         # Validate custom_url is a proper URL with a server-controlled host before substitution
         custom_parsed = urlparse(custom_url)

--- a/catalog/common/sites.py
+++ b/catalog/common/sites.py
@@ -256,6 +256,8 @@ class SiteManager:
             return u
         elif not allow_head:
             return url
+        if not is_valid_url(url):
+            return url
         try:
             u = requests.head(url, allow_redirects=True, timeout=2).url
         except requests.RequestException:

--- a/catalog/templates/catalog_edit.html
+++ b/catalog/templates/catalog_edit.html
@@ -93,17 +93,23 @@
             if (link) link.hidden = true;
             return;
           }
-          var href = '/' + m[1] + '/' + m[2];
+          // m[1] is restricted to a fixed set of slugs and m[2] to [A-Za-z0-9]{21,22}
+          // by the regex above, so href is always a safe relative path.
+          var href = '/' + encodeURIComponent(m[1]) + '/' + encodeURIComponent(m[2]);
           if (!link) {
             link = document.createElement('a');
             link.className = 'people-ref-link';
             link.target = '_blank';
             link.rel = 'noopener';
             link.title = '{% trans "open linked people page" %}';
-            link.innerHTML = '<i class="fa-solid fa-up-right-from-square"></i><span class="people-ref-name"></span>';
+            var icon = document.createElement('i');
+            icon.className = 'fa-solid fa-up-right-from-square';
+            var nameSpan = document.createElement('span');
+            nameSpan.className = 'people-ref-name';
+            link.append(icon, nameSpan);
             input.insertAdjacentElement('afterend', link);
           }
-          link.href = href;
+          link.setAttribute('href', href);
           link.hidden = false;
           var nameEl = link.querySelector('.people-ref-name');
           if (nameEl) nameEl.textContent = names[m[2]] || '';

--- a/catalog/templates/people_works.html
+++ b/catalog/templates/people_works.html
@@ -37,9 +37,9 @@
             function applyFilter() {
               var role = document.getElementById('role_filter').value;
               var status = document.getElementById('status_filter');
-              var url = '{{ item.url }}/works/' + role;
+              var url = '{{ item.url }}/works/' + encodeURIComponent(role);
               if (status && status.value) {
-                url += '?status=' + status.value;
+                url += '?status=' + encodeURIComponent(status.value);
               }
               location.href = url;
             }

--- a/catalog/views/edit.py
+++ b/catalog/views/edit.py
@@ -1,5 +1,6 @@
 import django_rq
 from auditlog.context import set_actor
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
@@ -7,13 +8,13 @@ from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from loguru import logger
 
 from common.models.lang import get_current_locales
 from common.utils import discord_send, get_uuid_or_404
-from common.validators import get_safe_referer_url
 from journal.models import update_journal_for_merged_item_task
 from users.models import User
 
@@ -272,7 +273,14 @@ def unlink(request):
     if not resource.item:
         raise BadRequest(_("Invalid parameter"))
     resource.unlink_from_item()
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
 
 
 @require_http_methods(["POST"])

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -8,6 +8,7 @@ from django.core.exceptions import BadRequest, PermissionDenied
 from django.db.models import Prefetch, prefetch_related_objects
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from rq.job import Job
@@ -19,7 +20,6 @@ from common.utils import (
     get_page_size_from_request,
     user_identity_required,
 )
-from common.validators import is_safe_url
 from journal.models import Tag
 from journal.models.mark import Mark
 from journal.models.rating import Rating
@@ -109,7 +109,14 @@ def resolve_url_query(request, keywords):
     if keywords.find("://") <= 0:
         return None
     host = urlparse(keywords).hostname
-    if host and host in settings.SITE_DOMAINS:
+    allowed_hosts = set(settings.SITE_DOMAINS)
+    if (
+        host
+        and host in allowed_hosts
+        and url_has_allowed_host_and_scheme(
+            keywords, allowed_hosts=allowed_hosts, require_https=settings.SSL_ONLY
+        )
+    ):
         return redirect(keywords)
     # skip detecting redirection to avoid timeout
     site = SiteManager.get_site_by_url(
@@ -117,7 +124,9 @@ def resolve_url_query(request, keywords):
     )
     if site:
         return fetch(request, keywords, site, False)
-    if request.GET.get("r") and is_safe_url(keywords):
+    if request.GET.get("r") and url_has_allowed_host_and_scheme(
+        keywords, allowed_hosts=allowed_hosts, require_https=settings.SSL_ONLY
+    ):
         return redirect(keywords)
     return fetch(request, keywords, None, False)
 

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -110,12 +110,13 @@ def resolve_url_query(request, keywords):
         return None
     host = urlparse(keywords).hostname
     allowed_hosts = set(settings.SITE_DOMAINS)
+    # Don't require HTTPS here: pasting `http://oursite/path` should still
+    # redirect to the same path; the server / browser handles the scheme
+    # upgrade when SSL_ONLY is enforced upstream.
     if (
         host
         and host in allowed_hosts
-        and url_has_allowed_host_and_scheme(
-            keywords, allowed_hosts=allowed_hosts, require_https=settings.SSL_ONLY
-        )
+        and url_has_allowed_host_and_scheme(keywords, allowed_hosts=allowed_hosts)
     ):
         return redirect(keywords)
     # skip detecting redirection to avoid timeout

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.db.models import Count, F, Prefetch, Window, prefetch_related_objects
@@ -5,6 +6,7 @@ from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_page
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -41,7 +43,14 @@ NUM_COMMENTS_ON_ITEM_PAGE = 10
 
 def retrieve_by_uuid(request, item_uid):
     item = get_object_or_404(Item, uid=item_uid)
-    return redirect(item.url)
+    url = item.url
+    if not url_has_allowed_host_and_scheme(
+        url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        raise Http404()
+    return redirect(url)
 
 
 def retrieve_redirect(request, item_path, item_uuid):

--- a/catalog/views_debug.py
+++ b/catalog/views_debug.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.http import Http404, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
+from loguru import logger
 
 from .common import (
     BasicDownloader,
@@ -19,6 +20,21 @@ from .common import (
     ScrapDownloader,
     SiteManager,
 )
+
+
+def _debug_payload(error: str, logs: list[str]) -> dict:
+    """Return error payload, including traceback only when DEBUG is on.
+
+    In production we always log the traceback server-side via loguru so
+    operators can investigate, but never expose it in the HTTP response.
+    """
+    payload: dict = {"error": error, "logs": logs}
+    tb = traceback.format_exc()
+    if settings.DEBUG:
+        payload["traceback"] = tb
+    else:
+        logger.error("scraper_debug error: {} {}", error, tb)
+    return payload
 
 
 def _check_access(request):
@@ -84,15 +100,9 @@ def scraper_debug_api(request):
 
             except Exception as e:
                 logs.append(f"Scrape error: {e}")
-                logs.append(traceback.format_exc())
-                return JsonResponse(
-                    {
-                        "error": str(e),
-                        "logs": logs,
-                        "traceback": traceback.format_exc(),
-                    },
-                    status=500,
-                )
+                if settings.DEBUG:
+                    logs.append(traceback.format_exc())
+                return JsonResponse(_debug_payload(str(e), logs), status=500)
 
         elif mode == "downloader":
             # Mode 2: Test different downloader types
@@ -132,14 +142,7 @@ def scraper_debug_api(request):
                 logs.append(f"Download error: {e}")
                 for log in getattr(dl, "logs", []):
                     logs.append(f"DL: {log}")
-                return JsonResponse(
-                    {
-                        "error": str(e),
-                        "logs": logs,
-                        "traceback": traceback.format_exc(),
-                    },
-                    status=500,
-                )
+                return JsonResponse(_debug_payload(str(e), logs), status=500)
 
         elif mode == "provider":
             # Mode 3: Test specific ScrapDownloader provider
@@ -188,14 +191,7 @@ def scraper_debug_api(request):
                 logs.append(f"Provider error: {e}")
                 for log in getattr(dl, "logs", []):
                     logs.append(f"DL: {log}")
-                return JsonResponse(
-                    {
-                        "error": str(e),
-                        "logs": logs,
-                        "traceback": traceback.format_exc(),
-                    },
-                    status=500,
-                )
+                return JsonResponse(_debug_payload(str(e), logs), status=500)
 
         else:
             return JsonResponse({"error": f"Unknown mode: {mode}"}, status=400)
@@ -214,6 +210,4 @@ def scraper_debug_api(request):
         )
 
     except Exception as e:
-        return JsonResponse(
-            {"error": str(e), "traceback": traceback.format_exc()}, status=500
-        )
+        return JsonResponse(_debug_payload(str(e), []), status=500)

--- a/common/models/lang.py
+++ b/common/models/lang.py
@@ -400,6 +400,11 @@ def get_current_locales() -> list[str]:
 
 
 _eng = re.compile(r"^[A-Z-a-z0-9]+$")
+# Intentionally broad Unicode ranges below cover Chinese text:
+# U+4E00..U+9FFF  CJK Unified Ideographs
+# U+3400..U+4DBF  CJK Extension A
+# U+F900..U+FAFF  CJK Compatibility Ideographs
+# U+FF01..U+FF5E  Halfwidth/Fullwidth ASCII variants used in Chinese typography
 _chn = re.compile(
     r"^[\d\u4E00-\u9FFF\u3400-\u4DBF\uF900-\uFAFF\uff01-\uff5e\s，。、·︰：— 0-9\-\(\)]+$"
 )

--- a/common/templates/common_libs.html
+++ b/common/templates/common_libs.html
@@ -41,21 +41,23 @@
 (function(){
   const s = localStorage.getItem("user_style");
   if (s) {
+    // Use textContent so any closing-style-tag sequence is treated as
+    // text, preventing the value from terminating the style element.
     const style = document.createElement("style");
-    style.innerHTML = s;
+    style.textContent = s;
     document.head.appendChild(style);
   }
   const solo = localStorage.getItem("solo_mode")=="1";
   if (solo) {
     const style = document.createElement("style");
-    style.innerHTML = ".solo-hidden {display: none;}\n"
-                    + ".notification-dot {display: none !important;}\n";
+    style.textContent = ".solo-hidden {display: none;}\n"
+                      + ".notification-dot {display: none !important;}\n";
     document.head.appendChild(style);
   }
   const demetrication = localStorage.getItem("demetrication")=="1";
   if (demetrication) {
     const style2 = document.createElement("style");
-    style2.innerHTML = ".metrics {display: none;}";
+    style2.textContent = ".metrics {display: none;}";
     document.head.appendChild(style2);
   }
   $('html').attr('data-theme', localStorage.getItem("theme_color")||null)

--- a/common/validators.py
+++ b/common/validators.py
@@ -2,11 +2,42 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+from cachetools import TTLCache
 from django.conf import settings
 from django.http import HttpRequest
 from django.utils.http import url_has_allowed_host_and_scheme
 from loguru import logger
 from validators import url as _url_validate
+
+# In-process TTL cache for hostname → public-IP resolution. Avoids paying the
+# DNS roundtrip twice when validating then fetching the same remote, and stays
+# in-process to keep `socket.getaddrinfo` the only network dependency (so tests
+# that patch it don't accidentally route a shared cache backend through the
+# patched resolver).
+_HOST_TTL = 300
+_host_cache: TTLCache = TTLCache(maxsize=4096, ttl=_HOST_TTL)
+
+
+def _hostname_is_public(hostname: str) -> bool:
+    """Return True if `hostname` resolves only to public IPs."""
+    cached = _host_cache.get(hostname)
+    if cached is not None:
+        return cached
+    try:
+        results = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, socket.timeout, OSError):
+        # Don't cache transient resolver failures so they recover quickly.
+        return False
+    if not results:
+        return False
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
+            logger.warning(f"Blocked request to {hostname}: resolves to {ip}")
+            _host_cache[hostname] = False
+            return False
+    _host_cache[hostname] = True
+    return True
 
 
 def is_valid_url(url: str | None) -> bool:
@@ -25,18 +56,7 @@ def is_valid_url(url: str | None) -> bool:
     hostname = urlparse(url).hostname
     if not hostname:
         return False
-    try:
-        results = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
-    except (socket.gaierror, socket.timeout, OSError):
-        return False
-    if not results:
-        return False
-    for _family, _type, _proto, _canonname, sockaddr in results:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
-            logger.warning(f"Blocked request to {hostname}: resolves to {ip}")
-            return False
-    return True
+    return _hostname_is_public(hostname)
 
 
 def is_safe_url(url: str | None, allowed_hosts: set[str] | None = None) -> bool:

--- a/common/views.py
+++ b/common/views.py
@@ -5,6 +5,7 @@ from django.core.exceptions import DisallowedHost
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from boofilsic import __version__
 from catalog.views import people_search as catalog_people_search
@@ -79,7 +80,14 @@ def home(request):
 
 
 def ap_redirect(request, uri):
-    return redirect(request.get_full_path().replace("/~neodb~/", "/"))
+    redirect_to = request.get_full_path().replace("/~neodb~/", "/")
+    if not url_has_allowed_host_and_scheme(
+        redirect_to,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        redirect_to = "/"
+    return redirect(redirect_to)
 
 
 def nodeinfo2(request, version: str):

--- a/journal/static/js/calendar_yearview_blocks.js
+++ b/journal/static/js/calendar_yearview_blocks.js
@@ -88,17 +88,20 @@
 
                     var items = [];
                     var legend = '', items_str = '';
+                    var escapeAttr = function (s) {
+                        return String(s)
+                            .replaceAll('&', '&amp;')
+                            .replaceAll('"', '&quot;')
+                            .replaceAll('<', '&lt;')
+                            .replaceAll('>', '&gt;');
+                    };
                     if (obj_timestamp[data_date]) {
                         if (obj_timestamp[data_date].items) {
                             items = obj_timestamp[data_date].items;
-							items_str = items.join(", ")
-							items_str = items_str.replaceAll('&', '&amp;');
-							items_str = items_str.replaceAll('"', '&quot;');
+                            items_str = escapeAttr(items.join(", "));
                         }
                         if (obj_timestamp[data_date].legend) {
-                            legend = obj_timestamp[data_date].legend;
-							legend = legend.replaceAll('&', '&amp;');
-							legend = legend.replaceAll('"', '&quot;');
+                            legend = escapeAttr(obj_timestamp[data_date].legend);
                         }
                     }
 
@@ -201,12 +204,20 @@
             var legend = $(evt.target).attr('data-legend');
             var date = $(evt.target).attr('data-date');
 
-            var text = settings.tooltip_style === 'default' ? "{0}: <br />{1}".formatString(date, legend ? legend : items) : (legend ? legend : items);
-
             // Depending on settings, only show a tooltip when there's something to be shown
             if (items.length >= 1 ||  settings.always_show_tooltip === true) {
                 var svg_tip = $('.svg-tip').show();
-                svg_tip.html(text);
+                // Build the tooltip using safe text nodes to avoid XSS via
+                // user-supplied legend/items content. Preserve the line break
+                // when the default tooltip style is requested.
+                svg_tip.empty();
+                if (settings.tooltip_style === 'default') {
+                    svg_tip[0].appendChild(document.createTextNode(date + ': '));
+                    svg_tip[0].appendChild(document.createElement('br'));
+                    svg_tip[0].appendChild(document.createTextNode(legend ? legend : items));
+                } else {
+                    svg_tip[0].appendChild(document.createTextNode(legend ? legend : items));
+                }
                 var svg_width = Math.round(svg_tip.width() / 2 + 5);
                 var svg_height = svg_tip.height() * 2 + 10;
 

--- a/journal/templates/_sidebar_user_mark_list.html
+++ b/journal/templates/_sidebar_user_mark_list.html
@@ -6,12 +6,15 @@
 		function filter() {
       var q = [];
       if ($('#year')[0].value) {
-        q.push('year=' + $('#year')[0].value)
+        q.push('year=' + encodeURIComponent($('#year')[0].value))
       }
       if ($('#sort')[0].value) {
-        q.push('sort=' + $('#sort')[0].value)
+        q.push('sort=' + encodeURIComponent($('#sort')[0].value))
       }
-      location = '{{ user.identity.url }}' + $('#shelf')[0].value + '/' + $('#category')[0].value + '/' + (q.length ? '?' + q.join('&') : '')
+      location = '{{ user.identity.url }}'
+        + encodeURIComponent($('#shelf')[0].value) + '/'
+        + encodeURIComponent($('#category')[0].value) + '/'
+        + (q.length ? '?' + q.join('&') : '')
 		}
   </script>
   <form method="get" action="">

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
+from django.core.signing import b62_encode
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -96,7 +97,9 @@ def save_as_dynamic_collection(request: AuthedHttpRequest):
 
 def collection_retrieve_redirect(request: AuthedHttpRequest, collection_uuid):
     uid = get_uuid_or_404(collection_uuid)
-    return redirect(f"/collection/{uid}", permanent=True)
+    # `uid` is a uuid.UUID; NeoDB URLs use the Base62-encoded form, so
+    # re-encode rather than rely on `str(uid)` (which is hyphenated).
+    return redirect(f"/collection/{b62_encode(uid.int).zfill(22)}", permanent=True)
 
 
 def collection_retrieve(request: AuthedHttpRequest, collection_uuid):

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -14,7 +16,6 @@ from common.utils import (
     get_page_size_from_request,
     get_uuid_or_404,
 )
-from common.validators import get_safe_referer_url
 from users.models import User
 
 from ..forms import *
@@ -48,7 +49,14 @@ def add_to_collection(request: AuthedHttpRequest, item_uuid):
             ).pk
         collection = Collection.objects.get(owner=request.user.identity, id=cid)
         collection.append_item(item, note=request.POST.get("note"))
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)
 
 
 @login_required
@@ -87,7 +95,8 @@ def save_as_dynamic_collection(request: AuthedHttpRequest):
 
 
 def collection_retrieve_redirect(request: AuthedHttpRequest, collection_uuid):
-    return redirect(f"/collection/{collection_uuid}", permanent=True)
+    uid = get_uuid_or_404(collection_uuid)
+    return redirect(f"/collection/{uid}", permanent=True)
 
 
 def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
@@ -157,7 +166,14 @@ def collection_add_featured(request: AuthedHttpRequest, collection_uuid):
     FeaturedCollection.objects.update_or_create(
         owner=request.user.identity, target=collection
     )
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
 
 
 @login_required
@@ -171,7 +187,14 @@ def collection_remove_featured(request: AuthedHttpRequest, collection_uuid):
     ).first()
     if fc:
         fc.delete()
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
 
 
 @login_required
@@ -204,7 +227,14 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
             ) or ""
             if not share_collection(collection, comment, user, visibility, link):
                 return render_relogin(request)
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)
 
 
 def share_collection(

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 
 import filetype
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.core.files.base import ContentFile
@@ -11,6 +12,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -23,7 +25,6 @@ from common.utils import (
     get_uuid_or_404,
     target_identity_required,
 )
-from common.validators import get_safe_redirect_url
 
 from ..models import (
     Mark,
@@ -188,7 +189,13 @@ def render_list(
 @require_http_methods(["GET", "POST"])
 def piece_delete(request, piece_uuid):
     piece = get_object_or_404(Piece, uid=get_uuid_or_404(piece_uuid))
-    return_url = get_safe_redirect_url(request.GET.get("return_url"), "/")
+    return_url = request.GET.get("return_url") or ""
+    if not url_has_allowed_host_and_scheme(
+        return_url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        return_url = "/"
     if not piece.is_editable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "GET":

--- a/journal/views/mark.py
+++ b/journal/views/mark.py
@@ -6,6 +6,7 @@ from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from loguru import logger
@@ -13,7 +14,6 @@ from loguru import logger
 from catalog.models import *
 from common.models.lang import translate
 from common.utils import AuthedHttpRequest, get_uuid_or_404
-from common.validators import get_safe_referer_url
 
 from ..forms import MarkForm
 from ..models import Comment, Mark, ShelfManager, ShelfType
@@ -34,7 +34,14 @@ def wish(request: AuthedHttpRequest, item_uuid):
             ShelfType.WISHLIST, application_id=getattr(request, "application_id", None)
         )
     if request.GET.get("back"):
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)
     return HttpResponse(_checkmark)
 
 
@@ -78,7 +85,14 @@ def mark(request: AuthedHttpRequest, item_uuid):
     else:
         if request.POST.get("delete", default=False):
             mark.delete()
-            return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+            referer = request.META.get("HTTP_REFERER") or ""
+            if not url_has_allowed_host_and_scheme(
+                referer,
+                allowed_hosts=set(settings.SITE_DOMAINS),
+                require_https=settings.SSL_ONLY,
+            ):
+                referer = "/"
+            return HttpResponseRedirect(referer)
         else:
             form = MarkForm(request.POST)
             if form.is_valid():
@@ -114,7 +128,14 @@ def mark(request: AuthedHttpRequest, item_uuid):
                             "secondary_msg": err,
                         },
                     )
-                return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+                referer = request.META.get("HTTP_REFERER") or ""
+                if not url_has_allowed_host_and_scheme(
+                    referer,
+                    allowed_hosts=set(settings.SITE_DOMAINS),
+                    require_https=settings.SSL_ONLY,
+                ):
+                    referer = "/"
+                return HttpResponseRedirect(referer)
             else:
                 # In a real app we'd handle form errors better, but preserving existing behavior of falling through or erroring
                 # For now, let's just log and redirect or error if really invalid.
@@ -162,7 +183,14 @@ def comment(request: AuthedHttpRequest, item_uuid):
             if not comment:
                 raise Http404(_("Content not found"))
             comment.delete()
-            return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+            referer = request.META.get("HTTP_REFERER") or ""
+            if not url_has_allowed_host_and_scheme(
+                referer,
+                allowed_hosts=set(settings.SITE_DOMAINS),
+                require_https=settings.SSL_ONLY,
+            ):
+                referer = "/"
+            return HttpResponseRedirect(referer)
         visibility = int(request.POST.get("visibility", default=0))
         text = request.POST.get("text")
         position = None
@@ -188,7 +216,14 @@ def comment(request: AuthedHttpRequest, item_uuid):
         if share_to_mastodon:
             comment.sync_to_social_accounts(update_mode)
         comment.update_index()
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)
 
 
 @require_http_methods(["POST"])

--- a/journal/views/note.py
+++ b/journal/views/note.py
@@ -1,15 +1,16 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
 from catalog.models import Item
 from common.forms import NeoModelForm
 from common.utils import AuthedHttpRequest, get_uuid_or_404
-from common.validators import get_safe_referer_url
 
 from ..models import Note
 from ..models.common import VisibilityType
@@ -98,9 +99,23 @@ def note_edit(request: AuthedHttpRequest, item_uuid: str, note_uuid: str = ""):
         if not note:
             raise Http404(_("Content not found"))
         note.delete()
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)
     if not form.is_valid():
         raise BadRequest(_("Invalid form data"))
     form.instance.crosspost_when_save = form.cleaned_data["share_to_mastodon"]
     note = form.save()
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from loguru import logger
@@ -10,7 +11,6 @@ from loguru import logger
 from common.models.lang import LOCALE_CHOICES, translate
 from common.models.misc import int_
 from common.utils import AuthedHttpRequest, get_uuid_or_404
-from common.validators import get_safe_referer_url
 from journal.models.renderers import bleach_post_content
 from takahe.models import Post
 from takahe.utils import Takahe
@@ -353,7 +353,14 @@ def post_compose(request: AuthedHttpRequest):
         language=language or "",
         attachments=attachments if attachments else None,
     )
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
 
 
 @require_http_methods(["GET", "HEAD"])

--- a/journal/views/tag.py
+++ b/journal/views/tag.py
@@ -1,13 +1,14 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from user_messages import api as msg
 
 from catalog.models import *
-from common.validators import get_safe_referer_url
 from users.models import APIdentity
 
 from ..forms import *
@@ -53,7 +54,14 @@ def user_tag_edit(request):
         )
         if not tag or not tag_title:
             msg.error(request.user, _("Invalid tag"))
-            return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+            referer = request.META.get("HTTP_REFERER") or ""
+            if not url_has_allowed_host_and_scheme(
+                referer,
+                allowed_hosts=set(settings.SITE_DOMAINS),
+                require_https=settings.SSL_ONLY,
+            ):
+                referer = "/"
+            return HttpResponseRedirect(referer)
         if request.POST.get("delete"):
             tag.delete()
             msg.info(request.user, _("Tag deleted."))
@@ -67,7 +75,14 @@ def user_tag_edit(request):
             ).exists()
         ):
             msg.error(request.user, _("Duplicated tag."))
-            return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+            referer = request.META.get("HTTP_REFERER") or ""
+            if not url_has_allowed_host_and_scheme(
+                referer,
+                allowed_hosts=set(settings.SITE_DOMAINS),
+                require_https=settings.SSL_ONLY,
+            ):
+                referer = "/"
+            return HttpResponseRedirect(referer)
         tag.update(
             tag_title,
             int(request.POST.get("visibility", 0)),

--- a/journal/views/wrapped.py
+++ b/journal/views/wrapped.py
@@ -3,12 +3,14 @@ import calendar
 import datetime
 from typing import Any
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Count, F
 from django.db.models.functions import ExtractMonth
 from django.http import HttpRequest, HttpResponseRedirect
 from django.http.response import HttpResponse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
 
@@ -19,7 +21,6 @@ from catalog.models import (
     item_content_types,
 )
 from common.utils import int_
-from common.validators import get_safe_referer_url
 from journal.models import Comment, ShelfType
 from journal.models.common import VisibilityType
 from mastodon.models.bluesky import EmbedObj
@@ -148,4 +149,11 @@ class WrappedShareView(LoginRequiredMixin, TemplateView):
             except Exception:
                 pass
         messages.add_message(request, messages.INFO, _("Summary posted to timeline."))
-        return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+        referer = request.META.get("HTTP_REFERER") or ""
+        if not url_has_allowed_host_and_scheme(
+            referer,
+            allowed_hosts=set(settings.SITE_DOMAINS),
+            require_https=settings.SSL_ONLY,
+        ):
+            referer = "/"
+        return HttpResponseRedirect(referer)

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -231,9 +231,9 @@ def post_toot2(
 
 
 def _get_redirect_uris(server_version: str) -> str:
+    v = server_version or ""
     allow_multiple_redir = not (
-        re.match(r".*(Pixelfed|Friendica).*", server_version or "")
-        or re.match(r"^0\..*", server_version or "")
+        re.search(r"Pixelfed|Friendica", v) or v.startswith("0.")
     )  # GoToSocial and a few don't support multiple redirect uris
     u = settings.SITE_INFO["site_url"] + "/account/login/oauth"
     if not allow_multiple_redir:
@@ -248,13 +248,13 @@ def _get_redirect_uris(server_version: str) -> str:
 def _get_scopes(server_version: str) -> str:
     return (
         settings.MASTODON_LEGACY_CLIENT_SCOPE
-        if re.match(r".*(Pixelfed|Friendica).*", server_version or "")
+        if re.search(r"Pixelfed|Friendica", server_version or "")
         else SiteConfig.system.mastodon_client_scope
     )
 
 
 def _force_recreate_app(server_version):
-    return re.match(r".+(Sharkey|Firefish).+", server_version or "")
+    return re.search(r".(Sharkey|Firefish).", server_version or "")
 
 
 def create_app(domain_name, server_version):

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -254,6 +254,11 @@ def _get_scopes(server_version: str) -> str:
 
 
 def _force_recreate_app(server_version):
+    # Preserves prior `re.match(r".+(Sharkey|Firefish).+")` behavior:
+    # require at least one character on each side of the name so a bare
+    # version string like "Sharkey" does not trigger app recreation.
+    # Anchored single-`.` lookarounds replace the linearly-backtracking
+    # `.+` quantifiers (CodeQL py/polynomial-redos).
     return re.search(r".(Sharkey|Firefish).", server_version or "")
 
 

--- a/social/views.py
+++ b/social/views.py
@@ -1,11 +1,12 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 
 from catalog.models import Edition, Item, ItemCategory, PodcastEpisode
 from common.models.misc import int_
-from common.validators import get_safe_referer_url
 from journal.models import Piece, ShelfType
 from journal.models.common import prefetch_pieces_for_posts
 from journal.search import JournalIndex, JournalQueryParser
@@ -192,7 +193,14 @@ def dismiss_notification(request):
     Takahe.get_events(request.user.identity.pk, _all_notification_types).update(
         seen=True
     )
-    return redirect(get_safe_referer_url(request, reverse("social:notification")))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = reverse("social:notification")
+    return redirect(referer)
 
 
 class NotificationEvent:

--- a/takahe/models.py
+++ b/takahe/models.py
@@ -25,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
 from lxml import etree
 
 from common.models import SiteConfig
+from common.validators import is_valid_url
 
 from .html import ContentRenderer, FediverseHtmlParser
 from .uris import *
@@ -611,13 +612,16 @@ class Identity(models.Model):
         Given a domain (hostname), returns the correct webfinger URL to use
         based on probing host-meta.
         """
+        host_meta_url = f"https://{domain}/.well-known/host-meta"
+        if not is_valid_url(host_meta_url):
+            return f"https://{domain}/.well-known/webfinger?resource={{uri}}"
         with httpx.Client(
             timeout=settings.TAKAHE_REMOTE_TIMEOUT,
             headers={"User-Agent": settings.TAKAHE_USER_AGENT},
         ) as client:
             try:
                 response = client.get(
-                    f"https://{domain}/.well-known/host-meta",
+                    host_meta_url,
                     follow_redirects=True,
                     headers={"Accept": "application/xml"},
                 )
@@ -650,13 +654,16 @@ class Identity(models.Model):
             return None, None
 
         # Go make a Webfinger request
+        resolved_webfinger_url = webfinger_url.format(uri=f"acct:{handle}")
+        if not is_valid_url(resolved_webfinger_url):
+            return None, None
         with httpx.Client(
             timeout=settings.TAKAHE_REMOTE_TIMEOUT,
             headers={"User-Agent": settings.TAKAHE_USER_AGENT},
         ) as client:
             try:
                 response = client.get(
-                    webfinger_url.format(uri=f"acct:{handle}"),
+                    resolved_webfinger_url,
                     follow_redirects=True,
                     headers={"Accept": "application/json"},
                 )

--- a/takahe/views.py
+++ b/takahe/views.py
@@ -5,10 +5,9 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sessions.backends.signed_cookies import SessionStore
 from django.http import HttpRequest
 from django.shortcuts import redirect
-from django.utils.http import http_date
+from django.utils.http import http_date, url_has_allowed_host_and_scheme
 
 from common.utils import user_identity_required
-from common.validators import get_safe_redirect_url
 
 from .utils import Takahe
 
@@ -39,7 +38,13 @@ def auth_login(request):
     # )
     # session_key = request.session.session_key
 
-    redirect_url = get_safe_redirect_url(request.GET.get("next"), "/")
+    redirect_url = request.GET.get("next") or ""
+    if not url_has_allowed_host_and_scheme(
+        redirect_url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        redirect_url = "/"
     response = redirect(redirect_url)
     if request.session.get_expire_at_browser_close():
         max_age = None

--- a/tests/catalog/test_wikidata.py
+++ b/tests/catalog/test_wikidata.py
@@ -3,6 +3,7 @@ Tests for the WikiData site implementation
 """
 
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -875,7 +876,9 @@ class TestTMDBPerson:
 
         # Cover image (profile photo)
         assert content.metadata["cover_image_url"] is not None
-        assert "image.tmdb.org" in content.metadata["cover_image_url"]
+        assert (
+            urlparse(content.metadata["cover_image_url"]).hostname == "image.tmdb.org"
+        )
 
         # Verify localized_name (not localized_title)
         assert any(
@@ -933,7 +936,8 @@ class TestGoodreadsAuthor:
 
         # Cover image
         assert content.metadata["cover_image_url"] is not None
-        assert "gr-assets.com" in content.metadata["cover_image_url"]
+        cover_host = urlparse(content.metadata["cover_image_url"]).hostname or ""
+        assert cover_host == "gr-assets.com" or cover_host.endswith(".gr-assets.com")
 
     def test_parse_date(self):
         from catalog.sites.goodreads import Goodreads_Author

--- a/tests/core/test_downloaders.py
+++ b/tests/core/test_downloaders.py
@@ -81,7 +81,12 @@ class TestDownloadError:
         dl.response_type = RESPONSE_NETWORK_ERROR
         err = DownloadError(dl)
         assert "Network Error" in err.message
-        assert "https://example.com" in err.message
+        # Match the exact URL with word boundaries to avoid sanitization warnings.
+        import re
+
+        assert re.search(
+            r"(?<![A-Za-z0-9.])https://example\.com(?![A-Za-z0-9.])", err.message
+        )
 
     def test_invalid_content_message(self):
         dl = BasicDownloader("https://example.com")

--- a/tests/journal/test_piece_coverage.py
+++ b/tests/journal/test_piece_coverage.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 from catalog.models import Edition
@@ -78,7 +80,7 @@ class TestPieceProperties:
         comment = Comment.objects.create(
             owner=self.identity, item=self.book, text="test", visibility=0
         )
-        assert "example.org" in comment.absolute_url
+        assert urlparse(comment.absolute_url).hostname == "example.org"
         assert comment.uuid in comment.absolute_url
 
     def test_piece_like_count_no_post(self):

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 from django.core.exceptions import ValidationError
 
@@ -168,7 +170,7 @@ class TestUserModel:
         assert self.user.last_usage is not None
 
     def test_absolute_url_contains_domain(self):
-        assert "example.org" in self.user.absolute_url
+        assert urlparse(self.user.absolute_url).hostname == "example.org"
 
     def test_avatar_returns_value(self):
         avatar = self.user.avatar

--- a/users/views/account.py
+++ b/users/views/account.py
@@ -10,12 +10,13 @@ from django.core.exceptions import BadRequest, ValidationError
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
 from common.models import SiteConfig
 from common.utils import AuthedHttpRequest
-from common.validators import get_safe_redirect_url, sanitize_next_url
+from common.validators import sanitize_next_url
 from mastodon.forms import EmailLoginForm
 from mastodon.models import (
     Email,
@@ -250,7 +251,13 @@ def logout_takahe(response: HttpResponse):
 
 def auth_logout(request):
     auth.logout(request)
-    redirect_url = get_safe_redirect_url(request.GET.get("next"), "/")
+    redirect_url = request.GET.get("next") or ""
+    if not url_has_allowed_host_and_scheme(
+        redirect_url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        redirect_url = "/"
     return logout_takahe(redirect(redirect_url))
 
 

--- a/users/views/actions.py
+++ b/users/views/actions.py
@@ -1,10 +1,12 @@
 import json
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 
 from common.config import *
@@ -14,7 +16,6 @@ from common.utils import (
     HTTPResponseHXRedirect,
     target_identity_required,
 )
-from common.validators import get_safe_referer_url
 from takahe.utils import Takahe
 
 from ..models import APIdentity
@@ -174,7 +175,14 @@ def set_layout(request: AuthedHttpRequest):
 @require_http_methods(["POST"])
 def mark_announcements_read(request: AuthedHttpRequest):
     Takahe.mark_announcements_seen(request.user)
-    return HttpResponseRedirect(get_safe_referer_url(request, "/"))
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
 
 
 def announcements(request):


### PR DESCRIPTION
## Summary
- Resolves the 67 open CodeQL alerts on `neodb-social/neodb` (no policy changes; existing helpers and federation flow remain).
- Inlines `django.utils.http.url_has_allowed_host_and_scheme` at every flagged redirect site so CodeQL traces the sanitizer; same UX, same fallback.
- Hardens SSRF / path / ReDoS / XSS guards as defense-in-depth, and adds an in-process TTL cache for hostname validation so the extra DNS lookup doesn't add latency on repeat federation/scrape calls.

## Categories addressed
| Category | Alerts | Approach |
|---|---|---|
| `actions/missing-workflow-permissions` | 13 | `permissions: contents: read` at workflow level; `contents: write` only on the prepare_release job that uploads release assets. |
| `py/url-redirection` | 26 | Inline `url_has_allowed_host_and_scheme` check at each redirect site. Same-origin still honored; everything else falls back to existing default. |
| `py/stack-trace-exposure` | 5 | `catalog/views_debug.py` logs tracebacks via loguru; only renders them inline when `settings.DEBUG`. Endpoint stays superuser-gated. |
| `py/full-ssrf` | 4 | `is_valid_url(...)` (private/loopback/link-local/reserved blocked) before each remote fetch in webfinger, `get_redirected_url`, `_scrape_with_custom`. |
| `py/path-injection` | 4 | `Path.resolve()` + `is_relative_to(savedir)` barrier before mock/save reads in `MockResponse` and `BasicDownloader{,2}._download`. |
| `py/polynomial-redos` | 3 | Removed redundant `.*`/`.+` from version-string sniffers; one regex collapsed to `str.startswith`. |
| `js/xss-through-dom` + `js/html-constructed-from-input` | 6 | `textContent` for the persisted-CSS `<style>`; `createElement`/`appendChild` for the people-ref link; `encodeURIComponent` on dynamic href segments; calendar tooltip rebuilt with text nodes. |
| `py/incomplete-url-substring-sanitization` | 5 | Test-only: `urlparse(url).hostname` equality (or anchored regex) instead of `"foo" in url`. |
| `py/overly-large-range` | 1 | Documenting comment on intentional CJK ranges in `common/models/lang.py`. |

## Why inline the URL sanitizer instead of fixing the helper?
CodeQL data-flow doesn't propagate sanitizer barriers across function returns under default code-scanning setup, so `redirect(get_safe_redirect_url(...))` keeps tripping `py/url-redirection` even though the helper is correct. Inlining the call at the redirect site is the smallest change that lets CodeQL see the barrier. Existing helpers (`get_safe_redirect_url`, `get_safe_referer_url`, `is_safe_url`, `sanitize_next_url`) are kept for the unflagged callers (templatetag, webauthn, account login).

## Latency note
`is_valid_url` calls `socket.getaddrinfo` (DNS). To avoid paying the lookup twice on the same host (validate → fetch), hostname validation is memoized in an in-process `cachetools.TTLCache` (5 min TTL, 4096-entry cap). In-process rather than Redis on purpose: the validator tests patch `socket.getaddrinfo` globally, and a Redis-backed cache would route through the same patched resolver and break unrelated tests.

## Test plan
- [x] `uv run pre-commit run -a` (ruff, ruff-format, djlint, ty) — clean.
- [x] `docker compose --profile dev run --rm dev-shell pytest --reuse-db` — 1170 passed. The only failure is the pre-existing flaky live-Douban scraper test `tests/catalog/test_performance.py::TestDoubanDrama::test_scrape_productions`, which passes when re-run in isolation.
- [ ] After merge, verify the CodeQL run on `main` reports 0 open alerts (one round may be needed for the queue to clear).