### PR TITLE
social: show full article body in single post view

### DIFF
--- a/journal/templates/_list_item.html
+++ b/journal/templates/_list_item.html
@@ -1,4 +1,3 @@
-{# parameters: item, mark, collection_member, collection_edit + parameters passing down: show_tags, hide_category #}
 {% load thumb %}
 {% load i18n %}
 {% load l10n %}

--- a/journal/templates/profile.html
+++ b/journal/templates/profile.html
@@ -264,7 +264,6 @@
             <script src="{% static 'js/sort_layout.js' %}"></script>
           {% endif %}
         {% endif %}
-        {# end feed_view else #}
       </div>
       {% if feed_view %}
         {% include "_sidebar.html" with show_profile=1 %}

--- a/social/templates/_event_post.html
+++ b/social/templates/_event_post.html
@@ -143,7 +143,7 @@
               {% elif piece and piece.classname == 'review' %}
                 {% include "_review_teaser.html" with review=piece %}
               {% elif post.type == 'Article' %}
-                {% include "_post_article_teaser.html" with post=post %}
+                {% include "_post_article_teaser.html" with post=post show_full=show_full %}
               {% else %}
                 {{ post.safe_content_local|default:"" }}
               {% endif %}

--- a/social/templates/_post_article_teaser.html
+++ b/social/templates/_post_article_teaser.html
@@ -1,16 +1,16 @@
 {% load i18n %}
-{# Title-card teaser for a Post whose type is "Article" but which has no local
-   Article Piece row (i.e. fetched from a non-NeoDB peer like write.as).
-   Reads from ``post.type_data.object`` which is populated for both local
-   Articles and inbound standalone Articles (see ``Post.by_ap``). Linking to
-   ``post.url`` lands the reader on the source for remote posts and on the
-   local Mastodon-flavor post view for local ones, matching how Article
-   timeline events work when a piece *is* present. #}
-{% with title=post.type_data.object.name|default:post.summary|striptags teaser=post.type_data.object.summary|default:post.content_plain_text %}
+{% with title=post.type_data.object.name|default:post.summary|striptags summary=post.type_data.object.summary %}
   <section class="article-teaser">
     <h4>
       <a href="{{ post.url|default:post.object_uri }}">{{ title|default:_("Untitled article") }}</a>
     </h4>
-    {% if teaser %}<p class="piece-summary">{{ teaser|striptags|truncatewords:60 }}</p>{% endif %}
+    {% if show_full %}
+      {% if summary %}<p class="piece-summary">{{ summary|striptags }}</p>{% endif %}
+      <div class="markdown-content">{{ post.safe_content_local }}</div>
+    {% else %}
+      {% with teaser=summary|default:post.content_plain_text %}
+        {% if teaser %}<p class="piece-summary">{{ teaser|striptags|truncatewords:60 }}</p>{% endif %}
+      {% endwith %}
+    {% endif %}
   </section>
 {% endwith %}

--- a/social/templates/single_post.html
+++ b/social/templates/single_post.html
@@ -10,12 +10,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ site_name }} {% trans "Post" %} | {{ owner.display_name }}</title>
-    {# For Article posts, prefer the AP ``name`` / ``summary`` (both local
-       and inbound standalone Articles land in ``post.type_data.object``).
-       ``post.summary`` for non-NeoDB peers like write.as is the full HTML
-       excerpt, not a usable og:title. ``striptags`` everywhere because
-       both ``post.summary`` and ``object.summary`` can carry inline HTML
-       from remote peers that has no business in social-share metadata. #}
     {% if post.type == 'Article' %}
       <meta property="og:title"
             content="{{ post.type_data.object.name|default:post.summary|striptags|default:_("Article") }}">
@@ -47,7 +41,7 @@
     {% include "_header.html" %}
     <main>
       <div class="grid__main">
-        {% include "_event_post.html" with item=post.item piece=post.piece show_replies=1 show_all_actions=1 %}
+        {% include "_event_post.html" with item=post.item piece=post.piece show_replies=1 show_all_actions=1 show_full=1 %}
       </div>
       {% include "_sidebar.html" with show_profile=1 identity=owner %}
     </main>


### PR DESCRIPTION
## Summary
- Article posts received from non-NeoDB peers (e.g. write.as) that never produce a local Article piece previously rendered the same 60-word teaser in the dedicated single-post page as in the feed. The detail view now renders the full sanitized HTML (`post.safe_content_local`) with the AP `summary` as a subtitle, so readers landing on the post URL can read the article without bouncing to the origin.
- Feeds and any other includer of `_event_post.html` keep the existing truncated teaser; the change is gated on a new `show_full` flag passed from `single_post.html`.
- Drive-by cleanup: removed five no-op `{# ... #}` template comments across `journal/templates/_list_item.html`, `journal/templates/profile.html`, `social/templates/_post_article_teaser.html`, and `social/templates/single_post.html`.

## Test plan
- [ ] View a single-post page for a remote standalone Article (write.as-style, no local piece) and confirm the full body renders below the title.
- [ ] View the same Article in a feed and confirm the truncated teaser still appears.
- [ ] View a single-post page for a Note and confirm rendering is unchanged.
- [ ] `uv run pre-commit run -a` (djLint + ty on touched templates passed locally).