### PR TITLE
refactor(cron): drive periodic jobs with rq.cron.CronScheduler

### DIFF
--- a/boofilsic/cron_config.py
+++ b/boofilsic/cron_config.py
@@ -1,0 +1,33 @@
+"""Cron job configuration loaded by ``rq.cron.CronScheduler``.
+
+Loaded either via ``rq cron boofilsic.cron_config`` (standalone) or via
+``neodb-manage cron --start`` (Django already set up). Importing this module
+triggers registration of every ``BaseJob`` subclass with ``rq.cron``.
+"""
+
+import os
+
+
+def _ensure_django():
+    import django
+    from django.apps import apps
+
+    if not apps.ready:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "boofilsic.settings")
+        django.setup()
+
+
+_ensure_django()
+
+# Importing the app job modules registers their BaseJob subclasses via the
+# @JobManager.register decorator. Each app's AppConfig.ready() does the same,
+# but apps.ready may have already finished by the time this module loads, so
+# we import explicitly to be safe.
+from catalog import jobs as _catalog_jobs  # noqa: F401, E402
+from common.models import JobManager, SiteConfig  # noqa: E402
+from mastodon import jobs as _mastodon_jobs  # noqa: F401, E402
+from takahe import jobs as _takahe_jobs  # noqa: F401, E402
+from users import jobs as _users_jobs  # noqa: F401, E402
+
+SiteConfig.ensure_loaded()
+JobManager.register_with_rq_cron()

--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -715,6 +715,7 @@ if _SENTRY_DSN:
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.logging import ignore_logger
     from sentry_sdk.integrations.loguru import LoguruIntegration
+    from sentry_sdk.integrations.rq import RqIntegration
 
     ignore_logger("podcastparser")
 
@@ -727,6 +728,7 @@ if _SENTRY_DSN:
         integrations=[
             DjangoIntegration(),
             LoguruIntegration(event_format="{name}:{function}:{line} - {message}"),
+            RqIntegration(),
         ],
         release=NEODB_VERSION,
         send_default_pii=True,

--- a/catalog/migrations/0003_reset_trends.py
+++ b/catalog/migrations/0003_reset_trends.py
@@ -7,7 +7,7 @@ from django.db import migrations
 def reset_trends(apps, schema_editor):
     """reset trends cache as the model class names changed"""
     cache.set("public_gallery", [], timeout=None)
-    # DiscoverGenerator is rescheduled by Setup.run() after all migrations
+    # DiscoverGenerator will repopulate the cache on its next scheduled run.
 
 
 class Migration(migrations.Migration):

--- a/common/management/commands/cron.py
+++ b/common/management/commands/cron.py
@@ -1,58 +1,69 @@
+import logging
+
+import django_rq
 from loguru import logger
+from rq import cron as rq_cron
 
 from common.management.base import SiteCommand
 from common.models import JobManager
+from common.models.cron import CRON_QUEUE
 
-# @JobManager.register
-# class DummyJob(BaseJob):
-#     interval = timedelta(seconds=10)
-
-#     def run(self):
-#         logger.info("Dummy job started")
-#         if random.choice([0, 1]) == 0:
-#             raise Exception("Dummy job randomly failed")
-#         sleep(3)
-#         logger.info("Dummy job stopped")
+CRON_CONFIG_MODULE = "boofilsic.cron_config"
 
 
 class Command(SiteCommand):
-    help = "Schedule timed jobs"
+    help = "Manage cron jobs via rq.cron"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--cancel-all",
+            "--start",
             action="store_true",
-        )
-        parser.add_argument(
-            "--reschedule-all",
-            action="store_true",
+            help="Run the rq.cron scheduler in the foreground.",
         )
         parser.add_argument(
             "--list",
             action="store_true",
+            help="List registered jobs and any active schedulers.",
         )
         parser.add_argument(
             "--run-once",
             action="append",
-        )
-        parser.add_argument(
-            "--reschedule-now",
-            action="append",
+            help="Execute the named job synchronously in this process.",
         )
 
     def handle(self, *args, **options):
-        if options["cancel_all"]:
-            JobManager.cancel_all()
-        if options["reschedule_all"]:
-            JobManager.reschedule_all()
-        if options["reschedule_now"]:
-            for job_id in options["reschedule_now"]:
-                JobManager.get(job_id).reschedule(now=True)
         if options["run_once"]:
             for job_id in options["run_once"]:
                 JobManager.get(job_id)().run()
         if options["list"]:
