### PR TITLE
fix: tolerate non-JSON responses from IMDB and Mastodon

### DIFF
--- a/catalog/sites/imdb.py
+++ b/catalog/sites/imdb.py
@@ -109,7 +109,13 @@ class IMDB(AbstractSite):
         src = self.query_str(h, '//script[@id="__NEXT_DATA__"]/text()')
         if not src:
             raise ParseError(self, "__NEXT_DATA__ element")
-        d = json.loads(src)["props"]["pageProps"]["aboveTheFoldData"]
+        try:
+            d = json.loads(src)["props"]["pageProps"]["aboveTheFoldData"]
+        except json.JSONDecodeError as e:
+            _logger.warning(
+                f"IMDB __NEXT_DATA__ JSON decode failed for {self.url}: {e}"
+            )
+            raise ParseError(self, "__NEXT_DATA__ JSON")
         title: str = d["titleText"]["text"]
         is_series: bool = d["titleType"]["isSeries"]
         is_episode: bool = d["titleType"]["isEpisode"]
@@ -197,7 +203,13 @@ class IMDB(AbstractSite):
                 if not episode:
                     site = SiteManager.get_site_by_url(e["url"])
                     if site:
-                        res = site.get_resource_ready()
+                        try:
+                            res = site.get_resource_ready()
+                        except ParseError as exc:
+                            _logger.warning(
+                                f"skip episode {e['url']} for season {season}: {exc}"
+                            )
+                            continue
                         if res and res.item and isinstance(res.item, TVEpisode):
                             episode = res.item
                             episode.set_parent_item(season)

--- a/catalog/sites/imdb.py
+++ b/catalog/sites/imdb.py
@@ -111,10 +111,8 @@ class IMDB(AbstractSite):
             raise ParseError(self, "__NEXT_DATA__ element")
         try:
             d = json.loads(src)["props"]["pageProps"]["aboveTheFoldData"]
-        except json.JSONDecodeError as e:
-            _logger.warning(
-                f"IMDB __NEXT_DATA__ JSON decode failed for {self.url}: {e}"
-            )
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            _logger.warning(f"IMDB __NEXT_DATA__ parse failed for {self.url}: {e}")
             raise ParseError(self, "__NEXT_DATA__ JSON")
         title: str = d["titleText"]["text"]
         is_series: bool = d["titleType"]["isSeries"]

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -430,17 +430,18 @@ def obtain_token(site, code, request):
         )
     try:
         response = post(url, data=payload, headers=headers, auth=auth)
-        if response.status_code != 200:
-            logger.warning(
-                f"Error {url} {payload} {response.status_code} {response.content}"
-            )
-            return None, None
+    except Exception as e:
+        logger.warning(f"Error {url} {e}")
+        return None, None
+    if response.status_code != 200:
+        logger.warning(
+            f"Error {url} {payload} {response.status_code} {response.content}"
+        )
+        return None, None
+    try:
         data = response.json()
     except ValueError as e:
         logger.warning(f"Error {url} non-JSON response: {e} {response.content!r}")
-        return None, None
-    except Exception as e:
-        logger.warning(f"Error {url} {e}")
         return None, None
     return data.get("access_token"), data.get("refresh_token", "")
 

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -398,7 +398,11 @@ def verify_client(mast_app):
     if response.status_code != 200:
         logger.warning(f"Error {url} {response.status_code}")
         return False
-    data = response.json()
+    try:
+        data = response.json()
+    except ValueError as e:
+        logger.warning(f"Error {url} non-JSON response: {e}")
+        return False
     return data.get("access_token") is not None
 
 
@@ -431,10 +435,13 @@ def obtain_token(site, code, request):
                 f"Error {url} {payload} {response.status_code} {response.content}"
             )
             return None, None
+        data = response.json()
+    except ValueError as e:
+        logger.warning(f"Error {url} non-JSON response: {e} {response.content!r}")
+        return None, None
     except Exception as e:
         logger.warning(f"Error {url} {e}")
         return None, None
-    data = response.json()
     return data.get("access_token"), data.get("refresh_token", "")
 
 


### PR DESCRIPTION
## Summary

Two related Sentry crashes where a downstream service returned an unexpected/non-JSON payload and we raised `JSONDecodeError` straight to the user (or the rq worker).

- **NEODB-SOCIAL-4K1** `catalog/sites/imdb.py` — IMDB's `__NEXT_DATA__` script payload was occasionally returned truncated by the scraping provider, raising a raw `JSONDecodeError` out of `scrape_imdb()`. Inside `fetch_episodes_for_season_task` this killed the entire season fetch on the first bad episode. Now converted to a `ParseError` with a logged warning, and the season loop skips episodes that fail to parse so the rest of the season still gets fetched.
- **NEODB-SOCIAL-4PP** `mastodon/models/mastodon.py` — `obtain_token()` (and `verify_client()`) called `response.json()` outside the `try`, so a Mastodon server returning 200 with a non-JSON body (e.g. an HTML maintenance / error page) surfaced as a 500 on the OAuth callback. Now caught and returned as `(None, None)` / `False` with the body logged.

Fixes NEODB-SOCIAL-4K1
Fixes NEODB-SOCIAL-4PP

## Test plan

- [ ] Trigger IMDB episode fetch on a season containing an episode whose `__NEXT_DATA__` parse fails (or simulate via patched `json.loads`); confirm the rq job logs a warning and continues to the next episode.
- [ ] Simulate a Mastodon `/oauth/token` 200 response with an empty / HTML body; confirm `obtain_token` returns `(None, None)` and the user lands on the standard login-failed path instead of a 500.
- [ ] `uv run pre-commit run -a` is clean.