### PR TITLE
fix(ap): follow Link rel=alternate to resolve WordPress AP Article URLs

### DIFF
--- a/takahe/management/commands/fetch.py
+++ b/takahe/management/commands/fetch.py
@@ -1,4 +1,5 @@
 from time import sleep
+from urllib.parse import urljoin
 
 import httpx
 
@@ -8,6 +9,71 @@ from takahe.models import Identity, InboxMessage, Post
 
 actor_types = ["person", "service", "application", "group", "organization"]
 post_types = ["note", "article", "post", "question", "event", "video", "audio", "image"]
+
+JSON_AP_TYPES = ("application/activity+json", "application/ld+json")
+
+
+def _split_link_entries(value: str) -> list[str]:
+    entries: list[str] = []
+    depth = 0
+    in_quote = False
+    start = i = 0
+    while i < len(value):
+        c = value[i]
+        if c == "\\" and i + 1 < len(value):
+            i += 2
+            continue
+        if c == '"':
+            in_quote = not in_quote
+        elif not in_quote:
+            if c == "<":
+                depth += 1
+            elif c == ">":
+                depth = max(0, depth - 1)
+            elif c == "," and depth == 0:
+                entries.append(value[start:i])
+                start = i + 1
+        i += 1
+    entries.append(value[start:])
+    return entries
+
+
+def find_ap_alternate_url(response: httpx.Response) -> str | None:
+    """Return an alternate ActivityPub URL advertised by ``response``.
+
+    Mirrors the helper in ``neodb-takahe/core/json.py`` so the standalone
+    fetch CLI can follow ``Link: rel="alternate"; type="application/activity+json"``
+    hints from hosts (like WordPress's ActivityPub plugin) that do not
+    content-negotiate the canonical permalink.
+    """
+    base = str(response.url)
+    try:
+        raw_links = list(response.headers.get_list("link"))
+    except AttributeError:
+        single = response.headers.get("link")
+        raw_links = [single] if single else []
+    for header_value in raw_links:
+        for entry in _split_link_entries(header_value):
+            entry = entry.strip()
+            if not entry.startswith("<"):
+                continue
+            try:
+                end = entry.index(">")
+            except ValueError:
+                continue
+            url = entry[1:end].strip()
+            params: dict[str, str] = {}
+            for piece in entry[end + 1 :].split(";"):
+                piece = piece.strip()
+                if "=" not in piece:
+                    continue
+                k, _, v = piece.partition("=")
+                params[k.strip().lower()] = v.strip().strip('"')
+            rels = params.get("rel", "").split()
+            link_type = params.get("type", "").split(";", 1)[0].strip().lower()
+            if "alternate" in rels and link_type in JSON_AP_TYPES:
+                return urljoin(base, url)
+    return None
 
 
 class Command(SiteCommand):
@@ -34,7 +100,9 @@ class Command(SiteCommand):
             headers = {
                 "Accept": "application/json,application/activity+json,application/ld+json"
             }
-            response = httpx.get(url, headers=headers, timeout=timeout)
+            response = httpx.get(
+                url, headers=headers, timeout=timeout, follow_redirects=True
+            )
             response.raise_for_status()
             content_type = response.headers.get("content-type", "")
             self.stdout.write(f"Content-Type: {content_type}")
@@ -43,11 +111,27 @@ class Command(SiteCommand):
             # the prior endswith("json; charset=utf-8") miss made the fetcher
             # silently bail with "Content type is not JSON".
             bare_media_type = content_type.split(";", 1)[0].strip().lower()
-            if bare_media_type in (
+            json_media_types = (
                 "application/json",
                 "application/activity+json",
                 "application/ld+json",
-            ):
+            )
+            # WordPress's ActivityPub plugin (and similar hosts) serve HTML
+            # on permalink URLs and advertise the AP object via
+            # ``Link: rel="alternate"; type="application/activity+json"``.
+            # Follow it once before giving up.
+            if bare_media_type not in json_media_types:
+                alt = find_ap_alternate_url(response)
+                if alt:
+                    self.stdout.write(f"Following AP alternate: {alt}")
+                    response = httpx.get(
+                        alt, headers=headers, timeout=timeout, follow_redirects=True
+                    )
+                    response.raise_for_status()
+                    content_type = response.headers.get("content-type", "")
+                    self.stdout.write(f"Content-Type: {content_type}")
+                    bare_media_type = content_type.split(";", 1)[0].strip().lower()
+            if bare_media_type in json_media_types:
                 j = response.json()
                 typ = j.get("type", "").lower()
                 uri = j.get("id", "")

--- a/takahe/management/commands/fetch.py
+++ b/takahe/management/commands/fetch.py
@@ -10,7 +10,13 @@ from takahe.models import Identity, InboxMessage, Post
 actor_types = ["person", "service", "application", "group", "organization"]
 post_types = ["note", "article", "post", "question", "event", "video", "audio", "image"]
 