-            all_jobs = [j.__name__ for j in JobManager.registry]
-            logger.info(f"{len(all_jobs)} available jobs: {' '.join(all_jobs)}")
-            jobs = JobManager.get_scheduled_job_ids()
-            logger.info(f"{len(jobs)} scheduled jobs: {' '.join(jobs)}")
+            self._list()
+        if options["start"]:
+            self._start()
+
+    def _list(self):
+        # Ensure all jobs are imported into the registry.
+        __import__(CRON_CONFIG_MODULE, fromlist=["*"])
+        names = sorted(j.__name__ for j in JobManager.registry)
+        logger.info(f"{len(names)} registered jobs: {' '.join(names)}")
+        try:
+            schedulers = JobManager.get_active_schedulers()
+        except Exception as e:
+            logger.warning(f"Unable to query active schedulers: {e}")
+            return
+        logger.info(f"{len(schedulers)} active cron scheduler(s):")
+        for s in schedulers:
+            for job in s.get_jobs():
+                logger.info(
+                    f"  {s.name}  {job.func_name}  args={job.args}  "
+                    f"interval={job.interval}  cron={job.cron}  "
+                    f"next={job.next_enqueue_time}"
+                )
+
+    def _start(self):
+        connection = django_rq.get_connection(CRON_QUEUE)
+        scheduler = rq_cron.CronScheduler(
+            connection=connection,
+            logging_level=logging.INFO,
+        )
+        scheduler.load_config_from_file(CRON_CONFIG_MODULE)
+        scheduler.start()

--- a/common/management/commands/cron.py
+++ b/common/management/commands/cron.py
@@ -32,6 +32,9 @@ class Command(SiteCommand):
         )
 
     def handle(self, *args, **options):
+        # Ensure every BaseJob subclass is loaded into JobManager.registry
+        # regardless of which subcommand we run.
+        __import__(CRON_CONFIG_MODULE, fromlist=["*"])
         if options["run_once"]:
             for job_id in options["run_once"]:
                 JobManager.get(job_id)().run()
@@ -41,8 +44,6 @@ class Command(SiteCommand):
             self._start()
 
     def _list(self):
-        # Ensure all jobs are imported into the registry.
-        __import__(CRON_CONFIG_MODULE, fromlist=["*"])
         names = sorted(j.__name__ for j in JobManager.registry)
         logger.info(f"{len(names)} registered jobs: {' '.join(names)}")
         try:

