### PR TITLE
fix(journal): journal search returns no articles for tag / free-text queries

### DIFF
--- a/journal/templates/search_journal.html
+++ b/journal/templates/search_journal.html
@@ -31,15 +31,7 @@
         {% if articles %}
           <div class="article-result-list">
             {% for article in articles %}
-              <p>
-                <span><a href="{{ article.url }}">{{ article.title }}</a></span>
-                <small>- {{ article.created_time|date }}</small>
-                {% if article.normalized_tags %}
-                  <span class="tags">
-                    {% for tag in article.normalized_tags %}<span class="tag">#{{ tag }}</span>{% endfor %}
-                  </span>
-                {% endif %}
-              </p>
+              {% include "_article_teaser.html" %}
             {% endfor %}
           </div>
         {% endif %}

--- a/journal/views/search.py
+++ b/journal/views/search.py
@@ -13,20 +13,20 @@ def search(request):
     page = int_(request.GET.get("page"), 1)
     q = JournalQueryParser(request.GET.get("q", default=""), page)
     q.filter_by_owner(request.user.identity)
-    # Articles are item-less so they would be excluded by ``item_id > 0``;
-    # only apply that gate when the caller did not explicitly target articles.
-    selected_types = [t.lower() for t in q.filter_by.get("piece_class", [])]
-    article_query = "article" in selected_types
-    if not article_query:
-        q.filter("item_id", ">0")
+    # Exclude orphan ``Post``-class docs (timeline posts with no linked
+    # journal piece) but let item-less pieces like ``Article`` through.
+    # The previous ``item_id > 0`` gate was a coarse stand-in for this and
+    # misclassified articles as orphans — tag links from /article/<uuid>
+    # silently returned no hits.
+    q.exclude("piece_class", "Post")
     if q:
         index = JournalIndex.instance()
         r = index.search(q)
         # Articles are item-less; ``r.items`` strips them. Surface them
-        # via ``r.pieces`` so item-less hits actually render.
-        articles = (
-            [p for p in r.pieces if isinstance(p, Article)] if article_query else []
-        )
+        # via ``r.pieces`` so item-less hits actually render alongside
+        # item-keyed pieces (matters for tag / free-text searches now
+        # that the gate isn't ``type:article``-only).
+        articles = [p for p in r.pieces if isinstance(p, Article)]
         return render(
             request,
             "search_journal.html",

--- a/tests/journal/test_article_search.py
+++ b/tests/journal/test_article_search.py
@@ -1,0 +1,92 @@
+"""Regression tests for the ``item_id > 0`` gate in journal search that
+silently dropped Articles for any query missing ``type:article`` — including
+the tag chips that link from ``/article/<uuid>`` to
+``/search?c=journal&q=tag:"<title>"``."""
+
+import pytest
+from django.test import Client
+
+from catalog.models import Edition
+from journal.models import Article, Mark, ShelfType
+from journal.search import JournalIndex
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestArticleJournalSearch:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.user = User.register(email="art_search@test.com", username="art_search")
+        self.identity = self.user.identity
+        self.client = Client()
+        self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+
+    def _make_article(self, *, title, body, tags=None):
+        return Article.update_local_article(
+            owner=self.identity,
+            title=title,
+            body=body,
+            tags=tags or [],
+            visibility=0,
+        )
+
+    def test_tag_search_surfaces_article(self):
+        """The tag chips on /article/<uuid> link at
+        ``/search?c=journal&q=tag:"foo"``. Before the fix, this gate
+        excluded articles via ``item_id > 0`` and returned nothing."""
+        article = self._make_article(
+            title="Findable Article",
+            body="indexable body content",
+            tags=["draftnote"],
+        )
+        resp = self.client.get('/search?c=journal&q=tag:"draftnote"')
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Findable Article" in body
+        assert article.url in body
+
+    def test_free_text_search_surfaces_article(self):
+        """Free-text journal search must also return articles, not just
+        item-keyed pieces."""
+        article = self._make_article(
+            title="Unique Article Title",
+            body="zzqxyz this body has a uniquely findable token",
+        )
+        resp = self.client.get("/search?c=journal&q=zzqxyz")
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert article.url in body
+
+    def test_type_article_filter_still_works(self):
+        """``type:article`` should keep working unchanged."""
+        a1 = self._make_article(title="Type Filtered", body="alpha beta")
+        # An item-keyed Mark should NOT appear when filtering by article.
+        book = Edition.objects.create(title="Some Book")
+        Mark(self.identity, book).update(
+            ShelfType.WISHLIST, "alpha beta gamma", None, [], 0
+        )
+        resp = self.client.get("/search?c=journal&q=type:article alpha")
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert a1.url in body
+        # The mark's catalog item shouldn't appear in the article-only view.
+        assert "Some Book" not in body
+
+    def test_search_renders_article_teaser_partial(self):
+        """Results should reuse ``_article_teaser.html`` so the rendering
+        matches the timeline (title link + display_summary + word count)."""
+        article = self._make_article(
+            title="Teaser-rendered",
+            body="word " * 50,  # 50 words for predictable word_count
+            tags=["t1"],
+        )
+        resp = self.client.get('/search?c=journal&q=tag:"t1"')
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # _article_teaser.html renders the title inside an <h4> with an
+        # <a> to the article URL — pin both so the include path can't
+        # silently regress to bespoke markup.
+        assert f'href="{article.url}"' in body
+        assert "Teaser-rendered" in body


### PR DESCRIPTION
## Summary

When a viewer clicks a tag chip on ``/article/<uuid>``, the link targets ``/search?c=journal&q=tag:\"<title>\"`` — which **always returned zero hits** for articles, even when the user is the author and articles with that tag exist in their journal.

Root cause: ``journal/views/search.py`` was applying ``q.filter(\"item_id\", \">0\")`` as a coarse stand-in for \"hide orphan ``Post``-class docs from the search index.\" That filter also excludes ``Article`` rows, which are item-less by design (introduced in #1503). The gate was relaxed only when the parsed query carried ``type:article``, so any *other* journal query (tag, free text, sort, etc.) silently dropped articles before Typesense even saw them.

Fix: switch the gate to ``q.exclude(\"piece_class\", \"Post\")`` — orphan post-fallback docs stay hidden, but every real piece class (Article included) flows through. Articles are now also always surfaced via ``r.pieces`` regardless of the type filter, so the template's existing ``articles`` slot renders them.

## Test plan

- [ ] Compose an Article with a tag (e.g. ``draft``). Visit ``/article/<uuid>`` as the author, click the tag chip — the article now appears in the journal-search result page (no longer empty).
- [ ] ``type:article`` and ``type:article tag:foo`` queries continue to return the same article set as before.
- [ ] Free-text journal search includes articles whose body / title matches, alongside item-keyed pieces (reviews, notes, etc.).
- [ ] Orphan ``Post``-class docs (timeline posts with no linked piece) remain hidden from journal search — pin via a search whose only hit would have been such a doc.
- [ ] ``uv run pre-commit run -a`` clean.