### PR TITLE
fix(discover): cap recent posts per author at 2; use h6 for teaser titles

### DIFF
--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -657,14 +657,13 @@ def discover_popular_posts(request):
         popular_posts = Takahe.get_public_posts(
             SiteConfig.system.discover_show_local_only
         )
-        # Limit to no more than 3 posts per author
-        popular_posts = popular_posts.annotate(
-            author_row=Window(
-                expression=RowNumber(),
-                partition_by="author_id",
-                order_by="-published",
-            )
-        ).filter(author_row__lte=3)
+    popular_posts = popular_posts.annotate(
+        author_row=Window(
+            expression=RowNumber(),
+            partition_by="author_id",
+            order_by="-published",
+        )
+    ).filter(author_row__lte=2)
     posts = list(
         popular_posts.not_blocked_by(request.user.identity.takahe_identity)[:20]
     )

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -657,16 +657,18 @@ def discover_popular_posts(request):
         popular_posts = Takahe.get_public_posts(
             SiteConfig.system.discover_show_local_only
         )
-    popular_posts = popular_posts.annotate(
-        author_row=Window(
-            expression=RowNumber(),
-            partition_by="author_id",
-            order_by="-published",
+    popular_posts = (
+        popular_posts.not_blocked_by(request.user.identity.takahe_identity)
+        .annotate(
+            author_row=Window(
+                expression=RowNumber(),
+                partition_by="author_id",
+                order_by="-published",
+            )
         )
-    ).filter(author_row__lte=2)
-    posts = list(
-        popular_posts.not_blocked_by(request.user.identity.takahe_identity)[:20]
+        .filter(author_row__lte=2)
     )
+    posts = list(popular_posts[:20])
     Takahe.prefetch_interaction_flags(posts, request.user.identity.pk)
     return render(
         request,

--- a/social/templates/_article_teaser.html
+++ b/social/templates/_article_teaser.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <section class="article-teaser">
-  <h4>
+  <h6>
     <a href="{{ article.url }}">{{ article.title }}</a>
-  </h4>
+  </h6>
   <p class="piece-summary">
     {% if article.display_summary %}
       {{ article.display_summary }}

--- a/social/templates/_post_article_teaser.html
+++ b/social/templates/_post_article_teaser.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 {% with title=post.type_data.object.name|default:post.summary|striptags summary=post.type_data.object.summary %}
   <section class="article-teaser">
-    <h4>
+    <h6>
       <a href="{{ post.url|default:post.object_uri }}">{{ title|default:_("Untitled article") }}</a>
-    </h4>
+    </h6>
     {% if show_full %}
       {% if summary %}<p class="piece-summary">{{ summary|striptags }}</p>{% endif %}
       <div class="markdown-content">{{ post.safe_content_local }}</div>

--- a/social/templates/_review_teaser.html
+++ b/social/templates/_review_teaser.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <section class="review-teaser">
-  <h4>
+  <h6>
     <a href="{{ review.url }}">{{ review.title }}</a>
-  </h4>
+  </h6>
   {% if review.display_summary %}<p class="piece-summary">{{ review.display_summary }}</p>{% endif %}
 </section>


### PR DESCRIPTION
## Summary
- Limit the discover sidebar's "Recent Posts" to at most 2 posts per author. The cached `popular_posts` path had no per-author cap, and the on-demand fallback used 3, so a single author could appear 5+ times.
- Shrink article/review teaser titles from `h4` to `h6` so they sit at the right visual weight in timelines and the discover sidebar.

## Test plan
- [ ] Load discover page as a logged-in user: sidebar "Recent Posts" shows at most 2 posts from any single author across the 20-post list.
- [ ] Toggle `discover_show_popular_posts` on/off and reload — the cap applies in both modes.
- [ ] View timelines/profile that render `_review_teaser.html`, `_article_teaser.html`, `_post_article_teaser.html`: titles render as `h6`, layout unchanged otherwise.