### PR TITLE
feat(catalog): item recommendation surfaces (#26)

### DIFF
--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -447,6 +447,27 @@ def _reco_gated(user, kind: str) -> bool:
     return bool(pref and pref.show_recommendations(kind))
 
 
+def _prepare_reco_items(request, items: list) -> None:
+    """Hydrate items for ItemSchema serialization. Mirrors search_item.
+
+    Without this the schema dereferences parents, credits, external resources,
+    ratings, tags and mark state per row -- a 60-item response would issue
+    hundreds of queries.
+    """
+    if not items:
+        return
+    Item.prefetch_parent_items(items)
+    Item.prefetch_edition_works(items)
+    prefetch_related_objects(
+        items,
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
+    Rating.attach_to_items(items)
+    Tag.attach_to_items(items)
+    if request.user.is_authenticated:
+        Mark.attach_to_items(request.user.identity, items, request.user)
+
+
 @api.get(
     "/catalog/item/{uuid}/similar",
     response={200: RecommendationResult, 404: Result},
@@ -463,8 +484,7 @@ def similar_for_item(request, uuid: str, limit: int = 10):
         return Status(404, {"message": "Item not found"})
     target = item.merged_to_item or item
     items = similar_items(target, request.user, limit=min(max(limit, 1), 50))
-    if request.user.is_authenticated:
-        Mark.attach_to_items(request.user.identity, items, request.user)
+    _prepare_reco_items(request, items)
     return Status(200, {"data": items, "count": len(items)})
 
 
@@ -486,5 +506,5 @@ def me_recommendations(request, limit: int = 30):
     ):
         return Status(200, {"data": [], "count": 0})
     items = blended_for_discover(request.user, limit=min(max(limit, 1), 60))
-    Mark.attach_to_items(request.user.identity, items, request.user)
+    _prepare_reco_items(request, items)
     return Status(200, {"data": items, "count": len(items)})

--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -435,3 +435,56 @@ def get_performance(request, uuid: str, response: HttpResponse):
 )
 def get_performance_production(request, uuid: str, response: HttpResponse):
     return _get_item(PerformanceProduction, uuid, response)
+
+
+class RecommendationResult(Schema):
+    data: List[ItemSchema]
+    count: int
+
+
+def _reco_gated(user, kind: str) -> bool:
+    pref = getattr(user, "preference", None) if user and user.is_authenticated else None
+    return bool(pref and pref.show_recommendations(kind))
+
+
+@api.get(
+    "/catalog/item/{uuid}/similar",
+    response={200: RecommendationResult, 404: Result},
+    summary="Items similar to the given item",
+    tags=["recommendation"],
+)
+def similar_for_item(request, uuid: str, limit: int = 10):
+    from .recommendation import similar_items
+
+    if not _reco_gated(request.user, "similar_items"):
+        return Status(200, {"data": [], "count": 0})
+    item = Item.get_by_url(uuid)
+    if not item or item.is_deleted:
+        return Status(404, {"message": "Item not found"})
+    target = item.merged_to_item or item
+    items = similar_items(target, request.user, limit=min(max(limit, 1), 50))
+    if request.user.is_authenticated:
+        Mark.attach_to_items(request.user.identity, items, request.user)
+    return Status(200, {"data": items, "count": len(items)})
+
+
+@api.get(
+    "/me/recommendations",
+    response={200: RecommendationResult, 401: Result},
+    summary="Personalised recommendations for the current user",
+    tags=["recommendation"],
+)
+def me_recommendations(request, limit: int = 30):
+    from .recommendation import blended_for_discover
+
+    if not request.user.is_authenticated:
+        return Status(401, {"message": "Login required"})
+    pref = getattr(request.user, "preference", None)
+    if not pref or not (
+        pref.show_recommendations("for_you")
+        or pref.show_recommendations("from_circles")
+    ):
+        return Status(200, {"data": [], "count": 0})
+    items = blended_for_discover(request.user, limit=min(max(limit, 1), 60))
+    Mark.attach_to_items(request.user.identity, items, request.user)
+    return Status(200, {"data": items, "count": len(items)})

--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -42,7 +42,7 @@ from .models import (
     TVShow,
     TVShowSchema,
 )
-from .recommendation import blended_for_discover, similar_items
+from .recommendation import blended_for_discover, can_show_reco, similar_items
 from .search.utils import enqueue_fetch, get_fetch_lock, query_index
 
 PAGE_SIZE = 20
@@ -443,11 +443,6 @@ class RecommendationResult(Schema):
     count: int
 
 
-def _reco_gated(user, kind: str) -> bool:
-    pref = getattr(user, "preference", None) if user and user.is_authenticated else None
-    return bool(pref and pref.show_recommendations(kind))
-
-
 def _prepare_reco_items(request, items: list) -> None:
     """Hydrate items for ItemSchema serialization. Mirrors search_item.
 
@@ -476,7 +471,7 @@ def _prepare_reco_items(request, items: list) -> None:
     tags=["recommendation"],
 )
 def similar_for_item(request, uuid: str, limit: int = 10):
-    if not _reco_gated(request.user, "similar_items"):
+    if not can_show_reco(request.user, "similar_items"):
         return Status(200, {"data": [], "count": 0})
     item = Item.get_by_url(uuid)
     if not item or item.is_deleted:
@@ -496,10 +491,9 @@ def similar_for_item(request, uuid: str, limit: int = 10):
 def me_recommendations(request, limit: int = 30):
     if not request.user.is_authenticated:
         return Status(401, {"message": "Login required"})
-    pref = getattr(request.user, "preference", None)
-    if not pref or not (
-        pref.show_recommendations("for_you")
-        or pref.show_recommendations("from_circles")
+    if not (
+        can_show_reco(request.user, "for_you")
+        or can_show_reco(request.user, "from_circles")
     ):
         return Status(200, {"data": [], "count": 0})
     items = blended_for_discover(request.user, limit=min(max(limit, 1), 60))

--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -42,6 +42,7 @@ from .models import (
     TVShow,
     TVShowSchema,
 )
+from .recommendation import blended_for_discover, similar_items
 from .search.utils import enqueue_fetch, get_fetch_lock, query_index
 
 PAGE_SIZE = 20
@@ -475,8 +476,6 @@ def _prepare_reco_items(request, items: list) -> None:
     tags=["recommendation"],
 )
 def similar_for_item(request, uuid: str, limit: int = 10):
-    from .recommendation import similar_items
-
     if not _reco_gated(request.user, "similar_items"):
         return Status(200, {"data": [], "count": 0})
     item = Item.get_by_url(uuid)
@@ -495,8 +494,6 @@ def similar_for_item(request, uuid: str, limit: int = 10):
     tags=["recommendation"],
 )
 def me_recommendations(request, limit: int = 30):
-    from .recommendation import blended_for_discover
-
     if not request.user.is_authenticated:
         return Status(401, {"message": "Login required"})
     pref = getattr(request.user, "preference", None)

--- a/catalog/apps.py
+++ b/catalog/apps.py
@@ -12,6 +12,12 @@ class CatalogConfig(AppConfig):
         from journal import models as journal_models  # noqa
 
         # register cron jobs
-        from catalog.jobs import DiscoverGenerator, PodcastUpdater, CatalogStats  # noqa
+        from catalog.jobs import (  # noqa
+            BuildItemSimilarity,
+            BuildUserRecommendations,
+            CatalogStats,
+            DiscoverGenerator,
+            PodcastUpdater,
+        )
 
         init_catalog_audit_log()

--- a/catalog/jobs/__init__.py
+++ b/catalog/jobs/__init__.py
@@ -1,9 +1,12 @@
 from .discover import DiscoverGenerator
 from .podcast import PodcastUpdater
+from .recommendation import BuildItemSimilarity, BuildUserRecommendations
 from .stats import CatalogStats
 
 __all__ = [
     "DiscoverGenerator",
     "PodcastUpdater",
     "CatalogStats",
+    "BuildItemSimilarity",
+    "BuildUserRecommendations",
 ]

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -1,0 +1,241 @@
+import math
+from collections import defaultdict
+from datetime import timedelta
+from heapq import nlargest
+
+from django.db import transaction
+from django.db.models import Count
+from django.utils import timezone
+from loguru import logger
+
+from catalog.models import (
+    Item,
+    ItemSimilarity,
+    UserRecommendation,
+)
+from common.models import BaseJob, JobManager, SiteConfig
+from journal.models import ShelfMember
+from takahe.models import Identity as TakaheIdentity
+
+PROGRESS_COMPLETE = ["progress", "complete"]
+
+
+def _non_discoverable_identity_ids() -> set[int]:
+    """Identities that have opted out of discovery features.
+
+    Reuses the existing ``discoverable`` flag on Takahe Identity (also the
+    source of truth for ``DiscoverGenerator``). Users uncheck "Include
+    profile and posts in discovery" on their account page to opt out of
+    being used as a training signal for recommendations.
+    """
+    return set(
+        TakaheIdentity.objects.filter(discoverable=False).values_list("pk", flat=True)
+    )
+
+
+def _enabled() -> bool:
+    return bool(SiteConfig.system.enable_recommendations)
+
+
+@JobManager.register
+class BuildItemSimilarity(BaseJob):
+    """Weekly item-item shelf co-occurrence builder.
+
+    Output: top-K rows in ``ItemSimilarity`` per active source item, scored by
+    cosine-like sum of per-user weights. Users contribute ``1/sqrt(n_marks)``
+    (IDF damping) when enabled to neutralise mega-shelvers, and are truncated
+    to the most recent ``reco_user_mark_cap`` marks each.
+    """
+
+    @classmethod
+    def get_interval(cls) -> timedelta:
+        if not _enabled():
+            return timedelta(0)
+        return timedelta(days=7)
+
+    def _active_item_ids(self, min_marks: int, excluded_owners: set[int]) -> set[int]:
+        qs = ShelfMember.objects.filter(
+            visibility=0, parent__shelf_type__in=PROGRESS_COMPLETE
+        )
+        if excluded_owners:
+            qs = qs.exclude(owner_id__in=excluded_owners)
+        rows = (
+            qs.values("item_id")
+            .annotate(n=Count("id"))
+            .filter(n__gte=min_marks)
+            .values_list("item_id", flat=True)
+        )
+        return set(rows)
+
+    def _user_item_pairs(
+        self, active_items: set[int], cap: int, excluded_owners: set[int]
+    ) -> dict[int, list[int]]:
+        """Per-user lists of active item ids, each truncated to ``cap`` most recent."""
+        pairs: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        qs = ShelfMember.objects.filter(
+            visibility=0,
+            parent__shelf_type__in=PROGRESS_COMPLETE,
+            item_id__in=active_items,
+        )
+        if excluded_owners:
+            qs = qs.exclude(owner_id__in=excluded_owners)
+        rows = qs.values_list("owner_id", "item_id", "edited_time").iterator(
+            chunk_size=20_000
+        )
+        for owner_id, item_id, edited in rows:
+            ts = int(edited.timestamp()) if edited else 0
+            pairs[owner_id].append((ts, item_id))
+        out: dict[int, list[int]] = {}
+        for owner_id, lst in pairs.items():
+            if len(lst) > cap:
+                lst.sort(reverse=True)
+                lst = lst[:cap]
+            out[owner_id] = [iid for _, iid in lst]
+        return out
+
+    def run(self) -> None:
+        sys = SiteConfig.system
+        min_source = sys.reco_min_source_marks
+        min_target = sys.reco_min_target_marks
+        cap = sys.reco_user_mark_cap
+        top_k = sys.reco_similarity_top_k
+        dampen = sys.reco_user_idf_dampen
+        excluded = _non_discoverable_identity_ids()
+        logger.info(
+            f"Similarity build start: min_source={min_source} min_target={min_target} "
+            f"cap={cap} top_k={top_k} dampen={dampen} excluded_owners={len(excluded)}"
+        )
+
+        active = self._active_item_ids(min_source, excluded)
+        if not active:
+            logger.info("No active items meet threshold; aborting")
+            return
+        target_set = (
+            self._active_item_ids(min_target, excluded)
+            if min_target < min_source
+            else active
+        )
+        logger.info(f"Active items: {len(active)} target candidates: {len(target_set)}")
+
+        user_items = self._user_item_pairs(active | target_set, cap, excluded)
+        logger.info(f"Users contributing: {len(user_items)}")
+
+        scores: dict[int, dict[int, float]] = defaultdict(lambda: defaultdict(float))
+        for items in user_items.values():
+            n = len(items)
+            if n < 2:
+                continue
+            w = (1.0 / math.sqrt(n)) if dampen else 1.0
+            ws = w * w
+            for i in range(n):
+                a = items[i]
+                row = scores[a]
+                for j in range(i + 1, n):
+                    b = items[j]
+                    row[b] += ws
+                    scores[b][a] += ws
+
+        category_by_id = dict(
+            Item.objects.filter(pk__in=active).values_list("pk", "polymorphic_ctype_id")
+        )
+
+        rows_written = 0
+        item_categories_map = {}
+        for src in active:
+            row = scores.get(src)
+            if not row:
+                continue
+            src_ct = category_by_id.get(src)
+            same_cat = [
+                (b, s)
+                for b, s in row.items()
+                if b in target_set and category_by_id.get(b) == src_ct
+            ]
+            if not same_cat:
+                continue
+            top = nlargest(top_k, same_cat, key=lambda t: t[1])
+            item_categories_map[src] = top
+
+        logger.info(f"Sources with similar rows: {len(item_categories_map)}")
+        with transaction.atomic():
+            ItemSimilarity.objects.filter(
+                method=ItemSimilarity.METHOD_SHELF_COOC
+            ).delete()
+            batch: list[ItemSimilarity] = []
+            for src, top in item_categories_map.items():
+                for tgt, score in top:
+                    batch.append(
+                        ItemSimilarity(
+                            source_id=src,
+                            target_id=tgt,
+                            score=score,
+                            method=ItemSimilarity.METHOD_SHELF_COOC,
+                        )
+                    )
+                    if len(batch) >= 5000:
+                        ItemSimilarity.objects.bulk_create(batch, ignore_conflicts=True)
+                        rows_written += len(batch)
+                        batch = []
+            if batch:
+                ItemSimilarity.objects.bulk_create(batch, ignore_conflicts=True)
+                rows_written += len(batch)
+        logger.info(f"Similarity build done: {rows_written} rows")
+
+
+@JobManager.register
+class BuildUserRecommendations(BaseJob):
+    """Nightly per-user personalised recommendations.
+
+    Refreshes only users with at least one public mark in the last
+    ``reco_user_active_days`` days. Cold users get on-demand compute via
+    ``catalog.recommendation.recommendations_for`` at request time.
+    """
+
+    @classmethod
+    def get_interval(cls) -> timedelta:
+        if not _enabled():
+            return timedelta(0)
+        return timedelta(days=1)
+
+    def _active_users(self, days: int) -> list[int]:
+        since = timezone.now() - timedelta(days=days)
+        return list(
+            ShelfMember.objects.filter(visibility=0, edited_time__gte=since)
+            .values_list("owner_id", flat=True)
+            .distinct()
+        )
+
+    def _user_pk_by_identity(self, identity_ids: list[int]) -> dict[int, int]:
+        from users.models import APIdentity
+
+        return dict(
+            APIdentity.objects.filter(pk__in=identity_ids).values_list("pk", "user_id")
+        )
+
+    def run(self) -> None:
+        sys = SiteConfig.system
+        active_days = sys.reco_user_active_days
+        identities = self._active_users(active_days)
+        if not identities:
+            logger.info("No active users in window; nothing to refresh")
+            return
+        user_by_identity = self._user_pk_by_identity(identities)
+        logger.info(
+            f"Refreshing recommendations for {len(user_by_identity)} active users"
+        )
+        from catalog.recommendation import compute_for_user
+
+        with transaction.atomic():
+            UserRecommendation.objects.filter(
+                user_id__in=user_by_identity.values()
+            ).delete()
+            built = 0
+            for identity_pk, user_pk in user_by_identity.items():
+                rows = compute_for_user(user_pk, identity_pk)
+                if not rows:
+                    continue
+                UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
+                built += len(rows)
+        logger.info(
+            f"User recommendations done: {built} rows across {len(user_by_identity)} users"
+        )

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -13,9 +13,11 @@ from catalog.models import (
     ItemSimilarity,
     UserRecommendation,
 )
+from catalog.recommendation import compute_for_user
 from common.models import BaseJob, JobManager, SiteConfig
 from journal.models import ShelfMember
 from takahe.models import Identity as TakaheIdentity
+from users.models import APIdentity
 
 PROGRESS_COMPLETE = ["progress", "complete"]
 
@@ -257,8 +259,6 @@ class BuildUserRecommendations(BaseJob):
         a NOT NULL violation in ``UserRecommendation.user_id`` and abort the
         whole nightly refresh.
         """
-        from users.models import APIdentity
-
         return dict(
             APIdentity.objects.filter(
                 pk__in=identity_ids, user_id__isnull=False
@@ -276,7 +276,6 @@ class BuildUserRecommendations(BaseJob):
         logger.info(
             f"Refreshing recommendations for {len(user_by_identity)} active users"
         )
-        from catalog.recommendation import compute_for_user
 
         # Per-user atomic replace: each user's refresh is independent, so a
         # transaction-per-user keeps each commit small and bounds rollback

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -128,6 +128,11 @@ class BuildItemSimilarity(BaseJob):
             user_items = self._user_item_pairs(active | target_set, cap, excluded)
             logger.info(f"Users contributing: {len(user_items)}")
 
+            # Co-occurrence scores live in a nested dict. With cap+IDF damping
+            # the unique-pair count is bounded by the top-K output size; at
+            # ~13M output rows the peak in-memory cost is ~1-2 GB on a Python
+            # worker, tolerable for a weekly job. If catalog growth pushes
+            # this past worker memory, partition `active` and run per-chunk.
             scores: dict[int, dict[int, float]] = defaultdict(
                 lambda: defaultdict(float)
             )
@@ -169,32 +174,57 @@ class BuildItemSimilarity(BaseJob):
                 item_categories_map[src] = top
 
         logger.info(f"Sources with similar rows: {len(item_categories_map)}")
-        rows_written = 0
-        # Always replace stale rows -- threshold or data changes can leave
-        # otherwise-invalid similarity rows visible to serving helpers.
-        with transaction.atomic():
-            ItemSimilarity.objects.filter(
-                method=ItemSimilarity.METHOD_SHELF_COOC
-            ).delete()
-            batch: list[ItemSimilarity] = []
-            for src, top in item_categories_map.items():
-                for tgt, score in top:
-                    batch.append(
-                        ItemSimilarity(
-                            source_id=src,
-                            target_id=tgt,
-                            score=score,
-                            method=ItemSimilarity.METHOD_SHELF_COOC,
-                        )
-                    )
-                    if len(batch) >= 5000:
-                        ItemSimilarity.objects.bulk_create(batch, ignore_conflicts=True)
-                        rows_written += len(batch)
-                        batch = []
-            if batch:
-                ItemSimilarity.objects.bulk_create(batch, ignore_conflicts=True)
-                rows_written += len(batch)
+        rows_written = self._write_similarity_rows(item_categories_map)
         logger.info(f"Similarity build done: {rows_written} rows")
+
+    def _write_similarity_rows(
+        self, item_categories_map: dict[int, list[tuple[int, float]]]
+    ) -> int:
+        """Replace shelf-cooc rows per source in short atomic batches.
+
+        Per-source transactions keep each commit small (<= top_k rows), avoid
+        holding a long-lived DB transaction across the whole rebuild, and
+        present a consistent per-source view to concurrent readers during the
+        run. Sources no longer covered are cleaned up afterwards in chunks.
+        """
+        rows_written = 0
+        covered: set[int] = set()
+        for src, top in item_categories_map.items():
+            covered.add(src)
+            new_rows = [
+                ItemSimilarity(
+                    source_id=src,
+                    target_id=tgt,
+                    score=score,
+                    method=ItemSimilarity.METHOD_SHELF_COOC,
+                )
+                for tgt, score in top
+            ]
+            with transaction.atomic():
+                ItemSimilarity.objects.filter(
+                    source_id=src, method=ItemSimilarity.METHOD_SHELF_COOC
+                ).delete()
+                if new_rows:
+                    ItemSimilarity.objects.bulk_create(new_rows, ignore_conflicts=True)
+            rows_written += len(new_rows)
+        # Drop orphan rows for sources that no longer meet thresholds. Chunk to
+        # avoid a single very large DELETE on a populated table.
+        stale_ids = list(
+            ItemSimilarity.objects.filter(method=ItemSimilarity.METHOD_SHELF_COOC)
+            .exclude(source_id__in=covered)
+            .values_list("source_id", flat=True)
+            .distinct()
+        )
+        if stale_ids:
+            logger.info(f"Pruning {len(stale_ids)} stale similarity sources")
+            for i in range(0, len(stale_ids), 1000):
+                chunk = stale_ids[i : i + 1000]
+                with transaction.atomic():
+                    ItemSimilarity.objects.filter(
+                        method=ItemSimilarity.METHOD_SHELF_COOC,
+                        source_id__in=chunk,
+                    ).delete()
+        return rows_written
 
 
 @JobManager.register
@@ -248,17 +278,21 @@ class BuildUserRecommendations(BaseJob):
         )
         from catalog.recommendation import compute_for_user
 
-        with transaction.atomic():
-            UserRecommendation.objects.filter(
-                user_id__in=user_by_identity.values()
-            ).delete()
-            built = 0
-            for identity_pk, user_pk in user_by_identity.items():
+        # Per-user atomic replace: each user's refresh is independent, so a
+        # transaction-per-user keeps each commit small and bounds rollback
+        # blast radius if any single user's compute fails.
+        built = 0
+        for identity_pk, user_pk in user_by_identity.items():
+            try:
                 rows = compute_for_user(user_pk, identity_pk)
-                if not rows:
-                    continue
-                UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
-                built += len(rows)
+            except Exception as e:
+                logger.exception(f"compute_for_user failed for user {user_pk}: {e}")
+                continue
+            with transaction.atomic():
+                UserRecommendation.objects.filter(user_id=user_pk).delete()
+                if rows:
+                    UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
+            built += len(rows)
         logger.info(
             f"User recommendations done: {built} rows across {len(user_by_identity)} users"
         )

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -70,8 +70,13 @@ class BuildItemSimilarity(BaseJob):
     def _user_item_pairs(
         self, active_items: set[int], cap: int, excluded_owners: set[int]
     ) -> dict[int, list[int]]:
-        """Per-user lists of active item ids, each truncated to ``cap`` most recent."""
-        pairs: dict[int, list[tuple[int, int]]] = defaultdict(list)
+        """Per-user lists of active item ids, each truncated to ``cap`` most recent.
+
+        Streams ordered by (owner_id, -edited_time) so we can drop overflow per
+        owner in-line without accumulating every mark in memory first. Critical
+        at scale: a mega-shelver with 22k marks would otherwise allocate before
+        being truncated.
+        """
         qs = ShelfMember.objects.filter(
             visibility=0,
             parent__shelf_type__in=PROGRESS_COMPLETE,
@@ -79,18 +84,22 @@ class BuildItemSimilarity(BaseJob):
         )
         if excluded_owners:
             qs = qs.exclude(owner_id__in=excluded_owners)
-        rows = qs.values_list("owner_id", "item_id", "edited_time").iterator(
-            chunk_size=20_000
-        )
-        for owner_id, item_id, edited in rows:
-            ts = int(edited.timestamp()) if edited else 0
-            pairs[owner_id].append((ts, item_id))
+        qs = qs.order_by("owner_id", "-edited_time")
+        rows = qs.values_list("owner_id", "item_id").iterator(chunk_size=20_000)
+
         out: dict[int, list[int]] = {}
-        for owner_id, lst in pairs.items():
-            if len(lst) > cap:
-                lst.sort(reverse=True)
-                lst = lst[:cap]
-            out[owner_id] = [iid for _, iid in lst]
+        current_owner: int | None = None
+        current_items: list[int] = []
+        for owner_id, item_id in rows:
+            if owner_id != current_owner:
+                if current_owner is not None and len(current_items) >= 2:
+                    out[current_owner] = current_items
+                current_owner = owner_id
+                current_items = []
+            if len(current_items) < cap:
+                current_items.append(item_id)
+        if current_owner is not None and len(current_items) >= 2:
+            out[current_owner] = current_items
         return out
 
     def run(self) -> None:
@@ -107,9 +116,6 @@ class BuildItemSimilarity(BaseJob):
         )
 
         active = self._active_item_ids(min_source, excluded)
-        if not active:
-            logger.info("No active items meet threshold; aborting")
-            return
         target_set = (
             self._active_item_ids(min_target, excluded)
             if min_target < min_source
@@ -117,46 +123,55 @@ class BuildItemSimilarity(BaseJob):
         )
         logger.info(f"Active items: {len(active)} target candidates: {len(target_set)}")
 
-        user_items = self._user_item_pairs(active | target_set, cap, excluded)
-        logger.info(f"Users contributing: {len(user_items)}")
+        item_categories_map: dict[int, list[tuple[int, float]]] = {}
+        if active:
+            user_items = self._user_item_pairs(active | target_set, cap, excluded)
+            logger.info(f"Users contributing: {len(user_items)}")
 
-        scores: dict[int, dict[int, float]] = defaultdict(lambda: defaultdict(float))
-        for items in user_items.values():
-            n = len(items)
-            if n < 2:
-                continue
-            w = (1.0 / math.sqrt(n)) if dampen else 1.0
-            ws = w * w
-            for i in range(n):
-                a = items[i]
-                row = scores[a]
-                for j in range(i + 1, n):
-                    b = items[j]
-                    row[b] += ws
-                    scores[b][a] += ws
+            scores: dict[int, dict[int, float]] = defaultdict(
+                lambda: defaultdict(float)
+            )
+            for items in user_items.values():
+                n = len(items)
+                if n < 2:
+                    continue
+                w = (1.0 / math.sqrt(n)) if dampen else 1.0
+                ws = w * w
+                for i in range(n):
+                    a = items[i]
+                    row = scores[a]
+                    for j in range(i + 1, n):
+                        b = items[j]
+                        row[b] += ws
+                        scores[b][a] += ws
 
-        category_by_id = dict(
-            Item.objects.filter(pk__in=active).values_list("pk", "polymorphic_ctype_id")
-        )
+            # category resolved from polymorphic content type for both source
+            # and target candidates -- target-only items would otherwise miss.
+            category_by_id = dict(
+                Item.objects.filter(pk__in=active | target_set).values_list(
+                    "pk", "polymorphic_ctype_id"
+                )
+            )
 
-        rows_written = 0
-        item_categories_map = {}
-        for src in active:
-            row = scores.get(src)
-            if not row:
-                continue
-            src_ct = category_by_id.get(src)
-            same_cat = [
-                (b, s)
-                for b, s in row.items()
-                if b in target_set and category_by_id.get(b) == src_ct
-            ]
-            if not same_cat:
-                continue
-            top = nlargest(top_k, same_cat, key=lambda t: t[1])
-            item_categories_map[src] = top
+            for src in active:
+                row = scores.get(src)
+                if not row:
+                    continue
+                src_ct = category_by_id.get(src)
+                same_cat = [
+                    (b, s)
+                    for b, s in row.items()
+                    if b in target_set and category_by_id.get(b) == src_ct
+                ]
+                if not same_cat:
+                    continue
+                top = nlargest(top_k, same_cat, key=lambda t: t[1])
+                item_categories_map[src] = top
 
         logger.info(f"Sources with similar rows: {len(item_categories_map)}")
+        rows_written = 0
+        # Always replace stale rows -- threshold or data changes can leave
+        # otherwise-invalid similarity rows visible to serving helpers.
         with transaction.atomic():
             ItemSimilarity.objects.filter(
                 method=ItemSimilarity.METHOD_SHELF_COOC
@@ -206,10 +221,18 @@ class BuildUserRecommendations(BaseJob):
         )
 
     def _user_pk_by_identity(self, identity_ids: list[int]) -> dict[int, int]:
+        """Map identity_pk -> user_pk for local identities only.
+
+        Remote identities have ``user_id`` null; including them would cause
+        a NOT NULL violation in ``UserRecommendation.user_id`` and abort the
+        whole nightly refresh.
+        """
         from users.models import APIdentity
 
         return dict(
-            APIdentity.objects.filter(pk__in=identity_ids).values_list("pk", "user_id")
+            APIdentity.objects.filter(
+                pk__in=identity_ids, user_id__isnull=False
+            ).values_list("pk", "user_id")
         )
 
     def run(self) -> None:

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -12,6 +12,8 @@ from catalog.models import (
     Item,
     ItemSimilarity,
     UserRecommendation,
+    item_categories,
+    item_content_types,
 )
 from catalog.recommendation import compute_for_user
 from common.models import BaseJob, JobManager, SiteConfig
@@ -152,23 +154,36 @@ class BuildItemSimilarity(BaseJob):
                         row[b] += ws
                         scores[b][a] += ws
 
-            # category resolved from polymorphic content type for both source
-            # and target candidates -- target-only items would otherwise miss.
-            category_by_id = dict(
-                Item.objects.filter(pk__in=active | target_set).values_list(
-                    "pk", "polymorphic_ctype_id"
-                )
-            )
+            # Group via Item.category (string), not polymorphic_ctype_id.
+            # Several content types map to the same category (e.g. TVShow,
+            # TVSeason and TVEpisode all live under "tv"); using ctype_id
+            # would block cross-type recommendations within a category.
+            ctype_to_cat: dict[int, str] = {}
+            cts = item_content_types()
+            for cat_enum, classes in item_categories().items():
+                for cls in classes:
+                    ct_id = cts.get(cls)
+                    if ct_id is not None:
+                        ctype_to_cat[ct_id] = str(cat_enum)
+            category_by_id: dict[int, str] = {}
+            for pk, ct_id in Item.objects.filter(
+                pk__in=active | target_set
+            ).values_list("pk", "polymorphic_ctype_id"):
+                cat = ctype_to_cat.get(ct_id)
+                if cat:
+                    category_by_id[pk] = cat
 
             for src in active:
                 row = scores.get(src)
                 if not row:
                     continue
-                src_ct = category_by_id.get(src)
+                src_cat = category_by_id.get(src)
+                if not src_cat:
+                    continue
                 same_cat = [
                     (b, s)
                     for b, s in row.items()
-                    if b in target_set and category_by_id.get(b) == src_ct
+                    if b in target_set and category_by_id.get(b) == src_cat
                 ]
                 if not same_cat:
                     continue

--- a/catalog/jobs/recommendation.py
+++ b/catalog/jobs/recommendation.py
@@ -15,13 +15,16 @@ from catalog.models import (
     item_categories,
     item_content_types,
 )
-from catalog.recommendation import compute_for_user
+from catalog.recommendation import (
+    SHELF_TYPES_AS_SEED,
+    compute_for_user,
+    excluded_target_ctype_ids,
+    production_to_performance_map,
+)
 from common.models import BaseJob, JobManager, SiteConfig
 from journal.models import ShelfMember
 from takahe.models import Identity as TakaheIdentity
 from users.models import APIdentity
-
-PROGRESS_COMPLETE = ["progress", "complete"]
 
 
 def _non_discoverable_identity_ids() -> set[int]:
@@ -57,34 +60,92 @@ class BuildItemSimilarity(BaseJob):
             return timedelta(0)
         return timedelta(days=7)
 
-    def _active_item_ids(self, min_marks: int, excluded_owners: set[int]) -> set[int]:
+    def _active_item_ids(
+        self,
+        min_marks: int,
+        excluded_owners: set[int],
+        rewrite: dict[int, int],
+    ) -> set[int]:
+        """Items with at least ``min_marks`` distinct owners after rewrite.
+
+        Marks on Productions count toward their parent Performance. Without
+        rewrite this is a one-shot SQL aggregation; with rewrite we keep the
+        fast SQL path for non-Production items and stream the Production
+        subset (typically small) to dedup owners against the parent.
+        """
         qs = ShelfMember.objects.filter(
-            visibility=0, parent__shelf_type__in=PROGRESS_COMPLETE
+            visibility=0, parent__shelf_type__in=SHELF_TYPES_AS_SEED
         )
         if excluded_owners:
             qs = qs.exclude(owner_id__in=excluded_owners)
-        rows = (
-            qs.values("item_id")
+        if not rewrite:
+            return set(
+                qs.values("item_id")
+                .annotate(n=Count("id"))
+                .filter(n__gte=min_marks)
+                .values_list("item_id", flat=True)
+            )
+
+        rewrite_keys = set(rewrite)
+        rewrite_targets = set(rewrite.values())
+
+        counts: dict[int, int] = dict(
+            qs.exclude(item_id__in=rewrite_keys)
+            .values("item_id")
             .annotate(n=Count("id"))
-            .filter(n__gte=min_marks)
-            .values_list("item_id", flat=True)
+            .values_list("item_id", "n")
         )
-        return set(rows)
+
+        # Build per-Performance owner sets, seeded by direct Performance marks.
+        perf_owners: dict[int, set[int]] = {}
+        for owner_id, item_id in (
+            qs.filter(item_id__in=rewrite_targets)
+            .values_list("owner_id", "item_id")
+            .iterator(chunk_size=20_000)
+        ):
+            perf_owners.setdefault(item_id, set()).add(owner_id)
+        # Add Production marks rewritten to their Performance.
+        for owner_id, item_id in (
+            qs.filter(item_id__in=rewrite_keys)
+            .values_list("owner_id", "item_id")
+            .iterator(chunk_size=20_000)
+        ):
+            mapped = rewrite[item_id]
+            perf_owners.setdefault(mapped, set()).add(owner_id)
+        # Replace direct counts with the deduped Performance total.
+        for perf_id, owners in perf_owners.items():
+            counts[perf_id] = len(owners)
+        # Productions are intentionally absent from `counts` (excluded above).
+        return {iid for iid, c in counts.items() if c >= min_marks}
 
     def _user_item_pairs(
-        self, active_items: set[int], cap: int, excluded_owners: set[int]
+        self,
+        active_items: set[int],
+        cap: int,
+        excluded_owners: set[int],
+        rewrite: dict[int, int],
     ) -> dict[int, list[int]]:
         """Per-user lists of active item ids, each truncated to ``cap`` most recent.
 
         Streams ordered by (owner_id, -edited_time) so we can drop overflow per
         owner in-line without accumulating every mark in memory first. Critical
         at scale: a mega-shelver with 22k marks would otherwise allocate before
-        being truncated.
+        being truncated. Production marks are rewritten to Performance ids and
+        deduplicated per owner.
         """
+        # Production ids whose Performance is in active_items also need to be
+        # streamed (so they can rewrite into the active set).
+        prod_ids_to_include = (
+            {pid for pid, perf in rewrite.items() if perf in active_items}
+            if rewrite
+            else set()
+        )
+        item_filter = active_items | prod_ids_to_include
+
         qs = ShelfMember.objects.filter(
             visibility=0,
-            parent__shelf_type__in=PROGRESS_COMPLETE,
-            item_id__in=active_items,
+            parent__shelf_type__in=SHELF_TYPES_AS_SEED,
+            item_id__in=item_filter,
         )
         if excluded_owners:
             qs = qs.exclude(owner_id__in=excluded_owners)
@@ -94,14 +155,20 @@ class BuildItemSimilarity(BaseJob):
         out: dict[int, list[int]] = {}
         current_owner: int | None = None
         current_items: list[int] = []
+        current_seen: set[int] = set()
         for owner_id, item_id in rows:
             if owner_id != current_owner:
                 if current_owner is not None and len(current_items) >= 2:
                     out[current_owner] = current_items
                 current_owner = owner_id
                 current_items = []
+                current_seen = set()
+            mapped = rewrite.get(item_id, item_id) if rewrite else item_id
+            if mapped in current_seen:
+                continue
             if len(current_items) < cap:
-                current_items.append(item_id)
+                current_items.append(mapped)
+                current_seen.add(mapped)
         if current_owner is not None and len(current_items) >= 2:
             out[current_owner] = current_items
         return out
@@ -114,22 +181,38 @@ class BuildItemSimilarity(BaseJob):
         top_k = sys.reco_similarity_top_k
         dampen = sys.reco_user_idf_dampen
         excluded = _non_discoverable_identity_ids()
+        rewrite = production_to_performance_map()
+        excluded_target_ctypes = excluded_target_ctype_ids()
         logger.info(
             f"Similarity build start: min_source={min_source} min_target={min_target} "
-            f"cap={cap} top_k={top_k} dampen={dampen} excluded_owners={len(excluded)}"
+            f"cap={cap} top_k={top_k} dampen={dampen} excluded_owners={len(excluded)} "
+            f"production_rewrites={len(rewrite)} excluded_target_ctypes={len(excluded_target_ctypes)}"
         )
 
-        active = self._active_item_ids(min_source, excluded)
+        active = self._active_item_ids(min_source, excluded, rewrite)
         target_set = (
-            self._active_item_ids(min_target, excluded)
+            self._active_item_ids(min_target, excluded, rewrite)
             if min_target < min_source
             else active
         )
+        # Remove classes that should never be recommendation targets, even if
+        # they otherwise meet the threshold (Production marks have already been
+        # rewritten upstream, so PerformanceProductions never appear here).
+        if excluded_target_ctypes:
+            excluded_target_ids = set(
+                Item.objects.filter(
+                    pk__in=target_set,
+                    polymorphic_ctype_id__in=excluded_target_ctypes,
+                ).values_list("pk", flat=True)
+            )
+            target_set = target_set - excluded_target_ids
         logger.info(f"Active items: {len(active)} target candidates: {len(target_set)}")
 
         item_categories_map: dict[int, list[tuple[int, float]]] = {}
         if active:
-            user_items = self._user_item_pairs(active | target_set, cap, excluded)
+            user_items = self._user_item_pairs(
+                active | target_set, cap, excluded, rewrite
+            )
             logger.info(f"Users contributing: {len(user_items)}")
 
             # Co-occurrence scores live in a nested dict. With cap+IDF damping

--- a/catalog/management/commands/recommendation.py
+++ b/catalog/management/commands/recommendation.py
@@ -1,0 +1,37 @@
+from common.management.base import SiteCommand
+
+_HELP_TEXT = """
+similarity:    rebuild ItemSimilarity (full)
+users:         refresh UserRecommendation for active users
+all:           similarity + users
+
+Runs unconditionally, independent of the `enable_recommendations` site flag,
+so operators can pre-build data and inspect it before enabling the surfaces.
+The serving layer remains gated by the flag and user preference until enabled.
+"""
+
+
+class Command(SiteCommand):
+    help = "Run recommendation batch jobs immediately (bypasses site flag for dry-run)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "action",
+            choices=["similarity", "users", "all"],
+            help=_HELP_TEXT,
+        )
+
+    def handle(self, *args, **options):
+        from catalog.jobs.recommendation import (
+            BuildItemSimilarity,
+            BuildUserRecommendations,
+        )
+
+        action = options["action"]
+        if action in ("similarity", "all"):
+            self.stdout.write("Building item similarity ...")
+            BuildItemSimilarity().run()
+        if action in ("users", "all"):
+            self.stdout.write("Refreshing user recommendations ...")
+            BuildUserRecommendations().run()
+        self.stdout.write(self.style.SUCCESS("Done."))

--- a/catalog/migrations/0023_itemsimilarity_userrecommendation.py
+++ b/catalog/migrations/0023_itemsimilarity_userrecommendation.py
@@ -1,0 +1,119 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("catalog", "0022_alter_itemcredit_role"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ItemSimilarity",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("score", models.FloatField()),
+                ("method", models.PositiveSmallIntegerField(default=0)),
+                ("computed_at", models.DateTimeField(auto_now=True)),
+                (
+                    "source",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="similarity_out",
+                        to="catalog.item",
+                    ),
+                ),
+                (
+                    "target",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="similarity_in",
+                        to="catalog.item",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "catalog_item_similarity",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="itemsimilarity",
+            constraint=models.UniqueConstraint(
+                fields=("source", "target", "method"),
+                name="catalog_item_similarity_uniq",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="itemsimilarity",
+            constraint=models.CheckConstraint(
+                condition=~models.Q(source=models.F("target")),
+                name="catalog_item_similarity_no_self",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="itemsimilarity",
+            index=models.Index(
+                fields=["source", "-score"],
+                name="catalog_item_sim_src_score",
+            ),
+        ),
+        migrations.CreateModel(
+            name="UserRecommendation",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("score", models.FloatField()),
+                ("seed_item_ids", models.JSONField(default=list)),
+                ("category", models.CharField(db_index=True, max_length=20)),
+                ("computed_at", models.DateTimeField(auto_now=True)),
+                (
+                    "item",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="recommended_to",
+                        to="catalog.item",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=models.deletion.CASCADE,
+                        related_name="recommendations",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "catalog_user_recommendation",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="userrecommendation",
+            constraint=models.UniqueConstraint(
+                fields=("user", "item"), name="catalog_user_reco_uniq"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="userrecommendation",
+            index=models.Index(
+                fields=["user", "category", "-score"],
+                name="catalog_user_reco_lookup",
+            ),
+        ),
+    ]

--- a/catalog/models/__init__.py
+++ b/catalog/models/__init__.py
@@ -45,6 +45,7 @@ from .podcast import (
     PodcastInSchema,
     PodcastSchema,
 )
+from .recommendation import ItemSimilarity, UserRecommendation
 from .tv import (
     TVEpisode,
     TVEpisodeSchema,
@@ -160,4 +161,6 @@ __all__ = [
     "ItemPeopleRelation",
     "CreditRole",
     "ItemCredit",
+    "ItemSimilarity",
+    "UserRecommendation",
 ]

--- a/catalog/models/recommendation.py
+++ b/catalog/models/recommendation.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING
+
+from django.db import models
+
+from .item import Item
+
+
+class ItemSimilarity(models.Model):
+    """Top-K similar items per source item.
+
+    Populated by the weekly batch job. Derived data: rows are recomputed in
+    full per source on each run, so cascading deletes are intentional.
+    """
+
+    METHOD_SHELF_COOC = 0
+    METHOD_TAG_COOC = 1
+    METHOD_BLENDED = 2
+
+    if TYPE_CHECKING:
+        source_id: int
+        target_id: int
+
+    source = models.ForeignKey(
+        Item, on_delete=models.CASCADE, related_name="similarity_out"
+    )
+    target = models.ForeignKey(
+        Item, on_delete=models.CASCADE, related_name="similarity_in"
+    )
+    score = models.FloatField()
+    method = models.PositiveSmallIntegerField(default=METHOD_SHELF_COOC)
+    computed_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "catalog_item_similarity"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source", "target", "method"],
+                name="catalog_item_similarity_uniq",
+            ),
+            models.CheckConstraint(
+                condition=~models.Q(source=models.F("target")),
+                name="catalog_item_similarity_no_self",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["source", "-score"],
+                name="catalog_item_sim_src_score",
+            ),
+        ]
+
+
+class UserRecommendation(models.Model):
+    """Per-user precomputed recommendation list, refreshed nightly.
+
+    Score is the raw producer output; visibility filtering happens at serve time.
+    `seed_item_ids` lets the UI render "because you liked X". `category` is
+    denormalized off ``Item`` so category-scoped queries avoid a join.
+    """
+
+    if TYPE_CHECKING:
+        user_id: int
+        item_id: int
+
+    user = models.ForeignKey(
+        "users.User", on_delete=models.CASCADE, related_name="recommendations"
+    )
+    item = models.ForeignKey(
+        Item, on_delete=models.CASCADE, related_name="recommended_to"
+    )
+    score = models.FloatField()
+    seed_item_ids = models.JSONField(default=list)
+    category = models.CharField(max_length=20, db_index=True)
+    computed_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "catalog_user_recommendation"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "item"],
+                name="catalog_user_reco_uniq",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["user", "category", "-score"],
+                name="catalog_user_reco_lookup",
+            ),
+        ]

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -1,0 +1,282 @@
+"""Serving-time helpers for item and user recommendations.
+
+Three surfaces, all visibility- and pref-gated by Preference.show_recommendations:
+- similar_items(item, viewer): item-page "you might also like"
+- recommendations_for(viewer): personalised, merging cached + circles
+- from_your_circles(viewer): recent shelves from followees
+"""
+
+from collections import defaultdict
+from datetime import timedelta
+from heapq import nlargest
+
+from django.db import transaction
+from django.db.models import Count
+from django.utils import timezone
+from loguru import logger
+
+from common.models import SiteConfig
+from journal.models import ShelfMember, q_piece_visible_to_user
+
+from .models import Item, ItemSimilarity, UserRecommendation
+
+SHELF_TYPES_AS_SEED = ("progress", "complete")
+SHELF_TYPES_TO_EXCLUDE = ("wishlist", "progress", "complete", "dropped")
+
+
+def _live_items(qs):
+    return qs.filter(is_deleted=False, merged_to_item_id__isnull=True)
+
+
+def _user_shelved_item_ids(identity_pk: int) -> set[int]:
+    return set(
+        ShelfMember.objects.filter(
+            owner_id=identity_pk,
+            parent__shelf_type__in=SHELF_TYPES_TO_EXCLUDE,
+        ).values_list("item_id", flat=True)
+    )
+
+
+def similar_items(item: Item, viewer=None, limit: int = 10) -> list[Item]:
+    """Return up to ``limit`` items similar to ``item``.
+
+    Excludes items the viewer has already shelved (any state). Drops deleted
+    and merged items. No author/owner visibility filter needed: ItemSimilarity
+    is built from public marks only.
+    """
+    rows = list(
+        ItemSimilarity.objects.filter(source=item)
+        .order_by("-score")
+        .values_list("target_id", flat=True)[: limit * 2]
+    )
+    if not rows:
+        return []
+    exclude: set[int] = set()
+    if viewer and viewer.is_authenticated and getattr(viewer, "identity", None):
+        exclude = _user_shelved_item_ids(viewer.identity.pk)
+    qs = _live_items(Item.objects.filter(pk__in=rows))
+    by_id = {i.pk: i for i in qs}
+    out: list[Item] = []
+    for iid in rows:
+        if iid in exclude:
+            continue
+        i = by_id.get(iid)
+        if i is None:
+            continue
+        out.append(i)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]:
+    """Score candidate items for one user, returning unsaved UserRecommendation rows."""
+    sys = SiteConfig.system
+    seed_cap = sys.reco_per_user_seed_cap
+    top_n = sys.reco_user_top_n
+
+    seeds = list(
+        ShelfMember.objects.filter(
+            owner_id=identity_pk,
+            visibility=0,
+            parent__shelf_type__in=SHELF_TYPES_AS_SEED,
+        )
+        .order_by("-edited_time")
+        .values_list("item_id", flat=True)[:seed_cap]
+    )
+    if not seeds:
+        return []
+    shelved = _user_shelved_item_ids(identity_pk)
+    seed_set = set(seeds)
+
+    scores: dict[int, float] = defaultdict(float)
+    seeds_by_target: dict[int, list[int]] = defaultdict(list)
+    sim_rows = ItemSimilarity.objects.filter(source_id__in=seeds).values_list(
+        "source_id", "target_id", "score"
+    )
+    for src, tgt, score in sim_rows:
+        if tgt in shelved or tgt in seed_set:
+            continue
+        scores[tgt] += score
+        if len(seeds_by_target[tgt]) < 3:
+            seeds_by_target[tgt].append(src)
+
+    if not scores:
+        return []
+
+    top = nlargest(top_n, scores.items(), key=lambda t: t[1])
+    if not top:
+        return []
+    target_ids = [t for t, _ in top]
+    cats = dict(Item.objects.filter(pk__in=target_ids).values_list("pk", "category"))
+    rows: list[UserRecommendation] = []
+    for tgt, score in top:
+        cat = cats.get(tgt)
+        if not cat:
+            continue
+        rows.append(
+            UserRecommendation(
+                user_id=user_pk,
+                item_id=tgt,
+                score=score,
+                seed_item_ids=seeds_by_target.get(tgt, []),
+                category=str(cat),
+            )
+        )
+    return rows
+
+
+def _refresh_lazy(user_pk: int, identity_pk: int) -> None:
+    rows = compute_for_user(user_pk, identity_pk)
+    with transaction.atomic():
+        UserRecommendation.objects.filter(user_id=user_pk).delete()
+        if rows:
+            UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
+
+
+def _cached_user_rows(user_pk: int, ttl_days: int) -> list[UserRecommendation]:
+    qs = UserRecommendation.objects.filter(user_id=user_pk).order_by("-score")
+    rows = list(qs)
+    if not rows:
+        return []
+    horizon = timezone.now() - timedelta(days=ttl_days)
+    if rows[0].computed_at < horizon:
+        return []
+    return rows
+
+
+def for_you(viewer, category: str | None = None, limit: int = 30) -> list[Item]:
+    """Return personalised recommendations for the viewer."""
+    if not viewer or not viewer.is_authenticated:
+        return []
+    identity = getattr(viewer, "identity", None)
+    if identity is None:
+        return []
+    sys = SiteConfig.system
+    rows = _cached_user_rows(viewer.pk, sys.reco_lazy_ttl_days)
+    if not rows:
+        try:
+            _refresh_lazy(viewer.pk, identity.pk)
+        except Exception as e:
+            logger.exception(f"Lazy reco refresh failed for user {viewer.pk}: {e}")
+            return []
+        rows = _cached_user_rows(viewer.pk, sys.reco_lazy_ttl_days)
+    if category:
+        rows = [r for r in rows if r.category == category]
+    target_ids = [r.item_id for r in rows[:limit]]
+    if not target_ids:
+        return []
+    shelved = _user_shelved_item_ids(identity.pk)
+    qs = _live_items(Item.objects.filter(pk__in=target_ids))
+    by_id = {i.pk: i for i in qs}
+    out: list[Item] = []
+    for tid in target_ids:
+        if tid in shelved:
+            continue
+        i = by_id.get(tid)
+        if i:
+            out.append(i)
+    return out
+
+
+def from_your_circles(
+    viewer, category: str | None = None, limit: int = 30
+) -> list[Item]:
+    """Items recently marked by people the viewer follows, ranked by distinct shelvers.
+
+    Per-request query (no precompute). Respects visibility via
+    ``q_piece_visible_to_user`` and excludes items the viewer has already
+    shelved.
+    """
+    if not viewer or not viewer.is_authenticated:
+        return []
+    identity = getattr(viewer, "identity", None)
+    if identity is None:
+        return []
+    from takahe.models import Identity as TakaheIdentity
+
+    sys = SiteConfig.system
+    since = timezone.now() - timedelta(days=sys.reco_circles_window_days)
+    following = list(identity.following)
+    if not following:
+        return []
+    not_discoverable = set(
+        TakaheIdentity.objects.filter(pk__in=following, discoverable=False).values_list(
+            "pk", flat=True
+        )
+    )
+    eligible_followees = [f for f in following if f not in not_discoverable]
+    if not eligible_followees:
+        return []
+    shelved = _user_shelved_item_ids(identity.pk)
+    qs = (
+        ShelfMember.objects.filter(q_piece_visible_to_user(viewer))
+        .filter(
+            owner_id__in=eligible_followees,
+            edited_time__gte=since,
+            parent__shelf_type__in=SHELF_TYPES_AS_SEED,
+        )
+        .exclude(item_id__in=shelved)
+    )
+    rows = list(
+        qs.values("item_id")
+        .annotate(c=Count("owner_id", distinct=True))
+        .order_by("-c")
+        .values_list("item_id", "c")[: limit * 2]
+    )
+    target_ids = [iid for iid, _ in rows]
+    if not target_ids:
+        return []
+    items_qs = _live_items(Item.objects.filter(pk__in=target_ids))
+    by_id = {i.pk: i for i in items_qs}
+    if category:
+        by_id = {pk: i for pk, i in by_id.items() if str(i.category) == category}
+    out: list[Item] = []
+    for iid in target_ids:
+        i = by_id.get(iid)
+        if i:
+            out.append(i)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def blended_for_discover(viewer, limit: int = 30) -> list[Item]:
+    """Mix personalised and circles results for the discover top row.
+
+    Strategy: interleave by rank; dedup by item id; exclude items the viewer
+    has already shelved; preserve order of first appearance. Returned list
+    may be empty if neither source has data.
+    """
+    pref = (
+        getattr(viewer, "preference", None)
+        if viewer and viewer.is_authenticated
+        else None
+    )
+    if pref is None:
+        return []
+    show_for_you = pref.show_recommendations("for_you")
+    show_circles = pref.show_recommendations("from_circles")
+    if not show_for_you and not show_circles:
+        return []
+    a = for_you(viewer, limit=limit) if show_for_you else []
+    b = from_your_circles(viewer, limit=limit) if show_circles else []
+    seen: set[int] = set()
+    out: list[Item] = []
+    a_iter = iter(a)
+    b_iter = iter(b)
+    while len(out) < limit:
+        progressed = False
+        for it in (next(a_iter, None), next(b_iter, None)):
+            if it is None:
+                continue
+            progressed = True
+            if it.pk in seen:
+                continue
+            seen.add(it.pk)
+            out.append(it)
+            if len(out) >= limit:
+                break
+        if not progressed:
+            break
+    return out

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -18,6 +18,7 @@ from loguru import logger
 
 from common.models import SiteConfig
 from journal.models import ShelfMember, q_piece_visible_to_user
