### PR TITLE
fix: NDJSON path traversal + file-descriptor leaks

### DIFF
--- a/catalog/models/book.py
+++ b/catalog/models/book.py
@@ -427,7 +427,7 @@ class Edition(Item):
             return True
         return False
 
-    def normalize_metadata(self, override_resources=[]):
+    def normalize_metadata(self, override_resources=None):
         r = super().normalize_metadata(override_resources)
         r |= self.merge_title()
         return r

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -937,7 +937,7 @@ class Item(PolymorphicModel):
         item.sync_credits_from_metadata()
         return item
 
-    def _update_primary_lookup_id(self, override_resources=[]) -> bool:
+    def _update_primary_lookup_id(self, override_resources=None) -> bool:
         """
         Update primary_lookup_id from external resources
         """
@@ -996,7 +996,7 @@ class Item(PolymorphicModel):
                 changed = True
         return changed
 
-    def normalize_metadata(self, override_resources=[]) -> bool:
+    def normalize_metadata(self, override_resources=None) -> bool:
         r = self._update_primary_lookup_id(override_resources)
         r |= self._normalize_languages()
         r |= self._normalize_genres()

--- a/catalog/sites/rss.py
+++ b/catalog/sites/rss.py
@@ -41,7 +41,8 @@ class RSS(AbstractSite):
         if feed:
             return feed
         if get_mock_mode():
-            feed = pickle.load(open(_local_response_path + get_mock_file(url), "rb"))
+            with open(_local_response_path + get_mock_file(url), "rb") as f:
+                feed = pickle.load(f)
         else:
             req = urllib.request.Request(url)
             req.add_header("User-Agent", settings.NEODB_USER_AGENT)
@@ -58,10 +59,10 @@ class RSS(AbstractSite):
                 except Exception:
                     return None
             if settings.DOWNLOADER_SAVEDIR:
-                pickle.dump(
-                    feed,
-                    open(settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url), "wb"),
-                )
+                with open(
+                    settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url), "wb"
+                ) as f:
+                    pickle.dump(feed, f)
         cache.set(cache_key, feed, timeout=settings.DOWNLOADER_CACHE_TIMEOUT)
         return feed
 

--- a/journal/importers/douban.py
+++ b/journal/importers/douban.py
@@ -97,20 +97,25 @@ class DoubanImporter(Task):
 
     def load_sheets(self):
         """Load data into mark_data / review_data / entity_lookup"""
-        f = open(self.metadata["file"], "rb")
-        wb = openpyxl.load_workbook(f, read_only=True, data_only=True, keep_links=False)
-        for data, config in [
-            (self.mark_data, self.mark_sheet_config),
-            (self.review_data, self.review_sheet_config),
-        ]:
-            for name in config:
-                data[name] = []
-                if name in wb:
-                    logger.info(f"{self.user} parsing {name}")
-                    for row in wb[name].iter_rows(min_row=2, values_only=True):
-                        cells = [cell for cell in row]
-                        if len(cells) > 6 and cells[0]:
-                            data[name].append(cells)
+        with open(self.metadata["file"], "rb") as f:
+            wb = openpyxl.load_workbook(
+                f, read_only=True, data_only=True, keep_links=False
+            )
+            try:
+                for data, config in [
+                    (self.mark_data, self.mark_sheet_config),
+                    (self.review_data, self.review_sheet_config),
+                ]:
+                    for name in config:
+                        data[name] = []
+                        if name in wb:
+                            logger.info(f"{self.user} parsing {name}")
+                            for row in wb[name].iter_rows(min_row=2, values_only=True):
+                                cells = [cell for cell in row]
+                                if len(cells) > 6 and cells[0]:
+                                    data[name].append(cells)
+            finally:
+                wb.close()
         for sheet in self.mark_data.values():
             for cells in sheet:
                 # entity_lookup["title|rating"] = [(url, time), ...]

--- a/journal/importers/ndjson.py
+++ b/journal/importers/ndjson.py
@@ -77,7 +77,7 @@ class NdjsonImporter(BaseImporter):
                 query=data.get("query"),
             )
             cover_src = self._resolve_temp_path(data.get("cover"))
