### PR TITLE
perf(takahe): prefetch post mentions to fix render-time N+1

### DIFF
--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -102,6 +102,7 @@ def post_quotes(request: AuthedHttpRequest, post_id: int):
         .visible_to(viewer_identity, include_replies=True)
         .filter(quote_url=post.object_uri)
         .select_related("author")
+        .prefetch_related("mentions")
         .order_by("-published")[:20]
     )
     return render(request, "post_quotes.html", {"post": post, "quotes": quotes})

--- a/social/views.py
+++ b/social/views.py
@@ -122,7 +122,7 @@ def search_data(request):
         events = [
             SearchResultEvent(p)
             for p in r.posts.select_related("author")
-            .prefetch_related("attachments")
+            .prefetch_related("attachments", "mentions")
             .order_by("-id")
         ]
         _add_interaction_to_events(events, identity_id)

--- a/takahe/utils.py
+++ b/takahe/utils.py
@@ -747,7 +747,7 @@ class Takahe:
         return (
             Post.objects.filter(pk__in=post_pks)
             .exclude(state__in=["deleted", "deleted_fanned_out"])
-            .prefetch_related("author", "attachments")
+            .prefetch_related("author", "attachments", "mentions")
             .select_related("application")
         )
 
@@ -1099,7 +1099,7 @@ class Takahe:
         )
         if local_only:
             qs = qs.filter(local=True)
-        return qs.prefetch_related("attachments", "author").select_related(
+        return qs.prefetch_related("attachments", "author", "mentions").select_related(
             "application"
         )
 
@@ -1120,7 +1120,7 @@ class Takahe:
             qs = qs.exclude(visibility=3)
         else:
             qs = qs.filter(visibility__in=[0, 1, 4])
-        return qs.prefetch_related("attachments", "author").select_related(
+        return qs.prefetch_related("attachments", "author", "mentions").select_related(
             "application"
         )
 
@@ -1163,7 +1163,7 @@ class Takahe:
         return (
             qs.annotate(boost_pk=Subquery(boost_pk_subq))
             .order_by("-boost_pk")
-            .prefetch_related("attachments", "author")
+            .prefetch_related("attachments", "author", "mentions")
             .select_related("application")
         )
 

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -1,7 +1,7 @@
 """Tests for N+1 query optimizations."""
 
 import pytest
-from django.db import connection
+from django.db import connection, connections
 from django.test import Client
 from django.test.utils import CaptureQueriesContext
 
@@ -404,6 +404,47 @@ class TestPrefetchPiecesForPosts:
 
     def test_prefetch_empty_list(self):
         prefetch_pieces_for_posts([])  # should not raise
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPostMentionsPrefetch:
+    """Profile post querysets must prefetch mentions to avoid an N+1 from
+    safe_content_local -> ContentRenderer -> post.mentions.all()."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="pmen@example.com", username="pmenuser")
+        self.book = Edition.objects.create(title="Mentions Prefetch Book")
+        self.movie = Movie.objects.create(title="Mentions Prefetch Movie")
+        Mark(self.user.identity, self.book).update(
+            ShelfType.WISHLIST, "want to read", visibility=0
+        )
+        Mark(self.user.identity, self.movie).update(
+            ShelfType.COMPLETE, "great film", 8, visibility=0
+        )
+
+    def _assert_no_mention_queries(self, posts):
+        # Post.mentions lives in the takahe database; capture that connection.
+        with CaptureQueriesContext(connections["takahe"]) as ctx:
+            for post in posts:
+                _ = post.safe_content_local
+        mention_queries = [
+            q for q in ctx.captured_queries if "activities_post_mentions" in q["sql"]
+        ]
+        assert mention_queries == []
+
+    def test_recent_posts_render_avoids_mentions_n_plus_one(self):
+        posts = list(Takahe.get_recent_posts(self.user.identity.pk)[:10])
+        assert len(posts) >= 2
+        self._assert_no_mention_queries(posts)
+
+    def test_get_posts_render_avoids_mentions_n_plus_one(self):
+        post_ids = list(
+            Takahe.get_recent_posts(self.user.identity.pk).values_list("pk", flat=True)
+        )
+        posts = list(Takahe.get_posts(post_ids))
+        assert len(posts) >= 2
+        self._assert_no_mention_queries(posts)
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Summary

`ContentRenderer.render_post` (called by `Post.safe_content_local`) iterates `post.mentions.all()` per post. Any queryset that feeds template rendering therefore fires one `users_identity JOIN activities_post_mentions WHERE post_id = …` query per rendered post — Sentry flagged it on `/users/{user_name}/` profile pages (10 recent posts per render).

Adds `"mentions"` to `prefetch_related(...)` on the post querysets that feed render paths missing it:

- `Takahe.get_recent_posts` and `Takahe.get_boosted_posts` — profile page and `profile_posts_data` HTMX.
- `Takahe.get_posts` and `Takahe.get_public_posts` — discover popular posts panel.
- search results in `social/views.search_data`.
- post quotes in `journal/views/post.post_quotes`.

`Takahe.get_events` already prefetches `subject_post__mentions`, so notifications are unaffected.

## Test plan

- [x] `tests/journal/test_n_plus_one.py::TestPostMentionsPrefetch` — new regression test that captures queries on the `takahe` DB connection while iterating `safe_content_local` over `get_recent_posts` and `get_posts` output; asserts no `activities_post_mentions` queries fire. Verified it fails without the fix.
- [x] Full `tests/journal/test_n_plus_one.py` (57 tests) and broader `tests/journal/` + `tests/social/` (469 tests) pass.
- [x] `uv run pre-commit run -a` clean.

Fixes NEODB-SOCIAL-4ND
Fixes EGGPLANT-1AJ