--- a/common/models/cron.py
+++ b/common/models/cron.py
@@ -16,7 +16,14 @@ def run_job(job_id: str) -> None:
     module level (not as a classmethod) so RQ can resolve it by import path
     on the worker side.
     """
-    job_cls = JobManager.get(job_id)
+    try:
+        job_cls = JobManager.get(job_id)
+    except KeyError:
+        # Workers spawned without going through AppConfig.ready() (or where the
+        # app set is reduced) won't have the registry populated. The config
+        # module re-imports every jobs module.
+        __import__("boofilsic.cron_config", fromlist=["*"])
+        job_cls = JobManager.get(job_id)
     job_cls().run()
 
 
@@ -100,8 +107,11 @@ class JobManager:
                 "func": run_job,
                 "queue_name": j.queue_name,
                 "args": (job_id,),
-                "result_ttl": -1,
-                "failure_ttl": -1,
+                # Each tick creates a fresh job UUID under rq.cron (unlike the
+                # old fixed-job_id scheme that overwrote on re-enqueue), so
+                # finite TTLs are required to avoid unbounded Redis growth.
+                "result_ttl": 3600,
+                "failure_ttl": 604800,
             }
             timeout = j.get_job_timeout()
             if timeout is not None:

--- a/common/models/cron.py
+++ b/common/models/cron.py
@@ -2,73 +2,52 @@ from datetime import timedelta
 
 import django_rq
 from loguru import logger
-from rq.job import Job
-from rq.registry import ScheduledJobRegistry
+from rq import cron as rq_cron
 
 from common.models.site_config import SiteConfig
 
+CRON_QUEUE = "cron"
+
+
+def run_job(job_id: str) -> None:
+    """Module-level entry point used by rq.cron / RQ workers.
+
+    Looks up the BaseJob subclass in the registry and runs it. Defined at the
+    module level (not as a classmethod) so RQ can resolve it by import path
+    on the worker side.
+    """
+    job_cls = JobManager.get(job_id)
+    job_cls().run()
+
 
 class BaseJob:
-    @classmethod
-    def cancel(cls):
-        job_id = cls.__name__
-        try:
-            job = Job.fetch(id=job_id, connection=django_rq.get_connection("cron"))
-            if job.get_status() in ["queued", "scheduled"]:
-                logger.info(f"Cancel queued job: {job_id}")
-                job.cancel()
-            registry = ScheduledJobRegistry(queue=django_rq.get_queue("cron"))
-            registry.remove(job)
-        except Exception:
-            pass
+    """Base class for periodic jobs scheduled via rq.cron.
+
+    Subclasses override ``get_interval()`` (returning a ``timedelta``) and
+    ``run()``. The scheduler lifecycle is owned by an external
+    ``rq.cron.CronScheduler`` process, not by the job itself.
+    """
+
+    queue_name: str = CRON_QUEUE
 
     @classmethod
     def get_interval(cls) -> timedelta:
-        """Return job interval. Override to read from SiteConfig."""
+        """Return job interval. Override to read from SiteConfig.
+
+        A non-positive interval disables the job.
+        """
         return timedelta(0)
 
     @classmethod
-    def schedule(cls, now=False):
-        job_id = cls.__name__
-        interval = cls.get_interval()
-        i = timedelta(seconds=0) if now else interval
-        disabled = (
-            getattr(SiteConfig, "system", None)
-            and SiteConfig.system.disable_cron_jobs
-            or []
-        )
-        if interval <= timedelta(0) or job_id in disabled:
-            logger.info(f"Skip disabled job {job_id}")
-            return
-        logger.info(f"Scheduling job {job_id} in {i}")
-        if now:
-            django_rq.get_queue("cron").enqueue(
-                cls._run,
-                job_id=job_id,
-                result_ttl=-1,
-                failure_ttl=-1,
-                job_timeout=int(interval.total_seconds()) - 5,
-            )
-        else:
-            django_rq.get_queue("cron").enqueue_in(
-                interval,
-                cls._run,
-                job_id=job_id,
-                result_ttl=-1,
-                failure_ttl=-1,
-                job_timeout=int(interval.total_seconds()) - 5,
-            )
+    def get_cron(cls) -> str | None:
+        """Return a cron expression. Overrides ``get_interval`` when set."""
+        return None
 
     @classmethod
-    def reschedule(cls, now: bool = False):
-        cls.cancel()
-        cls.schedule(now=now)
-
-    @classmethod
-    def _run(cls):
-        # SiteConfig is reloaded automatically by SiteConfigJob.perform()
-        cls.schedule()  # schedule next run
-        cls().run()
+    def get_job_timeout(cls) -> int | None:
+        """Default timeout slightly shorter than the interval to avoid overlap."""
+        seconds = int(cls.get_interval().total_seconds())
+        return seconds - 5 if seconds > 5 else None
 
     def run(self):
         pass
@@ -78,33 +57,68 @@ class JobManager:
     registry: set[type[BaseJob]] = set()
 
     @classmethod
-    def register(cls, target):
+    def register(cls, target: type[BaseJob]) -> type[BaseJob]:
         cls.registry.add(target)
         return target
 
     @classmethod
-    def get(cls, job_id) -> type[BaseJob]:
+    def get(cls, job_id: str) -> type[BaseJob]:
         for j in cls.registry:
             if j.__name__ == job_id:
                 return j
         raise KeyError(f"Job not found: {job_id}")
 
     @classmethod
-    def get_scheduled_job_ids(cls):
-        registry = ScheduledJobRegistry(queue=django_rq.get_queue("cron"))
-        return registry.get_job_ids()
+    def _disabled_set(cls) -> tuple[set[str], bool]:
+        disabled = (
+            getattr(SiteConfig, "system", None)
+            and SiteConfig.system.disable_cron_jobs
+            or []
+        )
+        return set(disabled), "*" in disabled
 
     @classmethod
-    def schedule_all(cls):
-        for j in cls.registry:
-            j.schedule()
+    def register_with_rq_cron(cls) -> int:
+        """Register every job in the registry with the rq.cron global registry.
+
+        Called from a cron config module loaded by ``CronScheduler``.
+        Returns the number of jobs registered.
+        """
+        disabled, wildcard = cls._disabled_set()
+        count = 0
+        for j in sorted(cls.registry, key=lambda c: c.__name__):
+            job_id = j.__name__
+            if wildcard or job_id in disabled:
+                logger.info(f"Skip disabled cron job: {job_id}")
+                continue
+            cron_expr = j.get_cron()
+            interval_seconds = int(j.get_interval().total_seconds())
+            if not cron_expr and interval_seconds <= 0:
+                logger.info(f"Skip cron job with no schedule: {job_id}")
+                continue
+            options: dict = {
+                "func": run_job,
+                "queue_name": j.queue_name,
+                "args": (job_id,),
+                "result_ttl": -1,
+                "failure_ttl": -1,
+            }
+            timeout = j.get_job_timeout()
+            if timeout is not None:
+                options["job_timeout"] = timeout
+            if cron_expr:
+                options["cron"] = cron_expr
+                logger.info(f"Registering cron job {job_id} with cron '{cron_expr}'")
+            else:
+                options["interval"] = interval_seconds
+                logger.info(f"Registering cron job {job_id} every {interval_seconds}s")
+            rq_cron.register(**options)
+            count += 1
+        return count
 
     @classmethod
-    def cancel_all(cls):
-        for j in cls.registry:
-            j.cancel()
-
-    @classmethod
-    def reschedule_all(cls):
-        cls.cancel_all()
-        cls.schedule_all()
+    def get_active_schedulers(cls):
+        """Return live ``CronScheduler`` snapshots from Redis (one per process)."""
+        return rq_cron.CronScheduler.all(
+            connection=django_rq.get_connection(CRON_QUEUE)
+        )

--- a/common/models/cron.py
+++ b/common/models/cron.py
@@ -5,6 +5,7 @@ from loguru import logger
 from rq import cron as rq_cron
 
 from common.models.site_config import SiteConfig
+from common.sentry import cron_monitor
 
 CRON_QUEUE = "cron"
 
@@ -15,7 +16,8 @@ def run_job(job_id: str) -> None:
     Looks up the BaseJob subclass in the registry and runs it. Defined at the
     module level (not as a classmethod) so RQ can resolve it by import path
     on the worker side. For singleton jobs, a Redis lock prevents a second
-    copy from starting while a previous run is still active.
+    copy from starting while a previous run is still active. When Sentry is
+    configured, each run reports a check-in to Sentry Crons.
     """
     try:
         job_cls = JobManager.get(job_id)