+from takahe.models import Identity as TakaheIdentity
 
 from .models import Item, ItemSimilarity, UserRecommendation
 
@@ -211,8 +212,6 @@ def from_your_circles(
     identity = getattr(viewer, "identity", None)
     if identity is None:
         return []
-    from takahe.models import Identity as TakaheIdentity
-
     sys = SiteConfig.system
     since = timezone.now() - timedelta(days=sys.reco_circles_window_days)
     following = list(identity.following)

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -27,6 +27,34 @@ _LAZY_LOCK_TTL = 120  # seconds — covers typical compute duration
 SHELF_TYPES_AS_SEED = ("progress", "complete")
 SHELF_TYPES_TO_EXCLUDE = ("wishlist", "progress", "complete", "dropped")
 
+# Surfaces that can be shown to anonymous viewers (the rest require a User).
+ANON_VISIBLE_KINDS = frozenset({"similar_items"})
+
+
+def can_show_reco(user, kind: str) -> bool:
+    """Single visibility gate used by both HTML views and the Ninja API.
+
+    - Authenticated user with a Preference row: defer to
+      Preference.show_recommendations (site flags AND user opt-out).
+    - Authenticated user without a Preference row: conservatively False
+      (we can't read their opt-out, so don't show them anything).
+    - Anonymous viewer: only non-personalized surfaces, gated by site
+      flags only.
+    """
+    sys = SiteConfig.system
+    if user and getattr(user, "is_authenticated", False):
+        pref = getattr(user, "preference", None)
+        return bool(pref and pref.show_recommendations(kind))
+    if kind not in ANON_VISIBLE_KINDS:
+        return False
+    if not sys.enable_recommendations:
+        return False
+    return bool(
+        {
+            "similar_items": sys.enable_reco_similar_items,
+        }.get(kind, False)
+    )
+
 
 def _live_items(qs):
     return qs.filter(is_deleted=False, merged_to_item_id__isnull=True)

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -108,7 +108,9 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
     if not top:
         return []
     target_ids = [t for t, _ in top]
-    cats = dict(Item.objects.filter(pk__in=target_ids).values_list("pk", "category"))
+    # category is a class attribute on each Item subclass, not a DB column,
+    # so resolve via the polymorphic queryset and read the attribute.
+    cats = {i.pk: str(i.category) for i in Item.objects.filter(pk__in=target_ids)}
     rows: list[UserRecommendation] = []
     for tgt, score in top:
         cat = cats.get(tgt)
@@ -120,7 +122,7 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
                 item_id=tgt,
                 score=score,
                 seed_item_ids=seeds_by_target.get(tgt, []),
-                category=str(cat),
+                category=cat,
             )
         )
     return rows

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from datetime import timedelta
 from heapq import nlargest
 
