### PR TITLE
perf(catalog/podcast): tiered polling, conditional GET, parallel fetch

### DIFF
--- a/catalog/jobs/podcast.py
+++ b/catalog/jobs/podcast.py
@@ -1,11 +1,53 @@
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 
+from django.db import close_old_connections
+from django.db.models import Max
+from django.utils import timezone
 from loguru import logger
 
-from catalog.models import IdType, Podcast
+from catalog.models import IdType, Podcast, PodcastEpisode
 from catalog.sites import RSS
 from common.models import BaseJob, JobManager
+
+FRESH_DELAY = timedelta(hours=2)
+MID_DELAY = timedelta(hours=12)
+COLD_DELAY = timedelta(days=7)
+ACTIVE_THRESHOLD = timedelta(days=30)
+RECENT_THRESHOLD = timedelta(days=180)
+MAX_FAILURE_EXP = 6  # cap exponential backoff at 2^6 = 64x base delay
+MAX_FETCH_WORKERS = 16
+
+
+def _tier_delay(last_pub, now):
+    if last_pub is None:
+        return COLD_DELAY
+    age = now - last_pub
+    if age <= ACTIVE_THRESHOLD:
+        return FRESH_DELAY
+    if age <= RECENT_THRESHOLD:
+        return MID_DELAY
+    return COLD_DELAY
+
+
+def _is_due(podcast: Podcast, last_pub, now) -> bool:
+    base = _tier_delay(last_pub, now)
+    failures = max(0, int(podcast.feed_consecutive_failures or 0))
+    delay = base * (2 ** min(failures, MAX_FAILURE_EXP)) if failures else base
+    last_fetched = podcast.feed_last_fetched_at
+    if last_fetched is None:
+        return True
+    return (now - last_fetched) >= delay
+
+
+def _fetch_one(podcast: Podcast):
+    feed, etag, last_modified, status = RSS.fetch_feed_with_metadata(
+        podcast.feed_url,
+        podcast.feed_etag or "",
+        podcast.feed_last_modified or "",
+    )
+    return podcast, feed, etag, last_modified, status
 
 
 @JobManager.register
@@ -17,25 +59,84 @@ class PodcastUpdater(BaseJob):
     def run(self):
         logger.info("Podcasts update start.")
         start = time.time()
-        count = 0
+        now = timezone.now()
+
         qs = Podcast.objects.filter(
-            is_deleted=False, merged_to_item__isnull=True
-        ).order_by("pk")
-        for p in qs:
-            if (
-                p.primary_lookup_id_type == IdType.RSS
-                and p.primary_lookup_id_value is not None
-            ):
-                logger.debug(f"updating {p}")
-                c = p.episodes.count()
-                site = RSS(p.feed_url)
-                r = site.scrape_additional_data()
-                if r:
-                    c2 = p.episodes.count()
-                    if c2 - c:
-                        logger.info(f"updated {p}, {c2 - c} new episodes.")
-                    count += c2 - c
-                else:
-                    logger.warning(f"failed to update {p}")
+            is_deleted=False,
+            merged_to_item__isnull=True,
+            primary_lookup_id_type=IdType.RSS,
+            primary_lookup_id_value__isnull=False,
+        )
+
+        last_pub_map = dict(
+            PodcastEpisode.objects.filter(program__in=qs)
+            .values("program_id")
+            .annotate(last=Max("pub_date"))
+            .values_list("program_id", "last")
+        )
+
+        candidates: list[Podcast] = []
+        skipped = 0
+        for p in qs.iterator(chunk_size=500):
+            if _is_due(p, last_pub_map.get(p.pk), now):
+                candidates.append(p)
+            else:
+                skipped += 1
+        logger.info(
+            f"Podcasts: {len(candidates)} due, {skipped} skipped by tier/backoff."
+        )
+
+        new_episodes_total = 0
+        updated = 0
+        not_modified = 0
+        failed = 0
+
+        if candidates:
+            with ThreadPoolExecutor(max_workers=MAX_FETCH_WORKERS) as ex:
+                for p, feed, etag, last_modified, status in ex.map(
+                    _fetch_one, candidates
+                ):
+                    added = 0
+                    if status == 200 and feed is not None:
+                        try:
+                            added = RSS.update_episodes_from_feed(p, feed)
+                        except Exception as e:
+                            logger.warning(f"episode write failed for {p}: {e}")
+                            status = 0
+                    fetched_at = timezone.now()
+                    if status == 200:
+                        p.feed_etag = etag or ""
+                        p.feed_last_modified = last_modified or ""
+                        p.feed_consecutive_failures = 0
+                        p.feed_last_fetched_at = fetched_at
+                        updated += 1
+                        if added:
+                            logger.info(f"updated {p}, {added} new episodes.")
+                    elif status == 304:
+                        p.feed_etag = etag or p.feed_etag or ""
+                        p.feed_last_modified = (
+                            last_modified or p.feed_last_modified or ""
+                        )
+                        p.feed_consecutive_failures = 0
+                        p.feed_last_fetched_at = fetched_at
+                        not_modified += 1
+                    else:
+                        p.feed_consecutive_failures = (
+                            int(p.feed_consecutive_failures or 0) + 1
+                        )
+                        p.feed_last_fetched_at = fetched_at
+                        failed += 1
+                        logger.warning(f"failed to update {p}")
+                    try:
+                        p.save(update_fields=["metadata"])
+                    except Exception as e:
+                        logger.warning(f"failed to persist feed metadata for {p}: {e}")
+                    new_episodes_total += added
+            close_old_connections()
+
         t = round(time.time() - start, 3)