@@ -26,24 +28,28 @@ def run_job(job_id: str) -> None:
         __import__("boofilsic.cron_config", fromlist=["*"])
         job_cls = JobManager.get(job_id)
 
-    instance = job_cls()
-    if not job_cls.singleton:
-        instance.run()
-        return
+    with cron_monitor(
+        monitor_slug=f"neodb-{job_id.lower()}",
+        monitor_config=job_cls.get_monitor_config(),
+    ):
+        instance = job_cls()
+        if not job_cls.singleton:
+            instance.run()
+            return
 
-    conn = django_rq.get_connection(job_cls.queue_name)
-    lock_key = f"cron:lock:{job_id}"
-    # Lock TTL slightly outlives job_timeout so a crashed worker can't pin the
-    # lock past the next tick + a small buffer. Fallback to 1 hour for
-    # cron-string jobs where get_job_timeout() is None.
-    lock_ttl = (job_cls.get_job_timeout() or 3600) + 60
-    if not conn.set(lock_key, "1", nx=True, ex=lock_ttl):
-        logger.info(f"Skipping {job_id}: previous run still active")
-        return
-    try:
-        instance.run()
-    finally:
-        conn.delete(lock_key)
+        conn = django_rq.get_connection(job_cls.queue_name)
+        lock_key = f"cron:lock:{job_id}"
+        # Lock TTL slightly outlives job_timeout so a crashed worker can't pin
+        # the lock past the next tick + a small buffer. Fallback to 1 hour for
+        # cron-string jobs where get_job_timeout() is None.
+        lock_ttl = (job_cls.get_job_timeout() or 3600) + 60
+        if not conn.set(lock_key, "1", nx=True, ex=lock_ttl):
+            logger.info(f"Skipping {job_id}: previous run still active")
+            return
+        try:
+            instance.run()
+        finally:
+            conn.delete(lock_key)
 
 
 class BaseJob:
@@ -79,6 +85,32 @@ class BaseJob:
         """Default timeout slightly shorter than the interval to avoid overlap."""
         seconds = int(cls.get_interval().total_seconds())
         return seconds - 5 if seconds > 5 else None
