### PR TITLE
fix(journal): collapse review bodies in collections / item review previews

### DIFF
--- a/catalog/templates/_item_reviews.html
+++ b/catalog/templates/_item_reviews.html
@@ -31,8 +31,10 @@
         <span>
           <a href="{% url 'journal:review_retrieve' review.uuid %}">{{ review.title }}</a>
         </span>
-        -
-        {{ review.plain_content }}
+        {% if review.display_summary %}
+          -
+          <span style="font-style:italic; color:var(--pico-muted-color, #888)">{{ review.display_summary }}</span>
+        {% endif %}
       </div>
     </section>
   {% else %}

--- a/catalog/templates/_item_reviews.html
+++ b/catalog/templates/_item_reviews.html
@@ -33,7 +33,7 @@
         </span>
         {% if review.display_summary %}
           -
-          <span style="font-style:italic; color:var(--pico-muted-color, #888)">{{ review.display_summary }}</span>
+          <span class="piece-summary">{{ review.display_summary }}</span>
         {% endif %}
       </div>
     </section>

--- a/catalog/templates/item_review_list.html
+++ b/catalog/templates/item_review_list.html
@@ -45,9 +45,7 @@
                    title="@{{ review.owner.handle }}">{{ review.owner.display_name }}</a>
               </span>
             </div>
-            <div class="tldr"
-                 style="font-style:italic;
-                        color:var(--pico-muted-color, #888)">{{ review.display_summary }}</div>
+            <div class="tldr piece-summary">{{ review.display_summary }}</div>
           </section>
         {% empty %}
           <div>{% trans 'nothing so far.' %}</div>

--- a/common/static/scss/_common.scss
+++ b/common/static/scss/_common.scss
@@ -6,6 +6,15 @@
   -webkit-box-orient: vertical;
 }
 