+from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Count
 from django.utils import timezone
@@ -19,6 +20,8 @@ from common.models import SiteConfig
 from journal.models import ShelfMember, q_piece_visible_to_user
 
 from .models import Item, ItemSimilarity, UserRecommendation
+
+_LAZY_LOCK_TTL = 120  # seconds — covers typical compute duration
 
 SHELF_TYPES_AS_SEED = ("progress", "complete")
 SHELF_TYPES_TO_EXCLUDE = ("wishlist", "progress", "complete", "dropped")
@@ -128,12 +131,25 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
     return rows
 
 
-def _refresh_lazy(user_pk: int, identity_pk: int) -> None:
-    rows = compute_for_user(user_pk, identity_pk)
-    with transaction.atomic():
-        UserRecommendation.objects.filter(user_id=user_pk).delete()
-        if rows:
-            UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
+def _refresh_lazy(user_pk: int, identity_pk: int) -> bool:
+    """Lazy on-demand recompute for one user.
+
+    Guarded by a cache-based lock so concurrent requests for the same user
+    don't dogpile compute + write. Returns True if this caller did the work,
+    False if another request already holds the lock (skip-and-serve-stale).
+    """
+    lock_key = f"reco:lazy_refresh:{user_pk}"
+    if not cache.add(lock_key, "1", timeout=_LAZY_LOCK_TTL):
+        return False
+    try:
+        rows = compute_for_user(user_pk, identity_pk)
+        with transaction.atomic():
+            UserRecommendation.objects.filter(user_id=user_pk).delete()
+            if rows:
+                UserRecommendation.objects.bulk_create(rows, ignore_conflicts=True)
+        return True
+    finally:
+        cache.delete(lock_key)
 
 
 def _cached_user_rows(user_pk: int, ttl_days: int) -> list[UserRecommendation]:

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -97,25 +97,18 @@ def can_show_reco(user, kind: str) -> bool:
     """Single visibility gate used by both HTML views and the Ninja API.
 
     - Authenticated user with a Preference row: defer to
-      Preference.show_recommendations (site flags AND user opt-out).
-    - Authenticated user without a Preference row: conservatively False
-      (we can't read their opt-out, so don't show them anything).
-    - Anonymous viewer: only non-personalized surfaces, gated by site
-      flags only.
+      Preference.show_recommendations (master switch OR test_enabled, AND
+      user has not opted out).
+    - Authenticated user without a Preference row: conservatively False.
+    - Anonymous viewer: only non-personalised surfaces (similar_items),
+      gated by the site master switch.
     """