-        logger.info(f"Podcasts update finished in {t} sec, {count} new episodes total.")
+        logger.info(
+            f"Podcasts update finished in {t}s: "
+            f"{updated} updated, {not_modified} unchanged, {failed} failed, "
+            f"{skipped} skipped, {new_episodes_total} new episodes."
+        )

--- a/catalog/jobs/podcast.py
+++ b/catalog/jobs/podcast.py
@@ -2,7 +2,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 
-from django.db import close_old_connections
+from django.db import close_old_connections, connections
 from django.db.models import Max
 from django.utils import timezone
 from loguru import logger
@@ -42,12 +42,18 @@ def _is_due(podcast: Podcast, last_pub, now) -> bool:
 
 
 def _fetch_one(podcast: Podcast):
-    feed, etag, last_modified, status = RSS.fetch_feed_with_metadata(
-        podcast.feed_url,
-        podcast.feed_etag or "",
-        podcast.feed_last_modified or "",
-    )
-    return podcast, feed, etag, last_modified, status
+    try:
+        feed, etag, last_modified, status = RSS.fetch_feed_with_metadata(
+            podcast.feed_url,
+            podcast.feed_etag or "",
+            podcast.feed_last_modified or "",
+        )
+        return podcast, feed, etag, last_modified, status
+    finally:
+        # Worker threads do no DB I/O today, but Django connections are
+        # thread-local: if any future code path opens one in here, close
+        # it before the pool reuses the thread to avoid connection leaks.
+        connections.close_all()
 
 
 @JobManager.register

--- a/catalog/models/podcast.py
+++ b/catalog/models/podcast.py
@@ -87,6 +87,12 @@ class Podcast(Item):
         verbose_name=_("website"), max_length=1000, null=True, blank=True
     )
 
+    # Polling tracking (used by PodcastUpdater); stored in Item.metadata
+    feed_last_fetched_at = jsondata.DateTimeField(null=True, blank=True, default=None)
+    feed_etag = jsondata.CharField(max_length=255, default="", blank=True)
+    feed_last_modified = jsondata.CharField(max_length=255, default="", blank=True)
+    feed_consecutive_failures = jsondata.IntegerField(default=0, blank=True)
+
     METADATA_COPY_LIST = [
         # "title",
         # "brief",

--- a/catalog/sites/rss.py
+++ b/catalog/sites/rss.py
@@ -1,5 +1,6 @@
 import logging
 import pickle
+import urllib.error
 import urllib.request
 from datetime import datetime
 
@@ -33,6 +34,62 @@ class RSS(AbstractSite):
     URL_PATTERNS = [r".+[./](rss|xml)"]
 
     @staticmethod
+    def _open_feed(url: str, etag: str = "", last_modified: str = ""):
+        req = urllib.request.Request(url)
+        req.add_header("User-Agent", settings.NEODB_USER_AGENT)
+        if etag:
+            req.add_header("If-None-Match", etag)
+        if last_modified:
+            req.add_header("If-Modified-Since", last_modified)
+        return urllib.request.urlopen(req, timeout=3)
+
+    @staticmethod
+    def fetch_feed_with_metadata(
+        url: str, etag: str = "", last_modified: str = ""
+    ) -> tuple[dict | None, str, str, int]:
+        """Fetch and parse an RSS feed with conditional-GET support.
+
+        Returns (feed, new_etag, new_last_modified, status):
+          - status 200: feed parsed
+          - status 304: not modified, feed is None
+          - status 0:   network/parse error, feed is None
+        """
+        if not url or not is_valid_url(url):
+            return None, etag, last_modified, 0
+        if get_mock_mode():
+            with open(_local_response_path + get_mock_file(url), "rb") as f:
+                feed = pickle.load(f)
+            return feed, etag, last_modified, 200
+        try_urls = [url]
+        if url.startswith("https://"):
+            try_urls.append(url.replace("https://", "http://"))
+        resp = None
+        for try_url in try_urls:
+            try:
+                resp = RSS._open_feed(try_url, etag, last_modified)
+                break
+            except urllib.error.HTTPError as e:
+                if e.code == 304:
+                    return None, etag, last_modified, 304
+                resp = None
+            except Exception:
+                resp = None
+        if resp is None:
+            return None, etag, last_modified, 0
+        new_etag = resp.headers.get("ETag", "") or ""
+        new_last_modified = resp.headers.get("Last-Modified", "") or ""
+        try:
+            feed = podcastparser.parse(url, resp)
+        except Exception:
+            return None, etag, last_modified, 0
+        if settings.DOWNLOADER_SAVEDIR:
+            with open(
+                settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url), "wb"
+            ) as f:
+                pickle.dump(feed, f)
+        return feed, new_etag, new_last_modified, 200
+
+    @staticmethod
     def parse_feed_from_url(url):
         if not url or not is_valid_url(url):
             return None