+# Strict set used for ``Link: rel="alternate"`` discovery. ``application/json``
+# is deliberately excluded -- a bare-JSON alternate is too broad to safely
+# auto-follow as ActivityPub.
 JSON_AP_TYPES = ("application/activity+json", "application/ld+json")
+# Broader set we are willing to parse as the response body once content is
+# in hand (matches the existing handle() behaviour).
+JSON_MEDIA_TYPES = ("application/json",) + JSON_AP_TYPES
 
 
 def _split_link_entries(value: str) -> list[str]:
@@ -41,18 +47,15 @@ def _split_link_entries(value: str) -> list[str]:
 def find_ap_alternate_url(response: httpx.Response) -> str | None:
     """Return an alternate ActivityPub URL advertised by ``response``.
 
-    Mirrors the helper in ``neodb-takahe/core/json.py`` so the standalone
-    fetch CLI can follow ``Link: rel="alternate"; type="application/activity+json"``
-    hints from hosts (like WordPress's ActivityPub plugin) that do not
-    content-negotiate the canonical permalink.
+    Mirrors the helper in ``neodb-takahe/core/json.py``: looks at both the
+    HTTP ``Link`` header (``rel="alternate"; type="application/activity+json"``)
+    and -- when the body is HTML -- the equivalent ``<link>`` tag in the
+    document head. WordPress's ActivityPub plugin (and similar hosts) do
+    not content-negotiate the canonical permalink; the AP object is only
+    reachable through one of these hints.
     """
     base = str(response.url)
-    try:
-        raw_links = list(response.headers.get_list("link"))
-    except AttributeError:
-        single = response.headers.get("link")
-        raw_links = [single] if single else []
-    for header_value in raw_links:
+    for header_value in response.headers.get_list("link"):
         for entry in _split_link_entries(header_value):
             entry = entry.strip()
             if not entry.startswith("<"):
@@ -73,6 +76,23 @@ def find_ap_alternate_url(response: httpx.Response) -> str | None:
             link_type = params.get("type", "").split(";", 1)[0].strip().lower()
             if "alternate" in rels and link_type in JSON_AP_TYPES:
                 return urljoin(base, url)
+
+    content_type = (
+        response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+    )
+    if "html" in content_type:
+        from lxml import html as lxml_html
+
+        try:
+            doc = lxml_html.fromstring(response.content)
+        except Exception:
+            return None
+        for link in doc.iter("link"):
+            rels = (link.get("rel") or "").lower().split()
+            link_type = (link.get("type") or "").split(";", 1)[0].strip().lower()
+            href = link.get("href")
+            if "alternate" in rels and link_type in JSON_AP_TYPES and href:
+                return urljoin(base, href)
     return None
 
 
@@ -111,16 +131,11 @@ class Command(SiteCommand):
             # the prior endswith("json; charset=utf-8") miss made the fetcher
             # silently bail with "Content type is not JSON".
             bare_media_type = content_type.split(";", 1)[0].strip().lower()
-            json_media_types = (
-                "application/json",
-                "application/activity+json",
-                "application/ld+json",
-            )
             # WordPress's ActivityPub plugin (and similar hosts) serve HTML
             # on permalink URLs and advertise the AP object via
-            # ``Link: rel="alternate"; type="application/activity+json"``.
-            # Follow it once before giving up.
-            if bare_media_type not in json_media_types:
+            # ``Link: rel="alternate"; type="application/activity+json"`` or
+            # the equivalent ``<link>`` tag. Follow it once before giving up.
+            if bare_media_type not in JSON_MEDIA_TYPES:
                 alt = find_ap_alternate_url(response)
                 if alt:
                     self.stdout.write(f"Following AP alternate: {alt}")
@@ -131,7 +146,7 @@ class Command(SiteCommand):
                     content_type = response.headers.get("content-type", "")
                     self.stdout.write(f"Content-Type: {content_type}")
                     bare_media_type = content_type.split(";", 1)[0].strip().lower()
-            if bare_media_type in json_media_types:
+            if bare_media_type in JSON_MEDIA_TYPES:
                 j = response.json()
                 typ = j.get("type", "").lower()
                 uri = j.get("id", "")

