### PR TITLE
feat(api): expose per-category item counts on CollectionSchema

### DIFF
--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import List
+from typing import Any, List
 
 from django.core.cache import cache
 from django.core.signing import b62_encode
-from django.db.models import Count
-from django.http import Http404, HttpResponse
+from django.db.models import Count, QuerySet
+from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
 from ninja import Field, Schema, Status
@@ -23,6 +23,30 @@ from common.api import (
 from journal.models.common import q_piece_visible_to_user
 
 from ..models import Collection, FeaturedCollection, ShelfMember, ShelfType
+
+
+class CollectionPageNumberPagination(PageNumberPagination):
+    """Pagination that batch-attaches ``item_count_by_category`` after slicing.
+
+    Plain ``PageNumberPagination`` would serialize each Collection one at a
+    time, each triggering its own ``get_summary()``; this hook fetches all
+    static collections' member→category counts in a single query.
+    """
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        if isinstance(val, tuple):
+            return val
+        data = val.get("data") if isinstance(val, dict) else None
+        if data:
+            Collection.attach_item_count_by_category(list(data))
+        return val
 
 
 class CollectionSchema(Schema):
@@ -76,7 +100,7 @@ class FeaturedCollectionStatsSchema(Schema):
     response={200: List[CollectionSchema], 401: Result, 403: Result},
     tags=["collection"],
 )
-@paginate(PageNumberPagination)
+@paginate(CollectionPageNumberPagination)
 def list_user_collections(request):
     """
     Get collections created by current user
@@ -339,7 +363,7 @@ def collection_delete_item(request, collection_uuid: str, item_uuid: str):
     tags=["collection"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
-@paginate(PageNumberPagination)
+@paginate(CollectionPageNumberPagination)
 def list_item_collections(request, item_uuid: str):
     """
     List collections containing the item
@@ -396,7 +420,9 @@ def list_featured_collections(request):
     """
     List featured collections for current user.
     """