-            if cover_src and os.path.exists(cover_src):
+            if cover_src and os.path.isfile(cover_src):
                 with open(cover_src, "rb") as f:
                     collection.cover.save(
                         os.path.basename(cover_src), File(f), save=True
@@ -289,7 +289,7 @@ class NdjsonImporter(BaseImporter):
                     file_rel = atta.get("file")
                     mimetype = atta.get("mimetype", "")
                     src = self._resolve_temp_path(file_rel)
-                    if not src or not os.path.exists(src):
+                    if not src or not os.path.isfile(src):
                         continue
                     ext = os.path.splitext(src)[1]
                     storage_name = f"journal/attachments/{uuid.uuid4()}{ext}"

--- a/journal/importers/ndjson.py
+++ b/journal/importers/ndjson.py
@@ -38,6 +38,21 @@ class NdjsonImporter(BaseImporter):
         super().__init__(*args, **kwargs)
         self.items = {}
 
+    def _resolve_temp_path(self, rel_path: str | None) -> str | None:
+        """Resolve a path relative to self.temp_dir, rejecting traversal.
+
+        Returns the absolute path if it stays within self.temp_dir, else None.
+        rel_path comes from user-supplied JSON, so must be validated before use.
+        """
+        if not rel_path or not hasattr(self, "temp_dir"):
+            return None
+        base = os.path.realpath(self.temp_dir)
+        resolved = os.path.realpath(os.path.join(base, rel_path))
+        if resolved != base and not resolved.startswith(base + os.sep):
+            logger.warning(f"Rejected path outside import temp dir: {rel_path}")
+            return None
+        return resolved
+
     def import_collection(self, data: Dict[str, Any]) -> BaseImporter.ImportResult:
         """Import a collection from NDJSON data."""
         try:
@@ -61,14 +76,12 @@ class NdjsonImporter(BaseImporter):
                 collaborative=data.get("collaborative", 0),
                 query=data.get("query"),
             )
-            cover_rel = data.get("cover")
-            if cover_rel and hasattr(self, "temp_dir"):
-                cover_src = os.path.join(self.temp_dir, cover_rel)
-                if os.path.exists(cover_src):
-                    with open(cover_src, "rb") as f:
-                        collection.cover.save(
-                            os.path.basename(cover_src), File(f), save=True
-                        )
+            cover_src = self._resolve_temp_path(data.get("cover"))
+            if cover_src and os.path.exists(cover_src):
+                with open(cover_src, "rb") as f:
+                    collection.cover.save(
+                        os.path.basename(cover_src), File(f), save=True
+                    )
             item_data = data.get("items", [])
             for item_entry in item_data:
                 item_url = item_entry.get("item")
@@ -275,10 +288,8 @@ class NdjsonImporter(BaseImporter):
                 for atta in attachments_data:
                     file_rel = atta.get("file")
                     mimetype = atta.get("mimetype", "")
-                    if not file_rel:
-                        continue
-                    src = os.path.join(self.temp_dir, file_rel)
-                    if not os.path.exists(src):
+                    src = self._resolve_temp_path(file_rel)
+                    if not src or not os.path.exists(src):
                         continue
                     ext = os.path.splitext(src)[1]
                     storage_name = f"journal/attachments/{uuid.uuid4()}{ext}"

--- a/tests/journal/test_ndjson.py
+++ b/tests/journal/test_ndjson.py
@@ -658,3 +658,19 @@ class TestNdjsonExportImport:
         assert TagMember.objects.filter(
             owner=self.user2.identity, parent__title="tag-only"
         ).exists()