-    sys = SiteConfig.system
     if user and getattr(user, "is_authenticated", False):
         pref = getattr(user, "preference", None)
         return bool(pref and pref.show_recommendations(kind))
     if kind not in ANON_VISIBLE_KINDS:
         return False
-    if not sys.enable_recommendations:
-        return False
-    return bool(
-        {
-            "similar_items": sys.enable_reco_similar_items,
-        }.get(kind, False)
-    )
+    return bool(SiteConfig.system.enable_recommendations)
 
 
 def _live_items(qs):

--- a/catalog/recommendation.py
+++ b/catalog/recommendation.py
@@ -20,11 +20,73 @@ from common.models import SiteConfig
 from journal.models import ShelfMember, q_piece_visible_to_user
 from takahe.models import Identity as TakaheIdentity
 
-from .models import Item, ItemSimilarity, UserRecommendation
+from .models import (
+    Item,
+    ItemSimilarity,
+    PerformanceProduction,
+    PodcastEpisode,
+    TVEpisode,
+    TVShow,
+    UserRecommendation,
+    item_content_types,
+)
+
+# Item classes that should never appear as recommendation targets.
+# - TVShow: container; users typically mark TVSeasons
+# - TVEpisode: too granular vs the season
+# - PerformanceProduction: container under Performance
+# - PodcastEpisode: too granular vs the podcast
+EXCLUDED_RECO_TARGET_CLASSES: tuple[type[Item], ...] = (
+    TVShow,
+    TVEpisode,
+    PerformanceProduction,
+    PodcastEpisode,
+)
+
+
+def excluded_target_ctype_ids() -> set[int]:
+    """ContentType ids for classes that must not be recommendation targets."""
+    cts = item_content_types()
+    return {cts[cls] for cls in EXCLUDED_RECO_TARGET_CLASSES if cls in cts}
+
+
+def production_to_performance_map() -> dict[int, int]:
+    """item_id of PerformanceProduction -> item_id of parent Performance.
+
+    Marks on a Production are aggregated to its parent Performance so the
+    aggregated signal reflects what users actually engaged with (the show),
+    not a specific staging. Productions with no parent are not in the map.
+    """
+    return dict(
+        PerformanceProduction.objects.filter(show_id__isnull=False).values_list(
+            "pk", "show_id"
+        )
+    )
+
+
+_PROD_TO_PERF_CACHE_KEY = "reco:prod_to_perf"
+_PROD_TO_PERF_TTL = 3600
+
+
+def production_to_performance_cached() -> dict[int, int]:
+    cached = cache.get(_PROD_TO_PERF_CACHE_KEY)
+    if cached is not None:
+        return cached
+    m = production_to_performance_map()
+    cache.set(_PROD_TO_PERF_CACHE_KEY, m, timeout=_PROD_TO_PERF_TTL)
+    return m
+
 
 _LAZY_LOCK_TTL = 120  # seconds — covers typical compute duration
 
-SHELF_TYPES_AS_SEED = ("progress", "complete")
+# Shelves that count as positive interest signal for recommendation training
+# and as seeds for personalised recommendations. Wishlist is an explicit
+# forward-looking taste signal; dropped is excluded (negative signal).
+SHELF_TYPES_AS_SEED = ("wishlist", "progress", "complete")
+
+# Shelves that mean the user has already engaged with an item, so we should
+# never recommend it back to them. Includes "dropped" so we don't re-surface
+# things they actively disliked.
 SHELF_TYPES_TO_EXCLUDE = ("wishlist", "progress", "complete", "dropped")
 
 # Surfaces that can be shown to anonymous viewers (the rest require a User).
@@ -57,7 +119,16 @@ def can_show_reco(user, kind: str) -> bool:
 
 
 def _live_items(qs):
-    return qs.filter(is_deleted=False, merged_to_item_id__isnull=True)
+    """Filter to items that are valid recommendation *targets*.
+
+    Drops soft-deleted/merged rows and the four classes that should never be
+    recommended (TVShow / TVEpisode / PerformanceProduction / PodcastEpisode).
+    """
+    excluded = excluded_target_ctype_ids()
+    qs = qs.filter(is_deleted=False, merged_to_item_id__isnull=True)
+    if excluded:
+        qs = qs.exclude(polymorphic_ctype_id__in=excluded)
+    return qs
 
 
 def _user_shelved_item_ids(identity_pk: int) -> set[int]:
@@ -107,17 +178,30 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
     seed_cap = sys.reco_per_user_seed_cap
     top_n = sys.reco_user_top_n
 