@@ -40,29 +97,9 @@ class RSS(AbstractSite):
         feed = cache.get(cache_key)
         if feed:
             return feed
-        if get_mock_mode():
-            with open(_local_response_path + get_mock_file(url), "rb") as f:
-                feed = pickle.load(f)
-        else:
-            req = urllib.request.Request(url)
-            req.add_header("User-Agent", settings.NEODB_USER_AGENT)
-            try:
-                feed = podcastparser.parse(url, urllib.request.urlopen(req, timeout=3))
-            except Exception:
-                url = url.replace("https://", "http://")
-                req = urllib.request.Request(url)
-                req.add_header("User-Agent", settings.NEODB_USER_AGENT)
-                try:
-                    feed = podcastparser.parse(
-                        url, urllib.request.urlopen(req, timeout=3)
-                    )
-                except Exception:
-                    return None
-            if settings.DOWNLOADER_SAVEDIR:
-                with open(
-                    settings.DOWNLOADER_SAVEDIR + "/" + get_mock_file(url), "wb"
-                ) as f:
-                    pickle.dump(feed, f)
+        feed, _e, _m, status = RSS.fetch_feed_with_metadata(url)
+        if status != 200 or feed is None:
+            return None
         cache.set(cache_key, feed, timeout=settings.DOWNLOADER_CACHE_TIMEOUT)
         return feed
 
@@ -116,31 +153,30 @@ class RSS(AbstractSite):
         pd.lookup_ids[IdType.RSS] = RSS.url_to_id(self.url)
         return pd
 
-    def scrape_additional_data(self):
-        feed = self.parse_feed_from_url(self.url)
-        if not feed:
-            logger.warning(f"unable to parse RSS {self.url}")
-            return False
-        item = self.get_item()
-        if not item:
-            logger.warning(f"item for RSS {self.url} not found")
-            return False
-        episodes = feed["episodes"]
+    @staticmethod
+    def update_episodes_from_feed(podcast: Podcast, feed: dict) -> int:
+        """Insert any new episodes from a parsed feed; return count added."""
+        episodes = feed.get("episodes") or []
         if not episodes:
-            return True
+            return 0
         # Batch-fetch existing episodes to avoid N+1 get_or_create queries
         guids = [ep.get("guid") for ep in episodes if ep.get("guid")]
