### PR TITLE
catalog/reco: (re)schedule cron jobs when enable_recommendations toggles

### DIFF
--- a/common/views_manage.py
+++ b/common/views_manage.py
@@ -13,6 +13,7 @@ from django.views.generic import FormView
 from django_jsonform.forms.fields import JSONFormField
 from loguru import logger
 
+from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommendations
 from common.models import SiteConfig
 
 
@@ -354,6 +355,23 @@ class DiscoverSettings(SiteConfigSettingsPage):
 
 class RecommendationSettings(SiteConfigSettingsPage):
     section = "recommendations"
+
+    def form_valid(self, form):
+        was_enabled = bool(SiteConfig.system.enable_recommendations)
+        response = super().form_valid(form)
+        is_enabled = bool(SiteConfig.system.enable_recommendations)
+        if was_enabled != is_enabled:
+            try:
+                if is_enabled:
+                    BuildItemSimilarity.reschedule(now=True)
+                    BuildUserRecommendations.reschedule(now=True)
+                else:
+                    BuildItemSimilarity.cancel()
+                    BuildUserRecommendations.cancel()
+            except Exception as e:
+                logger.warning(f"Failed to (re)schedule recommendation jobs: {e}")
+        return response
+
     options = {
         "enable_recommendations": {
             "title": _("Enable Recommendations"),


### PR DESCRIPTION
## Summary
- Toggling `enable_recommendations` in the admin UI updated `SiteConfig` but did not touch the cron scheduler in either direction:
  - **off → on**: `get_interval()` had been returning `timedelta(0)` while the flag was off, so every prior `schedule()` short-circuited and the self-perpetuating chain was dead. The jobs stayed idle until the next container restart fired `post_migrate` → `Setup().run()` → `JobManager.reschedule_all()`.
  - **on → off**: an already-enqueued run remained in the RQ scheduler and would still execute (`BaseJob.run()` does not check the flag); only the *next* reschedule from `_run` would skip.
- Override `RecommendationSettings.form_valid` to handle both edges: `reschedule(now=True)` on enable so the first run lands immediately instead of after the full 7d / 1d interval, and `cancel()` on disable so no further reco compute fires after the operator opts out.

## Test plan
- [ ] Toggle `enable_recommendations` off → on in `/manage/recommendations/`. Confirm both jobs appear in `neodb-manage cron --list` and the worker picks them up immediately.
- [ ] Toggle on → off. Confirm both jobs disappear from `neodb-manage cron --list` and no further runs occur.
- [ ] Toggle while already on (e.g. tweak a threshold field): confirm no extra enqueue or cancel happens.
- [ ] `uv run pre-commit run -a` (ruff + ty passed on touched file locally).