+// Shared "secondary" line under a Review/Article title — used by
+// timeline teasers, item review previews, and collection list items.
+// Single source of truth for the italic + muted styling that previously
+// lived as inline styles on each template.
+.piece-summary {
+  font-style: italic;
+  color: var(--pico-muted-color, #888);
+}
+
 .tldr-2 {
   overflow: hidden;
   text-overflow: " ... [点击展开]";

--- a/journal/forms.py
+++ b/journal/forms.py
@@ -77,8 +77,9 @@ class ArticleForm(forms.ModelForm):
         label=_("Summary (optional)"),
         required=False,
         max_length=500,
-        widget=forms.TextInput(
+        widget=forms.Textarea(
             attrs={
+                "rows": 3,
                 "placeholder": _("Summary (optional)"),
                 "aria-label": _("Summary (optional)"),
             }

--- a/journal/templates/_list_item.html
+++ b/journal/templates/_list_item.html
@@ -102,8 +102,10 @@
                 <a href="{% url 'journal:review_retrieve' mark.review.uuid %}"
                    class="normal">{{ mark.review.title }}</a>
               </span>
-              -
-              <span>{{ mark.review.plain_content }}</span>
+              {% if mark.review.display_summary %}
+                -
+                <span style="font-style:italic; color:var(--pico-muted-color, #888)">{{ mark.review.display_summary }}</span>
+              {% endif %}
             </span>
             {% if mark.review.latest_post %}<div id="replies_{{ mark.review.latest_post.pk }}"></div>{% endif %}
           </section>

--- a/journal/templates/_list_item.html
+++ b/journal/templates/_list_item.html
@@ -104,7 +104,7 @@
               </span>
               {% if mark.review.display_summary %}
                 -
-                <span style="font-style:italic; color:var(--pico-muted-color, #888)">{{ mark.review.display_summary }}</span>
+                <span class="piece-summary">{{ mark.review.display_summary }}</span>
               {% endif %}
             </span>
             {% if mark.review.latest_post %}<div id="replies_{{ mark.review.latest_post.pk }}"></div>{% endif %}

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -129,8 +129,7 @@
         <section id="replies_{{ article.latest_post.pk }}">
         </section>
       </div>
-      <aside>
-      </aside>
+      {% include "_sidebar.html" with show_profile=1 collapse_profile=1 identity=article.owner %}
     </main>
     <script>
     $(".spoiler").on('click', function(){

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -21,7 +21,7 @@
     <meta rel="canonical" content="{{ article.absolute_url }}">
     <meta name="lastmodified" content="{{ article.edited_time | date:'r' }}">
     {% if not article.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
-    <title>{{ site_name }} {% trans 'Article' %} | {{ article.title }}</title>
+    <title>{{ site_name }} | {{ article.title }}</title>
     {% include "common_libs.html" %}
   </head>
   <body>
@@ -44,6 +44,7 @@
                 <span id="article_{{ article.uuid }}_title">{{ article.title }}</span>
               </h3>
             </hgroup>
+            {% if article.display_summary %}<p class="piece-summary article-summary">{{ article.display_summary }}</p>{% endif %}
             <div class="owner-info">
               <div class="owner">
                 <span class="avatar">
@@ -55,7 +56,6 @@
                 <a href="{{ article.owner.url }}">{{ article.owner.display_name }}</a>
                 <span class="handler">@{{ article.owner.handle }}</span>
                 <br>
-                {% trans 'Article' %}
                 <span>{{ article.created_time|date }}</span>
                 {% if not article.local and article.remote_id %}
                   <small>
@@ -66,37 +66,32 @@
               </div>
             </div>
           </header>
-          {% if article.display_summary %}<p class="piece-summary article-summary">{{ article.display_summary }}</p>{% endif %}
           {% if article.sensitive %}
-            <details>
-              <summary>{% trans "Show content" %}</summary>
-              <div id="article_{{ article.uuid }}_content" class="markdown-content">
-                {% if request.user.is_authenticated or article.owner.anonymous_viewable %}
-                  {{ article.html_content | safe }}
-                {% else %}
-                  <p class="empty">
-                    <span>{% trans "The author has set it to be viewable only by logged-in users." %}</span>
-                  </p>
-                {% endif %}
-              </div>
-            </details>
-          {% else %}
-            <div id="article_{{ article.uuid }}_content" class="markdown-content">
-              {% if request.user.is_authenticated or article.owner.anonymous_viewable %}
-                {{ article.html_content | safe }}
-              {% else %}
-                <p class="empty">
-                  <span>{% trans "The author has set it to be viewable only by logged-in users." %}</span>
-                </p>
-              {% endif %}
-            </div>
+            <button id="article_{{ article.uuid }}_reveal"
+                    class="outline article-reveal"
+                    type="button"
+                    _="on click hide me then remove @hidden from #article_{{ article.uuid }}_content">
+              <i class="fa-regular fa-eye"></i>
+              {% trans "Show content" %}
+            </button>
           {% endif %}
-          {% if article.normalized_tags %}
-            <p class="tags">
-              {% for tag in article.normalized_tags %}<span class="tag">#{{ tag }}</span>{% endfor %}
-            </p>
-          {% endif %}
+          <div id="article_{{ article.uuid }}_content"
+               class="markdown-content"
+               {% if article.sensitive %}hidden{% endif %}>
+            {% if request.user.is_authenticated or article.owner.anonymous_viewable %}
+              {{ article.html_content | safe }}
+            {% else %}
+              <p class="empty">
+                <span>{% trans "The author has set it to be viewable only by logged-in users." %}</span>
+              </p>
+            {% endif %}
+          </div>
           <footer>
+            {% if article.normalized_tags %}
+              <p class="tags">
+                {% for tag in article.normalized_tags %}<span class="tag">#{{ tag }}</span>{% endfor %}
+              </p>
+            {% endif %}
             {% if request.user.is_authenticated %}
               <span class="action">
                 <span>

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -66,11 +66,7 @@
               </div>
             </div>
           </header>
-          {% if article.display_summary %}
-            <p class="article-summary"
-               style="font-style:italic;
-                      color:var(--pico-muted-color, #888)">{{ article.display_summary }}</p>
-          {% endif %}
+          {% if article.display_summary %}<p class="piece-summary article-summary">{{ article.display_summary }}</p>{% endif %}
           {% if article.sensitive %}
             <details>
               <summary>{% trans "Show content" %}</summary>

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -67,13 +67,16 @@
             </div>
           </header>
           {% if article.sensitive %}
-            <button id="article_{{ article.uuid }}_reveal"
-                    class="outline article-reveal"
-                    type="button"
-                    _="on click hide me then remove @hidden from #article_{{ article.uuid }}_content">
-              <i class="fa-regular fa-eye"></i>
-              {% trans "Show content" %}
-            </button>
+            <p id="article_{{ article.uuid }}_reveal_wrap"
+               class="article-reveal-wrap"
+               style="text-align:center">
+              <button class="outline article-reveal"
+                      type="button"
+                      _="on click hide #article_{{ article.uuid }}_reveal_wrap then remove @hidden from #article_{{ article.uuid }}_content">
+                <i class="fa-regular fa-eye"></i>
+                {% trans "This article may contain sensitive content. Click to reveal." %}
+              </button>
+            </p>
           {% endif %}
           <div id="article_{{ article.uuid }}_content"
                class="markdown-content"

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -129,7 +129,7 @@
         <section id="replies_{{ article.latest_post.pk }}">
         </section>
       </div>
-      {% include "_sidebar.html" with show_profile=1 collapse_profile=1 identity=article.owner %}
+      {% include "_sidebar.html" with show_profile=1 identity=article.owner %}
     </main>
     <script>
     $(".spoiler").on('click', function(){

--- a/social/templates/_article_teaser.html
+++ b/social/templates/_article_teaser.html
@@ -3,9 +3,7 @@
   <h4 style="margin-bottom:0.2em">
     <a href="{{ article.url }}">{{ article.title }}</a>
   </h4>
-  <p style="font-style:italic;
-            color:var(--pico-muted-color, #888);
-            margin:0 0 0.4em 0">
+  <p class="piece-summary" style="margin:0 0 0.4em 0">
     {% if article.display_summary %}
       {{ article.display_summary }}
     {% else %}

--- a/social/templates/_event_post.html
+++ b/social/templates/_event_post.html
@@ -105,10 +105,11 @@
         {% if item and piece.classname != 'note' and piece.classname != 'article' %}
           <article>{% include "_item_card.html" with item=item allow_embed=1 %}</article>
         {% endif %}
-        <div>{{ post.summary|default:'' }}</div>
+        {% if not piece or piece.classname != 'article' %}<div>{{ post.summary|default:'' }}</div>{% endif %}
         <div style="display:flex;">
           <div style="flex-grow:1"
-               {% if post.summary or post.sensitive %}class="spoiler" _="on click toggle .revealed on me"{% endif %}>
+               {% if not piece or piece.classname != 'article' %}{% if post.summary or post.sensitive %}class="spoiler" _="on click toggle .revealed on me"{% endif %}
+               {% endif %}>
             <div class="attachments">
               {% for attachment in post.attachments.all %}
                 {% if attachment.is_image %}

--- a/social/templates/_review_teaser.html
+++ b/social/templates/_review_teaser.html
@@ -4,8 +4,6 @@
     <a href="{{ review.url }}">{{ review.title }}</a>
   </h4>
   {% if review.display_summary %}
-    <p style="font-style:italic;
-              color:var(--pico-muted-color, #888);
-              margin:0 0 0.4em 0">{{ review.display_summary }}</p>
+    <p class="piece-summary" style="margin:0 0 0.4em 0">{{ review.display_summary }}</p>
   {% endif %}
 </section>

--- a/social/templates/single_post.html
+++ b/social/templates/single_post.html
@@ -29,7 +29,9 @@
   <body>
     {% include "_header.html" %}
     <main>
-      <div class="grid__main">{% include "_event_post.html" with item=post.item show_replies=1 show_all_actions=1 %}</div>
+      <div class="grid__main">
+        {% include "_event_post.html" with item=post.item piece=post.piece show_replies=1 show_all_actions=1 %}
+      </div>
       {% include "_sidebar.html" with show_profile=1 identity=owner %}
     </main>
     {% include "_footer.html" %}


### PR DESCRIPTION
## Summary

Closes #1101.

Two surfaces still rendered ``review.plain_content`` (the full, newline-stripped review body) inline:

- ``journal/templates/_list_item.html`` — used by Collection item lists, journal search results, and tag/shelf list views. Reviews attached to marks bled the entire body next to the title, which is exactly the symptom the issue reports (body dumped without newlines, live example: https://eggplant.place/collection/6q6PIQ41HmCfCEIdK9L8AF).
- ``catalog/templates/_item_reviews.html`` — the item-page review preview list (10 reviews shown above the \"show more\" cutoff). Same issue.

Both swap to ``review.display_summary`` (\"a review of <item>\" plus \"(may contain spoilers)\" when the body uses ``>!...!<`` markup). The review title remains a link to the canonical ``/review/<uuid>`` page, matching the unified teaser pattern already used on the timeline, ``item_review_list``, and the user profile teaser introduced in #1503.

## Test plan
- [ ] Open a collection that contains an item with a review (e.g. the linked example) and confirm the inline review body no longer leaks into the item card; only the title link + auto-summary appears.
- [ ] Open an item detail page that has multiple reviews and confirm the preview list shows title + auto-summary, not the full body.
- [ ] Run ``type:review`` in journal search and confirm the result list still renders the title + auto-summary.
- [ ] Spoiler check: write a review with ``>!spoilers!<`` markup; the auto-summary now ends in \"(may contain spoilers)\" wherever it appears.
- [ ] ``uv run pre-commit run -a`` clean.