### PR TITLE
perf(catalog): avoid JOIN in Podcast.child_item_ids

### DIFF
--- a/catalog/models/podcast.py
+++ b/catalog/models/podcast.py
@@ -126,6 +126,24 @@ class Podcast(Item):
     def child_items(self):
         return self.episodes.filter(is_deleted=False, merged_to_item=None)
 
+    @property
+    def child_item_ids(self) -> list[int]:
+        # The default implementation evaluates ``child_items`` which forces a
+        # JOIN with catalog_item to filter on is_deleted / merged_to_item_id;
+        # for podcasts with many episodes this becomes a slow query
+        # (Sentry: EGGPLANT-1BH). Split into two simple index lookups so the
+        # FK scan and the PK-bounded filter happen independently.
+        raw_ids = list(self.episodes.values_list("id", flat=True))
+        if not raw_ids:
+            return []
+        return list(
+            Item.objects.filter(
+                id__in=raw_ids,
+                is_deleted=False,
+                merged_to_item__isnull=True,
+            ).values_list("id", flat=True)
+        )
+
     def is_deletable(self):
         # override is_deletable() and allow delete podcast with episodes
         return (


### PR DESCRIPTION
## Summary

- `Podcast.child_item_ids` previously evaluated `self.episodes.filter(is_deleted=False, merged_to_item=None).values_list("id")`, which compiles to an `INNER JOIN catalog_item` so the `is_deleted` / `merged_to_item_id` predicates can be applied. For podcasts with thousands of episodes this is slow enough to trip Sentry's slow-query alert (EGGPLANT-1BH), with the `/podcast/{uuid}/notes` view being the surface where it surfaces most.
- Override `Podcast.child_item_ids` to split the work: one FK-index scan over `catalog_podcastepisode` returning raw IDs, then one PK-bounded filter on `catalog_item`. Each query is a simple index lookup; neither matches the original alert's SQL pattern.
- Aggregation semantics are unchanged: only non-deleted, non-merged episode IDs are returned, so notes / comments / reviews / mark counts that aggregate from child episodes continue to behave exactly as before.

Fixes EGGPLANT-1BH

## Test plan

- [ ] Visit `/podcast/{uuid}/notes`, `/comments`, `/reviews` on a podcast with many episodes and confirm episode-attached entries still surface on the parent page
- [ ] Confirm soft-deleted / merged episodes are still excluded
- [ ] Verify `get_mark_count_for_item` continues to return the same value for a Podcast (uses the same `child_item_ids`)
- [ ] Monitor Sentry — EGGPLANT-1BH should auto-close on merge and not reopen