--- a/tests/core/test_takahe.py
+++ b/tests/core/test_takahe.py
@@ -1,2 +1,117 @@
-# Create your tests here.
-# The takahe/tests.py file was empty, so this is a placeholder for future tests.
+import httpx
+
+from takahe.management.commands.fetch import find_ap_alternate_url
+
+
+def _resp(url: str, *, content: bytes = b"", headers=None) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers=headers or [],
+        content=content,
+        request=httpx.Request("GET", url),
+    )
+
+
+def test_find_ap_alternate_url_from_link_header():
+    """WordPress AP plugin: HTML body + Link header pointing at the AP object."""
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html></html>",
+        headers=[
+            ("content-type", "text/html; charset=UTF-8"),
+            (
+                "link",
+                '<https://blog.example/?p=42>; rel="alternate"; '
+                'type="application/activity+json"',
+            ),
+        ],
+    )
+    assert find_ap_alternate_url(response) == "https://blog.example/?p=42"
+
+
+def test_find_ap_alternate_url_picks_ap_among_multiple_alternates():
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html></html>",
+        headers=[
+            ("content-type", "text/html"),
+            (
+                "link",
+                '<https://blog.example/feed/>; rel="alternate"; type="application/rss+xml",'
+                ' <https://blog.example/?p=42>; rel="alternate"; type="application/activity+json"',
+            ),
+        ],
+    )
+    assert find_ap_alternate_url(response) == "https://blog.example/?p=42"
+
+
+def test_find_ap_alternate_url_resolves_relative_url():
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html></html>",
+        headers=[
+            ("content-type", "text/html"),
+            ("link", '</?p=42>; rel="alternate"; type="application/activity+json"'),
+        ],
+    )
+    assert find_ap_alternate_url(response) == "https://blog.example/?p=42"
+
+
+def test_find_ap_alternate_url_from_html_link_tag():
+    """Fall back to <link rel="alternate" type="application/activity+json">
+    in the HTML head when no Link header is present."""
+    body = (
+        b"<html><head>"
+        b'<link rel="alternate" type="application/rss+xml" href="/feed/">'
+        b'<link rel="alternate" type="application/activity+json"'
+        b' href="https://blog.example/?p=42">'
+        b"</head></html>"
+    )
+    response = _resp(
+        "https://blog.example/post/",
+        content=body,
+        headers=[("content-type", "text/html; charset=utf-8")],
+    )
+    assert find_ap_alternate_url(response) == "https://blog.example/?p=42"
+
+
+def test_find_ap_alternate_url_returns_none_without_hints():
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html><head></head></html>",
+        headers=[("content-type", "text/html")],
+    )
+    assert find_ap_alternate_url(response) is None
+
+
+def test_find_ap_alternate_url_ignores_non_ap_alternates():
+    """A bare ``application/json`` alternate must not be auto-followed as AP."""
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html></html>",
+        headers=[
+            ("content-type", "text/html"),
+            (
+                "link",
+                '<https://blog.example/api/post/42>; rel="alternate"; '
+                'type="application/json"',
+            ),
+        ],
+    )
+    assert find_ap_alternate_url(response) is None
+
+
+def test_find_ap_alternate_url_ignores_non_alternate_rels():
+    response = _resp(
+        "https://blog.example/post/",
+        content=b"<html></html>",
+        headers=[
+            ("content-type", "text/html"),
+            (
+                "link",
+                '<https://blog.example/?p=42>; rel="self"; '
+                'type="application/activity+json"',
+            ),
+        ],
+    )
+    assert find_ap_alternate_url(response) is None


### PR DESCRIPTION
## Summary
- Pasting a WordPress ActivityPub permalink (e.g. `https://activitypub.blog/2026/04/22/8-1-0-by-the-numbers/`) into NeoDB silently fails. WordPress's AP plugin does not content-negotiate on the canonical permalink — even with `Accept: application/activity+json` it returns HTML. The AP `Article` object lives at a different URL (e.g. `https://activitypub.blog/?p=15463`), advertised only via `Link: rel="alternate"; type="application/activity+json"` (and the equivalent `<link>` in the HTML head).
- `SearchService.search_url` and `neodb-manage fetch` both bailed out as soon as the response wasn't JSON.
- This PR mirrors Mastodon's `FetchResourceService` behaviour: when the first response isn't JSON, follow the advertised AP alternate once before giving up.

## Changes
- `neodb-takahe`:
  - Add `core.json.find_ap_alternate(response)` — parses the `Link` header (multi-value, quoting, relative URL resolution) and falls back to `<link rel="alternate" type="application/activity+json">` in the HTML head.
  - `SearchService.search_url`: retry once on the alternate URL when the response isn't JSON; guard against self-referential loops.
  - Regression tests for the helper (6) and search_url (3).
- `neodb-app`:
  - Mirror the Link-header follow in `takahe/management/commands/fetch.py` so `neodb-manage fetch <wordpress-permalink>` succeeds.
  - Bump the submodule pointer.

## Test plan
- [x] `pytest tests/core/test_json.py tests/activities/services/test_search.py` (9 passed) in the submodule
- [x] Pre-existing failing tests (`test_signup_*`, `test_fetch_post`) were unchanged by this PR (verified by re-running with the changes stashed)
- [x] `uv run pre-commit run -a` clean in both repos
- [x] End-to-end live check: `find_ap_alternate` resolves the real `activitypub.blog` permalink to `https://activitypub.blog/?p=15463`; `json_from_response` then parses it as `type: Article` titled "8.1.0 — By the Numbers"