-    seeds = list(
+    raw_seeds = list(
         ShelfMember.objects.filter(
             owner_id=identity_pk,
             visibility=0,
             parent__shelf_type__in=SHELF_TYPES_AS_SEED,
         )
         .order_by("-edited_time")
-        .values_list("item_id", flat=True)[:seed_cap]
+        .values_list("item_id", flat=True)[: seed_cap * 2]
     )
-    if not seeds:
+    if not raw_seeds:
         return []
+    # Rewrite Production marks to their parent Performance so the user's
+    # signal aggregates the same way it does in the similarity matrix.
+    rewrite = production_to_performance_cached()
+    seen: set[int] = set()
+    seeds: list[int] = []
+    for sid in raw_seeds:
+        mapped = rewrite.get(sid, sid)
+        if mapped in seen:
+            continue
+        seen.add(mapped)
+        seeds.append(mapped)
+        if len(seeds) >= seed_cap:
+            break
     shelved = _user_shelved_item_ids(identity_pk)
     seed_set = set(seeds)
 
@@ -254,6 +338,7 @@ def from_your_circles(
     if not eligible_followees:
         return []
     shelved = _user_shelved_item_ids(identity.pk)
+    excluded_ctypes = excluded_target_ctype_ids()
     qs = (
         ShelfMember.objects.filter(q_piece_visible_to_user(viewer))
         .filter(
@@ -263,6 +348,8 @@ def from_your_circles(
         )
         .exclude(item_id__in=shelved)
     )
+    if excluded_ctypes:
+        qs = qs.exclude(item__polymorphic_ctype_id__in=excluded_ctypes)
     rows = list(
         qs.values("item_id")
         .annotate(c=Count("owner_id", distinct=True))

--- a/catalog/templates/_item_similar.html
+++ b/catalog/templates/_item_similar.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% load thumb %}
+{% if items %}
+  <section id="item-similar">
+    <h5>{% trans "Similar items" %}</h5>
+    <ul class="cards">
+      {% for sim in items %}
+        <li class="card">
+          <a href="{{ sim.url }}" title="{{ sim.display_title }}">
+            <img src="{{ sim.cover|thumb:'normal' }}"
+                 alt="{{ sim.display_title }}"
+                 loading="lazy">
+            <div class="card-title">{{ sim.display_title }}</div>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/catalog/templates/discover.html
+++ b/catalog/templates/discover.html
@@ -45,6 +45,31 @@
     <main>
       <div class="grid__main">
         <div class="sortable">
+          {% if reco_items %}
+            <section class="entity-sort shelf" id="recommendations">
+              <span class="action">
+                <span>
+                  <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
+                </span>
+                <span>
+                  <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
+                </span>
+              </span>
+              <h5>{% trans "Recommended for you" %}</h5>
+              <ul class="cards">
+                {% for item in reco_items %}
+                  <li class="card">
+                    <a href="{{ item.url }}" title="{{ item.display_title }}">
+                      <img src="{{ item.cover|thumb:'normal' }}"
+                           alt="{{ item.display_title }}"
+                           loading="lazy">
+                      <div class="card-title">{{ item.display_title }}</div>
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </section>
+          {% endif %}
           {% for gallery in gallery_list %}
             <section class="entity-sort shelf"
                      id="{{ gallery.name }}"

--- a/catalog/templates/item_base.html
+++ b/catalog/templates/item_base.html
@@ -333,7 +333,9 @@
         {% endblock %}
       </div>
       <div id="item-more" class="middle">
-        <!-- test more content -->
+        <div hx-get="{% url 'catalog:similar' item.url_path item.uuid %}"
+             hx-trigger="intersect once"
+             hx-swap="outerHTML"></div>
       </div>
       <div style="clear: both;display: table;"></div>
     </main>

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -209,6 +209,13 @@ urlpatterns = [
     re_path(
         r"^(?P<item_path>"
         + _get_all_url_paths()
+        + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/similar$",
+        similar,
+        name="similar",
+    ),
+    re_path(
+        r"^(?P<item_path>"
+        + _get_all_url_paths()
         + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/wikidata/(?P<wikidata_id>\w+)/",
         wikipedia_pages,
         name="wikipedia_pages",

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -527,6 +527,10 @@ def similar(request, item_path, item_uuid):
             items = similar_items(item, request.user, limit=10)
     elif pref.show_recommendations("similar_items"):
         items = similar_items(item, request.user, limit=10)
+    if items:
+        Item.prefetch_parent_items(items)
+        Item.prefetch_edition_works(items)
+        prefetch_related_objects(items, "external_resources")
     return render(
         request,
         "_item_similar.html",
@@ -635,6 +639,10 @@ def discover(request):
         reco_items = blended_for_discover(request.user, limit=30)
         if len(reco_items) < 3:
             reco_items = []
+        else:
+            Item.prefetch_parent_items(reco_items)
+            Item.prefetch_edition_works(reco_items)
+            prefetch_related_objects(reco_items, "external_resources")
 
     updated = cache.get("trends_updated", timezone.now())
     return render(

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -36,7 +36,7 @@ from takahe.utils import Takahe
 
 from ..models import ExternalResource, IdType, Item, ItemCredit, Podcast, TVEpisode
 from ..models.people import ItemPeopleRelation, People, PeopleRole
-from ..recommendation import blended_for_discover, similar_items
+from ..recommendation import blended_for_discover, can_show_reco, similar_items
 from ..sites import WikiData
 
 NUM_COMMENTS_ON_ITEM_PAGE = 10
@@ -512,19 +512,8 @@ def similar(request, item_path, item_uuid):
     fragment is empty.
     """
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
-    pref = (
-        getattr(request.user, "preference", None)
-        if request.user.is_authenticated
-        else None
-    )
     items: list = []
-    if pref is None:
-        if (
-            SiteConfig.system.enable_recommendations
-            and SiteConfig.system.enable_reco_similar_items
-        ):
-            items = similar_items(item, request.user, limit=10)
-    elif pref.show_recommendations("similar_items"):
+    if can_show_reco(request.user, "similar_items"):
         items = similar_items(item, request.user, limit=10)
     if items:
         Item.prefetch_parent_items(items)

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -36,6 +36,7 @@ from takahe.utils import Takahe
 
 from ..models import ExternalResource, IdType, Item, ItemCredit, Podcast, TVEpisode
 from ..models.people import ItemPeopleRelation, People, PeopleRole
+from ..recommendation import blended_for_discover, similar_items
 from ..sites import WikiData
 
 NUM_COMMENTS_ON_ITEM_PAGE = 10
@@ -510,8 +511,6 @@ def similar(request, item_path, item_uuid):
     or there are no similar items. The block is hidden visually whenever the
     fragment is empty.
     """
-    from catalog.recommendation import similar_items
-
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     pref = (
         getattr(request.user, "preference", None)
@@ -634,8 +633,6 @@ def discover(request):
 
     reco_items = []
     if request.user.is_authenticated:
-        from catalog.recommendation import blended_for_discover
-
         reco_items = blended_for_discover(request.user, limit=30)
         if len(reco_items) < 3:
             reco_items = []

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -503,6 +503,37 @@ def reviews(request, item_path, item_uuid):
     )
 
 
+def similar(request, item_path, item_uuid):
+    """HTMX partial: items similar to the given one.
+
+    Returns an empty fragment if the surface is disabled (site or user pref)
+    or there are no similar items. The block is hidden visually whenever the
+    fragment is empty.
+    """
+    from catalog.recommendation import similar_items
+
+    item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
+    pref = (
+        getattr(request.user, "preference", None)
+        if request.user.is_authenticated
+        else None
+    )
+    items: list = []
+    if pref is None:
+        if (
+            SiteConfig.system.enable_recommendations
+            and SiteConfig.system.enable_reco_similar_items
+        ):
+            items = similar_items(item, request.user, limit=10)
+    elif pref.show_recommendations("similar_items"):
+        items = similar_items(item, request.user, limit=10)
+    return render(
+        request,
+        "_item_similar.html",
+        {"item": item, "items": items},
+    )
+
+
 def notes(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     ids = item.child_item_ids + [item.pk] + item.sibling_item_ids
@@ -597,6 +628,14 @@ def discover(request):
     else:
         popular_tags = None
 
+    reco_items = []
+    if request.user.is_authenticated:
+        from catalog.recommendation import blended_for_discover
+
+        reco_items = blended_for_discover(request.user, limit=30)
+        if len(reco_items) < 3:
+            reco_items = []
+
     updated = cache.get("trends_updated", timezone.now())
     return render(
         request,
@@ -609,6 +648,7 @@ def discover(request):
             "popular_tags": popular_tags,
             "layout": layout,
             "updated": updated,
+            "reco_items": reco_items,
         },
     )
 

--- a/common/models/site_config.py
+++ b/common/models/site_config.py
@@ -52,11 +52,8 @@ class SiteConfig(models.Model):
         discover_show_popular_posts: bool = False
         discover_show_popular_tags: bool = False
 
-        # Recommendations (off by default; each surface gated independently)
+        # Recommendations (off by default; test-enabled users can preview)
         enable_recommendations: bool = False
-        enable_reco_similar_items: bool = False
-        enable_reco_for_you: bool = False
-        enable_reco_from_circles: bool = False
         reco_min_source_marks: int = 3
         reco_min_target_marks: int = 2
         reco_similarity_top_k: int = 50

--- a/common/models/site_config.py
+++ b/common/models/site_config.py
@@ -52,6 +52,22 @@ class SiteConfig(models.Model):
         discover_show_popular_posts: bool = False
         discover_show_popular_tags: bool = False
 
+        # Recommendations (off by default; each surface gated independently)
+        enable_recommendations: bool = False
+        enable_reco_similar_items: bool = False
+        enable_reco_for_you: bool = False
+        enable_reco_from_circles: bool = False
+        reco_min_source_marks: int = 3
+        reco_min_target_marks: int = 2
+        reco_similarity_top_k: int = 50
+        reco_user_top_n: int = 100
+        reco_user_idf_dampen: bool = True
+        reco_user_mark_cap: int = 500
+        reco_user_active_days: int = 30
+        reco_per_user_seed_cap: int = 200
+        reco_lazy_ttl_days: int = 7
+        reco_circles_window_days: int = 30
+
         # Localization
         preferred_languages: list[str] = ["en", "zh"]
 

--- a/common/urls.py
+++ b/common/urls.py
@@ -9,6 +9,7 @@ from .views_manage import (
     DiscoverSettings,
     DownloaderSettings,
     FederationSettings,
+    RecommendationSettings,
     manage_root,
 )
 
@@ -41,6 +42,11 @@ urlpatterns = [
         "manage/discover/",
         DiscoverSettings.as_view(),
         name="manage_discover",
+    ),
+    path(
+        "manage/recommendations/",
+        RecommendationSettings.as_view(),
+        name="manage_recommendations",
     ),
     path(
         "manage/access/",

--- a/common/views_manage.py
+++ b/common/views_manage.py
@@ -359,20 +359,10 @@ class RecommendationSettings(SiteConfigSettingsPage):
             "title": _("Enable Recommendations"),
             "help_text": _(
                 "Master switch. When off, all recommendation surfaces are "
-                "hidden and the cron jobs are not scheduled."
+                "hidden for regular users and the cron jobs are not "
+                "scheduled. Test-enabled accounts (DEBUG mode or '!bazinga' "
+                "in their bio) still see the surfaces, for preview."
             ),
-        },
-        "enable_reco_similar_items": {
-            "title": _("Enable Similar Items"),
-            "help_text": _("Show a 'Similar items' block on item pages."),
-        },
-        "enable_reco_for_you": {
-            "title": _("Enable 'For You' Recommendations"),
-            "help_text": _("Show personalised recommendations on the discover page."),
-        },
-        "enable_reco_from_circles": {
-            "title": _("Enable 'From Your Circles' Recommendations"),
-            "help_text": _("Show items recently marked by people the viewer follows."),
         },
         "reco_min_source_marks": {
             "title": _("Source Item Mark Threshold"),
@@ -449,11 +439,8 @@ class RecommendationSettings(SiteConfigSettingsPage):
         },
     }
     layout = {
-        _("Surfaces"): [
+        _("Master Switch"): [
             "enable_recommendations",
-            "enable_reco_similar_items",
-            "enable_reco_for_you",
-            "enable_reco_from_circles",
         ],
         _("Similarity Builder"): [
             "reco_min_source_marks",

--- a/common/views_manage.py
+++ b/common/views_manage.py
@@ -142,6 +142,7 @@ class SiteConfigSettingsPage(FormView):
         context["nav_sections"] = [
             ("branding", _("Branding"), "common:manage_branding"),
             ("discover", _("Discover"), "common:manage_discover"),
+            ("recommendations", _("Recommendations"), "common:manage_recommendations"),
             ("access", _("Access"), "common:manage_access"),
             ("federation", _("Federation"), "common:manage_federation"),
             ("api_keys", _("API Keys"), "common:manage_api_keys"),
@@ -347,6 +348,126 @@ class DiscoverSettings(SiteConfigSettingsPage):
             "discover_show_local_only",
             "discover_show_popular_posts",
             "discover_show_popular_tags",
+        ],
+    }
+
+
+class RecommendationSettings(SiteConfigSettingsPage):
+    section = "recommendations"
+    options = {
+        "enable_recommendations": {
+            "title": _("Enable Recommendations"),
+            "help_text": _(
+                "Master switch. When off, all recommendation surfaces are "
+                "hidden and the cron jobs are not scheduled."
+            ),
+        },
+        "enable_reco_similar_items": {
+            "title": _("Enable Similar Items"),
+            "help_text": _("Show a 'Similar items' block on item pages."),
+        },
+        "enable_reco_for_you": {
+            "title": _("Enable 'For You' Recommendations"),
+            "help_text": _("Show personalised recommendations on the discover page."),
+        },
+        "enable_reco_from_circles": {
+            "title": _("Enable 'From Your Circles' Recommendations"),
+            "help_text": _("Show items recently marked by people the viewer follows."),
+        },
+        "reco_min_source_marks": {
+            "title": _("Source Item Mark Threshold"),
+            "help_text": _(
+                "Minimum public marks an item needs before similarity rows "
+                "are built for it."
+            ),
+            "min_value": 1,
+        },
+        "reco_min_target_marks": {
+            "title": _("Target Item Mark Threshold"),
+            "help_text": _(
+                "Minimum public marks an item needs to be eligible as a "
+                "recommendation target."
+            ),
+            "min_value": 1,
+        },
+        "reco_similarity_top_k": {
+            "title": _("Top-K Similar Items per Source"),
+            "help_text": _("Number of similar items stored per source item."),
+            "min_value": 1,
+        },
+        "reco_user_top_n": {
+            "title": _("Top-N Recommendations per User"),
+            "help_text": _("Number of personalised rows stored per user."),
+            "min_value": 1,
+        },
+        "reco_user_idf_dampen": {
+            "title": _("Dampen Heavy Shelvers"),
+            "help_text": _(
+                "Weight each user's contribution by 1/sqrt(n_marks) to "
+                "neutralise mega-shelvers in similarity scoring."
+            ),
+        },
+        "reco_user_mark_cap": {
+            "title": _("Per-User Mark Cap (training)"),
+            "help_text": _(
+                "Truncate each user's contribution to their N most recent "
+                "marks when building the similarity matrix."
+            ),
+            "min_value": 2,
+        },
+        "reco_user_active_days": {
+            "title": _("Active-User Window (days)"),
+            "help_text": _(
+                "Refresh personalised recommendations for users with at "
+                "least one public mark in the last N days."
+            ),
+            "min_value": 1,
+        },
+        "reco_per_user_seed_cap": {
+            "title": _("Per-User Seed Cap (serving)"),
+            "help_text": _(
+                "Number of recent marks used as seeds when scoring "
+                "personalised recommendations for one user."
+            ),
+            "min_value": 1,
+        },
+        "reco_lazy_ttl_days": {
+            "title": _("Lazy Refresh TTL (days)"),
+            "help_text": _(
+                "How long cached on-demand recommendations are valid before "
+                "the next request triggers a refresh."
+            ),
+            "min_value": 1,
+        },
+        "reco_circles_window_days": {
+            "title": _("Circles Window (days)"),
+            "help_text": _(
+                "Look back N days when finding items recently marked by "
+                "people the viewer follows."
+            ),
+            "min_value": 1,
+        },
+    }
+    layout = {
+        _("Surfaces"): [
+            "enable_recommendations",
+            "enable_reco_similar_items",
+            "enable_reco_for_you",
+            "enable_reco_from_circles",
+        ],
+        _("Similarity Builder"): [
+            "reco_min_source_marks",
+            "reco_min_target_marks",
+            "reco_similarity_top_k",
+            "reco_user_idf_dampen",
+            "reco_user_mark_cap",
+        ],
+        _("Personalisation"): [
+            "reco_user_top_n",
+            "reco_user_active_days",
+            "reco_per_user_seed_cap",
+            "reco_lazy_ttl_days",
+            "reco_circles_window_days",
         ],
     }
 

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 00:51-0400\n"
+"POT-Creation-Date: 2026-05-12 02:07-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -598,7 +598,7 @@ msgstr ""
 msgid "year of publication"
 msgstr ""
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:176
+#: catalog/models/game.py:135 catalog/models/podcast.py:194
 msgid "date of publication"
 msgstr ""
 
@@ -1117,6 +1117,10 @@ msgstr ""
 msgid "write a review"
 msgstr ""
 
+#: catalog/templates/_item_similar.html:5
+msgid "Similar items"
+msgstr ""
+
 #: catalog/templates/_item_user_mark_history.html:20
 msgid "no history."
 msgstr ""
@@ -1550,7 +1554,7 @@ msgstr ""
 #: journal/templates/review_edit.html:39 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
 #: users/templates/users/account.html:38 users/templates/users/account.html:67
-#: users/templates/users/preferences.html:209
+#: users/templates/users/preferences.html:222
 msgid "Save"
 msgstr ""
 
@@ -1585,47 +1589,51 @@ msgstr ""
 msgid "Discover"
 msgstr ""
 
-#: catalog/templates/discover.html:86
+#: catalog/templates/discover.html:58
+msgid "Recommended for you"
+msgstr ""
+
+#: catalog/templates/discover.html:111
 #: journal/templates/user_collection_list.html:18
 #: journal/templates/user_collection_list.html:32
 msgid "Collections"
 msgstr ""
 
-#: catalog/templates/discover.html:104 journal/templates/profile.html:235
+#: catalog/templates/discover.html:129 journal/templates/profile.html:235
 msgid "edit layout"
 msgstr ""
 
-#: catalog/templates/discover.html:107 journal/templates/profile.html:238
+#: catalog/templates/discover.html:132 journal/templates/profile.html:238
 msgid "save"
 msgstr ""
 
-#: catalog/templates/discover.html:118 journal/templates/profile.html:249
+#: catalog/templates/discover.html:143 journal/templates/profile.html:249
 msgid "cancel"
 msgstr ""
 
-#: catalog/templates/discover.html:124 journal/templates/profile.html:255
+#: catalog/templates/discover.html:149 journal/templates/profile.html:255
 msgid "show"
 msgstr ""
 
-#: catalog/templates/discover.html:125 journal/templates/profile.html:256
+#: catalog/templates/discover.html:150 journal/templates/profile.html:256
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:157 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:182 common/templates/_sidebar.html:14
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:163 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:188 common/templates/_sidebar.html:20
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
-#: catalog/templates/discover.html:173
+#: catalog/templates/discover.html:198
 #: common/templates/_sidebar_anonymous.html:55
 msgid "Popular Tags"
 msgstr ""
 
-#: catalog/templates/discover.html:180 catalog/templates/item_base.html:273
+#: catalog/templates/discover.html:205 catalog/templates/item_base.html:273
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28 common/templates/_sidebar.html:114
@@ -1642,7 +1650,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:190 common/templates/_sidebar.html:237
+#: catalog/templates/discover.html:215 common/templates/_sidebar.html:237
 msgid "Recent Posts"
 msgstr ""
 
@@ -4250,7 +4258,7 @@ msgstr ""
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:373
+#: journal/models/collection.py:419
 msgid "created collection"
 msgstr ""
 
@@ -6025,7 +6033,7 @@ msgid "Manually approve new followers"
 msgstr ""
 
 #: takahe/models.py:459
-msgid "Include profile and posts in discovery"
+msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
 #: takahe/models.py:462
@@ -6980,6 +6988,14 @@ msgstr ""
 msgid "Show your name on item page if you recently edited it"
 msgstr ""
 
+#: users/templates/users/preferences.html:215
+msgid "Do not show me item recommendations"
+msgstr ""
+
+#: users/templates/users/preferences.html:218
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
+msgstr ""
+
 #: users/templates/users/profile_actions.html:12
 msgid "click to unblock"
 msgstr ""
@@ -7306,99 +7322,99 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:202 users/views/data.py:231
+#: users/views/data.py:207 users/views/data.py:236
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:225
+#: users/views/data.py:230
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:243
+#: users/views/data.py:248
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:258 users/views/data.py:278
+#: users/views/data.py:263 users/views/data.py:283
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:292
+#: users/views/data.py:297
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:306
+#: users/views/data.py:311
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:315 users/views/data.py:339 users/views/data.py:363
-#: users/views/data.py:388 users/views/data.py:412 users/views/data.py:436
+#: users/views/data.py:320 users/views/data.py:344 users/views/data.py:368
+#: users/views/data.py:393 users/views/data.py:417 users/views/data.py:441
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:556
+#: users/views/data.py:561
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:578
+#: users/views/data.py:583
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:594
+#: users/views/data.py:599
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:599
+#: users/views/data.py:604
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:609 users/views/data.py:660
+#: users/views/data.py:614 users/views/data.py:665
 msgid "Looking up the account. Please try again in a few seconds."
-msgstr ""
-
-#: users/views/data.py:616
-#, python-brace-format
-msgid "Alias to {handle} removed."
 msgstr ""
 
 #: users/views/data.py:621
 #, python-brace-format
+msgid "Alias to {handle} removed."
+msgstr ""
+
+#: users/views/data.py:626
+#, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:647
+#: users/views/data.py:652
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:652
+#: users/views/data.py:657
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:665
+#: users/views/data.py:670
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:676
+#: users/views/data.py:681
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:682
+#: users/views/data.py:687
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:740
+#: users/views/data.py:745
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:756
+#: users/views/data.py:761
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:760
+#: users/views/data.py:765
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:769
+#: users/views/data.py:774
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 02:07-0400\n"
+"POT-Creation-Date: 2026-05-12 09:33-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1585,7 +1585,7 @@ msgid "This operation cannot be undone. Sure to merge?"
 msgstr ""
 
 #: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:343 users/templates/users/preferences.html:34
+#: common/views_manage.py:344 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -2022,15 +2022,15 @@ msgstr ""
 msgid "Unsupported URL"
 msgstr ""
 
-#: catalog/views/view.py:65 catalog/views/view.py:90
+#: catalog/views/view.py:66 catalog/views/view.py:91
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:69 catalog/views/view.py:98
+#: catalog/views/view.py:70 catalog/views/view.py:99
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:165
+#: catalog/views/view.py:166
 msgid "Invalid role"
 msgstr ""
 
@@ -3509,7 +3509,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:358
+#: common/templates/common/about.html:35 common/views_manage.py:466
 msgid "Invite Only"
 msgstr ""
 
@@ -3517,7 +3517,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:379
+#: common/templates/common/about.html:40 common/views_manage.py:487
 msgid "Preferred Languages"
 msgstr ""
 
@@ -3573,7 +3573,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:443
+#: common/templates/common/scan.html:60 common/views_manage.py:551
 msgid "Search"
 msgstr ""
 
@@ -3668,492 +3668,596 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: common/views_manage.py:143 common/views_manage.py:292
+#: common/views_manage.py:143 common/views_manage.py:293
 msgid "Branding"
 msgstr ""
 
 #: common/views_manage.py:145
+msgid "Recommendations"
+msgstr ""
+
+#: common/views_manage.py:146
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:146 common/views_manage.py:438
+#: common/views_manage.py:147 common/views_manage.py:546
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:148
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:149 common/views_manage.py:300
+#: common/views_manage.py:150 common/views_manage.py:301
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:199
+#: common/views_manage.py:200
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:203
+#: common/views_manage.py:204
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:208
+#: common/views_manage.py:209
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:228
+#: common/views_manage.py:229
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:231
+#: common/views_manage.py:232
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:235
+#: common/views_manage.py:236
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:240
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:244
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:248
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:273
+#: common/views_manage.py:274
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:277
+#: common/views_manage.py:278
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:282
+#: common/views_manage.py:283
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:312
+#: common/views_manage.py:313
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:314
+#: common/views_manage.py:315
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:319
+#: common/views_manage.py:320
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:324
+#: common/views_manage.py:325
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:329
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:330
+#: common/views_manage.py:331
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:334
+#: common/views_manage.py:335
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:339
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:360
-msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+#: common/views_manage.py:359
+msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:365
-msgid "Enable Local-Only Posting"
+#: common/views_manage.py:361
+msgid "Master switch. When off, all recommendation surfaces are hidden for regular users and the cron jobs are not scheduled. Test-enabled accounts (DEBUG mode or '!bazinga' in their bio) still see the surfaces, for preview."
 msgstr ""
 
-#: common/views_manage.py:366
-msgid "Allow users to create posts visible only to local users."
-msgstr ""
-
-#: common/views_manage.py:369
-msgid "Mastodon Login Whitelist"
+#: common/views_manage.py:368
+msgid "Source Item Mark Threshold"
 msgstr ""
 
 #: common/views_manage.py:370
-msgid "One domain per line. Leave empty to allow any instance."
-msgstr ""
-
-#: common/views_manage.py:373
-msgid "Enable Bluesky Login"
+msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
 #: common/views_manage.py:376
-msgid "Enable Threads Login"
+msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:381
-msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
+#: common/views_manage.py:378
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:387
-msgid "Access Control"
+#: common/views_manage.py:384
+msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:392
-msgid "Login Methods"
+#: common/views_manage.py:385
+msgid "Number of similar items stored per source item."
+msgstr ""
+
+#: common/views_manage.py:389
+msgid "Top-N Recommendations per User"
+msgstr ""
+
+#: common/views_manage.py:390
+msgid "Number of personalised rows stored per user."
+msgstr ""
+
+#: common/views_manage.py:394
+msgid "Dampen Heavy Shelvers"
 msgstr ""
 
 #: common/views_manage.py:396
-msgid "Localization"
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:406
-msgid "Disable Default Relay"
+#: common/views_manage.py:401
+msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:408
-msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+#: common/views_manage.py:403
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:413
-msgid "Fanout Limit (days)"
+#: common/views_manage.py:409
+msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:414
-msgid "Posts older than this many days will not be fanned out."
+#: common/views_manage.py:411
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:418
-msgid "Remote Prune Horizon (days)"
+#: common/views_manage.py:417
+msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:420
-msgid "Remote profiles inactive for this many days will be pruned."
+#: common/views_manage.py:419
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
 #: common/views_manage.py:425
-msgid "Search Sites"
+msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:426
-msgid "External search sites to include, one per line."
-msgstr ""
-
-#: common/views_manage.py:429
-msgid "Federated Search Peers"
-msgstr ""
-
-#: common/views_manage.py:430
-msgid "NeoDB peer instances for federated search, one per line."
+#: common/views_manage.py:427
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
 #: common/views_manage.py:433
-msgid "Hidden Categories"
+msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:434
-msgid "Category values to hide from the catalog, one per line."
+#: common/views_manage.py:435
+msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:455
-msgid "Spotify API Key"
+#: common/views_manage.py:442
+msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:456
-msgid "https://developer.spotify.com/"
+#: common/views_manage.py:445
+msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:459
-msgid "TMDB API Key"
+#: common/views_manage.py:452
+msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:460
-msgid "https://developer.themoviedb.org/"
-msgstr ""
-
-#: common/views_manage.py:463
-msgid "Google Books API Key"
-msgstr ""
-
-#: common/views_manage.py:464
-msgid "https://developers.google.com/books/"
-msgstr ""
-
-#: common/views_manage.py:467
-msgid "Discogs API Key"
-msgstr ""
-
-#: common/views_manage.py:469
-msgid "Personal access token from https://www.discogs.com/settings/developers"
+#: common/views_manage.py:468
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
 #: common/views_manage.py:473
-msgid "IGDB Client ID"
+msgid "Enable Local-Only Posting"
 msgstr ""
 
 #: common/views_manage.py:474
-msgid "https://api-docs.igdb.com/"
+msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
 #: common/views_manage.py:477
-msgid "IGDB Client Secret"
+msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:480 users/templates/users/steam_import.html:26
-msgid "Steam API Key"
+#: common/views_manage.py:478
+msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:482
-msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
+#: common/views_manage.py:481
+msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:487
-msgid "DeepL API Key"
+#: common/views_manage.py:484
+msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:488
-msgid "For translation features."
+#: common/views_manage.py:489
+msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:491
-msgid "LibreTranslate API URL"
+#: common/views_manage.py:495
+msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:494
-msgid "LibreTranslate API Key"
-msgstr ""
-
-#: common/views_manage.py:497
-msgid "Threads App ID"
-msgstr ""
-
-#: common/views_manage.py:498
-msgid "OAuth app ID for Threads login."
-msgstr ""
-
-#: common/views_manage.py:501
-msgid "Threads App Secret"
+#: common/views_manage.py:500
+msgid "Login Methods"
 msgstr ""
 
 #: common/views_manage.py:504
-msgid "Sentry DSN"
-msgstr ""
-
-#: common/views_manage.py:505
-msgid "Requires restart to take effect."
-msgstr ""
-
-#: common/views_manage.py:508
-msgid "Sentry Sample Rate"
-msgstr ""
-
-#: common/views_manage.py:509
-msgid "0.0 to 1.0. Requires restart to take effect."
+msgid "Localization"
 msgstr ""
 
 #: common/views_manage.py:514
-msgid "Discord Webhooks"
+msgid "Disable Default Relay"
 msgstr ""
 
 #: common/views_manage.py:516
-msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
+msgstr ""
+
+#: common/views_manage.py:521
+msgid "Fanout Limit (days)"
+msgstr ""
+
+#: common/views_manage.py:522
+msgid "Posts older than this many days will not be fanned out."
+msgstr ""
+
+#: common/views_manage.py:526
+msgid "Remote Prune Horizon (days)"
+msgstr ""
+
+#: common/views_manage.py:528
+msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
 #: common/views_manage.py:533
-msgid "Catalog APIs"
+msgid "Search Sites"
+msgstr ""
+
+#: common/views_manage.py:534
+msgid "External search sites to include, one per line."
+msgstr ""
+
+#: common/views_manage.py:537
+msgid "Federated Search Peers"
+msgstr ""
+
+#: common/views_manage.py:538
+msgid "NeoDB peer instances for federated search, one per line."
+msgstr ""
+
+#: common/views_manage.py:541
+msgid "Hidden Categories"
 msgstr ""
 
 #: common/views_manage.py:542
-msgid "Translation"
-msgstr ""
-
-#: common/views_manage.py:547
-msgid "Third-Party Login"
-msgstr ""
-
-#: common/views_manage.py:551
-msgid "Monitoring"
+msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
 #: common/views_manage.py:563
-msgid "Scraping Providers"
+msgid "Spotify API Key"
 msgstr ""
 
 #: common/views_manage.py:564
-msgid "Comma-separated list of providers to try in order."
+msgid "https://developer.spotify.com/"
 msgstr ""
 
 #: common/views_manage.py:567
-msgid "Proxy List"
+msgid "TMDB API Key"
 msgstr ""
 
 #: common/views_manage.py:568
-msgid "One per line, format: http://server?url=__URL__"
+msgid "https://developer.themoviedb.org/"
 msgstr ""
 
 #: common/views_manage.py:571
-msgid "Backup Proxy"
+msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:574
-msgid "Scrapfly API Key"
+#: common/views_manage.py:572
+msgid "https://developers.google.com/books/"
+msgstr ""
+
+#: common/views_manage.py:575
+msgid "Discogs API Key"
 msgstr ""
 
 #: common/views_manage.py:577
-msgid "Decodo Base64 Auth Token"
+msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:580
-msgid "ScraperAPI Key"
+#: common/views_manage.py:581
+msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:583
-msgid "ScrapingBee API Key"
+#: common/views_manage.py:582
+msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:586
-msgid "Custom Scraper URL"
+#: common/views_manage.py:585
+msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:587
-msgid "URL with __URL__ and __SELECTOR__ placeholders."
+#: common/views_manage.py:588 users/templates/users/steam_import.html:26
+msgid "Steam API Key"
 msgstr ""
 
 #: common/views_manage.py:590
-msgid "Request Timeout (seconds)"
+msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:594
-msgid "Cache Timeout (seconds)"
+#: common/views_manage.py:595
+msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:598
-msgid "Retries"
+#: common/views_manage.py:596
+msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:603
-msgid "Providers"
+#: common/views_manage.py:599
+msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:608
-msgid "Provider Keys"
+#: common/views_manage.py:602
+msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:615
-msgid "Timeouts"
+#: common/views_manage.py:605
+msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:627
-msgid "Alternative Domains"
+#: common/views_manage.py:606
+msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:628
-msgid "One domain per line."
+#: common/views_manage.py:609
+msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:631
-msgid "Mastodon Client Scope"
+#: common/views_manage.py:612
+msgid "Sentry DSN"
 msgstr ""
 
-#: common/views_manage.py:632
-msgid "OAuth scope when creating Mastodon apps."
+#: common/views_manage.py:613
+msgid "Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:635
-msgid "Disable Cron Jobs"
+#: common/views_manage.py:616
+msgid "Sentry Sample Rate"
 msgstr ""
 
-#: common/views_manage.py:636
-msgid "Job names to disable, one per line. Use * to disable all."
+#: common/views_manage.py:617
+msgid "0.0 to 1.0. Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:639
-msgid "Index Aliases"
+#: common/views_manage.py:622
+msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:640
-msgid "Map index names to their aliases."
+#: common/views_manage.py:624
+msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
+msgstr ""
+
+#: common/views_manage.py:641
+msgid "Catalog APIs"
 msgstr ""
 
 #: common/views_manage.py:650
+msgid "Translation"
+msgstr ""
+
+#: common/views_manage.py:655
+msgid "Third-Party Login"
+msgstr ""
+
+#: common/views_manage.py:659
+msgid "Monitoring"
+msgstr ""
+
+#: common/views_manage.py:671
+msgid "Scraping Providers"
+msgstr ""
+
+#: common/views_manage.py:672
+msgid "Comma-separated list of providers to try in order."
+msgstr ""
+
+#: common/views_manage.py:675
+msgid "Proxy List"
+msgstr ""
+
+#: common/views_manage.py:676
+msgid "One per line, format: http://server?url=__URL__"
+msgstr ""
+
+#: common/views_manage.py:679
+msgid "Backup Proxy"
+msgstr ""
+
+#: common/views_manage.py:682
+msgid "Scrapfly API Key"
+msgstr ""
+
+#: common/views_manage.py:685
+msgid "Decodo Base64 Auth Token"
+msgstr ""
+
+#: common/views_manage.py:688
+msgid "ScraperAPI Key"
+msgstr ""
+
+#: common/views_manage.py:691
+msgid "ScrapingBee API Key"
+msgstr ""
+
+#: common/views_manage.py:694
+msgid "Custom Scraper URL"
+msgstr ""
+
+#: common/views_manage.py:695
+msgid "URL with __URL__ and __SELECTOR__ placeholders."
+msgstr ""
+
+#: common/views_manage.py:698
+msgid "Request Timeout (seconds)"
+msgstr ""
+
+#: common/views_manage.py:702
+msgid "Cache Timeout (seconds)"
+msgstr ""
+
+#: common/views_manage.py:706
+msgid "Retries"
+msgstr ""
+
+#: common/views_manage.py:711
+msgid "Providers"
+msgstr ""
+
+#: common/views_manage.py:716
+msgid "Provider Keys"
+msgstr ""
+
+#: common/views_manage.py:723
+msgid "Timeouts"
+msgstr ""
+
+#: common/views_manage.py:735
+msgid "Alternative Domains"
+msgstr ""
+
+#: common/views_manage.py:736
+msgid "One domain per line."
+msgstr ""
+
+#: common/views_manage.py:739
+msgid "Mastodon Client Scope"
+msgstr ""
+
+#: common/views_manage.py:740
+msgid "OAuth scope when creating Mastodon apps."
+msgstr ""
+
+#: common/views_manage.py:743
+msgid "Disable Cron Jobs"
+msgstr ""
+
+#: common/views_manage.py:744
+msgid "Job names to disable, one per line. Use * to disable all."
+msgstr ""
+
+#: common/views_manage.py:747
+msgid "Index Aliases"
+msgstr ""
+
+#: common/views_manage.py:748
+msgid "Map index names to their aliases."
+msgstr ""
+
+#: common/views_manage.py:758
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:760
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:766
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:660
+#: common/views_manage.py:768
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:667
+#: common/views_manage.py:775
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:670
+#: common/views_manage.py:778
 msgid "Operational"
 msgstr ""
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 00:51-0400\n"
+"POT-Creation-Date: 2026-05-12 02:07-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -597,7 +597,7 @@ msgstr "开发者"
 msgid "year of publication"
 msgstr "发行年份"
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:176
+#: catalog/models/game.py:135 catalog/models/podcast.py:194
 msgid "date of publication"
 msgstr "发行日期"
 
@@ -1116,6 +1116,10 @@ msgstr "作笔记或摘抄"
 msgid "write a review"
 msgstr "撰写评论"
 
+#: catalog/templates/_item_similar.html:5
+msgid "Similar items"
+msgstr "相似条目"
+
 #: catalog/templates/_item_user_mark_history.html:20
 msgid "no history."
 msgstr "暂无标记历史。"
@@ -1551,7 +1555,7 @@ msgstr "创建"
 #: journal/templates/review_edit.html:39 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
 #: users/templates/users/account.html:38 users/templates/users/account.html:67
-#: users/templates/users/preferences.html:209
+#: users/templates/users/preferences.html:222
 msgid "Save"
 msgstr "保存"
 
@@ -1588,47 +1592,51 @@ msgstr "本操作不可撤销。确认合并吗？"
 msgid "Discover"
 msgstr "发现"
 
-#: catalog/templates/discover.html:86
+#: catalog/templates/discover.html:58
+msgid "Recommended for you"
+msgstr "为你推荐"
+
+#: catalog/templates/discover.html:111
 #: journal/templates/user_collection_list.html:18
 #: journal/templates/user_collection_list.html:32
 msgid "Collections"
 msgstr "收藏单"
 
-#: catalog/templates/discover.html:104 journal/templates/profile.html:235
+#: catalog/templates/discover.html:129 journal/templates/profile.html:235
 msgid "edit layout"
 msgstr "编辑布局"
 
-#: catalog/templates/discover.html:107 journal/templates/profile.html:238
+#: catalog/templates/discover.html:132 journal/templates/profile.html:238
 msgid "save"
 msgstr "保存"
 
-#: catalog/templates/discover.html:118 journal/templates/profile.html:249
+#: catalog/templates/discover.html:143 journal/templates/profile.html:249
 msgid "cancel"
 msgstr "取消"
 
-#: catalog/templates/discover.html:124 journal/templates/profile.html:255
+#: catalog/templates/discover.html:149 journal/templates/profile.html:255
 msgid "show"
 msgstr "显示"
 
-#: catalog/templates/discover.html:125 journal/templates/profile.html:256
+#: catalog/templates/discover.html:150 journal/templates/profile.html:256
 msgid "hide"
 msgstr "隐藏"
 
-#: catalog/templates/discover.html:157 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:182 common/templates/_sidebar.html:14
 msgid "Unread Announcements"
 msgstr "未读公告"
 
-#: catalog/templates/discover.html:163 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:188 common/templates/_sidebar.html:20
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "全部标为已读"
 
-#: catalog/templates/discover.html:173
+#: catalog/templates/discover.html:198
 #: common/templates/_sidebar_anonymous.html:55
 msgid "Popular Tags"
 msgstr "热门标签"
 
-#: catalog/templates/discover.html:180 catalog/templates/item_base.html:273
+#: catalog/templates/discover.html:205 catalog/templates/item_base.html:273
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28 common/templates/_sidebar.html:114
@@ -1645,7 +1653,7 @@ msgstr "热门标签"
 msgid "nothing so far."
 msgstr "暂无内容。"
 
-#: catalog/templates/discover.html:190 common/templates/_sidebar.html:237
+#: catalog/templates/discover.html:215 common/templates/_sidebar.html:237
 msgid "Recent Posts"
 msgstr "近期帖文"
 
@@ -4348,7 +4356,7 @@ msgstr "备注"
 msgid "search query for dynamic collection"
 msgstr "动态收藏单查询条件"
 
-#: journal/models/collection.py:373
+#: journal/models/collection.py:419
 msgid "created collection"
 msgstr "创建了收藏单"
 
@@ -6283,8 +6291,8 @@ msgid "Manually approve new followers"
 msgstr "手工审核关注者"
 
 #: takahe/models.py:459
-msgid "Include profile and posts in discovery"
-msgstr "允许个人资料和帖文包含在发现中"
+msgid "Include profile, marks and posts in discovery"
+msgstr "允许个人资料、标记和帖文包含在发现中"
 
 #: takahe/models.py:462
 msgid "Include posts in search results"
@@ -7238,6 +7246,14 @@ msgstr "此选项仅针对网页访客，如果不希望被联邦网络用户看
 msgid "Show your name on item page if you recently edited it"
 msgstr "显示你是某条目的最近编辑者"
 
+#: users/templates/users/preferences.html:215
+msgid "Do not show me item recommendations"
+msgstr "不向我展示条目推荐"
+
+#: users/templates/users/preferences.html:218
+msgid "Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck \"Include profile, marks and posts in discovery\" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features."
+msgstr "推荐仅基于公开标记在本服务器批量计算生成。你的私密标记与仅关注者可见的标记不会被用作任何人的推荐信号；本功能也不会与任何第三方共享你的数据。当你公开分享标记并保持个人资料可被发现时，你的标记会帮助本服务器与联邦宇宙中的其他人发现他们可能喜欢的内容——正是这种自愿的分享让本功能对每个人都有价值。如果你不希望参与贡献，请在账户页面取消勾选「允许个人资料、标记和帖文包含在发现中」；该设置会通过 ActivityPub 发布，其他服务器也会据此将你排除在他们的发现功能之外。"
+
 #: users/templates/users/profile_actions.html:12
 msgid "click to unblock"
 msgstr "点击可取消屏蔽"
@@ -7585,99 +7601,99 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:202 users/views/data.py:231
+#: users/views/data.py:207 users/views/data.py:236
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:225
+#: users/views/data.py:230
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:243
+#: users/views/data.py:248
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:258 users/views/data.py:278
+#: users/views/data.py:263 users/views/data.py:283
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:292
+#: users/views/data.py:297
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:306
+#: users/views/data.py:311
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:315 users/views/data.py:339 users/views/data.py:363
-#: users/views/data.py:388 users/views/data.py:412 users/views/data.py:436
+#: users/views/data.py:320 users/views/data.py:344 users/views/data.py:368
+#: users/views/data.py:393 users/views/data.py:417 users/views/data.py:441
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:556
+#: users/views/data.py:561
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:578
+#: users/views/data.py:583
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:594
+#: users/views/data.py:599
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:599
+#: users/views/data.py:604
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:609 users/views/data.py:660
+#: users/views/data.py:614 users/views/data.py:665
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:616
+#: users/views/data.py:621
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:621
+#: users/views/data.py:626
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:647
+#: users/views/data.py:652
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:652
+#: users/views/data.py:657
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:665
+#: users/views/data.py:670
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:676
+#: users/views/data.py:681
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:682
+#: users/views/data.py:687
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:740
+#: users/views/data.py:745
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:756
+#: users/views/data.py:761
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:760
+#: users/views/data.py:765
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:769
+#: users/views/data.py:774
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 02:07-0400\n"
+"POT-Creation-Date: 2026-05-12 09:33-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1588,7 +1588,7 @@ msgid "This operation cannot be undone. Sure to merge?"
 msgstr "本操作不可撤销。确认合并吗？"
 
 #: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:343 users/templates/users/preferences.html:34
+#: common/views_manage.py:344 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "发现"
 
@@ -2025,15 +2025,15 @@ msgstr "无效网址"
 msgid "Unsupported URL"
 msgstr "尚未支持的网址"
 
-#: catalog/views/view.py:65 catalog/views/view.py:90
+#: catalog/views/view.py:66 catalog/views/view.py:91
 msgid "Item not found"
 msgstr "条目不存在"
 
-#: catalog/views/view.py:69 catalog/views/view.py:98
+#: catalog/views/view.py:70 catalog/views/view.py:99
 msgid "Item no longer exists"
 msgstr "条目已不存在"
 
-#: catalog/views/view.py:165
+#: catalog/views/view.py:166
 #, fuzzy
 #| msgid "Invalid file."
 msgid "Invalid role"
@@ -3535,7 +3535,7 @@ msgstr "源代码"
 msgid "Registration"
 msgstr "注册"
 
-#: common/templates/common/about.html:35 common/views_manage.py:358
+#: common/templates/common/about.html:35 common/views_manage.py:466
 msgid "Invite Only"
 msgstr "仅限邀请"
 
@@ -3543,7 +3543,7 @@ msgstr "仅限邀请"
 msgid "Open Registration"
 msgstr "开放注册"
 
-#: common/templates/common/about.html:40 common/views_manage.py:379
+#: common/templates/common/about.html:40 common/views_manage.py:487
 msgid "Preferred Languages"
 msgstr "主要语言"
 
@@ -3599,7 +3599,7 @@ msgstr "正在请求摄像头权限…"
 msgid "Or type barcode / ISBN manually"
 msgstr "或手动输入条形码 / ISBN"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:443
+#: common/templates/common/scan.html:60 common/views_manage.py:551
 msgid "Search"
 msgstr "搜索"
 
@@ -3698,7 +3698,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: common/views_manage.py:143 common/views_manage.py:292
+#: common/views_manage.py:143 common/views_manage.py:293
 #, fuzzy
 #| msgid "reading"
 msgid "Branding"
@@ -3706,542 +3706,652 @@ msgstr "在读"
 
 #: common/views_manage.py:145
 #, fuzzy
+#| msgid "comments"
+msgid "Recommendations"
+msgstr "短评"
+
+#: common/views_manage.py:146
+#, fuzzy
 #| msgid "Accept"
 msgid "Access"
 msgstr "接受"
 
-#: common/views_manage.py:146 common/views_manage.py:438
+#: common/views_manage.py:147 common/views_manage.py:546
 #, fuzzy
 #| msgid "duration"
 msgid "Federation"
 msgstr "时长"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:148
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 #, fuzzy
 #| msgid "Download"
 msgid "Downloader"
 msgstr "下载"
 
-#: common/views_manage.py:149 common/views_manage.py:300
+#: common/views_manage.py:150 common/views_manage.py:301
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:199
+#: common/views_manage.py:200
 #, fuzzy
 #| msgid "Invalid user."
 msgid "Invalid value."
 msgstr "无效用户。"
 
-#: common/views_manage.py:203
+#: common/views_manage.py:204
 #, fuzzy
 #| msgid "Invalid verification code"
 msgid "Invalid configuration. Please check your input."
 msgstr "验证码无效或已过期"
 
-#: common/views_manage.py:208
+#: common/views_manage.py:209
 #, fuzzy
 #| msgid "Settings saved."
 msgid "Settings have been saved."
 msgstr "设置已保存"
 
-#: common/views_manage.py:228
+#: common/views_manage.py:229
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:231
+#: common/views_manage.py:232
 #, fuzzy
 #| msgid "Title and Description"
 msgid "Site Description"
 msgstr "标题和描述"
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:235
+#: common/views_manage.py:236
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:239
+#: common/views_manage.py:240
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:243
+#: common/views_manage.py:244
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:247
+#: common/views_manage.py:248
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:273
+#: common/views_manage.py:274
 #, fuzzy
 #| msgid "Production"
 msgid "Site Introduction"
 msgstr "上演"
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:277
+#: common/views_manage.py:278
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:282
+#: common/views_manage.py:283
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:312
+#: common/views_manage.py:313
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:314
+#: common/views_manage.py:315
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:319
+#: common/views_manage.py:320
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:324
+#: common/views_manage.py:325
 #, fuzzy
 #| msgid "Preferred Languages"
 msgid "Filter by Preferred Languages"
 msgstr "主要语言"
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:328
+#: common/views_manage.py:329
 #, fuzzy
 #| msgid "show all"
 msgid "Show Local Only"
 msgstr "显示全部"
 
-#: common/views_manage.py:330
+#: common/views_manage.py:331
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:334
+#: common/views_manage.py:335
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Posts"
 msgstr "热门标签"
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:338
+#: common/views_manage.py:339
 #, fuzzy
 #| msgid "Popular Tags"
 msgid "Show Popular Tags"
 msgstr "热门标签"
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:360
-msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
-msgstr ""
+#: common/views_manage.py:359
+msgid "Enable Recommendations"
+msgstr "启用推荐"
 
-#: common/views_manage.py:365
-msgid "Enable Local-Only Posting"
-msgstr ""
+#: common/views_manage.py:361
+msgid "Master switch. When off, all recommendation surfaces are hidden for regular users and the cron jobs are not scheduled. Test-enabled accounts (DEBUG mode or '!bazinga' in their bio) still see the surfaces, for preview."
+msgstr "推荐功能总开关。关闭时，常规用户不会看到推荐界面，相关定时任务也不会被调度。处于测试模式的账户（DEBUG 模式或 bio 中包含「!bazinga」）仍可看到推荐界面以便预览。"
 
-#: common/views_manage.py:366
-msgid "Allow users to create posts visible only to local users."
-msgstr ""
-
-#: common/views_manage.py:369
-msgid "Mastodon Login Whitelist"
+#: common/views_manage.py:368
+msgid "Source Item Mark Threshold"
 msgstr ""
 
 #: common/views_manage.py:370
+msgid "Minimum public marks an item needs before similarity rows are built for it."
+msgstr ""
+
+#: common/views_manage.py:376
+msgid "Target Item Mark Threshold"
+msgstr ""
+
+#: common/views_manage.py:378
+msgid "Minimum public marks an item needs to be eligible as a recommendation target."
+msgstr ""
+
+#: common/views_manage.py:384
+msgid "Top-K Similar Items per Source"
+msgstr ""
+
+#: common/views_manage.py:385
+msgid "Number of similar items stored per source item."
+msgstr ""
+
+#: common/views_manage.py:389
+msgid "Top-N Recommendations per User"
+msgstr ""
+
+#: common/views_manage.py:390
+msgid "Number of personalised rows stored per user."
+msgstr ""
+
+#: common/views_manage.py:394
+msgid "Dampen Heavy Shelvers"
+msgstr ""
+
+#: common/views_manage.py:396
+msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
+msgstr ""
+
+#: common/views_manage.py:401
+msgid "Per-User Mark Cap (training)"
+msgstr ""
+
+#: common/views_manage.py:403
+msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
+msgstr ""
+
+#: common/views_manage.py:409
+msgid "Active-User Window (days)"
+msgstr ""
+
+#: common/views_manage.py:411
+msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
+msgstr ""
+
+#: common/views_manage.py:417
+msgid "Per-User Seed Cap (serving)"
+msgstr ""
+
+#: common/views_manage.py:419
+msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
+msgstr ""
+
+#: common/views_manage.py:425
+msgid "Lazy Refresh TTL (days)"
+msgstr ""
+
+#: common/views_manage.py:427
+msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
+msgstr ""
+
+#: common/views_manage.py:433
+msgid "Circles Window (days)"
+msgstr ""
+
+#: common/views_manage.py:435
+msgid "Look back N days when finding items recently marked by people the viewer follows."
+msgstr ""
+
+#: common/views_manage.py:442
+msgid "Master Switch"
+msgstr "总开关"
+
+#: common/views_manage.py:445
+#, fuzzy
+#| msgid "Similar items"
+msgid "Similarity Builder"
+msgstr "相似条目"
+
+#: common/views_manage.py:452
+#, fuzzy
+#| msgid "Person / Organization"
+msgid "Personalisation"
+msgstr "人物 / 团体"
+
+#: common/views_manage.py:468
+msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
+msgstr ""
+
+#: common/views_manage.py:473
+msgid "Enable Local-Only Posting"
+msgstr ""
+
+#: common/views_manage.py:474
+msgid "Allow users to create posts visible only to local users."
+msgstr ""
+
+#: common/views_manage.py:477
+msgid "Mastodon Login Whitelist"
+msgstr ""
+
+#: common/views_manage.py:478
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:373
+#: common/views_manage.py:481
 #, fuzzy
 #| msgid "Bluesky Login ID"
 msgid "Enable Bluesky Login"
 msgstr "Bluesky 登录名"
 
-#: common/views_manage.py:376
+#: common/views_manage.py:484
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:381
+#: common/views_manage.py:489
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:387
+#: common/views_manage.py:495
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:392
+#: common/views_manage.py:500
 #, fuzzy
 #| msgid "Import Method"
 msgid "Login Methods"
 msgstr "导入方式"
 
-#: common/views_manage.py:396
+#: common/views_manage.py:504
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:406
+#: common/views_manage.py:514
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:408
+#: common/views_manage.py:516
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:413
+#: common/views_manage.py:521
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:522
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:418
+#: common/views_manage.py:526
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:420
+#: common/views_manage.py:528
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:425
+#: common/views_manage.py:533
 #, fuzzy
 #| msgid "Search filters"
 msgid "Search Sites"
 msgstr "筛选搜索结果"
 
-#: common/views_manage.py:426
+#: common/views_manage.py:534
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:429
+#: common/views_manage.py:537
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:430
+#: common/views_manage.py:538
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:433
+#: common/views_manage.py:541
 #, fuzzy
 #| msgid "Add tv series"
 msgid "Hidden Categories"
 msgstr "添加电视剧集"
 
-#: common/views_manage.py:434
+#: common/views_manage.py:542
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:455
+#: common/views_manage.py:563
 #, fuzzy
 #| msgid "Spotify Album"
 msgid "Spotify API Key"
 msgstr "Spotify专辑"
 
-#: common/views_manage.py:456
+#: common/views_manage.py:564
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:459
+#: common/views_manage.py:567
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:460
+#: common/views_manage.py:568
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:463
+#: common/views_manage.py:571
 #, fuzzy
 #| msgid "Google Books"
 msgid "Google Books API Key"
 msgstr "谷歌图书"
 
-#: common/views_manage.py:464
+#: common/views_manage.py:572
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:467
+#: common/views_manage.py:575
 #, fuzzy
 #| msgid "Discogs"
 msgid "Discogs API Key"
 msgstr "Discogs"
 
-#: common/views_manage.py:469
+#: common/views_manage.py:577
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:473
+#: common/views_manage.py:581
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:474
+#: common/views_manage.py:582
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:585
 #, fuzzy
 #| msgid "client secret"
 msgid "IGDB Client Secret"
 msgstr "实例应用Client Secret"
 
-#: common/views_manage.py:480 users/templates/users/steam_import.html:26
+#: common/views_manage.py:588 users/templates/users/steam_import.html:26
 #, fuzzy
 #| msgid "Steam Game"
 msgid "Steam API Key"
 msgstr "Steam游戏"
 
-#: common/views_manage.py:482
+#: common/views_manage.py:590
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:487
+#: common/views_manage.py:595
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:488
+#: common/views_manage.py:596
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:491
+#: common/views_manage.py:599
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:494
+#: common/views_manage.py:602
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:497
+#: common/views_manage.py:605
 #, fuzzy
 #| msgid "Threads"
 msgid "Threads App ID"
 msgstr "Threads"
 
-#: common/views_manage.py:498
+#: common/views_manage.py:606
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:609
 #, fuzzy
 #| msgid "Threads.net"
 msgid "Threads App Secret"
 msgstr "Threads.net"
 
-#: common/views_manage.py:504
+#: common/views_manage.py:612
 msgid "Sentry DSN"
 msgstr ""
 
-#: common/views_manage.py:505
+#: common/views_manage.py:613
 msgid "Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:508
+#: common/views_manage.py:616
 msgid "Sentry Sample Rate"
 msgstr ""
 
-#: common/views_manage.py:509
+#: common/views_manage.py:617
 msgid "0.0 to 1.0. Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:514
+#: common/views_manage.py:622
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:516
+#: common/views_manage.py:624
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:533
+#: common/views_manage.py:641
 #, fuzzy
 #| msgid "Catalog Moderators"
 msgid "Catalog APIs"
 msgstr "条目管理员"
 
-#: common/views_manage.py:542
+#: common/views_manage.py:650
 #, fuzzy
 #| msgid "translator"
 msgid "Translation"
 msgstr "译者"
 
-#: common/views_manage.py:547
+#: common/views_manage.py:655
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:551
+#: common/views_manage.py:659
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:563
+#: common/views_manage.py:671
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:672
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:567
+#: common/views_manage.py:675
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:568
+#: common/views_manage.py:676
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:679
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:574
+#: common/views_manage.py:682
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:577
+#: common/views_manage.py:685
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:580
+#: common/views_manage.py:688
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:583
+#: common/views_manage.py:691
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:586
+#: common/views_manage.py:694
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:587
+#: common/views_manage.py:695
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:590
+#: common/views_manage.py:698
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:594
+#: common/views_manage.py:702
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:598
+#: common/views_manage.py:706
 #, fuzzy
 #| msgid "series"
 msgid "Retries"
 msgstr "丛书"
 
-#: common/views_manage.py:603
+#: common/views_manage.py:711
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:608
+#: common/views_manage.py:716
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:723
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:627
+#: common/views_manage.py:735
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:628
+#: common/views_manage.py:736
 #, fuzzy
 #| msgid "site domain name"
 msgid "One domain per line."
 msgstr "站点域名"
 
-#: common/views_manage.py:631
+#: common/views_manage.py:739
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:632
+#: common/views_manage.py:740
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:635
+#: common/views_manage.py:743
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:636
+#: common/views_manage.py:744
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:639
+#: common/views_manage.py:747
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:640
+#: common/views_manage.py:748
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:650
+#: common/views_manage.py:758
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:760
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:658
+#: common/views_manage.py:766
 #, fuzzy
 #| msgid "Start Migration"
 msgid "Skip Migration Jobs"
 msgstr "开始迁移"
 
-#: common/views_manage.py:660
+#: common/views_manage.py:768
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:667
+#: common/views_manage.py:775
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:670
+#: common/views_manage.py:778
 #, fuzzy
 #| msgid "optional"
 msgid "Operational"

--- a/takahe/migrations/0001_initial.py
+++ b/takahe/migrations/0001_initial.py
@@ -166,7 +166,7 @@ class Migration(migrations.Migration):
                     "discoverable",
                     models.BooleanField(
                         default=True,
-                        verbose_name="Include profile and posts in discovery",
+                        verbose_name="Include profile, marks and posts in discovery",
                     ),
                 ),
                 (

--- a/takahe/models.py
+++ b/takahe/models.py
@@ -456,7 +456,7 @@ class Identity(models.Model):
     )
     discoverable = models.BooleanField(
         default=True,
-        verbose_name=_("Include profile and posts in discovery"),
+        verbose_name=_("Include profile, marks and posts in discovery"),
     )
     indexable = models.BooleanField(
         default=True, verbose_name=_("Include posts in search results")

--- a/tests/catalog/test_recommendation.py
+++ b/tests/catalog/test_recommendation.py
@@ -34,29 +34,27 @@ class TestPreferenceGate:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.user = User.register(email="g@test.com", username="g_user")
-        _set(
-            enable_recommendations=False,
-            enable_reco_similar_items=False,
-            enable_reco_for_you=False,
-            enable_reco_from_circles=False,
-        )
+        _set(enable_recommendations=False)
 
-    def test_off_when_master_off(self):
-        _set(enable_recommendations=False, enable_reco_similar_items=True)
+    def test_off_when_master_off_and_not_test_enabled(self, monkeypatch):
+        _set(enable_recommendations=False)
+        monkeypatch.setattr(type(self.user), "test_enabled", property(lambda s: False))
         assert self.user.preference.show_recommendations("similar_items") is False
 
-    def test_off_when_kind_off(self):
-        _set(enable_recommendations=True, enable_reco_similar_items=False)
-        assert self.user.preference.show_recommendations("similar_items") is False
+    def test_on_when_test_enabled_even_if_master_off(self, monkeypatch):
+        _set(enable_recommendations=False)
+        monkeypatch.setattr(type(self.user), "test_enabled", property(lambda s: True))
+        assert self.user.preference.show_recommendations("similar_items") is True
 
-    def test_off_when_user_opted_out(self):
-        _set(enable_recommendations=True, enable_reco_similar_items=True)
+    def test_off_when_user_opted_out_even_if_test_enabled(self, monkeypatch):
+        _set(enable_recommendations=True)
+        monkeypatch.setattr(type(self.user), "test_enabled", property(lambda s: True))
         self.user.preference.disable_recommendations = True
         self.user.preference.save()
         assert self.user.preference.show_recommendations("similar_items") is False
 
-    def test_on_when_all_enabled(self):
-        _set(enable_recommendations=True, enable_reco_similar_items=True)
+    def test_on_when_master_on(self):
+        _set(enable_recommendations=True)
         self.user.preference.disable_recommendations = False
         self.user.preference.save()
         assert self.user.preference.show_recommendations("similar_items") is True
@@ -68,7 +66,6 @@ class TestSimilarityBuilder:
     def setup(self):
         _set(
             enable_recommendations=True,
-            enable_reco_similar_items=True,
             reco_min_source_marks=3,
             reco_min_target_marks=2,
             reco_similarity_top_k=10,
@@ -215,7 +212,6 @@ class TestUserRecommendations:
     def setup(self):
         _set(
             enable_recommendations=True,
-            enable_reco_for_you=True,
             reco_min_source_marks=2,
             reco_min_target_marks=2,
             reco_similarity_top_k=10,
@@ -297,14 +293,12 @@ class TestSimilarItemsHelper:
 class TestBlendedReturnsEmptyWhenDisabled:
     @pytest.fixture(autouse=True)
     def setup(self):
-        _set(
-            enable_recommendations=False,
-            enable_reco_for_you=False,
-            enable_reco_from_circles=False,
-        )
+        _set(enable_recommendations=False)
         self.user = User.register(email="bd@t.com", username="bd_user")
 
-    def test_empty_when_master_off(self):
+    def test_empty_when_master_off(self, monkeypatch):
+        # Ensure test_enabled is off so the master switch is the only gate.
+        monkeypatch.setattr(type(self.user), "test_enabled", property(lambda s: False))
         out = blended_for_discover(self.user, limit=10)
         assert out == []
 

--- a/tests/catalog/test_recommendation.py
+++ b/tests/catalog/test_recommendation.py
@@ -1,0 +1,306 @@
+import pytest
+
+from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommendations
+from catalog.models import (
+    Edition,
+    ItemSimilarity,
+    UserRecommendation,
+)
+from catalog.recommendation import (
+    blended_for_discover,
+    compute_for_user,
+    similar_items,
+)
+from common.models import SiteConfig
+from journal.models import Mark, ShelfType
+from users.models import User
+
+
+def _set(**kwargs):
+    """Override SiteConfig.system for the duration of a test."""
+    for k, v in kwargs.items():
+        setattr(SiteConfig.system, k, v)
+
+
+def _public_mark(identity, item, shelf=ShelfType.COMPLETE, rating=8):
+    Mark(identity, item).update(shelf, "", rating, [], 0)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPreferenceGate:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.user = User.register(email="g@test.com", username="g_user")
+        _set(
+            enable_recommendations=False,
+            enable_reco_similar_items=False,
+            enable_reco_for_you=False,
+            enable_reco_from_circles=False,
+        )
+
+    def test_off_when_master_off(self):
+        _set(enable_recommendations=False, enable_reco_similar_items=True)
+        assert self.user.preference.show_recommendations("similar_items") is False
+
+    def test_off_when_kind_off(self):
+        _set(enable_recommendations=True, enable_reco_similar_items=False)
+        assert self.user.preference.show_recommendations("similar_items") is False
+
+    def test_off_when_user_opted_out(self):
+        _set(enable_recommendations=True, enable_reco_similar_items=True)
+        self.user.preference.disable_recommendations = True
+        self.user.preference.save()
+        assert self.user.preference.show_recommendations("similar_items") is False
+
+    def test_on_when_all_enabled(self):
+        _set(enable_recommendations=True, enable_reco_similar_items=True)
+        self.user.preference.disable_recommendations = False
+        self.user.preference.save()
+        assert self.user.preference.show_recommendations("similar_items") is True
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSimilarityBuilder:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            enable_reco_similar_items=True,
+            reco_min_source_marks=3,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=True,
+        )
+        # 4 users, 4 books. Build co-occurrence A-B, C-D strong; A-D weak.
+        self.users = [
+            User.register(email=f"s{i}@test.com", username=f"s_user{i}")
+            for i in range(5)
+        ]
+        self.identities = [u.identity for u in self.users]
+        self.book_a = Edition.objects.create(title="A")
+        self.book_b = Edition.objects.create(title="B")
+        self.book_c = Edition.objects.create(title="C")
+        self.book_d = Edition.objects.create(title="D")
+        # 3 users co-shelve A+B
+        for ident in self.identities[:3]:
+            _public_mark(ident, self.book_a)
+            _public_mark(ident, self.book_b)
+        # 3 users co-shelve C+D
+        for ident in self.identities[2:5]:
+            _public_mark(ident, self.book_c)
+            _public_mark(ident, self.book_d)
+        # 1 cross-shelving for noise
+        _public_mark(self.identities[0], self.book_d)
+
+    def test_active_items_meet_threshold(self):
+        BuildItemSimilarity().run()
+        sources = set(
+            ItemSimilarity.objects.values_list("source_id", flat=True).distinct()
+        )
+        # All four books have >= 3 marks (A=3, B=3, C=3, D=4)
+        assert {
+            self.book_a.pk,
+            self.book_b.pk,
+            self.book_c.pk,
+            self.book_d.pk,
+        } <= sources
+
+    def test_top_similarity_pair_is_strongest(self):
+        BuildItemSimilarity().run()
+        a_top = (
+            ItemSimilarity.objects.filter(source=self.book_a).order_by("-score").first()
+        )
+        assert a_top is not None
+        assert a_top.target_id == self.book_b.pk
+
+    def test_idf_damping_softens_heavy_user(self):
+        # Add a heavy user that shelves all 4 books -- their pair contribution
+        # should be heavily damped vs. the non-heavy users above.
+        heavy = User.register(email="h@test.com", username="h_user").identity
+        for b in (self.book_a, self.book_b, self.book_c, self.book_d):
+            _public_mark(heavy, b)
+        BuildItemSimilarity().run()
+        # A-B score should remain larger than A-C, because A and C only share
+        # the heavy user (damped) while A-B has 3 distinct dedicated co-shelvers.
+        ab = ItemSimilarity.objects.filter(
+            source=self.book_a, target=self.book_b
+        ).first()
+        ac = ItemSimilarity.objects.filter(
+            source=self.book_a, target=self.book_c
+        ).first()
+        assert ab is not None
+        if ac is not None:
+            assert ab.score > ac.score
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestDiscoverableOptOut:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.users = [
+            User.register(email=f"d{i}@test.com", username=f"d_user{i}")
+            for i in range(2)
+        ]
+        self.identities = [u.identity for u in self.users]
+        self.p = Edition.objects.create(title="P")
+        self.q = Edition.objects.create(title="Q")
+        for ident in self.identities:
+            _public_mark(ident, self.p)
+            _public_mark(ident, self.q)
+
+    def _set_discoverable(self, identity, value: bool) -> None:
+        t = identity.takahe_identity
+        t.discoverable = value
+        t.save(update_fields=["discoverable"])
+
+    def test_marks_skipped_when_owner_not_discoverable(self):
+        # Both users opt out -> no co-occurrence at all.
+        for ident in self.identities:
+            self._set_discoverable(ident, False)
+        BuildItemSimilarity().run()
+        assert not ItemSimilarity.objects.filter(source=self.p).exists()
+
+    def test_single_holdout_drops_cooc_below_threshold(self):
+        # Only one user opts out -> threshold of 2 marks no longer met for P or Q.
+        self._set_discoverable(self.identities[0], False)
+        BuildItemSimilarity().run()
+        assert not ItemSimilarity.objects.filter(source=self.p).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestVisibilityRegression:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.users = [
+            User.register(email=f"v{i}@test.com", username=f"v_user{i}")
+            for i in range(3)
+        ]
+        self.identities = [u.identity for u in self.users]
+        self.x = Edition.objects.create(title="X")
+        self.y = Edition.objects.create(title="Y")
+
+    def test_private_marks_excluded(self):
+        # 2 users mark X+Y privately (visibility=2)
+        for ident in self.identities[:2]:
+            Mark(ident, self.x).update(ShelfType.COMPLETE, "", 5, [], 2)
+            Mark(ident, self.y).update(ShelfType.COMPLETE, "", 5, [], 2)
+        BuildItemSimilarity().run()
+        # No similarity should appear -- private marks shouldn't contribute
+        assert not ItemSimilarity.objects.filter(source=self.x).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestUserRecommendations:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            enable_reco_for_you=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_top_n=10,
+            reco_per_user_seed_cap=50,
+            reco_user_mark_cap=100,
+            reco_user_active_days=30,
+            reco_user_idf_dampen=False,
+            reco_lazy_ttl_days=7,
+        )
+        self.alice = User.register(email="a@t.com", username="alice").identity
+        self.bob = User.register(email="b@t.com", username="bob").identity
+        self.target_user = User.register(email="t@t.com", username="target_user")
+        self.target_id = self.target_user.identity
+        self.b1 = Edition.objects.create(title="Sci-Fi 1")
+        self.b2 = Edition.objects.create(title="Sci-Fi 2")
+        self.b3 = Edition.objects.create(title="Sci-Fi 3")
+        # Two strangers co-shelve b1+b2 and b1+b3, giving b1 similarity to b2 & b3.
+        for ident in (self.alice, self.bob):
+            _public_mark(ident, self.b1)
+            _public_mark(ident, self.b2)
+            _public_mark(ident, self.b3)
+        BuildItemSimilarity().run()
+        # Target user shelves only b1.
+        _public_mark(self.target_id, self.b1)
+
+    def test_excludes_already_shelved(self):
+        rows = compute_for_user(self.target_user.pk, self.target_id.pk)
+        ids = {r.item_id for r in rows}
+        assert self.b1.pk not in ids
+        # b2 and b3 should appear as candidates.
+        assert self.b2.pk in ids or self.b3.pk in ids
+
+    def test_batch_job_writes_rows(self):
+        BuildUserRecommendations().run()
+        assert UserRecommendation.objects.filter(user=self.target_user).exists()
+        # Each row's item must not be one the user already shelved.
+        for row in UserRecommendation.objects.filter(user=self.target_user):
+            assert row.item_id != self.b1.pk
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSimilarItemsHelper:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.viewers = [
+            User.register(email=f"sv{i}@t.com", username=f"sv{i}").identity
+            for i in range(3)
+        ]
+        self.src = Edition.objects.create(title="Src")
+        self.t1 = Edition.objects.create(title="T1")
+        self.t2 = Edition.objects.create(title="T2")
+        for v in self.viewers:
+            _public_mark(v, self.src)
+            _public_mark(v, self.t1)
+            _public_mark(v, self.t2)
+        BuildItemSimilarity().run()
+
+    def test_returns_items(self):
+        out = similar_items(self.src, viewer=None, limit=5)
+        assert {i.pk for i in out} >= {self.t1.pk, self.t2.pk} - {0}
+
+    def test_excludes_shelved_for_viewer(self):
+        watcher = User.register(email="w@t.com", username="watcher")
+        _public_mark(watcher.identity, self.t1)
+        out = similar_items(self.src, viewer=watcher, limit=5)
+        assert all(i.pk != self.t1.pk for i in out)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestBlendedReturnsEmptyWhenDisabled:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=False,
+            enable_reco_for_you=False,
+            enable_reco_from_circles=False,
+        )
+        self.user = User.register(email="bd@t.com", username="bd_user")
+
+    def test_empty_when_master_off(self):
+        out = blended_for_discover(self.user, limit=10)
+        assert out == []

--- a/tests/catalog/test_recommendation.py
+++ b/tests/catalog/test_recommendation.py
@@ -4,6 +4,9 @@ from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommenda
 from catalog.models import (
     Edition,
     ItemSimilarity,
+    Performance,
+    PerformanceProduction,
+    TVShow,
     UserRecommendation,
 )
 from catalog.recommendation import (
@@ -304,3 +307,115 @@ class TestBlendedReturnsEmptyWhenDisabled:
     def test_empty_when_master_off(self):
         out = blended_for_discover(self.user, limit=10)
         assert out == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestWishlistAsSeed:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.users = [
+            User.register(email=f"w{i}@test.com", username=f"w_user{i}")
+            for i in range(2)
+        ]
+        self.identities = [u.identity for u in self.users]
+        self.k = Edition.objects.create(title="K")
+        self.l = Edition.objects.create(title="L")
+        # Both users wishlist both books.
+        for ident in self.identities:
+            Mark(ident, self.k).update(ShelfType.WISHLIST, "", 0, [], 0)
+            Mark(ident, self.l).update(ShelfType.WISHLIST, "", 0, [], 0)
+
+    def test_wishlist_marks_train_similarity(self):
+        BuildItemSimilarity().run()
+        # K and L are co-wishlisted by 2 distinct users -> threshold met,
+        # similarity row should exist.
+        assert ItemSimilarity.objects.filter(source=self.k, target=self.l).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestProductionRewritesToPerformance:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.users = [
+            User.register(email=f"pp{i}@test.com", username=f"pp_user{i}")
+            for i in range(2)
+        ]
+        self.identities = [u.identity for u in self.users]
+        # Performance with two Productions; both users shelve one Production each.
+        self.show = Performance.objects.create(title="Hamilton")
+        self.prod_a = PerformanceProduction.objects.create(title="2015 Broadway")
+        self.prod_a.show = self.show
+        self.prod_a.save()
+        self.prod_b = PerformanceProduction.objects.create(title="2024 Tour")
+        self.prod_b.show = self.show
+        self.prod_b.save()
+        # Another Performance that one user shelved (Performance-direct).
+        self.peer = Performance.objects.create(title="Other Show")
+        _public_mark(self.identities[0], self.prod_a)
+        _public_mark(self.identities[1], self.prod_b)
+        # Both also mark the peer Performance so co-occurrence is non-trivial.
+        _public_mark(self.identities[0], self.peer)
+        _public_mark(self.identities[1], self.peer)
+
+    def test_production_marks_aggregate_to_performance(self):
+        BuildItemSimilarity().run()
+        # Hamilton (Performance) should appear as a source even though
+        # nobody marked it directly -- two distinct users shelved its
+        # Productions, meeting min_source_marks=2 after rewrite.
+        assert ItemSimilarity.objects.filter(source=self.show).exists()
+
+    def test_productions_are_not_recommended(self):
+        BuildItemSimilarity().run()
+        # PerformanceProduction must never appear as a target.
+        target_ids = set(
+            ItemSimilarity.objects.values_list("target_id", flat=True).distinct()
+        )
+        assert self.prod_a.pk not in target_ids
+        assert self.prod_b.pk not in target_ids
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestExcludedTargetClasses:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_mark_cap=100,
+            reco_user_idf_dampen=False,
+        )
+        self.users = [
+            User.register(email=f"ex{i}@test.com", username=f"ex_user{i}")
+            for i in range(2)
+        ]
+        self.identities = [u.identity for u in self.users]
+        self.show = TVShow.objects.create(title="A Show")
+        self.peer = Edition.objects.create(title="A Book")
+        for ident in self.identities:
+            _public_mark(ident, self.show)
+            _public_mark(ident, self.peer)
+
+    def test_tvshow_never_recommended(self):
+        BuildItemSimilarity().run()
+        target_ids = set(
+            ItemSimilarity.objects.values_list("target_id", flat=True).distinct()
+        )
+        assert self.show.pk not in target_ids

--- a/tests/core/test_views_manage.py
+++ b/tests/core/test_views_manage.py
@@ -9,11 +9,13 @@ from common.views_manage import (
     DiscoverSettings,
     DownloaderSettings,
     FederationSettings,
+    RecommendationSettings,
 )
 
 ALL_SETTINGS_PAGES = [
     BrandingSettings,
     DiscoverSettings,
+    RecommendationSettings,
     AccessSettings,
     FederationSettings,
     APIKeysSettings,

--- a/users/migrations/0011_preference_disable_recommendations.py
+++ b/users/migrations/0011_preference_disable_recommendations.py
@@ -10,6 +10,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="preference",
             name="disable_recommendations",
-            field=models.BooleanField(default=False),
+            field=models.BooleanField(default=False, null=True),
         ),
     ]

--- a/users/migrations/0011_preference_disable_recommendations.py
+++ b/users/migrations/0011_preference_disable_recommendations.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0010_preference_disabled_search_sources"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="preference",
+            name="disable_recommendations",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/users/models/preference.py
+++ b/users/models/preference.py
@@ -44,7 +44,7 @@ class Preference(models.Model):
     mastodon_skip_userinfo = models.BooleanField(null=False, default=False)
     mastodon_skip_relationship = models.BooleanField(null=False, default=False)
     mastodon_boost_enabled = models.BooleanField(null=True, default=False)
-    disable_recommendations = models.BooleanField(null=False, default=False)
+    disable_recommendations = models.BooleanField(null=True, default=False)
 
     def __str__(self):
         return str(self.user)

--- a/users/models/preference.py
+++ b/users/models/preference.py
@@ -1,7 +1,11 @@
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
+from common.models.site_config import SiteConfig
+
 from .user import User
+
+RECO_KINDS = ("similar_items", "for_you", "from_circles")
 
 
 def _default_book_cats():
@@ -40,6 +44,24 @@ class Preference(models.Model):
     mastodon_skip_userinfo = models.BooleanField(null=False, default=False)
     mastodon_skip_relationship = models.BooleanField(null=False, default=False)
     mastodon_boost_enabled = models.BooleanField(null=True, default=False)
+    disable_recommendations = models.BooleanField(null=False, default=False)
 
     def __str__(self):
         return str(self.user)
+
+    def show_recommendations(self, kind: str) -> bool:
+        """Whether to show the given recommendation surface to this user.
+
+        Gate: site master switch AND surface sub-switch AND user opt-in.
+        """
+        if self.disable_recommendations:
+            return False
+        sys = SiteConfig.system
+        if not sys.enable_recommendations:
+            return False
+        sub = {
+            "similar_items": sys.enable_reco_similar_items,
+            "for_you": sys.enable_reco_for_you,
+            "from_circles": sys.enable_reco_from_circles,
+        }.get(kind, False)
+        return bool(sub)

--- a/users/models/preference.py
+++ b/users/models/preference.py
@@ -52,16 +52,15 @@ class Preference(models.Model):
     def show_recommendations(self, kind: str) -> bool:
         """Whether to show the given recommendation surface to this user.
 
-        Gate: site master switch AND surface sub-switch AND user opt-in.
+        Gate: user opt-in AND (site master switch OR user is test-enabled).
+        ``kind`` is kept in the signature so callers can pass it through; the
+        anonymous-vs-authenticated routing in ``catalog.recommendation`` still
+        distinguishes which surfaces an anonymous viewer can see.
         """
         if self.disable_recommendations:
             return False
-        sys = SiteConfig.system
-        if not sys.enable_recommendations:
-            return False
-        sub = {
-            "similar_items": sys.enable_reco_similar_items,
-            "for_you": sys.enable_reco_for_you,
-            "from_circles": sys.enable_reco_from_circles,
-        }.get(kind, False)
-        return bool(sub)
+        if SiteConfig.system.enable_recommendations:
+            return True
+        # Internal testers (DEBUG mode or marker in their bio) can preview the
+        # feature even when the site master switch is still off.
+        return bool(getattr(self.user, "test_enabled", False))

--- a/users/templates/users/preferences.html
+++ b/users/templates/users/preferences.html
@@ -206,6 +206,19 @@
                   {% trans 'Show your name on item page if you recently edited it' %}
                 </label>
               </fieldset>
+              {% if enable_recommendations %}
+                <fieldset>
+                  <label>
+                    <input type="checkbox"
+                           name="disable_recommendations"
+                           {% if request.user.preference.disable_recommendations %}checked{% endif %}>
+                    {% trans 'Do not show me item recommendations' %}
+                  </label>
+                  <small>
+                    {% blocktrans %}Recommendations are generated only from public marks, processed in batch on this server. Your private and follower-only marks are never used as a signal for anyone, and we never share your data with third parties for this feature. When you share marks publicly and keep your profile discoverable, your marks help others here and across the Fediverse find things they might enjoy -- that voluntary contribution is what makes the feature work for everyone. If you'd rather not contribute, uncheck "Include profile, marks and posts in discovery" on your account page; this setting is published over ActivityPub, so other servers will also stop including you in their discovery features.{% endblocktrans %}
+                  </small>
+                </fieldset>
+              {% endif %}
               <input type="submit" value="{% trans 'Save' %}">
             </form>
           </details>

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -76,6 +76,9 @@ def preferences(request):
         preference.mastodon_append_tag = request.POST.get(
             "mastodon_append_tag", ""
         ).strip()
+        preference.disable_recommendations = bool(
+            request.POST.get("disable_recommendations")
+        )
         preference.save(
             update_fields=[
                 "default_visibility",
@@ -89,6 +92,7 @@ def preferences(request):
                 "show_last_edit",
                 "hidden_categories",
                 "disabled_search_sources",
+                "disable_recommendations",
             ]
         )
         lang = request.POST.get("language")
@@ -110,6 +114,7 @@ def preferences(request):
         {
             "enable_local_only": SiteConfig.system.enable_local_only,
             "search_sources": search_sources,
+            "enable_recommendations": SiteConfig.system.enable_recommendations,
         },
     )
 


### PR DESCRIPTION
Closes #26.

Adds three opt-in recommendation surfaces, gated by a site master switch, three per-surface sub-switches, and a user preference. Disabled by default; can be dry-run before being shown to users.

## Surfaces

- **Similar items** — HTMX-lazy block at the bottom of the item-page middle column. Empty fragment hides itself.
- **Recommended for you** — top row on the discover page. Blends personalised + from-your-circles; hidden when fewer than 3 items survive the already-shelved filter.
- **APIs** — `GET /api/catalog/item/{uuid}/similar` and `GET /api/me/recommendations`, both gated identically to the UI surfaces.

## How it works

- `ItemSimilarity` (top-K per source) and `UserRecommendation` (per-user precomputed) tables in `catalog`.
- Weekly `BuildItemSimilarity` RQ job builds item-item shelf co-occurrence with `1/sqrt(n)` user-IDF damping and a per-user mark cap, neutralising mega-shelvers.
- Nightly `BuildUserRecommendations` refreshes users with public marks in the configured active window. Cold users get on-demand compute on first request, cached for `reco_lazy_ttl_days`.
- `from_your_circles` is a per-request query; respects existing `q_piece_visible_to_user` filter so it never surfaces private/follower-only marks.

## Privacy posture

- Only public marks (`visibility=0`) are used as training signal. Private and follower-only marks are never read by the builder.
- Training opt-out reuses the existing Takahe `Identity.discoverable` flag (same lever as `DiscoverGenerator`). Non-discoverable owners are excluded from the similarity matrix and from from-your-circles. Setting federates as `toot:discoverable` so the opt-out propagates across the Fediverse.
- Account-page checkbox renamed to "Include profile, marks and posts in discovery" (`verbose_name` folded into `takahe/0001_initial.py`; no SQL change).
- Preferences-page checkbox ("Don't show me recommendations") is independent of the training opt-out so all four positions remain expressible.
- Privacy explanation under the preferences checkbox: privacy floor first, community contribution framing, then opt-out + federation transparency. zh_Hans translation updated.

## Operations

- `neodb-manage recommendation [similarity|users|all]` bypasses the master flag so operators can pre-build data and inspect tables before enabling user-facing surfaces.
- Site config knobs live in `SystemOptions`: `enable_recommendations`, three sub-switches, plus `reco_min_source_marks` (3), `reco_min_target_marks` (2), `reco_similarity_top_k` (50), `reco_user_top_n` (100), `reco_user_idf_dampen` (True), `reco_user_mark_cap` (500), `reco_user_active_days` (30), `reco_per_user_seed_cap` (200), `reco_lazy_ttl_days` (7), `reco_circles_window_days` (30).
- Jobs auto-register via `JobManager` + explicit import in `catalog/apps.py`. `get_interval()` returns `timedelta(0)` when disabled so cron stays dormant until the flag flips and `neodb-manage cron --reschedule-all` runs.

## Scale check

Sized against a probe of the current 100k-identity / 4.2M-item / 11M-public-mark dataset. ~265k items meet the default `min_source` threshold; per-user batch covers ~1.4k users active in the last 30 days; expected sizes are `ItemSimilarity` ~13M rows / ~2GB, `UserRecommendation` ~140k rows / ~30MB. Builder runs in pure Python with stream-cap — no scipy dependency added.

## Tests

`tests/catalog/test_recommendation.py` covers:
- Preference gate (master / kind / opt-out / all-enabled)
- Similarity threshold + top-pair ordering + IDF damping vs heavy user
- Discoverable opt-out (both-out and single-holdout-below-threshold)
- Private-mark exclusion regression
- `compute_for_user` excludes already-shelved items and the batch job writes consistent rows
- `similar_items` helper viewer filtering
- Blended call returns empty when disabled

## Test plan
- [ ] Run pytest in Docker: `docker compose --profile dev run --rm dev-shell /neodb-venv/bin/pytest --reuse-db tests/catalog/test_recommendation.py`
- [ ] Apply migrations on a copy of prod-shape data: `python manage.py migrate` and `python /takahe/manage.py migrate` (the `verbose_name` change is in `0001_initial.py` and is noop SQL).
- [ ] Dry-run the batch: `neodb-manage recommendation all` and inspect `ItemSimilarity` / `UserRecommendation` row counts and a few sample neighbourhoods.
- [ ] Toggle `enable_recommendations` + sub-switches in site config; `neodb-manage cron --reschedule-all`; verify the discover row, item-page block, and API endpoints render.
- [ ] Verify a non-discoverable identity's marks are excluded from a rebuilt similarity table.