+
+    @classmethod
+    def get_monitor_config(cls) -> dict | None:
+        """Sentry Crons monitor_config describing this job's schedule.
+
+        Returns ``None`` for jobs without a usable schedule so Sentry just
+        records check-ins without late/missed alerting.
+        """
+        config: dict = {}
+        cron_expr = cls.get_cron()
+        interval_seconds = int(cls.get_interval().total_seconds())
+        if cron_expr:
+            config["schedule"] = {"type": "crontab", "value": cron_expr}
+        elif interval_seconds > 0:
+            minutes = max(1, interval_seconds // 60)
+            config["schedule"] = {
+                "type": "interval",
+                "value": minutes,
+                "unit": "minute",
+            }
+        else:
+            return None
+        timeout = cls.get_job_timeout()
+        if timeout:
+            config["max_runtime"] = max(1, timeout // 60)
+        return config
 
     def run(self):
         pass

--- a/common/models/cron.py
+++ b/common/models/cron.py
@@ -14,7 +14,8 @@ def run_job(job_id: str) -> None:
 
     Looks up the BaseJob subclass in the registry and runs it. Defined at the
     module level (not as a classmethod) so RQ can resolve it by import path
-    on the worker side.
+    on the worker side. For singleton jobs, a Redis lock prevents a second
+    copy from starting while a previous run is still active.
     """
     try:
         job_cls = JobManager.get(job_id)
@@ -24,7 +25,25 @@ def run_job(job_id: str) -> None:
         # module re-imports every jobs module.
         __import__("boofilsic.cron_config", fromlist=["*"])
         job_cls = JobManager.get(job_id)
-    job_cls().run()
+
+    instance = job_cls()
+    if not job_cls.singleton:
+        instance.run()
+        return
+
+    conn = django_rq.get_connection(job_cls.queue_name)
+    lock_key = f"cron:lock:{job_id}"
+    # Lock TTL slightly outlives job_timeout so a crashed worker can't pin the
+    # lock past the next tick + a small buffer. Fallback to 1 hour for
+    # cron-string jobs where get_job_timeout() is None.
+    lock_ttl = (job_cls.get_job_timeout() or 3600) + 60
+    if not conn.set(lock_key, "1", nx=True, ex=lock_ttl):
+        logger.info(f"Skipping {job_id}: previous run still active")
+        return
+    try:
+        instance.run()
+    finally:
+        conn.delete(lock_key)
 
 
 class BaseJob:
@@ -36,6 +55,11 @@ class BaseJob:
     """
 
     queue_name: str = CRON_QUEUE
+
+    #: When True, ``run_job`` acquires a Redis lock keyed on the job name so a
+    #: long-running tick cannot collide with the scheduler's next enqueue.
+    #: Set to ``False`` on subclasses that are intentionally re-entrant.
+    singleton: bool = True
 
     @classmethod
     def get_interval(cls) -> timedelta:

--- a/common/sentry.py
+++ b/common/sentry.py
@@ -1,5 +1,6 @@
+import contextlib
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, ContextManager
 from urllib.parse import urlparse
 
 MetricAttributes = Mapping[str, str | int | float | bool | None]
@@ -42,3 +43,29 @@ def count(
         metrics_count(key, value, attributes=_clean_attributes(attributes))
     except Exception:
         return
+
+
+def cron_monitor(
+    monitor_slug: str,
+    monitor_config: dict | None = None,
+) -> ContextManager[None]:
+    """Return a Sentry crons ``monitor`` context manager when Sentry is
+    initialized, otherwise a no-op context. Used to wrap scheduled jobs so
+    Sentry receives in-progress / ok / error check-ins per run.
+    """
+    try:
+        import sentry_sdk
+        from sentry_sdk.crons import monitor as sentry_monitor
+    except ImportError:
+        return contextlib.nullcontext()
+
+    is_initialized = getattr(sentry_sdk, "is_initialized", None)
+    if not callable(is_initialized) or not is_initialized():
+        return contextlib.nullcontext()
+
+    # monitor_config is a TypedDict at Sentry's typing layer but we accept any
+    # plain dict here; runtime is identical.
+    return sentry_monitor(
+        monitor_slug=monitor_slug,
+        monitor_config=monitor_config,  # ty: ignore[invalid-argument-type]
+    )

--- a/common/setup.py
+++ b/common/setup.py
@@ -3,7 +3,7 @@ from django.core.checks import Error, Warning
 from loguru import logger
 
 from catalog.search import CatalogIndex, PeopleIndex
-from common.models import JobManager, SiteConfig
+from common.models import SiteConfig
 from journal.search import JournalIndex
 from takahe.models import Config as TakaheConfig
 from takahe.models import Domain as TakaheDomain
@@ -125,15 +125,8 @@ class Setup:
             logger.info("Finished post-migration setup, skipped some for testing.")
             return
 
-        # Register cron jobs if not yet
-        if (
-            SiteConfig.system.disable_cron_jobs
-            and "*" in SiteConfig.system.disable_cron_jobs
-        ):
-            logger.info("Cron jobs are disabled.")
-            JobManager.cancel_all()
-        else:
-            JobManager.reschedule_all()
+        # Cron jobs are scheduled by the separate rq.cron service
+        # (neodb-manage cron --start); nothing to do here.
 
         # Subscribe to default relay if enabled
         self.sync_relay()

--- a/compose.yml
+++ b/compose.yml
@@ -237,6 +237,14 @@ services:
       migration:
         condition: service_completed_successfully
 
+  neodb-cron:
+    <<: *neodb-service
+    command: neodb-manage cron --start
+    stop_signal: SIGINT
+    depends_on:
+      migration:
+        condition: service_completed_successfully
+
   takahe-web:
     <<: *neodb-service
     command: ${TAKAHE_VENV:-/takahe-venv}/bin/gunicorn --chdir /takahe takahe.wsgi -w ${TAKAHE_WEB_WORKER_NUM:-8} --max-requests 2000 --timeout 60 --preload -b 0.0.0.0:8000
@@ -299,6 +307,11 @@ services:
     <<: *dev-neodb-service
     # command: neodb-manage rqworker-pool --num-workers 4 import export mastodon fetch crawl ap cron
     command: neodb-manage rqworker --with-scheduler import export mastodon fetch crawl ap cron
+
+  dev-neodb-cron:
+    <<: *dev-neodb-service
+    command: neodb-manage cron --start
+    stop_signal: SIGINT
 
   dev-takahe-web:
     <<: *dev-neodb-service


### PR DESCRIPTION
## Summary
- Replace the home-grown self-rescheduling `BaseJob`/`JobManager` machinery with RQ 2.8's native `rq.cron.CronScheduler`. A dedicated cron scheduler process owns the lifecycle; workers just consume the `cron` queue.
- Existing job subclasses (`CatalogStats`, `DiscoverGenerator`, `MastodonSiteCheck`, `MastodonUserSync`, `PodcastUpdater`, `TakaheStats`, `TaskCleanup`) keep their existing `get_interval()` / `run()` contract — no per-job changes.
- New `boofilsic/cron_config.py` is the config module loaded by `CronScheduler`: it triggers `django.setup()`, imports the apps' `jobs` modules, ensures `SiteConfig` is loaded, then registers everything via `rq.cron.register`.
- New compose service `neodb-cron` (and `dev-neodb-cron`) runs `neodb-manage cron --start`. Workers still consume the `cron` queue.
- `cron` management command: replaced `--cancel-all`/`--reschedule-all`/`--reschedule-now` with `--start`. `--list` now reports both registered jobs and live schedulers from Redis. `--run-once` retained.
- `common/setup.py` no longer calls `JobManager.reschedule_all()`/`cancel_all()` from post-migrate; that lifecycle moved to the scheduler service.

## Tradeoffs
- Intervals (incl. `SiteConfig.system.discover_update_interval`) and the `disable_cron_jobs` list are now applied at **scheduler startup**, so changes require restarting `neodb-cron` rather than picking up on the next iteration. Document this in operations.
- Deployments need to run the new `neodb-cron` service alongside workers.

## Test plan
- [x] `uv run pre-commit run -a` clean.
- [x] `boofilsic.cron_config` imports cleanly; 7 jobs register with expected intervals.
- [x] `neodb-manage cron --list` lists 7 registered jobs and (when running) the active scheduler's queued items with next-run timestamps.
- [x] `neodb-manage cron --start` running in a container — scheduler enqueued the jobs into the `cron` queue on first tick.
- [x] `neodb-manage rqworker --burst cron` dequeued `run_job('TaskCleanup')` / `run_job('CatalogStats')` and ran the underlying `BaseJob.run()` end-to-end.
- [x] `neodb-manage cron --run-once CatalogStats` runs synchronously in-process.
- [x] Full `pytest` — 1282 passed.