+
+    def test_resolve_temp_path_rejects_traversal(self):
+        """Paths referenced by user-supplied NDJSON must stay inside temp_dir."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        with TemporaryDirectory() as tmp:
+            importer.temp_dir = tmp
+            # Sentinel file inside temp_dir resolves fine
+            inside = os.path.join(tmp, "cover.jpg")
+            with open(inside, "wb") as f:
+                f.write(b"x")
+            assert importer._resolve_temp_path("cover.jpg") == os.path.realpath(inside)
+            # Traversal attempts resolve to None
+            assert importer._resolve_temp_path("../../etc/passwd") is None
+            assert importer._resolve_temp_path("/etc/passwd") is None
+            assert importer._resolve_temp_path("") is None
+            assert importer._resolve_temp_path(None) is None

--- a/tests/journal/test_ndjson.py
+++ b/tests/journal/test_ndjson.py
@@ -724,3 +724,14 @@ class TestNdjsonExportImport:
             )
             # Traversal path is rejected: no cover stored, default still in place
             assert not coll.cover.name or coll.cover.name == settings.DEFAULT_ITEM_COVER
+
+            # A cover entry pointing at a directory inside temp_dir resolves
+            # cleanly but must not raise IsADirectoryError on open().
+            os.mkdir(os.path.join(tmp, "subdir"))
+            data["content"]["name"] = "Cover Directory Skipped"
+            data["cover"] = "subdir"
+            assert importer.import_collection(data) == "imported"
+            coll = Collection.objects.get(
+                owner=self.user2.identity, title="Cover Directory Skipped"
+            )
+            assert not coll.cover.name or coll.cover.name == settings.DEFAULT_ITEM_COVER

--- a/tests/journal/test_ndjson.py
+++ b/tests/journal/test_ndjson.py
@@ -4,6 +4,7 @@ import zipfile
 from tempfile import TemporaryDirectory
 
 import pytest
+from django.conf import settings
 from django.utils.dateparse import parse_datetime
 from loguru import logger
 
@@ -674,3 +675,52 @@ class TestNdjsonExportImport:
             assert importer._resolve_temp_path("/etc/passwd") is None
             assert importer._resolve_temp_path("") is None
             assert importer._resolve_temp_path(None) is None
+
+    def test_import_collection_cover_inside_temp_dir(self):
+        """import_collection accepts a cover that resolves inside temp_dir
+        and rejects one that escapes it."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        with TemporaryDirectory() as tmp:
+            importer.temp_dir = tmp
+            cover_path = os.path.join(tmp, "cover.jpg")
+            # Minimal valid JPEG (1x1 pixel) so cover.save accepts it
+            with open(cover_path, "wb") as f:
+                f.write(
+                    bytes.fromhex(
+                        "ffd8ffe000104a46494600010101006000600000ffdb004300080606070605"
+                        "08070707090908"
+                        + "0a"
+                        + "10"
+                        + "0b" * 5
+                        + "0c"
+                        + "13" * 4
+                        + "0e" * 6
+                        + "0f" * 8
+                        + "ffd9"
+                    )
+                )
+            data = {
+                "content": {
+                    "name": "Cover Import OK",
+                    "content": "",
+                    "published": "2024-01-01T00:00:00+00:00",
+                },
+                "visibility": 0,
+                "cover": "cover.jpg",
+                "items": [],
+            }
+            assert importer.import_collection(data) == "imported"
+            coll = Collection.objects.get(
+                owner=self.user2.identity, title="Cover Import OK"
+            )
+            # Cover populated from the on-disk file (not the model default)
+            assert coll.cover.name and coll.cover.name != settings.DEFAULT_ITEM_COVER
+
+            data["content"]["name"] = "Cover Traversal Rejected"
+            data["cover"] = "../../etc/passwd"
+            assert importer.import_collection(data) == "imported"
+            coll = Collection.objects.get(
+                owner=self.user2.identity, title="Cover Traversal Rejected"
+            )
+            # Traversal path is rejected: no cover stored, default still in place
+            assert not coll.cover.name or coll.cover.name == settings.DEFAULT_ITEM_COVER


### PR DESCRIPTION
## Summary

Targeted bug audit; two commits, all defensive:

- **NDJSON importer path traversal (security):** `cover` and attachment `file` JSON fields were joined with the per-import temp dir without checking the result stayed inside it. A crafted NDJSON export (e.g. `"cover": "../../etc/passwd"`) could cause the importer to read that path and store it as the user's own collection cover, disclosing readable files from the Django process to the importing user. Fixed by validating user-supplied paths through `realpath` and rejecting anything that escapes `temp_dir`.
- **File-descriptor leaks:** `catalog/sites/rss.py` (`pickle.load`/`pickle.dump` on bare `open()` results) and `journal/importers/douban.py` (`open()` + `openpyxl.load_workbook` with no `with`/`.close()`) leaked fds on every call; both now use context managers and `wb.close()`.
- **Mutable default args:** `Item.normalize_metadata`/`_update_primary_lookup_id` and `Edition.normalize_metadata` used `override_resources=[]`; switched to `None` (body already does `override_resources or self.external_resources.all()`, so behavior is unchanged).

## Test plan

- [x] Added `test_resolve_temp_path_rejects_traversal` covering the security fix
- [x] `pytest tests/journal/test_ndjson.py` — 7/7 pass
- [x] `pytest tests/catalog/test_book.py tests/catalog/test_podcast.py` — 38/38 pass (touches `normalize_metadata` + RSS site)
- [x] `pre-commit` clean on all touched files (ruff, ruff-format, ty)