-        existing = set(
-            PodcastEpisode.objects.filter(program=item, guid__in=guids).values_list(
-                "guid", flat=True
+        existing = (
+            set(
+                PodcastEpisode.objects.filter(
+                    program=podcast, guid__in=guids
+                ).values_list("guid", flat=True)
             )
+            if guids
+            else set()
         )
+        added = 0
         for episode in episodes:
             guid = episode.get("guid")
-            if guid in existing:
+            if guid and guid in existing:
                 continue
-            PodcastEpisode.objects.get_or_create(
-                program=item,
+            _, created = PodcastEpisode.objects.get_or_create(
+                program=podcast,
                 guid=guid,
                 defaults={
                     "title": episode["title"],
@@ -161,4 +197,18 @@ class RSS(AbstractSite):
                     "link": episode.get("link"),
                 },
             )
+            if created:
+                added += 1
+        return added
+
+    def scrape_additional_data(self):
+        feed = self.parse_feed_from_url(self.url)
+        if not feed:
+            logger.warning(f"unable to parse RSS {self.url}")
+            return False
+        item = self.get_item()
+        if not item:
+            logger.warning(f"item for RSS {self.url} not found")
+            return False
+        self.update_episodes_from_feed(item, feed)
         return True

--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -229,19 +229,22 @@ class DateField(JSONFieldMixin, fields.DateField):
 
 class DateTimeField(JSONFieldMixin, fields.DateTimeField):
     def to_json(self, value: datetime | date | str):
-        if value:
-            if not isinstance(value, (datetime, date)):
-                v = dateparse.parse_date(value)
-                if v is None:
-                    raise ValueError(
-                        f"DateTimeField: '{value}' has invalid datetime format"
-                    )
-                value = v
-            if isinstance(value, date):
-                value = datetime.combine(value, datetime.min.time())
-            if not timezone.is_aware(value):
-                value = timezone.make_aware(value)
-            return value.isoformat()
+        if not value:
+            return None
+        if isinstance(value, str):
+            # Try full datetime first to preserve time/offset; fall back to date-only.
+            v = dateparse.parse_datetime(value) or dateparse.parse_date(value)
+            if v is None:
+                raise ValueError(
+                    f"DateTimeField: '{value}' has invalid datetime format"
+                )
+            value = v
+        # datetime is a subclass of date, so check datetime first.
+        if not isinstance(value, datetime) and isinstance(value, date):
+            value = datetime.combine(value, datetime.min.time())
+        if not timezone.is_aware(value):
+            value = timezone.make_aware(value)
+        return value.isoformat()
 
     def from_json(self, value):
         if value:


### PR DESCRIPTION
## Summary

`PodcastUpdater` walked all ~8k active podcasts sequentially every 2h, re-downloading and re-parsing each feed in full regardless of whether anything changed. On the production dataset (8,030 active podcasts, ~44% stale 180d+, p99 feed has 2,758 episodes, max 21,890) this dominated worker time and CPU.

This PR rewrites the job to skip work that doesn't need to happen:

- **Tiered polling cadence** from a single `Max(pub_date)` aggregation per cycle:
  - fresh (<= 30d): every 2h
  - mid (30-180d): every 12h
  - stale (> 180d) or never-published: every 7d
- **Exponential backoff** on `consecutive_failures` (capped at 64x base), so dead URLs are not retried every 2h forever.
- **Conditional GET** via `If-None-Match` / `If-Modified-Since` in the new `RSS.fetch_feed_with_metadata` helper; a 304 short-circuits the XML parse entirely.
- **Parallel fetch** via `ThreadPoolExecutor(max_workers=16)` for the network/parse step; DB writes stay serial on the main thread.
- Queryset cleanup: filter `primary_lookup_id_type=RSS` and `primary_lookup_id_value__isnull=False` in SQL; iterator chunking; drop the double `episodes.count()`.

Tracking state (`feed_last_fetched_at`, `feed_etag`, `feed_last_modified`, `feed_consecutive_failures`) is stored as `jsondata` on `Item.metadata` — no schema migration required. On the first cycle every podcast looks "due" and populates these fields; subsequent cycles get the full benefit.

Episode-insert logic is factored into `RSS.update_episodes_from_feed` so `scrape_additional_data` and the updater share the same write path.

## Bonus fix

`jsondata.DateTimeField.to_json` was collapsing every `datetime` to midnight (`datetime` is a subclass of `date`, so the `isinstance(value, date)` branch fired for datetimes and `datetime.combine(d, midnight)` keeps only the date part). Fixed by checking `datetime` before `date`, and letting string inputs go through `parse_datetime` before falling back to `parse_date`. Without this, the new hour-level cadence would not work; the other caller (`mastodon/models/threads.py token_expires_at`) silently had the same bug.

## Test plan

- [x] `uv run pre-commit run -a` — clean
- [x] `pytest tests/catalog/test_podcast.py` — 7 passed, including the existing `test_scrape_idempotent_and_batch_optimized` query-count assertion
- [x] Round-trip smoke test for `jsondata.DateTimeField`: `datetime`, `date`, ISO datetime string, date-only string, and `Podcast.feed_last_fetched_at` descriptor all preserve the expected time component
- [x] Manual smoke test for `_tier_delay` / `_is_due` boundaries (30d / 180d, backoff after N consecutive failures)