### PR TITLE
feat(api): rearrange items in a collection

### DIFF
--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List
 
 from django.core.cache import cache
+from django.core.signing import b62_encode
 from django.db.models import Count
 from django.http import Http404, HttpResponse
 from django.utils import timezone
@@ -55,6 +56,10 @@ class CollectionItemSchema(Schema):
 class CollectionItemInSchema(Schema):
     item_uuid: str
     note: str
+
+
+class CollectionItemReorderInSchema(Schema):
+    item_uuids: list[str]
 
 
 class FeaturedCollectionStatsSchema(Schema):
@@ -256,6 +261,49 @@ def collection_add_item(
     if not item:
         return Status(404, {"message": "Item not found"})
     c.append_item(item, note=collection_item.note)
+    return Status(200, {"message": "OK"})
+
+
+@api.post(
+    "/me/collection/{collection_uuid}/reorder_items",
+    response={200: Result, 400: Result, 401: Result, 403: Result, 404: Result},
+    tags=["collection"],
+)
+def collection_reorder_items(
+    request, collection_uuid: str, payload: CollectionItemReorderInSchema
+):
+    """
+    Reorder items in a collection.
+
+    `item_uuids` must contain the uuid of every item currently in the
+    collection, in the desired order. Partial lists are rejected because
+    they would leave the collection with conflicting positions.
+    """
+    c = Collection.get_by_url(collection_uuid)
+    if not c:
+        return Status(404, {"message": "Collection not found"})
+    if c.owner != request.user.identity:
+        return Status(403, {"message": "Not owner"})
+    if c.is_dynamic:
+        return Status(
+            403, {"message": "Item list of dynamic collection cannot be updated"}
+        )
+    item_uuids = payload.item_uuids
+    if len(item_uuids) != len(set(item_uuids)):
+        return Status(400, {"message": "Duplicate item_uuids"})
+    members_by_uuid = {
+        b62_encode(uid.int).zfill(22): pk
+        for pk, uid in c.members.values_list("pk", "item__uid")
+    }
+    if set(item_uuids) != set(members_by_uuid.keys()):
+        return Status(
+            400,
+            {
+                "message": "item_uuids must list every item in the collection exactly once"
+            },
+        )
+    ordered_member_ids = [members_by_uuid[u] for u in item_uuids]
+    c.update_member_order(ordered_member_ids)
     return Status(200, {"message": "OK"})
 
 

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import django.dispatch
 import django_rq
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from loguru import logger
@@ -124,17 +124,16 @@ class List(Piece):
             member.delete()
 
     def update_member_order(self, ordered_member_ids):
-        changed = False
+        position_by_id = {pk: i + 1 for i, pk in enumerate(ordered_member_ids)}
+        to_update = []
         for m in self.members.all():
-            try:
-                i = ordered_member_ids.index(m.pk)
-                if m.position != i + 1:
-                    m.position = i + 1
-                    m.save(update_fields=["position"])
-                    changed = True
-            except ValueError:
-                pass
-        if changed:
+            new_pos = position_by_id.get(m.pk)
+            if new_pos is not None and m.position != new_pos:
+                m.position = new_pos
+                to_update.append(m)
+        if to_update:
+            with transaction.atomic():
+                self.MEMBER_CLASS.objects.bulk_update(to_update, ["position"])
             list_add.send(sender=self.__class__, instance=self, item=None, member=None)
 
     def move_up_item(self, item):

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -126,14 +126,18 @@ class List(Piece):
     def update_member_order(self, ordered_member_ids):
         position_by_id = {pk: i + 1 for i, pk in enumerate(ordered_member_ids)}
         to_update = []
+        now = timezone.now()
         for m in self.members.all():
             new_pos = position_by_id.get(m.pk)
             if new_pos is not None and m.position != new_pos:
                 m.position = new_pos
+                m.edited_time = now
                 to_update.append(m)
         if to_update:
             with transaction.atomic():
-                self.MEMBER_CLASS.objects.bulk_update(to_update, ["position"])
+                self.MEMBER_CLASS.objects.bulk_update(
+                    to_update, ["position", "edited_time"]
+                )
             list_add.send(sender=self.__class__, instance=self, item=None, member=None)
 
     def move_up_item(self, item):

--- a/tests/journal/test_api.py
+++ b/tests/journal/test_api.py
@@ -479,6 +479,160 @@ def test_collection_api_crud_and_items():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_collection_reorder_items():
+    user = User.register(email="reorder@example.com", username="reorderer")
+    book1 = Edition.objects.create(title="Reorder Book 1")
+    book2 = Edition.objects.create(title="Reorder Book 2")
+    book3 = Edition.objects.create(title="Reorder Book 3")
+    collection = Collection.objects.create(
+        owner=user.identity,
+        title="Reorder Collection",
+        brief="",
+        visibility=0,
+    )
+    collection.append_item(book1)
+    collection.append_item(book2)
+    collection.append_item(book3)
+
+    app = Takahe.get_or_create_app(
+        "Collection Reorder API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": [book3.uuid, book1.uuid, book2.uuid]}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+
+    ordered = [m.item.uuid for m in collection.ordered_members]
+    assert ordered == [book3.uuid, book1.uuid, book2.uuid]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_collection_reorder_items_validation():
+    user = User.register(email="reorder2@example.com", username="reorderer2")
+    book1 = Edition.objects.create(title="Reorder2 Book 1")
+    book2 = Edition.objects.create(title="Reorder2 Book 2")
+    extra = Edition.objects.create(title="Reorder2 Book Extra")
+    collection = Collection.objects.create(
+        owner=user.identity,
+        title="Reorder2 Collection",
+        brief="",
+        visibility=0,
+    )
+    collection.append_item(book1)
+    collection.append_item(book2)
+
+    app = Takahe.get_or_create_app(
+        "Collection Reorder Validation Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    # Duplicate uuids in payload -> 400
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": [book1.uuid, book1.uuid]}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 400
+
+    # Partial list missing book2 -> 400
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": [book1.uuid]}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 400
+
+    # Unknown uuid in payload -> 400
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": [book1.uuid, extra.uuid]}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 400
+
+    # Order remains untouched after rejected requests
+    ordered = [m.item.uuid for m in collection.ordered_members]
+    assert ordered == [book1.uuid, book2.uuid]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_collection_reorder_items_permissions():
+    owner = User.register(email="reorder_owner@example.com", username="reorderowner")
+    intruder = User.register(
+        email="reorder_intruder@example.com", username="reorderintruder"
+    )
+    book1 = Edition.objects.create(title="Reorder3 Book 1")
+    book2 = Edition.objects.create(title="Reorder3 Book 2")
+    collection = Collection.objects.create(
+        owner=owner.identity,
+        title="Reorder3 Collection",
+        brief="",
+        visibility=0,
+    )
+    collection.append_item(book1)
+    collection.append_item(book2)
+
+    app = Takahe.get_or_create_app(
+        "Collection Reorder Permission Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=intruder.identity.pk,
+    )
+    intruder_token = Takahe.refresh_token(app, intruder.identity.pk, intruder.pk)
+    client = Client()
+
+    # Non-owner -> 403
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": [book2.uuid, book1.uuid]}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {intruder_token}",
+    )
+    assert response.status_code == 403
+
+    # Missing collection -> 404
+    response = client.post(
+        "/api/me/collection/does-not-exist/reorder_items",
+        data=json.dumps({"item_uuids": []}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {intruder_token}",
+    )
+    assert response.status_code == 404
+
+    # Dynamic collection -> 403
+    dynamic = Collection.objects.create(
+        owner=intruder.identity,
+        title="Dynamic Reorder",
+        brief="",
+        visibility=0,
+        query="tag:any",
+    )
+    response = client.post(
+        f"/api/me/collection/{dynamic.uuid}/reorder_items",
+        data=json.dumps({"item_uuids": []}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {intruder_token}",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_collection_trending_endpoint():
     cache.clear()
     owner = User.register(email="trend@example.com", username="trenduser")

--- a/tests/journal/test_collection.py
+++ b/tests/journal/test_collection.py
@@ -128,6 +128,7 @@ class TestCollectionListOperations:
         self.collection.append_item(self.book3)
 
         members = list(self.collection.ordered_members)
+        original_edited_times = {m.pk: m.edited_time for m in members}
         # Reverse the order
         new_order = [members[2].pk, members[1].pk, members[0].pk]
         self.collection.update_member_order(new_order)
@@ -136,6 +137,12 @@ class TestCollectionListOperations:
         assert reordered[0].item == self.book3
         assert reordered[1].item == self.book2
         assert reordered[2].item == self.book1
+        # bulk_update skips auto_now -- positions that moved must still bump
+        # edited_time so AP "updated" timestamps stay correct.
+        moved_pks = {members[0].pk, members[2].pk}
+        for m in reordered:
+            if m.pk in moved_pks:
+                assert m.edited_time > original_edited_times[m.pk]
 
     def test_update_member_order_partial(self):
         self.collection.append_item(self.book1)


### PR DESCRIPTION
## Summary

- Adds `POST /api/me/collection/{uuid}/reorder_items`, accepting `{"item_uuids": [...]}` — a complete list of item uuids in the desired new order. Owner-only; rejects dynamic collections and partial / duplicate / unknown-uuid lists.
- Tightens `List.update_member_order` (used by both the new endpoint and the existing web UI handler in `journal/views/collection.py`): dict-indexed position lookup (O(N) instead of O(N^2) from repeated `list.index`), a single `bulk_update` instead of one UPDATE per row, and a `transaction.atomic` wrapper so partial failures can't leave the collection in a mixed-position state.
- Avoids the obvious N+1 in the API path by reading `members.values_list("pk", "item__uid")` and computing the uuid via `b62_encode`, rather than touching `member.item` per row.

Closes #1306

## Test plan

- [x] `pytest tests/journal/test_api.py tests/journal/test_collection.py` — 43 passed, including the new `test_collection_reorder_items`, `..._validation`, `..._permissions` cases and the pre-existing `test_update_member_order` / `test_update_member_order_partial` (which confirm the optimized model method preserves its existing semantics, including lenient partial updates that the web UI relies on).
- [x] `pre-commit run` clean.