-    return Collection.objects.filter(featured_by=request.user.identity)
+    collections = list(Collection.objects.filter(featured_by=request.user.identity))
+    Collection.attach_item_count_by_category(collections)
+    return collections
 
 
 @api.get(
@@ -484,4 +510,5 @@ def trending_collection(request):
         qs = qs.exclude(owner_id__in=restricted_owner_ids)
     collections = list(qs)
     prefetch_latest_posts(collections)
+    Collection.attach_item_count_by_category(collections)
     return collections

--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -39,6 +39,7 @@ class CollectionSchema(Schema):
     html_content: str
     is_dynamic: bool
     query: str | None = None
+    item_count_by_category: dict[str, int]
 
 
 class CollectionInSchema(Schema):

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -334,12 +334,51 @@ class Collection(List):
         else:
             return super().get_summary()
 
-    @property
+    @cached_property
     def item_count_by_category(self) -> dict[str, int]:
         from catalog.models import ItemCategory
 
         summary = self.get_summary()
-        return {cat.value: int(summary.get(cat.value, 0)) for cat in ItemCategory}
+        return {cat.value: int(summary.get(cat.value) or 0) for cat in ItemCategory}
+
+    @classmethod
+    def attach_item_count_by_category(cls, collections: list["Collection"]) -> None:
+        """Pre-compute ``item_count_by_category`` for many static collections in one query.
+
+        Without this, serializing a list of Collections triggers one
+        per-collection ``get_summary()`` query (N+1). Dynamic collections
+        each issue a distinct search and are left to per-instance
+        ``cached_property`` resolution.
+        """
+        from catalog.models import ItemCategory
+        from catalog.models.item import item_content_types
+
+        if not collections:
+            return
+        static = [c for c in collections if not c.is_dynamic]
+        if not static:
+            return
+        ctype_to_category = {
+            ctype_id: getattr(cls_, "category", None)
+            for cls_, ctype_id in item_content_types().items()
+        }
+        all_cats = {cat.value for cat in ItemCategory}
+        counts_by_collection: dict[int, dict[str, int]] = {
+            c.pk: {cat.value: 0 for cat in ItemCategory} for c in static
+        }
+        rows = (
+            CollectionMember.objects.filter(parent_id__in=[c.pk for c in static])
+            .values("parent_id", "item__polymorphic_ctype_id")
+            .annotate(count=models.Count("id"))
+        )
+        for row in rows:
+            category = ctype_to_category.get(row["item__polymorphic_ctype_id"])
+            if category and category in all_cats:
+                counts_by_collection[row["parent_id"]][category] += row["count"]
+        for c in static:
+            # Seed ``cached_property`` storage so the descriptor returns
+            # the precomputed dict without re-running get_summary().
+            c.__dict__["item_count_by_category"] = counts_by_collection[c.pk]
 
     def save(self, *args, **kwargs):
         # Remote mirrors don't need a CatalogCollection — those rows would

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -334,6 +334,13 @@ class Collection(List):
         else:
             return super().get_summary()
 
+    @property
+    def item_count_by_category(self) -> dict[str, int]:
+        from catalog.models import ItemCategory
+
+        summary = self.get_summary()
+        return {cat.value: int(summary.get(cat.value, 0)) for cat in ItemCategory}
+
     def save(self, *args, **kwargs):
         # Remote mirrors don't need a CatalogCollection — those rows would
         # otherwise pollute the catalog with stub entries that have no

--- a/tests/journal/test_api.py
+++ b/tests/journal/test_api.py
@@ -443,7 +443,10 @@ def test_collection_api_crud_and_items():
     response = Client().get(f"/api/collection/{collection_uuid}")
 
     assert response.status_code == 200
-    assert response.json()["uuid"] == collection_uuid
+    detail = response.json()
+    assert detail["uuid"] == collection_uuid
+    assert detail["item_count_by_category"]["book"] == 1
+    assert detail["item_count_by_category"]["movie"] == 0
 
     response = Client().get(f"/api/collection/{collection_uuid}/item/")
 

--- a/tests/journal/test_collection.py
+++ b/tests/journal/test_collection.py
@@ -200,6 +200,33 @@ class TestCollectionListOperations:
         assert set(counts.keys()) == {c.value for c in ItemCategory}
         assert all(v == 0 for v in counts.values())
 
+    def test_attach_item_count_by_category_batches_queries(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        self.collection.append_item(self.book1)
+        self.collection.append_item(self.movie)
+        other = Collection(
+            owner=self.user.identity,
+            title="Second Collection",
+            brief="",
+        )
+        other.save()
+        other.append_item(self.book2)
+
+        # Fresh instances mirror the API list path (no cached_property yet).
+        fresh = list(Collection.objects.filter(pk__in=[self.collection.pk, other.pk]))
+        with CaptureQueriesContext(connection) as ctx:
+            Collection.attach_item_count_by_category(fresh)
+            # Reading the property must hit the cache populated above, not DB.
+            counts_by_pk = {c.pk: c.item_count_by_category for c in fresh}
+        assert len(ctx.captured_queries) == 1, ctx.captured_queries
+
+        assert counts_by_pk[self.collection.pk]["book"] == 1
+        assert counts_by_pk[self.collection.pk]["movie"] == 1
+        assert counts_by_pk[other.pk]["book"] == 1
+        assert counts_by_pk[other.pk]["movie"] == 0
+
     def test_collection_member_note(self):
         member, _ = self.collection.append_item(self.book1, note="A note about this")
         assert member.note == "A note about this"

--- a/tests/journal/test_collection.py
+++ b/tests/journal/test_collection.py
@@ -180,6 +180,26 @@ class TestCollectionListOperations:
         summary = self.collection.get_summary()
         assert all(v == 0 for v in summary.values())
 
+    def test_item_count_by_category(self):
+        from catalog.models import ItemCategory
+
+        self.collection.append_item(self.book1)
+        self.collection.append_item(self.book2)
+        self.collection.append_item(self.movie)
+
+        counts = self.collection.item_count_by_category
+        assert set(counts.keys()) == {c.value for c in ItemCategory}
+        assert counts["book"] == 2
+        assert counts["movie"] == 1
+        assert counts["tv"] == 0
+
+    def test_item_count_by_category_empty(self):
+        from catalog.models import ItemCategory
+
+        counts = self.collection.item_count_by_category
+        assert set(counts.keys()) == {c.value for c in ItemCategory}
+        assert all(v == 0 for v in counts.values())
+
     def test_collection_member_note(self):
         member, _ = self.collection.append_item(self.book1, note="A note about this")
         assert member.note == "A note about this"


### PR DESCRIPTION
## Summary
- Adds an `item_count_by_category` field to `CollectionSchema`, mapping every `ItemCategory` value to an integer count.
- Works for both static and dynamic collections; always returns the full set of category keys (zero when absent).
- Lets API clients render per-category breakdowns without paging through items.

Closes neodb-social/neodb#1307

## Test plan
- [x] `pytest tests/journal/test_collection.py tests/journal/test_api.py` (42 passed)
- [x] `uv run pre-commit run -a`
- [ ] Reviewer: sanity-check the new field shape (`dict[str, int]`) and key naming in OpenAPI docs