### PR TITLE
feat(catalog/sites): add RateYourMusic scraper

### DIFF
--- a/catalog/models/common.py
+++ b/catalog/models/common.py
@@ -44,6 +44,7 @@ class SiteName(models.TextChoices):
     MobyGames = "mobygames", _("MobyGames")
     StoryGraph = "storygraph", _("StoryGraph")
     YouTubeMusic = "yt_music", _("YouTube Music")
+    RateYourMusic = "rateyourmusic", _("RateYourMusic")
 
 
 class IdType(models.TextChoices):  # values must be in lowercase
@@ -109,6 +110,7 @@ class IdType(models.TextChoices):  # values must be in lowercase
     OpenLibrary_Work = "openlibrary_work", _("Open Library Work")
     MobyGames = "mobygames", _("MobyGames")
     StoryGraph = "storygraph", _("StoryGraph")
+    RateYourMusic_Release = "rateyourmusic_release", _("RateYourMusic Release")
 
 
 IdealIdTypes = [

--- a/catalog/sites/__init__.py
+++ b/catalog/sites/__init__.py
@@ -25,6 +25,7 @@ from .mobygames import MobyGames
 from .musicbrainz import MusicBrainzRelease, MusicBrainzReleaseGroup
 from .openlibrary import OpenLibrary, OpenLibrary_Work
 from .qidian import Qidian
+from .rateyourmusic import RateYourMusic
 from .rss import RSS
 from .spotify import Spotify
 from .steam import Steam
@@ -64,6 +65,7 @@ __all__ = [
     "Itch",
     "JJWXC",
     "Qidian",
+    "RateYourMusic",
     "RSS",
     "Spotify",
     "Steam",

--- a/catalog/sites/rateyourmusic.py
+++ b/catalog/sites/rateyourmusic.py
@@ -77,14 +77,6 @@ class RateYourMusic(AbstractSite):
     def id_to_url(cls, id_value: str) -> str:
         return f"https://rateyourmusic.com/{id_value}/"
 
-    @classmethod
-    def url_to_id(cls, url: str) -> str | None:
-        m = next(
-            iter([re.match(p, url) for p in cls.URL_PATTERNS if re.match(p, url)]),
-            None,
-        )
-        return m.group(1) if m else None
-
     def scrape(self) -> ResourceContent:
         assert self.url
         h = RateYourMusicDownloader(self.url).download().html()
@@ -230,10 +222,17 @@ class RateYourMusic(AbstractSite):
     def _parse_release_date(raw: str | None) -> str | None:
         if not raw:
             return None
-        # Strip the "1997" link suffix the page sometimes leaves behind.
         cleaned = re.sub(r"\s+", " ", raw).strip()
         try:
-            dt = dateparser.parse(cleaned)
+            # Partial dates (year only / month + year) default to the first
+            # day/month rather than today's date.
+            dt = dateparser.parse(
+                cleaned,
+                settings={
+                    "PREFER_DAY_OF_MONTH": "first",
+                    "PREFER_MONTH_OF_YEAR": "first",
+                },
+            )
         except Exception:
             dt = None
         return dt.strftime("%Y-%m-%d") if dt else None
@@ -306,8 +305,10 @@ class RateYourMusic(AbstractSite):
             data = json.loads(html_lib.unescape(raw))
         except (json.JSONDecodeError, TypeError):
             return {}
+        if not isinstance(data, dict):
+            return {}
         out: dict[str, str] = {}
-        for platform, entries in (data or {}).items():
+        for platform, entries in data.items():
             if not isinstance(entries, dict) or not entries:
                 continue
             chosen_key: str | None = None

--- a/catalog/sites/rateyourmusic.py
+++ b/catalog/sites/rateyourmusic.py
@@ -1,0 +1,339 @@
+"""
+RateYourMusic (rateyourmusic.com).
+
+Public release pages are gated by an aggressive bot challenge, so runtime
+fetches go through ScrapDownloader (Scrapfly / Decodo / ScraperAPI /
+ScrapingBee / custom — configured via Django settings). Tests use
+@use_local_response which short-circuits to local HTML fixtures.
+
+RYM does not expose stable numeric release IDs publicly, so the id_value
+is the URL slug path: e.g. `release/album/radiohead/ok-computer`.
+"""
+
+import html as html_lib
+import json
+import logging
+import re
+from typing import Any, cast
+
+import dateparser
+
+from catalog.common import *
+from catalog.models import *
+from common.models.lang import detect_language
+
+_logger = logging.getLogger(__name__)
+
+
+RELEASE_TYPES = (
+    "album",
+    "ep",
+    "single",
+    "comp",
+    "mixtape",
+    "video",
+    "djmix",
+    "bootleg",
+    "unauth",
+)
+
+
+class RateYourMusicDownloader(ScrapDownloader):
+    def __init__(
+        self,
+        url: str,
+        headers: dict | None = None,
+        timeout: float | None = None,
+    ):
+        super().__init__(url, headers, timeout, "#tracks")
+
+    def validate_response(self, response) -> int:
+        if response is None:
+            return RESPONSE_NETWORK_ERROR
+        if response.status_code != 200:
+            return RESPONSE_INVALID_CONTENT
+        content = response.content.decode("utf-8", errors="ignore")
+        if "page_release" not in content and 'id="tracks"' not in content:
+            return RESPONSE_INVALID_CONTENT
+        return RESPONSE_OK
+
+
+@SiteManager.register
+class RateYourMusic(AbstractSite):
+    SITE_NAME = SiteName.RateYourMusic
+    ID_TYPE = IdType.RateYourMusic_Release
+    URL_PATTERNS = [
+        r"^https?://rateyourmusic\.com/(release/(?:"
+        + "|".join(RELEASE_TYPES)
+        + r")/[^/?#]+/[^/?#]+)/?",
+        r"^https?://www\.rateyourmusic\.com/(release/(?:"
+        + "|".join(RELEASE_TYPES)
+        + r")/[^/?#]+/[^/?#]+)/?",
+    ]
+    WIKI_PROPERTY_ID = "P8392"
+    DEFAULT_MODEL = Album
+
+    @classmethod
+    def id_to_url(cls, id_value: str) -> str:
+        return f"https://rateyourmusic.com/{id_value}/"
+
+    @classmethod
+    def url_to_id(cls, url: str) -> str | None:
+        m = next(
+            iter([re.match(p, url) for p in cls.URL_PATTERNS if re.match(p, url)]),
+            None,
+        )
+        return m.group(1) if m else None
+
+    def scrape(self) -> ResourceContent:
+        assert self.url
+        h = RateYourMusicDownloader(self.url).download().html()
+        og = self._extract_og(h)
+        info = self._extract_info_table(h)
+
+        title = self._extract_title(h) or og.get("og:title", "").split(" by ", 1)[0]
+        if not title:
+            raise ParseError(self, "title")
+
+        artists = self._extract_artists(h, info)
+        genres = self._extract_genres(h)
+        release_date = self._parse_release_date(info.get("Released"))
+        tracks, total_duration = self._extract_tracks(h)
+        company = self._extract_labels(h, og.get("og:description"))
+        cover_url = og.get("og:image")
+        brief = self._extract_brief(og.get("og:description"))
+        album_type = info.get("Type") or None
+
+        title_lang = detect_language(title)
+        localized_title = [{"lang": title_lang, "text": title}]
+        localized_description = (
+            [{"lang": detect_language(brief), "text": brief}] if brief else []
+        )
+
+        data: dict[str, Any] = {
+            "title": title,
+            "localized_title": localized_title,
+            "localized_description": localized_description,
+            "brief": brief,
+            "artist": artists,
+            "genre": genres,
+            "track_list": "\n".join(tracks),
+            "duration": total_duration or None,
+            "release_date": release_date,
+            "company": company,
+            "album_type": album_type,
+            "cover_image_url": cover_url,
+        }
+        pd = ResourceContent(metadata=data)
+        links = self._extract_streaming_ids(h)
+        spotify_id = links.get("spotify")
+        if spotify_id:
+            pd.lookup_ids[IdType.Spotify_Album] = spotify_id
+        applemusic_id = links.get("applemusic")
+        if applemusic_id:
+            pd.lookup_ids[IdType.AppleMusic] = applemusic_id
+        bandcamp_id = links.get("bandcamp")
+        if bandcamp_id:
+            pd.lookup_ids[IdType.Bandcamp] = bandcamp_id
+        return pd
+
+    @staticmethod
+    def _extract_og(h) -> dict[str, str]:
+        og: dict[str, str] = {}
+        for m in h.xpath("//meta[@property or @name]"):
+            key = m.get("property") or m.get("name")
+            val = m.get("content")
+            if key and val:
+                og[key] = val
+        return og
+
+    @staticmethod
+    def _extract_title(h) -> str | None:
+        node = h.xpath("//div[contains(@class, 'album_title')]")
+        if not node:
+            return None
+        # The first text node before the nested <input>/<div> contains the title.
+        first = node[0].text
+        return first.strip() if first else None
+
+    @staticmethod
+    def _extract_info_table(h) -> dict[str, str]:
+        info: dict[str, str] = {}
+        for row in h.xpath("//th[contains(@class, 'info_hdr')]/ancestor::tr[1]"):
+            keys = row.xpath(".//th[contains(@class, 'info_hdr')]/text()")
+            key = keys[0].strip() if keys else None
+            if not key:
+                continue
+            value = " ".join(
+                t.strip() for t in row.xpath(".//td//text()") if t and t.strip()
+            )
+            info[key] = value
+        return info
+
+    @staticmethod
+    def _extract_artists(h, info: dict[str, str]) -> list[str]:
+        names = [
+            t.strip()
+            for t in h.xpath(
+                "//tr[th[contains(@class, 'info_hdr')][contains(., 'Artist')]]"
+                "//a[contains(@class, 'artist')]/text()"
+            )
+            if t and t.strip()
+        ]
+        if not names:
+            names = [
+                t.strip()
+                for t in h.xpath(
+                    "//div[contains(@class, 'album_artist_small')]"
+                    "//a[contains(@class, 'artist')]/text()"
+                )
+                if t and t.strip()
+            ]
+        if not names and "Artist" in info:
+            names = [info["Artist"].strip()]
+        # de-dupe while preserving order
+        seen: set[str] = set()
+        out: list[str] = []
+        for n in names:
+            if n not in seen:
+                seen.add(n)
+                out.append(n)
+        return out
+
+    @staticmethod
+    def _extract_genres(h) -> list[str]:
+        primary = [
+            t.strip()
+            for t in h.xpath(
+                "//span[contains(@class, 'release_pri_genres')]"
+                "//a[contains(@class, 'genre')]/text()"
+            )
+            if t and t.strip()
+        ]
+        secondary = [
+            t.strip()
+            for t in h.xpath(
+                "//span[contains(@class, 'release_sec_genres')]"
+                "//a[contains(@class, 'genre')]/text()"
+            )
+            if t and t.strip()
+        ]
+        seen: set[str] = set()
+        out: list[str] = []
+        for g in primary + secondary:
+            if g not in seen:
+                seen.add(g)
+                out.append(g)
+        return out
+
+    @staticmethod
+    def _parse_release_date(raw: str | None) -> str | None:
+        if not raw:
+            return None
+        # Strip the "1997" link suffix the page sometimes leaves behind.
+        cleaned = re.sub(r"\s+", " ", raw).strip()
+        try:
+            dt = dateparser.parse(cleaned)
+        except Exception:
+            dt = None
+        return dt.strftime("%Y-%m-%d") if dt else None
+
+    @staticmethod
+    def _extract_tracks(h) -> tuple[list[str], int]:
+        lines: list[str] = []
+        total = 0
+        for li in h.xpath("//ul[@id='tracks']/li[contains(@class, 'track')]"):
+            num = "".join(li.xpath(".//span[@class='tracklist_num']//text()")).strip()
+            title_parts = li.xpath(
+                ".//span[contains(@class, 'tracklist_title')]"
+                "//a[contains(@class, 'song')]//text()"
+            )
+            title = "".join(title_parts).strip()
+            if not title:
+                continue
+            duration_secs = li.xpath(
+                ".//span[contains(@class, 'tracklist_duration')]/@data-inseconds"
+            )
+            duration_txt = "".join(
+                li.xpath(".//span[contains(@class, 'tracklist_duration')]//text()")
+            ).strip()
+            try:
+                total += int(duration_secs[0]) if duration_secs else 0
+            except (TypeError, ValueError):
+                pass
+            prefix = f"{num}. " if num else ""
+            suffix = f" ({duration_txt})" if duration_txt else ""
+            lines.append(f"{prefix}{title}{suffix}")
+        return lines, total * 1000
+
+    @staticmethod
+    def _extract_labels(h, og_description: str | None) -> list[str]:
+        # The og:description starts with "Released <date> on <Label> (catalog no. ...".
+        if og_description:
+            m = re.search(
+                r"\bReleased\b[^.]*?\bon\s+(.+?)\s*\(catalog no\.",
+                og_description,
+            )
+            if m:
+                primary = m.group(1).strip()
+                if primary:
+                    return [primary]
+        # Fallback: first /label/ anchor on the page.
+        for t in h.xpath("//a[contains(@href, '/label/')]/text()"):
+            s = t.strip()
+            if s:
+                return [s]
+        return []
+
+    @staticmethod
+    def _extract_streaming_ids(h) -> dict[str, str]:
+        """Parse the data-links JSON on #media_link_button_container_top.
+
+        Schema: {platform: {RymInternalId: {"default": true|absent, "url": "...", ...}}}.
+        Returns one external ID per platform — the entry flagged "default" if
+        present, else the first. For bandcamp, the `url` field is RYM's stored
+        slug (e.g. "kinggizzard.bandcamp.com/album/12-bar-bruise") which already
+        matches NeoDB's IdType.Bandcamp value format; for other platforms we
+        return the dict key (Spotify base62, Apple Music numeric, etc).
+        """
+        raw_list = h.xpath(
+            "//div[@id='media_link_button_container_top']/@data-links"
+        ) or h.xpath("//div[contains(@class, 'media_link_container')]/@data-links")
+        if not raw_list:
+            return {}
+        raw = raw_list[0]
+        try:
+            data = json.loads(html_lib.unescape(raw))
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        out: dict[str, str] = {}
+        for platform, entries in (data or {}).items():
+            if not isinstance(entries, dict) or not entries:
+                continue
+            chosen_key: str | None = None
+            chosen_meta: Any = None
+            for ext_id, meta in entries.items():
+                if isinstance(meta, dict) and meta.get("default"):
+                    chosen_key = str(ext_id)
+                    chosen_meta = meta
+                    break
+            if chosen_key is None:
+                first_key, first_meta = next(iter(entries.items()))
+                chosen_key = str(first_key)
+                chosen_meta = first_meta
+            if platform == "bandcamp" and isinstance(chosen_meta, dict):
+                # Bandcamp's external ID is the URL slug, not RYM's internal id.
+                url = cast(dict[str, Any], chosen_meta).get("url")
+                if isinstance(url, str) and url:
+                    out["bandcamp"] = url
+                    continue
+            out[str(platform)] = chosen_key
+        return out
+
+    @staticmethod
+    def _extract_brief(og_description: str | None) -> str:
+        if not og_description:
+            return ""
+        # Strip credit dumps after "Featured peformers:" / "Featured performers:"
+        cut = re.split(r"\s*\.\s*Featured pe[rf]+ormers:", og_description, maxsplit=1)
+        return cut[0].strip()

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -25,6 +25,7 @@ The following external sites are supported for importing catalog items.
 | MusicBrainz | Music (Album) | |
 | OpenLibrary | Book (Edition, Work) | |
 | Qidian 起点 | Book (Edition) | |
+| RateYourMusic | Music (Album) | |
 | RSS feed | Podcast | Yes — upload OPML |
 | Spotify | Music (Album) | |
 | Steam | Game | |

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 09:33-0400\n"
+"POT-Creation-Date: 2026-05-13 21:14-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,12 +68,12 @@ msgid "Primary ID Value"
 msgstr ""
 
 #: catalog/models/book.py:138 catalog/models/book.py:157
-#: catalog/models/common.py:205 catalog/models/common.py:223
+#: catalog/models/common.py:207 catalog/models/common.py:225
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:141 catalog/models/book.py:160
-#: catalog/models/common.py:208 catalog/models/common.py:228
+#: catalog/models/common.py:210 catalog/models/common.py:230
 msgid "text content"
 msgstr ""
 
@@ -173,11 +173,11 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:17 catalog/models/common.py:65
+#: catalog/models/common.py:17 catalog/models/common.py:66
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:18 catalog/models/common.py:67
+#: catalog/models/common.py:18 catalog/models/common.py:68
 msgid "Google Books"
 msgstr ""
 
@@ -185,16 +185,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:20 catalog/models/common.py:76
-#: catalog/models/common.py:78
+#: catalog/models/common.py:20 catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:21 catalog/models/common.py:77
+#: catalog/models/common.py:21 catalog/models/common.py:78
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:22 catalog/models/common.py:60
+#: catalog/models/common.py:22 catalog/models/common.py:61
 #: catalog/templates/movie.html:51 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:68 catalog/templates/tvshow.html:63
 msgid "IMDb"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:24 catalog/models/common.py:79
+#: catalog/models/common.py:24 catalog/models/common.py:80
 msgid "Bandcamp"
 msgstr ""
 
@@ -220,11 +220,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:98
+#: catalog/models/common.py:28 catalog/models/common.py:99
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:99
+#: catalog/models/common.py:29 catalog/models/common.py:100
 msgid "Bangumi"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:100
+#: catalog/models/common.py:31 catalog/models/common.py:101
 msgid "Apple Podcast"
 msgstr ""
 
@@ -244,35 +244,35 @@ msgstr ""
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:34 catalog/models/common.py:101
+#: catalog/models/common.py:34 catalog/models/common.py:102
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:103
+#: catalog/models/common.py:35 catalog/models/common.py:104
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:36 catalog/models/common.py:104
+#: catalog/models/common.py:36 catalog/models/common.py:105
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:37 catalog/models/common.py:105
+#: catalog/models/common.py:37 catalog/models/common.py:106
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:106
+#: catalog/models/common.py:38 catalog/models/common.py:107
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:107
+#: catalog/models/common.py:39 catalog/models/common.py:108
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:50
+#: catalog/models/common.py:40 catalog/models/common.py:51
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:41 catalog/models/common.py:108
+#: catalog/models/common.py:41 catalog/models/common.py:109
 msgid "Open Library"
 msgstr ""
 
@@ -284,267 +284,275 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:44 catalog/models/common.py:110
+#: catalog/models/common.py:44 catalog/models/common.py:111
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:111
+#: catalog/models/common.py:45 catalog/models/common.py:112
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:102
+#: catalog/models/common.py:46 catalog/models/common.py:103
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:47
+msgid "RateYourMusic"
+msgstr ""
+
+#: catalog/models/common.py:52
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:52 catalog/templates/edition.html:19
+#: catalog/models/common.py:53 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:53
+#: catalog/models/common.py:54
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:55
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:56
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:57
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:58
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:59
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:60
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:62
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:63
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:64
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:89
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:90
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:91
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:96
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:97
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:98
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:132
-msgid "Edition"
-msgstr ""
-
-#: catalog/models/common.py:133 catalog/templates/_sidebar_edit.html:237
-msgid "Work"
+#: catalog/models/common.py:113
+msgid "RateYourMusic Release"
 msgstr ""
 
 #: catalog/models/common.py:134
-msgid "TV Series"
+msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:135 catalog/templates/_sidebar_edit.html:158
-msgid "TV Season"
+#: catalog/models/common.py:135 catalog/templates/_sidebar_edit.html:237
+msgid "Work"
 msgstr ""
 
 #: catalog/models/common.py:136
+msgid "TV Series"
+msgstr ""
+
+#: catalog/models/common.py:137 catalog/templates/_sidebar_edit.html:158
+msgid "TV Season"
+msgstr ""
+
+#: catalog/models/common.py:138
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:137 catalog/models/common.py:153
-#: catalog/models/common.py:167 catalog/templates/_sidebar_edit.html:151
+#: catalog/models/common.py:139 catalog/models/common.py:155
+#: catalog/models/common.py:169 catalog/templates/_sidebar_edit.html:151
 #: journal/templates/_sidebar_user_mark_list.html:35
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:138
+#: catalog/models/common.py:140
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:139 catalog/models/common.py:156
-#: catalog/models/common.py:170 common/templates/_header.html:41
+#: catalog/models/common.py:141 catalog/models/common.py:158
+#: catalog/models/common.py:172 common/templates/_header.html:41
 #: journal/templates/_sidebar_user_mark_list.html:48
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:140
+#: catalog/models/common.py:142
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:143
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:142 catalog/models/common.py:158
-#: catalog/models/common.py:172 common/templates/_header.html:45
+#: catalog/models/common.py:144 catalog/models/common.py:160
+#: catalog/models/common.py:174 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:52
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:145
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:146
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:145 catalog/models/common.py:162
+#: catalog/models/common.py:147 catalog/models/common.py:164
 #: journal/templates/collection.html:23 journal/templates/collection.html:29
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:148 catalog/models/common.py:161
+#: catalog/models/common.py:150 catalog/models/common.py:163
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:152 catalog/models/common.py:166
+#: catalog/models/common.py:154 catalog/models/common.py:168
 #: common/templates/_header.html:25
 #: journal/templates/_sidebar_user_mark_list.html:32
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:154 catalog/models/common.py:168
+#: catalog/models/common.py:156 catalog/models/common.py:170
 #: journal/templates/_sidebar_user_mark_list.html:38
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:155 catalog/models/common.py:169
+#: catalog/models/common.py:157 catalog/models/common.py:171
 #: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:45
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/models/common.py:171
+#: catalog/models/common.py:159 catalog/models/common.py:173
 #: catalog/templates/_sidebar_edit.html:170 common/templates/_header.html:33
 #: journal/templates/_sidebar_user_mark_list.html:42
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:253 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:255 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:270 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:272 catalog/templates/_language_list.html:5
 #: users/models/user.py:128
 msgid "language"
 msgstr ""
@@ -1117,7 +1125,7 @@ msgstr ""
 msgid "write a review"
 msgstr ""
 
-#: catalog/templates/_item_similar.html:5
+#: catalog/templates/_item_similar.html:13
 msgid "similar items"
 msgstr ""
 
@@ -1584,8 +1592,8 @@ msgstr ""
 msgid "This operation cannot be undone. Sure to merge?"
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:344 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:145
+#: common/views_manage.py:345 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -3509,7 +3517,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:466
+#: common/templates/common/about.html:35 common/views_manage.py:484
 msgid "Invite Only"
 msgstr ""
 
@@ -3517,7 +3525,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:487
+#: common/templates/common/about.html:40 common/views_manage.py:505
 msgid "Preferred Languages"
 msgstr ""
 
@@ -3573,7 +3581,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:551
+#: common/templates/common/scan.html:60 common/views_manage.py:569
 msgid "Search"
 msgstr ""
 
@@ -3660,604 +3668,604 @@ msgstr ""
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:49
+#: common/views_manage.py:50
 msgid "Enabled"
 msgstr ""
 
-#: common/views_manage.py:49
+#: common/views_manage.py:50
 msgid "Disabled"
 msgstr ""
 
-#: common/views_manage.py:143 common/views_manage.py:293
+#: common/views_manage.py:144 common/views_manage.py:294
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:147
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:147 common/views_manage.py:546
+#: common/views_manage.py:148 common/views_manage.py:564
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:150 common/views_manage.py:301
+#: common/views_manage.py:151 common/views_manage.py:302
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:200
+#: common/views_manage.py:201
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:204
+#: common/views_manage.py:205
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:209
+#: common/views_manage.py:210
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:229
+#: common/views_manage.py:230
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:313
+#: common/views_manage.py:314
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:316
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:329
+#: common/views_manage.py:330
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:332
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:359
+#: common/views_manage.py:377
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:361
+#: common/views_manage.py:379
 msgid "Master switch. When off, all recommendation surfaces are hidden for regular users and the cron jobs are not scheduled. Test-enabled accounts (DEBUG mode or '!bazinga' in their bio) still see the surfaces, for preview."
 msgstr ""
 
-#: common/views_manage.py:368
+#: common/views_manage.py:386
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:370
+#: common/views_manage.py:388
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:376
+#: common/views_manage.py:394
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:378
+#: common/views_manage.py:396
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:384
+#: common/views_manage.py:402
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:385
+#: common/views_manage.py:403
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:389
+#: common/views_manage.py:407
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:390
+#: common/views_manage.py:408
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:394
+#: common/views_manage.py:412
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:396
+#: common/views_manage.py:414
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:419
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:403
+#: common/views_manage.py:421
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:427
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:411
+#: common/views_manage.py:429
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:417
+#: common/views_manage.py:435
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:437
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:425
+#: common/views_manage.py:443
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:427
+#: common/views_manage.py:445
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:433
+#: common/views_manage.py:451
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:435
+#: common/views_manage.py:453
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:460
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:445
+#: common/views_manage.py:463
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:452
+#: common/views_manage.py:470
 msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:468
+#: common/views_manage.py:486
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:473
+#: common/views_manage.py:491
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:474
+#: common/views_manage.py:492
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:495
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:478
+#: common/views_manage.py:496
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:481
+#: common/views_manage.py:499
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:484
+#: common/views_manage.py:502
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:489
+#: common/views_manage.py:507
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:495
+#: common/views_manage.py:513
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:518
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:522
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:514
+#: common/views_manage.py:532
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:516
+#: common/views_manage.py:534
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:521
+#: common/views_manage.py:539
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:522
+#: common/views_manage.py:540
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:526
+#: common/views_manage.py:544
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:528
+#: common/views_manage.py:546
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:533
+#: common/views_manage.py:551
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:534
+#: common/views_manage.py:552
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:537
+#: common/views_manage.py:555
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:556
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:541
+#: common/views_manage.py:559
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:542
+#: common/views_manage.py:560
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:563
+#: common/views_manage.py:581
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:582
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:567
+#: common/views_manage.py:585
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:568
+#: common/views_manage.py:586
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:589
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:572
+#: common/views_manage.py:590
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:575
+#: common/views_manage.py:593
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:577
+#: common/views_manage.py:595
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:581
+#: common/views_manage.py:599
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:582
+#: common/views_manage.py:600
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:585
+#: common/views_manage.py:603
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:588 users/templates/users/steam_import.html:26
+#: common/views_manage.py:606 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:590
+#: common/views_manage.py:608
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:595
+#: common/views_manage.py:613
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:596
+#: common/views_manage.py:614
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:617
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:602
+#: common/views_manage.py:620
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:623
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:606
+#: common/views_manage.py:624
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:609
+#: common/views_manage.py:627
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:612
+#: common/views_manage.py:630
 msgid "Sentry DSN"
 msgstr ""
 
-#: common/views_manage.py:613
+#: common/views_manage.py:631
 msgid "Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:616
+#: common/views_manage.py:634
 msgid "Sentry Sample Rate"
 msgstr ""
 
-#: common/views_manage.py:617
+#: common/views_manage.py:635
 msgid "0.0 to 1.0. Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:622
+#: common/views_manage.py:640
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:624
+#: common/views_manage.py:642
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:641
+#: common/views_manage.py:659
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:650
+#: common/views_manage.py:668
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:655
+#: common/views_manage.py:673
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:677
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:671
+#: common/views_manage.py:689
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:690
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:675
+#: common/views_manage.py:693
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:676
+#: common/views_manage.py:694
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:697
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:682
+#: common/views_manage.py:700
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:685
+#: common/views_manage.py:703
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:688
+#: common/views_manage.py:706
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:691
+#: common/views_manage.py:709
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:695
+#: common/views_manage.py:713
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:698
+#: common/views_manage.py:716
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:702
+#: common/views_manage.py:720
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:735
+#: common/views_manage.py:753
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:736
+#: common/views_manage.py:754
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:739
+#: common/views_manage.py:757
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:740
+#: common/views_manage.py:758
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:743
+#: common/views_manage.py:761
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:762
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:747
+#: common/views_manage.py:765
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:766
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:776
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:766
+#: common/views_manage.py:784
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:786
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:793
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Operational"
 msgstr ""
 
@@ -4934,39 +4942,39 @@ msgstr ""
 msgid "set as target"
 msgstr ""
 
-#: journal/templates/_list_item.html:15
+#: journal/templates/_list_item.html:14
 msgid "Move to top"
 msgstr ""
 
-#: journal/templates/_list_item.html:20
+#: journal/templates/_list_item.html:19
 msgid "Move to bottom"
 msgstr ""
 
-#: journal/templates/_list_item.html:25
+#: journal/templates/_list_item.html:24
 msgid "Remove from collection"
 msgstr ""
 
-#: journal/templates/_list_item.html:35
+#: journal/templates/_list_item.html:34
 msgid "add mark"
 msgstr ""
 
-#: journal/templates/_list_item.html:43
+#: journal/templates/_list_item.html:42
 msgid "update mark"
 msgstr ""
 
-#: journal/templates/_list_item.html:61
+#: journal/templates/_list_item.html:60
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:101 journal/templates/review.html:22
+#: journal/templates/_list_item.html:100 journal/templates/review.html:22
 #: journal/templates/review.html:28 journal/templates/review.html:71
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr ""
 
-#: journal/templates/_list_item.html:134
+#: journal/templates/_list_item.html:133
 #, python-format
 msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr ""
@@ -5101,7 +5109,7 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:19 social/templates/single_post.html:21
+#: journal/templates/article.html:19 social/templates/single_post.html:15
 msgid "Article"
 msgstr ""
 
@@ -5931,7 +5939,7 @@ msgstr ""
 msgid "replying to"
 msgstr ""
 
-#: social/templates/_post_article_teaser.html:12
+#: social/templates/_post_article_teaser.html:5
 msgid "Untitled article"
 msgstr ""
 
@@ -6120,7 +6128,7 @@ msgstr ""
 msgid "Poll ending at %(end_time)s"
 msgstr ""
 
-#: social/templates/single_post.html:12 social/templates/single_post.html:24
+#: social/templates/single_post.html:12 social/templates/single_post.html:18
 msgid "Post"
 msgstr ""
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-12 09:33-0400\n"
+"POT-Creation-Date: 2026-05-13 21:14-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -67,12 +67,12 @@ msgid "Primary ID Value"
 msgstr "主要标识数据"
 
 #: catalog/models/book.py:138 catalog/models/book.py:157
-#: catalog/models/common.py:205 catalog/models/common.py:223
+#: catalog/models/common.py:207 catalog/models/common.py:225
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:141 catalog/models/book.py:160
-#: catalog/models/common.py:208 catalog/models/common.py:228
+#: catalog/models/common.py:210 catalog/models/common.py:230
 msgid "text content"
 msgstr "文本内容"
 
@@ -172,11 +172,11 @@ msgstr "未知"
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:17 catalog/models/common.py:65
+#: catalog/models/common.py:17 catalog/models/common.py:66
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:18 catalog/models/common.py:67
+#: catalog/models/common.py:18 catalog/models/common.py:68
 msgid "Google Books"
 msgstr "谷歌图书"
 
@@ -184,16 +184,16 @@ msgstr "谷歌图书"
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:20 catalog/models/common.py:76
-#: catalog/models/common.py:78
+#: catalog/models/common.py:20 catalog/models/common.py:77
+#: catalog/models/common.py:79
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:21 catalog/models/common.py:77
+#: catalog/models/common.py:21 catalog/models/common.py:78
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:22 catalog/models/common.py:60
+#: catalog/models/common.py:22 catalog/models/common.py:61
 #: catalog/templates/movie.html:51 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:68 catalog/templates/tvshow.html:63
 msgid "IMDb"
@@ -203,7 +203,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:24 catalog/models/common.py:79
+#: catalog/models/common.py:24 catalog/models/common.py:80
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -219,11 +219,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:28 catalog/models/common.py:98
+#: catalog/models/common.py:28 catalog/models/common.py:99
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:99
+#: catalog/models/common.py:29 catalog/models/common.py:100
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -231,7 +231,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:31 catalog/models/common.py:100
+#: catalog/models/common.py:31 catalog/models/common.py:101
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
@@ -243,35 +243,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:34 catalog/models/common.py:101
+#: catalog/models/common.py:34 catalog/models/common.py:102
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:35 catalog/models/common.py:103
+#: catalog/models/common.py:35 catalog/models/common.py:104
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:36 catalog/models/common.py:104
+#: catalog/models/common.py:36 catalog/models/common.py:105
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:37 catalog/models/common.py:105
+#: catalog/models/common.py:37 catalog/models/common.py:106
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:38 catalog/models/common.py:106
+#: catalog/models/common.py:38 catalog/models/common.py:107
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:39 catalog/models/common.py:107
+#: catalog/models/common.py:39 catalog/models/common.py:108
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:40 catalog/models/common.py:50
+#: catalog/models/common.py:40 catalog/models/common.py:51
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:41 catalog/models/common.py:108
+#: catalog/models/common.py:41 catalog/models/common.py:109
 msgid "Open Library"
 msgstr "开放图书馆"
 
@@ -283,267 +283,275 @@ msgstr "MusicBrainz"
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:44 catalog/models/common.py:110
+#: catalog/models/common.py:44 catalog/models/common.py:111
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:45 catalog/models/common.py:111
+#: catalog/models/common.py:45 catalog/models/common.py:112
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:102
+#: catalog/models/common.py:46 catalog/models/common.py:103
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:47
+msgid "RateYourMusic"
+msgstr "RateYourMusic"
+
+#: catalog/models/common.py:52
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:52 catalog/templates/edition.html:19
+#: catalog/models/common.py:53 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:53
+#: catalog/models/common.py:54
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:55
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:56
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:57
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:58
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:59
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:60
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:62
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:63
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:64
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:89
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:90
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:91
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:96
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:97
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:98
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:132
+#: catalog/models/common.py:113
+msgid "RateYourMusic Release"
+msgstr "RateYourMusic发行"
+
+#: catalog/models/common.py:134
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:133 catalog/templates/_sidebar_edit.html:237
+#: catalog/models/common.py:135 catalog/templates/_sidebar_edit.html:237
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:134
+#: catalog/models/common.py:136
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:135 catalog/templates/_sidebar_edit.html:158
+#: catalog/models/common.py:137 catalog/templates/_sidebar_edit.html:158
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:136
+#: catalog/models/common.py:138
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:137 catalog/models/common.py:153
-#: catalog/models/common.py:167 catalog/templates/_sidebar_edit.html:151
+#: catalog/models/common.py:139 catalog/models/common.py:155
+#: catalog/models/common.py:169 catalog/templates/_sidebar_edit.html:151
 #: journal/templates/_sidebar_user_mark_list.html:35
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:138
+#: catalog/models/common.py:140
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:139 catalog/models/common.py:156
-#: catalog/models/common.py:170 common/templates/_header.html:41
+#: catalog/models/common.py:141 catalog/models/common.py:158
+#: catalog/models/common.py:172 common/templates/_header.html:41
 #: journal/templates/_sidebar_user_mark_list.html:48
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:140
+#: catalog/models/common.py:142
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:143
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:142 catalog/models/common.py:158
-#: catalog/models/common.py:172 common/templates/_header.html:45
+#: catalog/models/common.py:144 catalog/models/common.py:160
+#: catalog/models/common.py:174 common/templates/_header.html:45
 #: journal/templates/_sidebar_user_mark_list.html:52
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:145
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:146
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:145 catalog/models/common.py:162
+#: catalog/models/common.py:147 catalog/models/common.py:164
 #: journal/templates/collection.html:23 journal/templates/collection.html:29
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:148 catalog/models/common.py:161
+#: catalog/models/common.py:150 catalog/models/common.py:163
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:152 catalog/models/common.py:166
+#: catalog/models/common.py:154 catalog/models/common.py:168
 #: common/templates/_header.html:25
 #: journal/templates/_sidebar_user_mark_list.html:32
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:154 catalog/models/common.py:168
+#: catalog/models/common.py:156 catalog/models/common.py:170
 #: journal/templates/_sidebar_user_mark_list.html:38
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:155 catalog/models/common.py:169
+#: catalog/models/common.py:157 catalog/models/common.py:171
 #: common/templates/_header.html:37
 #: journal/templates/_sidebar_user_mark_list.html:45
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:157 catalog/models/common.py:171
+#: catalog/models/common.py:159 catalog/models/common.py:173
 #: catalog/templates/_sidebar_edit.html:170 common/templates/_header.html:33
 #: journal/templates/_sidebar_user_mark_list.html:42
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:253 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:255 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:270 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:272 catalog/templates/_language_list.html:5
 #: users/models/user.py:128
 msgid "language"
 msgstr "语言"
@@ -1116,7 +1124,7 @@ msgstr "作笔记或摘抄"
 msgid "write a review"
 msgstr "撰写评论"
 
-#: catalog/templates/_item_similar.html:5
+#: catalog/templates/_item_similar.html:13
 msgid "similar items"
 msgstr "相似条目"
 
@@ -1583,8 +1591,8 @@ msgstr "确定关联吗？"
 msgid "This operation cannot be undone. Sure to merge?"
 msgstr "本操作不可撤销。确认合并吗？"
 
-#: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:344 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:145
+#: common/views_manage.py:345 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "发现"
 
@@ -3529,7 +3537,7 @@ msgstr "源代码"
 msgid "Registration"
 msgstr "注册"
 
-#: common/templates/common/about.html:35 common/views_manage.py:466
+#: common/templates/common/about.html:35 common/views_manage.py:484
 msgid "Invite Only"
 msgstr "仅限邀请"
 
@@ -3537,7 +3545,7 @@ msgstr "仅限邀请"
 msgid "Open Registration"
 msgstr "开放注册"
 
-#: common/templates/common/about.html:40 common/views_manage.py:487
+#: common/templates/common/about.html:40 common/views_manage.py:505
 msgid "Preferred Languages"
 msgstr "主要语言"
 
@@ -3593,7 +3601,7 @@ msgstr "正在请求摄像头权限…"
 msgid "Or type barcode / ISBN manually"
 msgstr "或手动输入条形码 / ISBN"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:551
+#: common/templates/common/scan.html:60 common/views_manage.py:569
 msgid "Search"
 msgstr "搜索"
 
@@ -3680,604 +3688,604 @@ msgstr "访问被拒绝"
 msgid "Login required"
 msgstr "登录后访问"
 
-#: common/views_manage.py:49
+#: common/views_manage.py:50
 msgid "Enabled"
 msgstr ""
 
-#: common/views_manage.py:49
+#: common/views_manage.py:50
 msgid "Disabled"
 msgstr ""
 
-#: common/views_manage.py:143 common/views_manage.py:293
+#: common/views_manage.py:144 common/views_manage.py:294
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:147
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:147 common/views_manage.py:546
+#: common/views_manage.py:148 common/views_manage.py:564
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:150 common/views_manage.py:301
+#: common/views_manage.py:151 common/views_manage.py:302
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:200
+#: common/views_manage.py:201
 msgid "Invalid value."
 msgstr "无效值。"
 
-#: common/views_manage.py:204
+#: common/views_manage.py:205
 msgid "Invalid configuration. Please check your input."
 msgstr "配置无效"
 
-#: common/views_manage.py:209
+#: common/views_manage.py:210
 msgid "Settings have been saved."
 msgstr "设置已保存"
 
-#: common/views_manage.py:229
+#: common/views_manage.py:230
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Site Description"
 msgstr "站点描述"
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:313
+#: common/views_manage.py:314
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:316
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:329
+#: common/views_manage.py:330
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:332
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show Popular Tags"
 msgstr "显示热门标签"
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:359
+#: common/views_manage.py:377
 msgid "Enable Recommendations"
 msgstr "启用推荐"
 
-#: common/views_manage.py:361
+#: common/views_manage.py:379
 msgid "Master switch. When off, all recommendation surfaces are hidden for regular users and the cron jobs are not scheduled. Test-enabled accounts (DEBUG mode or '!bazinga' in their bio) still see the surfaces, for preview."
 msgstr "推荐功能总开关。关闭时，常规用户不会看到推荐界面，相关定时任务也不会被调度。处于测试模式的账户（DEBUG 模式或 bio 中包含「!bazinga」）仍可看到推荐界面以便预览。"
 
-#: common/views_manage.py:368
+#: common/views_manage.py:386
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:370
+#: common/views_manage.py:388
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:376
+#: common/views_manage.py:394
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:378
+#: common/views_manage.py:396
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:384
+#: common/views_manage.py:402
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:385
+#: common/views_manage.py:403
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:389
+#: common/views_manage.py:407
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:390
+#: common/views_manage.py:408
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:394
+#: common/views_manage.py:412
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:396
+#: common/views_manage.py:414
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:419
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:403
+#: common/views_manage.py:421
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:427
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:411
+#: common/views_manage.py:429
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:417
+#: common/views_manage.py:435
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:437
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:425
+#: common/views_manage.py:443
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:427
+#: common/views_manage.py:445
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:433
+#: common/views_manage.py:451
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:435
+#: common/views_manage.py:453
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:460
 msgid "Master Switch"
 msgstr "总开关"
 
-#: common/views_manage.py:445
+#: common/views_manage.py:463
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:452
+#: common/views_manage.py:470
 msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:468
+#: common/views_manage.py:486
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:473
+#: common/views_manage.py:491
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:474
+#: common/views_manage.py:492
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:477
+#: common/views_manage.py:495
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:478
+#: common/views_manage.py:496
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:481
+#: common/views_manage.py:499
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:484
+#: common/views_manage.py:502
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:489
+#: common/views_manage.py:507
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:495
+#: common/views_manage.py:513
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:518
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:522
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:514
+#: common/views_manage.py:532
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:516
+#: common/views_manage.py:534
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:521
+#: common/views_manage.py:539
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:522
+#: common/views_manage.py:540
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:526
+#: common/views_manage.py:544
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:528
+#: common/views_manage.py:546
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:533
+#: common/views_manage.py:551
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:534
+#: common/views_manage.py:552
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:537
+#: common/views_manage.py:555
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:556
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:541
+#: common/views_manage.py:559
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:542
+#: common/views_manage.py:560
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:563
+#: common/views_manage.py:581
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:564
+#: common/views_manage.py:582
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:567
+#: common/views_manage.py:585
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:568
+#: common/views_manage.py:586
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:571
+#: common/views_manage.py:589
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:572
+#: common/views_manage.py:590
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:575
+#: common/views_manage.py:593
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:577
+#: common/views_manage.py:595
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:581
+#: common/views_manage.py:599
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:582
+#: common/views_manage.py:600
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:585
+#: common/views_manage.py:603
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:588 users/templates/users/steam_import.html:26
+#: common/views_manage.py:606 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:590
+#: common/views_manage.py:608
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:595
+#: common/views_manage.py:613
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:596
+#: common/views_manage.py:614
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:599
+#: common/views_manage.py:617
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:602
+#: common/views_manage.py:620
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:623
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:606
+#: common/views_manage.py:624
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:609
+#: common/views_manage.py:627
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:612
+#: common/views_manage.py:630
 msgid "Sentry DSN"
 msgstr ""
 
-#: common/views_manage.py:613
+#: common/views_manage.py:631
 msgid "Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:616
+#: common/views_manage.py:634
 msgid "Sentry Sample Rate"
 msgstr ""
 
-#: common/views_manage.py:617
+#: common/views_manage.py:635
 msgid "0.0 to 1.0. Requires restart to take effect."
 msgstr ""
 
-#: common/views_manage.py:622
+#: common/views_manage.py:640
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:624
+#: common/views_manage.py:642
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:641
+#: common/views_manage.py:659
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:650
+#: common/views_manage.py:668
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:655
+#: common/views_manage.py:673
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:659
+#: common/views_manage.py:677
 msgid "Monitoring"
 msgstr ""
 
-#: common/views_manage.py:671
+#: common/views_manage.py:689
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:690
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:675
+#: common/views_manage.py:693
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:676
+#: common/views_manage.py:694
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:697
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:682
+#: common/views_manage.py:700
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:685
+#: common/views_manage.py:703
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:688
+#: common/views_manage.py:706
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:691
+#: common/views_manage.py:709
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:712
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:695
+#: common/views_manage.py:713
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:698
+#: common/views_manage.py:716
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:702
+#: common/views_manage.py:720
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:706
+#: common/views_manage.py:724
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:711
+#: common/views_manage.py:729
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:734
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:741
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:735
+#: common/views_manage.py:753
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:736
+#: common/views_manage.py:754
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:739
+#: common/views_manage.py:757
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:740
+#: common/views_manage.py:758
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:743
+#: common/views_manage.py:761
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:744
+#: common/views_manage.py:762
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:747
+#: common/views_manage.py:765
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:766
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:776
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:778
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:766
+#: common/views_manage.py:784
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:768
+#: common/views_manage.py:786
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:775
+#: common/views_manage.py:793
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:778
+#: common/views_manage.py:796
 msgid "Operational"
 msgstr ""
 
@@ -4507,6 +4515,7 @@ msgid "regarding {item_title}, may contain spoiler or triggering content"
 msgstr "关于 {item_title}，可能包含剧透或敏感内容"
 
 #: journal/models/review.py:65
+#, python-brace-format
 msgid "a review of {title}"
 msgstr "关于 {title} 的评论"
 
@@ -4953,39 +4962,39 @@ msgstr "停止追踪这个目标吗？"
 msgid "set as target"
 msgstr "设置为目标"
 
-#: journal/templates/_list_item.html:15
+#: journal/templates/_list_item.html:14
 msgid "Move to top"
 msgstr "移动到顶部"
 
-#: journal/templates/_list_item.html:20
+#: journal/templates/_list_item.html:19
 msgid "Move to bottom"
 msgstr "移动到底部"
 
-#: journal/templates/_list_item.html:25
+#: journal/templates/_list_item.html:24
 msgid "Remove from collection"
 msgstr "从收藏单中移除"
 
-#: journal/templates/_list_item.html:35
+#: journal/templates/_list_item.html:34
 msgid "add mark"
 msgstr "添加标记"
 
-#: journal/templates/_list_item.html:43
+#: journal/templates/_list_item.html:42
 msgid "update mark"
 msgstr "更新标记"
 
-#: journal/templates/_list_item.html:61
+#: journal/templates/_list_item.html:60
 #: journal/templates/collection_update_item_note_ok.html:3
 msgid "Update note"
 msgstr "修改备注"
 
-#: journal/templates/_list_item.html:101 journal/templates/review.html:22
+#: journal/templates/_list_item.html:100 journal/templates/review.html:22
 #: journal/templates/review.html:28 journal/templates/review.html:71
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
 msgstr "评论"
 
-#: journal/templates/_list_item.html:134
+#: journal/templates/_list_item.html:133
 #, python-format
 msgid "%(dups)s item(s) are from the same work or have the same identifier, click here to display:"
 msgstr "还有%(dups)s个属于同一作品或可能重复的条目，点击显示。"
@@ -5120,7 +5129,7 @@ msgstr "添加到收藏单"
 msgid "Create a new collection"
 msgstr "创建新收藏单"
 
-#: journal/templates/article.html:19 social/templates/single_post.html:21
+#: journal/templates/article.html:19 social/templates/single_post.html:15
 msgid "Article"
 msgstr "文章"
 
@@ -5974,6 +5983,7 @@ msgid "Invalid account data from Threads."
 msgstr "Threads返回了无效的账号数据。"
 
 #: social/templates/_article_teaser.html:10
+#, python-format
 msgid "%(counter)s word"
 msgid_plural "%(counter)s words"
 msgstr[0] "%(counter)s 词"
@@ -6011,7 +6021,7 @@ msgstr "写了文章"
 msgid "replying to"
 msgstr "回应"
 
-#: social/templates/_post_article_teaser.html:12
+#: social/templates/_post_article_teaser.html:5
 msgid "Untitled article"
 msgstr "无标题文章"
 
@@ -6236,7 +6246,7 @@ msgstr "提交"
 msgid "Poll ending at %(end_time)s"
 msgstr "投票将于%(end_time)s结束"
 
-#: social/templates/single_post.html:12 social/templates/single_post.html:24
+#: social/templates/single_post.html:12 social/templates/single_post.html:18
 msgid "Post"
 msgstr "帖文"
 

--- a/test_data/https___rateyourmusic_com_release_album_king_gizzard_and_the_lizard_wizard_12_bar_bruise_
+++ b/test_data/https___rateyourmusic_com_release_album_king_gizzard_and_the_lizard_wizard_12_bar_bruise_
@@ -1,0 +1,2921 @@
+<!DOCTYPE html>
+<html lang="en" id="page_release" class="rym page_release scope_music nonsubscriber logged-out ">
+<head>
+
+      
+<link rel="preconnect" href="//cdn.sonemic.net" />
+<link rel="preconnect" href="//www.googletagmanager.com" />
+<link rel="dns-prefetch" href="//lit.connatix.com" />
+<link rel="dns-prefetch" href="//csi.gstatic.com" />
+<link rel="dns-prefetch" href="//cm.g.doubleclick.net" />
+<link rel="dns-prefetch" href="//vid.connatix.com" />
+<link rel="dns-prefetch" href="//capi.connatix.com" />
+<link rel="dns-prefetch" href="//cds.connatix.com" />
+<link rel="dns-prefetch" href="//imasdk.googleapis.com" />
+<link rel="dns-prefetch" href="//aax.amazon-adsystem.com" />
+<link rel="dns-prefetch" href="//ib.adnxs.com" />
+<link rel="dns-prefetch" href="//securepubads.g.doubleclick.net" />
+<link rel="dns-prefetch" href="//tpc.googlesyndication.com" />
+<link rel="dns-prefetch" href="//pagead2.googlesyndication.com" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="icon" href="//cdn.sonemic.net/2.5/img/sonemic.png" type="image/png" />
+<title>12 Bar Bruise by King Gizzard &amp; The Lizard Wizard (Album, Garage Rock): Reviews, Ratings, Credits, Song list - Rate Your Music</title>
+      <meta name="description" content="12 Bar Bruise, an Album by King Gizzard &amp; The Lizard Wizard. Released 7 September 2012 on Flightless (catalog no. FLT001; CD). Genres: Garage Rock, Noise Rock, Garage Psych, Garage Punk.  Rated #1422 in the best albums of 2012.  Featured peformers: Stu Mackenzie (vocals, guitar), Michael Cavanagh (drums), Cook Craig (guitar, vocals), Ambrose Kenny-Smith (harmonica, vocals), Eric Moore (theremin, keyboards, percussion), Lucas Harwood (bass, vocals), Joey Walker (guitar, vocals), King Gizzard &amp; The Lizard Wizard (recording engineer, mixing), Paul Maybury (recording engineer, mixing), Joseph Carra (mastering engineer), Jason Galea (cover art)." /><meta name="robots" content="max-image-preview:large" /> <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:site" content="@Sonemic" />
+                <meta property="og:site_name" content="Rate Your Music">
+
+                <meta property="og:url" content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" />
+                <meta property="og:type" content="music.album">
+                <meta property="og:title" content="12 Bar Bruise by King Gizzard &amp; The Lizard Wizard - RYM/Sonemic" /><meta property="og:description" content="12 Bar Bruise, an Album by King Gizzard &amp; The Lizard Wizard. Released 7 September 2012 on Flightless (catalog no. FLT001; CD). Genres: Garage Rock, Noise Rock, Garage Psych, Garage Punk.  Rated #1422 in the best albums of 2012.  Featured peformers: Stu Mackenzie (vocals, guitar), Michael Cavanagh (drums), Cook Craig (guitar, vocals), Ambrose Kenny-Smith (harmonica, vocals), Eric Moore (theremin, keyboards, percussion), Lucas Harwood (bass, vocals), Joey Walker (guitar, vocals), King Gizzard &amp; The Lizard Wizard (recording engineer, mixing), Paul Maybury (recording engineer, mixing), Joseph Carra (mastering engineer), Jason Galea (cover art)." />
+<meta property="og:image" content="https://cdn.sonemic.net/i/1200/s/f48ac34c47e52ca016ddeecd9b7365f3/4311196" />
+
+         <!-- Global site tag (gtag.js) - Google Analytics -->
+         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-59057-1"></script>
+         <script>
+           window.dataLayer = window.dataLayer || [];
+           function gtag(){dataLayer.push(arguments);}
+
+      
+           console.log('rym.analytics: Google analytics pageview event sent.');
+           gtag('js', new Date());
+           gtag('config', 'UA-59057-1');
+            
+      </script><script> window.rym_dist_version = '48d17652-b15b-42b5-8f47-82aaba602ce7';</script> 
+      <script>
+         ryminit = window.ryminit || [];
+
+         function rymQ( a ) {
+            if ( !ryminit ) {
+               a();
+            } else {
+               ryminit.push(a);
+            }
+         }
+        if ( 'ontouchstart' in window ) {
+          document.documentElement.className += ' touch';
+        } else {
+          document.documentElement.className += ' noTouch';
+        }
+
+      </script>
+      <style id="inline-resources">html.noTouch .show-for-touch{display:none}html.touch .hide-for-touch{display:none}.grid-row-33-66{display:grid;grid-template-columns:34% 66%}.grid-row-reverse .grid-column:first-child{order:2}@media only screen and (max-width:48.1em){.grid-row-33-66{grid-template-columns:100%}.grid-row-reverse .grid-column:first-child{order:1}.grid-row-reverse .grid-column:last-child{order:2}}.column_filler{width:100%;height:1px}@media only screen and (max-width:48.1em){.column_filler{display:none}}.row,.columns,.column{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}.row{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0}.row:before,.row:after{content:" ";display:table}.row:after{clear:both}.row .column,.row .columns{position:relative;padding-left:.9375em;padding-right:.9375em;width:100%}.row .row{width:auto;margin-left:-.9375em;margin-right:-.9375em;margin-top:0;margin-bottom:0;max-width:none}.row .row:before,.row .row:after{content:" ";display:table}.row .row:after{clear:both}@media only screen{.row .column,.row .columns{position:relative;padding-left:0em;padding-right:0em;float:left}.row .small-4{position:relative;width:33.33333%}.row .small-6{position:relative;width:50%}.row .small-8{position:relative;width:66.66667%}.row .small-9{position:relative;width:75%}[class*=column]+[class*=column]:last-child{float:right}[class*=column]+[class*=column].end{float:left}.column.small-centered,.columns.small-centered{position:relative;margin-left:auto;margin-right:auto;float:none}}@media only screen and (min-width: 48.1em){.row .large-2{position:relative;width:16.66667%}.row .large-3{position:relative;width:25%}.row .large-4{position:relative;width:33.33333%}.row .large-5{position:relative;width:41.66667%}.row .large-6{position:relative;width:50%}.row .large-7{position:relative;width:58.33333%}.row .large-8{position:relative;width:66.66667%}.row .large-9{position:relative;width:75%}.row .large-10{position:relative;width:83.33333%}.row .large-12{position:relative;width:100%}.push-4{position:relative;left:33.33333%;right:auto}.pull-8{position:relative;right:66.66667%;left:auto}}
+.icon_globe{font-size:1.2em;position:relative;display:inline-block;width:1.5em;height:.8em}.icon_globe .fa-circle{color:#157d15}.icon_globe .globe{color:#add8e6}.fa-align-justify:before{content:"\f039"}.fa-apple:before{content:"\f179"}.fa-ban:before{content:"\f05e"}.fa-bandcamp:before{content:"\f2d5"}.fa-bars:before{content:"\f0c9"}.fa-bell:before{content:"\f0f3"}.fa-bold:before{content:"\f032"}.fa-bookmark:before{content:"\f02e"}.fa-calendar:before{content:"\f133"}.fa-caret-down:before{content:"\f0d7"}.fa-caret-left:before{content:"\f0d9"}.fa-caret-right:before{content:"\f0da"}.fa-caret-square-down:before{content:"\f150"}.fa-caret-square-left:before{content:"\f191"}.fa-caret-square-right:before{content:"\f152"}.fa-caret-square-up:before{content:"\f151"}.fa-caret-up:before{content:"\f0d8"}.fa-check:before{content:"\f00c"}.fa-check-circle:before{content:"\f058"}.fa-check-double:before{content:"\f560"}.fa-check-square:before{content:"\f14a"}.fa-chevron-circle-down:before{content:"\f13a"}.fa-chevron-circle-left:before{content:"\f137"}.fa-chevron-circle-right:before{content:"\f138"}.fa-chevron-circle-up:before{content:"\f139"}.fa-chevron-down:before{content:"\f078"}.fa-chevron-left:before{content:"\f053"}.fa-chevron-right:before{content:"\f054"}.fa-chevron-up:before{content:"\f077"}.fa-circle:before{content:"\f111"}.fa-circle-notch:before{content:"\f1ce"}.fa-clock:before{content:"\f017"}.fa-cog:before{content:"\f013"}.fa-copy:before{content:"\f0c5"}.fa-download:before{content:"\f019"}.fa-edit:before{content:"\f044"}.fa-ellipsis-h:before{content:"\f141"}.fa-ellipsis-v:before{content:"\f142"}.fa-envelope:before{content:"\f0e0"}.fa-exclamation:before{content:"\f12a"}.fa-exclamation-circle:before{content:"\f06a"}.fa-exclamation-triangle:before{content:"\f071"}.fa-expand:before{content:"\f065"}.fa-expand-alt:before{content:"\f424"}.fa-expand-arrows-alt:before{content:"\f31e"}.fa-external-link:before{content:"\f08e"}.fa-external-link-alt:before{content:"\f35d"}.fa-eye:before{content:"\f06e"}.fa-facebook:before{content:"\f09a"}.fa-facebook-f:before{content:"\f39e"}.fa-facebook-messenger:before{content:"\f39f"}.fa-facebook-square:before{content:"\f082"}.fa-flag:before{content:"\f024"}.fa-globe:before{content:"\f0ac"}.fa-globe-africa:before{content:"\f57c"}.fa-globe-americas:before{content:"\f57d"}.fa-globe-asia:before{content:"\f57e"}.fa-globe-europe:before{content:"\f7a2"}.fa-home-alt:before{content:"\f80a"}.fa-image:before{content:"\f03e"}.fa-images:before{content:"\f302"}.fa-info:before{content:"\f129"}.fa-info-circle:before{content:"\f05a"}.fa-instagram:before{content:"\f16d"}.fa-instagram-square:before{content:"\e055"}.fa-italic:before{content:"\f033"}.fa-key:before{content:"\f084"}.fa-link:before{content:"\f0c1"}.fa-list:before{content:"\f03a"}.fa-list-music:before{content:"\f8c9"}.fa-list-ol:before{content:"\f0cb"}.fa-list-ul:before{content:"\f0ca"}.fa-lock:before{content:"\f023"}.fa-map-marker-alt:before{content:"\f3c5"}.fa-play:before{content:"\f04b"}.fa-plus:before{content:"\f067"}.fa-plus-circle:before{content:"\f055"}.fa-plus-square:before{content:"\f0fe"}.fa-poll:before{content:"\f681"}.fa-poll-h:before{content:"\f682"}.fa-question:before{content:"\f128"}.fa-question-circle:before{content:"\f059"}.fa-question-square:before{content:"\f2fd"}.fa-quote-left:before{content:"\f10d"}.fa-quote-right:before{content:"\f10e"}.fa-random:before{content:"\f074"}.fa-rectangle-landscape:before{content:"\f2fa"}.fa-rectangle-portrait:before{content:"\f2fb"}.fa-rectangle-wide:before{content:"\f2fc"}.fa-reddit:before{content:"\f1a1"}.fa-search:before{content:"\f002"}.fa-share:before{content:"\f064"}.fa-share-alt:before{content:"\f1e0"}.fa-share-alt-square:before{content:"\f1e1"}.fa-share-square:before{content:"\f14d"}.fa-soundcloud:before{content:"\f1be"}.fa-spinner:before{content:"\f110"}.fa-spinner-third:before{content:"\f3f4"}.fa-spotify:before{content:"\f1bc"}.fa-square:before{content:"\f0c8"}.fa-square-full:before{content:"\f45c"}.fa-star:before{content:"\f005"}.fa-star-half:before{content:"\f089"}.fa-star-half-alt:before{content:"\f5c0"}.fa-step-backward:before{content:"\f048"}.fa-step-forward:before{content:"\f051"}.fa-sticky-note:before{content:"\f249"}.fa-sync:before{content:"\f021"}.fa-sync-alt:before{content:"\f2f1"}.fa-th-large:before{content:"\f009"}.fa-th-list:before{content:"\f00b"}.fa-thumbtack:before{content:"\f08d"}.fa-times:before{content:"\f00d"}.fa-times-circle:before{content:"\f057"}.fa-twitter:before{content:"\f099"}.fa-twitter-square:before{content:"\f081"}.fa-user-friends:before{content:"\f500"}.fa-video:before{content:"\f03d"}.fa-whatsapp:before{content:"\f232"}.fa-whatsapp-square:before{content:"\f40c"}.fa-youtube:before{content:"\f167"}.fa-youtube-square:before{content:"\f431"}
+html{line-height:1.15;-webkit-text-size-adjust:100%}body{margin:0}main{display:block}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}img{border-style:none}button,input,optgroup,select,textarea{font-family:inherit;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}button,[type=button],[type=reset],[type=submit]{-webkit-appearance:button}button::-moz-focus-inner,[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner{border-style:none;padding:0}button:-moz-focusring,[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em;border:none}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details{display:block}summary{display:list-item}template{display:none}[hidden]{display:none}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}html{font-size:62.5%}body{font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;font-feature-settings:"ss05" 1,"ss06" 1,"ss09" 1;font-size:12px}h1,h2,h3,h4,h5{font-weight:normal;margin:0;margin-bottom:.25em}h1{font-size:2.5em;font-weight:bold}h2{font-size:2.2em}h3{font-size:1.9em}h4{font-size:1.6em}h5{font-size:1.5em}@media only screen and (max-width:48.1em){h1{font-size:2em;font-weight:bold}h2{font-size:1.9em}h3{font-size:1.8em}h4{font-size:1.7em}h5{font-size:1.5em}}p{line-height:1.6em;margin-bottom:1em}blockquote{margin:0 1.5em}table{width:100%;border-collapse:collapse}td{border-collapse:collapse;padding:5px}tr{border-collapse:collapse}.anchor{scroll-margin-top:3em}a{text-decoration:none;color:var(--gen-blue-darker)}a.artist,.artist,a.game,a.work.major,a.user,a.film,a.film_artist{font-weight:bold}a.action{padding:.4em 0em;display:inline-block;text-transform:uppercase;font-size:.9em;font-weight:bold}img.lazyload:not([src]),picture.lazyload img:not([src]){visibility:hidden}img{object-fit:cover}img.cover{width:2.8em;height:2.8em;float:left;object-fit:cover;border-radius:4px;margin-right:.75em}img.size_2{width:2em;height:2em}img.image_release{width:2.8em;height:2.8em;float:left;object-fit:cover;border-radius:4px;margin-right:.75em;overflow:hidden}.image_aspect_padded_frame{position:relative;flex:1}.image_aspect_padded_frame img{position:absolute;width:100%;height:100%;top:0;left:0;right:0;bottom:0}.image_aspect_padded_frame a{display:flex}input,select,textarea,.input_auto_resize_frame,.input_auto_resize_frame::after{font-size:16px;font-weight:normal;padding:.15em;border-radius:3px;background:var(--surface-primary);color:var(--text-primary);border:1px solid var(--ui-detail-neutral);font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss05" 1,"ss06" 1,"ss09" 1}textarea{width:100%}input:disabled,select:disabled,textarea:disabled{color:var(--mono-8);background:var(--mono-e)}select{min-width:8em}label{font-weight:bold}.ui_section_overlay{background:var(--background);opacity:.7;z-index:30;position:absolute;top:0;left:0;right:0;bottom:0;margin:-.5em -1.5em;border-radius:10px;display:none}.show_overlay .ui_section_overlay{display:block}.show_overlay .component_discography_item{filter:saturate(70%)}.overlay_invisible{background:rgba(0,0,0,.1);z-index:105;position:fixed;top:0;left:0;right:0;bottom:0;display:none}.content_wrapper_outer{xbackground:var(--mono-f2);background-repeat:no-repeat;background-size:cover!important;background-position:center center!important}.preload{opacity:.05;position:absolute;top:-5000em;left:-5000em;pointer-events:none}.precontent{-webkit-transform:scale3d(1,1,1);position:absolute;top:-100vh;left:0;height:100vh;background-size:cover!important;width:100%;z-index:-1}#content_cover{position:absolute;z-index:7000;background:rgba(0,0,15,.6);display:none}#content_total_cover{position:fixed: top:0;left:0;right:0;bottom:0;z-index:50;background:rgba(0,0,0,.1)}body.has_background_image #content_wrapper{background:rgba(49,49,49,.2);margin:0 auto;max-width:132.5em;padding-left:2px;padding-right:2px}#content_cover{z-index:900}#content{padding:3em;font-size:1.25em;line-height:1.3;min-height:calc(100vh);max-width:106em;margin:0 auto;margin-top:4rem}html.size_mode_smaller #content{font-size:1.15em;line-height:1.25;max-width:115em}@media only screen and (max-width:48.1em){#content{margin-top:0;padding:.5em;padding-top:1em}}@media only screen and (min-width:48.125em){group{display:flex;flex-direction:column}.group_filler{flex:1;order:32767}}.smallgray,a.smallgray{font-size:.9em}.error{padding:.5em 1.5em;margin-bottom:1em}.code{font-family:"Courier new",monospace;border-left:5px solid;padding:1em}.note{border:1px solid;padding:1em 2em}.warning{padding:1em 2em;margin-bottom:1em}.warning p{margin:0}.notice{padding:1em 1.25em;font-size:.9em;margin-bottom:1em}.notice p{margin:0}.quote_user{margin-bottom:.2em}.quote{font-size:1.33rem;margin-bottom:1em;border-left:12px solid rgba(128,128,128,.4);padding:1.7em;padding-top:1.2em;padding-bottom:1.2em}.quote_link,.quote a.quote_link{float:right;font-weight:normal;font-size:1.2em}.quote .quote .quote .quote .quote{display:none}.quote .quote{border:none;border-radius:0;border-left:12px solid rgba(128,128,128,.3);margin-left:0em;margin-right:0em;margin-top:.6em}.quote_author{font-weight:bold;margin-left:-.7em;margin-bottom:.4em}.rendered_text{position:relative}.rendered_text_url_hidden{clip-path:inset(100%);clip:rect(1px,1px,1px,1px);height:1px;overflow:hidden;position:absolute;white-space:nowrap;width:1px}.rendered_text_url_pre_hidden:after{content:"..."}.clear,.clearfix{clear:both}.comma_separated:after{content:", "}.comma_separated:last-child:after{content:""}.pipe_separated:after{content:" | "}.pipe_separated:last-child:after{content:""}.slash_separated:after{content:"/ "}.slash_separated:last-child:after{content:""}.show-for-small-table-row{display:none}.show-for-small-inline{display:none}.hide-for-small-block{display:none}.hide-for-small-inline{display:none}.show-for-small{display:none}.hide-for-small{display:none}.rym_shortcut{font-size:.9em;border:none}.fa,.fas,.far,.fal,.fad,.fab{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;display:inline-block;font-style:normal;font-variant:normal;text-rendering:auto;line-height:1}.fa-spin{-webkit-animation:fa-spin 2s infinite linear;animation:fa-spin 2s infinite linear}@keyframes fa-spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}to{-webkit-transform:rotate(360deg);transform:rotate(360deg)}}.fa-stack{display:inline-block;height:1em;line-height:1.25em;position:relative;width:1em}.fa-stack-1x,.fa-stack-2x{left:0;position:absolute;text-align:center;width:100%}.fa-stack-1x{line-height:inherit}.fa-stack-2x{font-size:2em}.fa-inverse{color:#fff}.fab{font-family:"Font Awesome 5 Brands";font-weight:400}.far{font-family:"Font Awesome 5 Free";font-weight:400}.fa,.fas{font-family:"Font Awesome 5 Free";font-weight:900}.fad{position:relative;font-family:"Font Awesome 5 Duotone";font-weight:900}.fad{position:relative;font-family:"Font Awesome 5 Duotone";font-weight:900}.fal{font-family:"Font Awesome 5 Pro";font-weight:300}.fad:before{position:absolute;color:var(--fa-primary-color, inherit);opacity:1;opacity:var(--fa-primary-opacity, 1)}.fad:after{color:var(--fa-secondary-color, inherit);opacity:.4;opacity:var(--fa-secondary-opacity, .4)}.fa-swap-opacity .fad:before,.fad.fa-swap-opacity:before{opacity:.4;opacity:var(--fa-secondary-opacity, .4)}.fa-swap-opacity .fad:after,.fad.fa-swap-opacity:after{opacity:1;opacity:var(--fa-primary-opacity, 1)}.fad.fa-inverse{color:#fff}.fad.fa-stack-1x,.fad.fa-stack-2x{position:absolute}.fad.fa-stack-1x:before,.fad.fa-stack-2x:before,.fad.fa-fw:before{left:50%;-webkit-transform:translateX(-50%);transform:translateX(-50%)}.ui_flag{xfont-size:1.33em;line-height:.5}.ui_flag img{width:1.2em;height:.9em;border-bottom:.5px solid rgba(128,128,128,.4);border-right:.5px solid rgba(128,128,128,.4)}.rendered_text .documentation_sel_section li{margin-top:.5em;margin-bottom:.5em}.rendered_text .documentation_sel_section ul{margin-bottom:0;margin:1em 0}.documentation_sel_text{text-decoration:underline;text-decoration-color:rgba(128,128,128,.302)}.selectable .documentation_sel_text{text-decoration:underline;text-decoration-color:var(--ui-divider-line)}.selectable .documentation_sel_text.selected{color:var(--alert-error-background);font-weight:bold;text-decoration:none}.documentation_sel_section{display:block;padding:1em 0}.selectable .documentation_sel_section{padding:.5em .75em;margin:.33em 0;xborder:3px solid var(--ui-divider-line);xbackground:var(--surface-primary);border-radius:9px;display:block}.selectable .documentation_sel_section.search_hidden{display:none}.selectable .documentation_sel_section{user-select:none}.selectable .documentation_sel_section.selected{xbackground:linear-gradient(to bottom,var(--surface-primary),var(--surface-secondary));background:rgba(88,88,88,.14);xborder:3px solid var(--alert-error-background)}blockquote.rules,.page_documentation_item_frame blockquote.rules{margin:1em 0;padding:.5em 1em;background:transparent;color:var(--alert-error-background)}.documentation_sel_section_handle{font-weight:bold;margin-bottom:.25em;display:block;xdisplay:inline-block}.page_moderation_restriction_name{font-weight:bold;display:block;margin-bottom:.25em}.selectable .documentation_sel_section_handle{margin-bottom:.25em;display:block;cursor:pointer}.documentation_sel_section_handle i{display:none}.selectable .documentation_sel_section_handle i{color:var(--text-secondary);margin-right:.5em;display:inline}.selectable .documentation_sel_section_handle .fa-check-circle{display:none}.selectable .documentation_sel_section.selected .fa-check-circle{display:inline;color:var(--alert-error-background)}.selectable .documentation_sel_section.selected .fa-circle{display:none}blockquote.rules,.page_documentation_item_frame blockquote.rules{margin:1em 0;padding:.5em 1em;background:transparent;color:var(--alert-error-background)}@media only screen and (min-width: 48.063em){.hide-for-small-block{display:block}.hide-for-small{display:inherit}.hide-for-small-inline{display:inline}tr.hide-for-small{display:table-row}}@media only screen and (max-width: 48.1em){.show-for-small{display:inherit!important}.show-for-small-inline{display:inline!important}.show-for-small-table-row{display:table-row}}.adhesion_bottom{height:110px}@media only screen and (max-width:48em){.adhesion_bottom{height:78px}}html{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star_bold.svg)}html.theme_eve,html.theme_night,html.theme_darkgray{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star_bold.svg)}.bkg-metadata-star-bold{background-image:var(--metadata-star-bold)}img.metadata-star-bold{content:var(--metadata-star-bold)}.bkg-metadata-star{background-image:var(--metadata-star)}img.metadata-star{content:var(--metadata-star)}#track_rating_status{height:1.5em;display:flex;align-items:center;color:var(--text-secondary);margin-bottom:.5em;font-size:.875em}#track_rating_status .saving{display:none}#track_rating_status .saved{display:none}#track_rating_status.saving .saving{display:inline}#track_rating_status.saved .saved{display:inline}
+@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/Regular.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/Regular.woff?d) format("woff");font-weight:normal;font-style:normal;font-display:swap;font-feature-settings:"ss06" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/Bold.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/Bold.woff?d) format("woff");font-weight:700;font-display:swap;font-style:normal;font-feature-settings:"ss06" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/RegularIt.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/RegularIt.woff?d) format("woff");font-weight:normal;font-display:swap;font-style:italic;font-feature-settings:"ss06" 1,"ss05" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/BoldIt.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/BoldIt.woff?d) format("woff");font-weight:700;font-display:swap;font-style:italic;font-feature-settings:"ss06" 1,"ss05" 1,"ss09" 1}@font-face{font-family:"Font Awesome 5 Pro";font-style:normal;font-weight:300;font-display:block;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-light-300.woff2) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-light-300.woff) format("woff")}@font-face{font-family:"Font Awesome 5 Free";font-style:normal;font-weight:400;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-regular-400.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-regular-400.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Brands";font-style:normal;font-weight:400;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-brands-400.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-brands-400.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Free";font-style:normal;font-weight:900;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-solid-900.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-solid-900.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Duotone";font-style:normal;font-weight:900;font-display:block;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-duotone-900.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-duotone-900.woff?b) format("woff")}
+.media_link_container{min-height:2.9em;margin:.5em 0;display:flex;justify-content:center}.media_link_container.link_linkfire{min-height:3.2em}.media_link_container.link_linkfire.support_open{min-height:8em}.media_link_container.link_linkfire.support_open.allow_ads{min-height:12em}.page_features_secondary_metadata_field .linkfire_container{margin-left:-2em}.lnk-player,.lnk-dropdown-area{justify-content:center!important}.lnk-dropdown-title{white-space:nowrap;overflow:hidden;text-overflow:ellipsis!important;padding-right:.5em!important}.logo_header{width:2.22222em;height:2.22222em}html.scope_film .logo_header{width:2.22222em;height:2.22222em}.logo_sonemic_32,.logo_cinemos_32,.logo_glitchwave_32{width:2.22222em;height:2.22222em}.logo_name{float:left}.logo_header{float:left;margin-top:.35rem;margin-right:.7em;border-radius:50%}header{font-size:1.4em;line-height:2.41em;height:2.5em;text-align:left;padding-left:1.25em;padding-right:1.25em;position:fixed;background:linear-gradient(to bottom,#555,#666);background:var(--header-background);top:0;left:0;right:0;z-index:1000}div.badge_count_bubble{font-size:1rem;line-height:1.6em;padding-left:.3em;padding-right:.3em;border-radius:50%;font-weight:bold;top:.1em;position:absolute;right:.2em;text-align:center;z-index:5;min-width:1.7em;border-radius:3.7px}div.badge_count_pending{position:absolute;left:0;bottom:.2em;right:0;font-size:.6em;padding:0;line-height:1.3}.header_extended_section div.badge_count_pending{left:auto;right:1em;padding:.2em .8em;font-size:.7em;top:.9em;bottom:.8em}a.header_item .badge_count_bubble{left:auto;right:1em;top:1em;font-size:1.1rem}.header_item i.fa-circle{font-size:.7em}a.header_icon_link,.header_icon_link{line-height:2.3;position:relative;float:right;padding-left:.7em;font-size:1.1em;padding-right:.75em;display:none}.header_inner.logged_in .header_icon_link{display:block}a.header_icon_link_artist_profiles{font-size:1em;line-height:2.4}.header_items_spillover{display:none}@media only screen and (max-width:48.1em){.header_icon_link.hide-for-small,.header_inner.logged_in .header_icon_link.hide-for-small{display:none}}@media only screen and (max-width:1000px){header{padding-left:.25em;padding-right:.25em}.header_icon_link.header_icon_link_artist_profiles,.header_icon_link.header_icon_link_notepad,.header_icon_link_friends,.header_icon_link_requests{display:none!important}.header_items_spillover{display:block}a.header_item .badge_count_bubble{top:.7em}}.header_user_img{float:left;margin-top:.25em;display:inline-block;border-radius:3px;width:2em;height:2em}.header_inner{max-width:95em}.header_inner,.footer_inner{margin:0 auto;padding-left:.25em;padding-right:0em;margin:0 auto;text-align:center}.header_inner.logged_in{padding-right:0em}.header_menu{float:right}header img.logo{width:2.5em;height:2em;margin-right:.2em}.header_search{overflow:hidden}.header_search .ui_search_frame_inner{padding:.5em .25em}.header_extended_section{position:absolute;top:2.3em;border-top:3px;width:13.5em;left:0;z-index:1500;display:none}@media only screen and (max-width:48.1em){.header_extended_section{top:4em}}.header_extended_more_menu{left:auto;right:0em}.header_extended_section a{display:block;text-align:left;font-size:.9em;width:100%;border-bottom:1px}.header_profile_main{float:left;margin-left:.75em}.header_profile .header_extended_section{width:9.2em}a.header_profile_link{padding-left:1em;padding-right:.5em}.header_profile_logged_out a{margin-left:1em}.header_links{float:left}.header_links_inner{display:flex}.header_links i,.header_profile i{line-height:1.2;padding-left:.5em;padding-right:.5em}.header_exp{display:block;float:right}.header_item_icon{position:relative}a.header_item,.header_item,.header_mod_roles,.header_theme_buttons{display:block;float:left;text-decoration:none;padding-left:.5em;padding-right:.5em;position:relative}.subscribe_label_small{display:none}@media only screen and (max-width:70em){span.subscribe_label_large{display:none}span.subscribe_label_small{display:inline}a.header_item,.header_item,.header_mod_roles,.header_theme_buttons{font-size:.75em;line-height:2.84em}}#header_profile_username{font-weight:bold}.header_extended_section a.header_item,.header_extended_section .header_item{padding-left:1em;padding-right:1em;line-height:2.33;width:100%}div.header_mod_roles{width:100%;padding:0}a.header_mod_role{width:33.333%;font-size:.9em;float:left;text-align:center}div.header_theme_buttons{width:100%;padding:0}.header_theme_button{width:50%;min-height:1em;float:left;text-align:center;font-size:.9em;padding-top:.3em;padding-bottom:.3em}.header_theme_button_label{line-height:1.2;padding-top:.3em}.header_theme_button_mode{line-height:1.2;padding-bottom:.2em;font-size:1em;font-weight:bold}a.header_mod_role:last-child{border-right:none}.header_logo{font-weight:bold;font-size:.9em;text-transform:uppercase;position:relative;float:left}header .divider{display:block;float:left;width:1px;margin-top:.6em;height:1.45em;margin-right:.5em;margin-left:.5em}header .mobile_divider{display:none}header a.main{line-height:2.78em;text-transform:uppercase;font-weight:bold;font-size:1em;letter-spacing:0}header .menu_btn{margin-top:.45em;width:1.5em;height:1.5em;float:right;margin-left:1em}.header_search{overflow:hidden}.header_search input{width:100%;line-height:1.9}.header_profile{float:right;position:relative}.header_profile_mobile{float:right;position:relative;margin-left:.4em}@media only screen and (max-width: 48em){header{padding-left:0;padding-right:0}header .mobile_divider{display:block;float:left}.header_profile_main{margin-left:.25em}.header_links{display:none}.header_menu{display:block}.header_search{margin-left:5.75em}.header_profile_link{display:none!important}.header_exp{display:none}}.header_error,.header_message{display:none;position:fixed;z-index:60000;top:3.3333em;left:0;right:0;line-height:2.5em;border:1px solid #ecc;text-align:center}.header_error_close,.header_message_close{float:right;margin-right:.8em;font-size:1.2em;opacity:.7}@media only screen and (max-width:48.1em){.header_error,.header_message{left:0;right:0}}.mobile_header_menu{display:none;margin-top:3.3em}.mobile_header_menu.fixed{position:fixed;z-index:1001;width:100%}@media only screen and (max-width:48.1em){.mobile_header_menu{display:block}}a.mobile_header_menu_item{display:inline-block;line-height:2.7em;text-align:center;margin:0;font-size:1em;font-weight:bold}.mobile_header_menu_item_new_music{width:25%}.mobile_header_menu_item_charts{width:25%}.mobile_header_menu_item_genres{width:25%}.mobile_header_menu_item_lists{width:25%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_new_music{width:23%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_charts{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_genres{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_lists{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_community{width:23%}.mobile_header_menu_item_more{width:10%}.footer_inner{padding:0em;padding-top:.8em;padding-bottom:.8em;margin:0 auto;max-width:75em}.footer_main_section{width:15em;float:left;text-align:center;display:block}.minilogo{margin-top:.4em;margin-right:1em;text-transform:uppercase;font-weight:bold;font-size:1em;display:inline-block}.minilogo div{float:left}.minilogo_text{line-height:1.7rem;margin-left:.5em}.minilogo_frame{height:3em}.copyright{display:block;margin-bottom:.3em;line-height:1.42}.trademark{margin-top:.3em;margin-bottom:.9em}.othersites{margin-top:.3em;margin-bottom:.5em}.minilogo img{width:2.5em}.footer_sections{padding:.8em;padding-left:8em;padding-right:2em;margin:0 auto;font-size:1.1em;text-align:left}.footer_header{text-transform:uppercase;font-size:1em;margin-bottom:.5em}.footer_sub_links a{display:block;font-size:.9em;line-height:1.5em}.footer_sub_links .updated{font-size:.7em;margin-top:-.2em;margin-bottom:.2em}.footer_sub_links .sub{font-size:.8em;float:right}.footer_section{width:9em;float:left;margin-left:1em;margin-right:1em}#section_network{margin-right:2.5em;width:13em}.social_icons{font-size:1.3em}.social_icons i{width:2em;height:2em;line-height:2em;text-align:center;transition:color .1s}footer{color:var(--mono-abs-d);border-top:3px solid var(--mono-abs-9);background:var(--mono-abs-3);font-size:1.25em;width:100%;position:relative;padding-bottom:2em;padding-bottom:130px}footer .mobile_expandable_full{margin:0}.mobile_expand_footer .mobile_expandable_full_header{background:transparent;color:var(--mono-abs-d)!important}@media only screen and (min-width:48.063em){#expand_full_header_footer{display:none}}#expand_full_content_footer{overflow:inherit;padding:0}.server_info{position:absolute;font-size:.8em;color:var(--mono-8);right:1em;bottom:1em}@media only screen and (max-width:48.1em){.footer_main_section{margin:0 auto;float:none;margin-bottom:1em}.footer_sections{margin:0 auto;margin-top:1em;padding:.8em;float:none;clear:both}.footer_section{width:21em;padding:0;margin:0 auto;margin-top:1em;float:none;clear:both}.footer_sub_links a{font-size:1.1em;line-height:1.8em}#section_network{width:21em;margin:0 auto}}
+.ui_button{line-height:1.5em;font-size:1em;padding:.5em 1em;min-width:1.5em;font-weight:bold;font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss06" 1,"ss09" 1;text-align:center;text-decoration:none;display:inline-block;margin-right:.25em;cursor:pointer;background:var(--btn-primary-background-default);color:var(--btn-primary-text);border-radius:3px;border:none}.ui_button_text_plain{background:none;border:none;padding:0;margin:0;font-weight:normal;color:var(--surface-primary);display:inline;font-size:1em;touch-action:manipulation}.ui_button_text{background:none;border:none;padding:0;margin:0;font-weight:normal;color:var(--link-text-default);display:inline;cursor:pointer;font-size:1em;user-select:none;touch-action:manipulation}.ui_button_text:hover{color:var(--link-text-hover)}.ui_button_text:disabled{color:var(--link-text-disabled);cursor:default}.ui_button_text.primary{font-weight:bold}.ui_button:hover{background:var(--btn-primary-background-hover);color:var(--btn-primary-text)}.ui_button:active{background:var(--btn-primary-background-active)}.ui_button:disabled{cursor:default;color:var(--btn-primary-text-disabled);background:var(--btn-primary-background-disabled)}.ui_button.secondary{background:var(--btn-secondary-background-default);color:var(--btn-secondary-text)}.ui_button.secondary:hover{background:var(--btn-secondary-background-hover)}.ui_button.secondary:active{background:var(--btn-secondary-background-active)}.ui_button.secondary:disabled{cursor:default;background:var(--btn-secondary-background-disabled)}.ui_button.button_expand{width:100%;margin-right:0;font-size:1em;background:var(--btn-expand-background-default);color:var(--btn-expand-text);border-radius:3px;line-height:1.75;border:none;cursor:pointer;user-select:none;text-align:center}.ui_button.button_expand .ui_button_expand_text_expanded{display:none}.section_expanded .ui_button.button_expand .ui_button_expand_text_expanded{display:block}.section_expanded .ui_button.button_expand .ui_button_expand_text_default{display:none}.ui_button.button_expand:hover{background:var(--btn-expand-background-hover)}.ui_button.button_expand:active{background:var(--btn-expand-background-active)}.ui_button.button_expand:disabled{background:var(--btn-expand-background-disabled);color:var(--btn-expand-text-disabled)}.ui_button.button_create_playlist{background:var(--btn-secondary-background-selected);border:3px solid var(--btn-secondary-background-hover);color:var(--btn-secondary-text);border-radius:25px;padding:.5em 2em}.ui_button.button_create_playlist:hover{background:var(--btn-secondary-background-hover)}.btn,input[type=button],input[type=submit]{line-height:1.4em;font-size:1em;padding:.25em .8em;min-width:1.5em;font-weight:bold;font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss06" 1,"ss09" 1;text-align:center;text-decoration:none;display:inline-block;margin-right:.25em}.btn_small{font-size:.9em}@media only screen and (max-width:48.1em){.btn_small{font-size:1em}}.btn_xsmall{padding:.25em .5em;font-size:.9em}.btn.blue_btn,.darkgray_btn,.red_btn,.darkred_btn{width:auto;max-width:25em;text-align:center;border:1px solid transparent}.flat_btn{border:1px solid var(--ui-detail-neutral)}.flat_btn.disabled,.flat_btn.disabled:hover{border:1px solid var(--ui-detail-neutral)}.flat_btn:hover{border:1px solid var(--ui-detail-neutral)}.blue_btn:hover{text-decoration:none}.blue_btn.disabled,.blue_btn.disabled:hover{text-decoration:none}.expand_button,a.expand_button,li.expand_button{display:block;line-height:2.5em;font-weight:bold;text-align:center;border-radius:3px;margin-top:.5em;margin-bottom:.5em;text-decoration:none}
+.ui_search{background:var(--surface-secondary);border-radius:25px;position:relative;display:inline-block}header .ui_search{display:block}.ui_search_icon,.ui_clear_icon{position:absolute;top:.5em;font-size:1.2em;color:var(--text-secondary);z-index:2}.ui_search_icon{margin-left:.7em}i.ui_clear_icon{top:0;right:0;cursor:pointer;width:2.3em;text-align:center;line-height:2!important;display:none}.ui_search_frame.active i.ui_clear_icon{display:inline}.ui_search_frame.has_content i.ui_clear_icon{display:inline}.ui_search_debug{float:right;margin-left:.5em;line-height:2.5;font-size:.9em}.ui_search_debug a{color:var(--text-secondary)}.ui_clear_icon:hover{color:var(--text-secondary)}.ui_search_input{width:100%;color:var(--text-primary);outline:none;border:none;background:transparent;padding:0;padding-left:2.5em;padding-right:2.5em}.ui_search_object_category_label{text-align:right;font-size:1.3em;line-height:2;color:var(--text-secondary);padding-right:.5em}.ui_search_close{max-width:40em;margin:0 auto;display:none}.ui_search_close_bar{cursor:pointer;float:right;line-height:2em;font-size:2em;text-align:right;padding-right:.5em;color:var(--secondary-text)}.ui_search_rest{margin-top:.5em;width:40em;background:var(--background);box-shadow:1px 1px 3px rgba(0,0,0,.3);border-radius:3px;display:none}.ui_search_frame.active .ui_search_rest{display:block;position:absolute}.ui_search_type,.ui_search_results_frame{background:var(--surface-primary);padding:.5em 0}.ui_search_results_frame{height:28em;overflow-y:auto}@media only screen and (max-width:48.1em){header .ui_search_results_frame{height:calc(90vh - 5em)}}.ui_search_frame_inner{max-width:80em;margin:0 auto;font-size:.75em;padding:.5em;line-height:1.3;text-align:left;z-index:50}.ui_search_results_help{padding:1em;text-align:center;font-size:1.2em;line-height:1.3;color:var(--text-secondary)}.ui_search_results_help p{color:var(--text-secondary)}.ui_search_results_help i.fa{margin-left:.5em;margin-right:.5em}.ui_search_type{color:var(--text-secondary);padding:.5em;padding-left:1em;padding-right:1em;font-size:1.2em;border-bottom:1px solid var(--ui-detail-neutral);display:none}.ui_search_results{display:none;flex-direction:column;align-items:stretch}.ui_search_frame.active .ui_search_type,.ui_search_frame.active .ui_search_results{display:block}.ui_search_object_label{color:var(--text-secondary);font-size:.9em;margin-right:.25em;margin-left:.25em}.ui_search_scope_selector_item.selected{border-bottom:3px solid var(--background);font-weight:bold}.ui_search_scope_selector_item{min-width:2em;padding-left:.25em;padding-right:.25em;color:var(--text-secondary);line-height:2em;text-align:center;display:inline-block;cursor:pointer;user-select:none}.ui_search_object_category_only_btn{float:right;margin-left:.5em;font-size:.7em;background:var(--background);margin-top:.6em;font-weight:bold;line-height:1.6em;padding-left:1em;border-radius:3px;padding-right:1em;cursor:pointer}.ui_search_scope_selector_item.selected{cursor:default}.ui_search_scope_selector_item_music:hover{color:#207bbf!important}.ui_search_scope_selector_item_film:hover{color:#b96f00!important}.ui_search_scope_selector_item_games:hover{color:#c21c1c!important}.ui_search_scope_selector_item_music.selected{color:#207bbf;border-color:#207bbf!important}.ui_search_scope_selector_item_film.selected{color:#b96f00;border-color:#b96f00!important}.ui_search_scope_selector_item_games.selected{color:#c21c1c;border-color:#c21c1c!important}.ui_search_object_select_frame{position:relative;display:inline-block}.ui_search_object_select{background:var(--surface-primary);border:none;font-weight:bold;color:var(--text-primary);font-size:1em}.ui_search_configure{float:right;margin-left:1em;min-width:2em;padding-left:.25em;padding-right:.25em;color:var(--mono-8);line-height:2em;cursor:pointer;position:relative}.ui_search_configure:hover{background:var(--mono-f8)}.ui_search_result{display:flex;align-items:center;justify-content:center;border-radius:1px;background:var(--mono-f8);cursor:pointer;margin-bottom:.33em;padding-left:.5em;padding-right:.5em}.ui_search_result:hover{background:var(--mono-f0)}.ui_search_result_info{margin-top:.2em;margin-bottom:.2em;margin-left:1em;flex-grow:1}.ui_search_result_info_subtext,.ui_search_result_date_loc_info,.ui_search_result_hint,.ui_search_result_genres{margin-bottom:.15em}.ui_search_result_info_name{padding-top:.25em;font-size:1.2em;color:#207bbf}.ui_search_result_info_subtext{font-size:.9em;font-weight:bold;color:var(--mono-6)}.ui_search_result_date_loc_info .flag{float:left;margin-right:.4em}.ui_search_result_music_performers,.ui_search_result_music_composers{margin-top:.1em;font-weight:bold;color:var(--mono-5)}.ui_search_result_open_external,.ui_search_result_shortcut_frame{text-align:right;color:var(--mono-9);font-size:1.1em;min-height:2em;cursor:pointer;padding:.4em;padding-right:.6em;padding-left:.6em}.ui_search_result_open_external:hover,.ui_search_result_shortcut_frame:hover{background:var(--mono-d);color:var(--mono-6)}.ui_search_result_relevant_aka,.ui_search_result_name_display_original{font-size:.8em;color:var(--mono-8);margin-left:.3em}.ui_search_result_date_loc_info{font-size:.9em;color:var(--mono-6)}.ui_search_result_hint,.ui_search_result_debug{color:var(--mono-8);font-size:.9em;display:none}.ui_search_result_debug{display:none}.ui_search_result_image_bkg{width:5em;height:5em;background-color:var(--mono-f0)!important;box-shadow:1px 1px 0px var(--mono-c);background-position:center center!important;background-size:cover!important}.ui_search_result.result_film .ui_search_result_image_bkg{width:5em;height:7em}.ui_search_result.result_descriptor .ui_search_result_image_bkg{visibility:hidden;height:1px}.ui_search_result_action{align-self:flex-start;text-align:right}.ui_search_result_genres,.ui_search_result_genre_details{font-size:.9em;color:var(--mono-8)}.ui_search_result_film_directors,.ui_search_result_film_starring{margin-right:.25em;font-size:.9em;color:var(--mono-8)}.ui_search_context_indicator{margin-right:10em;color:var(--mono-9);line-height:4;padding-left:2em;padding-right:1em;overflow:hidden;text-align:right;white-space:nowrap;font-style:italic}.ui_search_context_indicator_inner{pointer-events:none;float:right}.ui_search_result_shortcut{font-size:.7em;width:98%;padding:1%;display:none}.ui_search_result_shortcut_frame.clicked .ui_search_result_shortcut{display:inline}.ui_search_result_shortcut_frame.clicked i{display:none}.ui_search_frame_outer{position:relative;height:2.5em;display:inline-block}header .ui_search_frame.active{position:initial;width:100%}header .ui_search_frame_outer{position:initial;display:block}.ui_search_frame.active{position:absolute;width:40em;z-index:3000}.ui_search_autocomplete_result{font-size:1.4em;font-weight:bold;padding:.33em 1em;display:block;width:100%;text-align:left;scroll-margin-top:3em;color:var(--text-primary)}.ui_search_autocomplete_result:hover,.ui_search_autocomplete_result:active,.ui_search_autocomplete_result:focus{background:var(--surface-secondary)}@media only screen and (max-width:48.1em){.ui_search_frame.active,header .ui_search_frame.active{background:var(--mono-f);position:fixed;top:0;left:0;right:0;bottom:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:0em;z-index:3000}.ui_search_clear{clear:both}.ui_search_rest{border:none;box-shadow:none;padding:0;width:100%}.ui_search_frame.active .ui_search_rest{position:relative}.ui_search_frame.active .ui_search_close{display:block}.ui_search_results_frame{position:relative;overflow-y:visible}.ui_search_frame.active .ui_search_frame_inner{padding:0}}
+.ui_page_nav_frame{white-space:nowrap;z-index:3;display:none}.ui_page_nav{text-align:left;margin:0 auto;font-size:1.2em;list-style-type:none;padding-left:.5em;text-align:left;padding:.25em;overflow-x:auto}.ui_page_nav li{display:inline-block;padding:.55em .55em;margin:.25em;border-radius:.25em;background:var(--mono-f8);min-width:8em;text-align:center;color:var(--gen-blue-med)}@media only screen and (max-width:48.1em){.ui_page_nav li{min-width:27%}}
+.page_section_features_frame h2{margin-bottom:.5em}.page_section_feature_image{width:15em;height:15em;object-fit:contain}@media only screen and (max-width:48.1em){.page_section_feature_image{width:9em;height:9em}}.page_section_feature{display:flex}.page_section_feature:hover{background:var(--mono-f8)}.page_section_feature_info{padding:0 1.5em;flex:1;display:flex;flex-direction:column;justify-content:center}.page_section_feature_info h3{font-size:1.6em;color:var(--mono-0);font-weight:bold;color:var(--gen-blue-dark);line-height:1.3}.page_section_feature_info p{color:var(--text-primary);font-size:1.1em;line-height:1.3;margin:0}
+.page_section_contributions_supported_page{background:var(--surface-secondary);padding:1em;margin:1em 0;display:inline-flex;flex-direction:row;align-items:center;border-radius:3px}.page_section_contributions_supported_page_actions{margin-left:1.66em}.page_section_contributions_supported_page_text{flex:1;padding:0 .66em;line-height:1.5}.page_section_contributions_supported_page_text_anonymous{display:none}.page_section_contributions_supported_page.is_anonymous .page_section_contributions_supported_page_text_anonymous{display:inline}.page_section_contributions_supported_page.is_anonymous .page_section_contributions_supported_page_text_user{display:none}.page_section_contributions_supported_page_actions a{font-size:.9em;color:var(--text-secondary);margin-right:1em}i.sponsor-star{background:var(--average-rating);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:bold;color:var(--text-primary);margin:0 .2em;cursor:pointer}h2 i.sponsor-star{font-size:.6em;float:right;line-height:2.2;padding:0 .2em}.page_section_contributions_supported_page img{border-radius:3px;object-fit:cover;width:3em;height:3em}#page_section_contributions_supported_page_thanks_count{font-weight:bold;margin:0 .5em;color:var(--text-primary)}.page_section_contributions_supported_page_intro{padding:1em 1.15em;max-width:35em;margin:0 auto}.page_section_contributions_supported_page_free_select{padding:.5em 1em;background:var(--surface-secondary);font-size:.9em}.page_section_contributions_supported_page_form{display:flex;align-items:center;margin-top:.5em}.page_section_contributions_supported_page_btn{flex:1;text-align:right}.page_section_contributions_sponsorship_intro{padding:1.25em 2em;background:var(--surface-secondary);color:var(--text-secondary)}.page_section_contributions_sponsorship_form{line-height:2.2;padding-top:1em;border-top:1px solid var(--ui-detail-neutral)}.page_section_contributions_sponsorship_btn{float:right}@media only screen and (max-width:48.1em){.page_section_contributions_supported_page_actions{margin:0}.page_section_contributions_supported_page_actions a{display:block;padding:.5em 0}.page_section_contributions_supported_page img{margin-right:1em}}
+.page_release #content{padding:0;background:var(--background)}.sub_text{font-size:.6em;color:var(--mono-8);margin-left:10px}.page_release body.has_background_image #content_wrapper_outer{background:var(--overlay)}.page_release .media_link_container{margin-top:1em;margin-bottom:0}a.song.bolded{font-weight:bold}.ui_media_links_container{xheight:4.3em}#page_release .ui_media_link_btn{height:2em;width:2em}.ui_media_links{display:flex;flex-flow:row wrap;justify-content:center;align-content:space-between;gap:.15em}@media screen and (max-width: 688px){.ui_media_links{max-width:31rem}}.page_object_section{padding:1.25em}@media only screen and (max-width: 48.1em){.page_object_section{padding:.5em}}.release_right_column,.film_right_column{background:var(--mono-f)}.no_content_message{background:var(--mono-f8);text-align:center;border:1px var(--mono-d8) solid;color:var(--mono-8);padding:5px;padding-left:15px;padding-right:15px;border-radius:3px}.release_right_column .page_section{max-width:82.5em;margin:0 auto}.my_review{height:auto;width:520px;overflow:hidden;display:none;background:var(--mono-f8);border:1px var(--mono-c) solid;padding:10px;padding-left:35px;padding-right:35px;margin-bottom:8px}.release_right_column .section_reviews.section_outer{padding:30px;padding-top:25px;padding-bottom:15px;border-top:1px var(--mono-e) solid;border-bottom:1px var(--mono-e) solid}.release_right_column .section_catalog.section_outer{padding:30px;padding-top:25px;padding-bottom:15px}.section_tracklisting{padding:10px;padding-top:15px;padding-left:20px;padding-right:20px}.section_lists,.section_videos,.section_discussion,.section_comments,.section_suggestions,.section_credits,.section_cast,.section_crew,.section_addl_info{padding:1em;padding-left:20px;padding-right:20px}.page_release .page_object_section_discussion{padding:1em;padding-left:20px;padding-right:20px}.release_right_column .section_main_info.section_outer{padding:1.5em;padding-right:.75em;padding-top:25px;padding-bottom:25px}.release_right_column .section_issues.section_outer{padding:30px;padding-top:25px;padding-bottom:15px}.release_right_column .section_my_catalog.section_outer{padding:30px;padding-top:25px;padding-bottom:15px;border-top:1px var(--mono-e) solid;border-bottom:1px var(--mono-e) solid}.page_release_art_frame{text-align:center;background:var(--mono-e);padding:20px;padding-top:20px;padding-bottom:12px}@media only screen and (max-width:1500px){.release_right_column .section_main_info.section_outer{padding:1em}}@media only screen and (max-width:1200px){#frame-div-gpt-ad-1465817209349-19{max-width:100%;overflow:hidden}.release_right_column .section_main_info.section_outer{padding:.5em}.page_release_art_frame{padding:.5em}.page_release .section_main_info{padding:1em}.release_right_column .section_main_info.section_outer{padding:2em .75em}#frame-div-gpt-ad-1465817209349-21{margin-right:-2.5em!important;margin-left:0em!important}}@media only screen and (max-width:48.1em){.release_right_column .section_reviews.section_outer,.section_issues.section_outer,.release_right_column .section_catalog.section_outer{padding-left:.5em;padding-right:.5em}.page_release .page_object_section_discussion{padding:1em .75em}.section_lists,.section_videos,.section_discussion,.section_comments,.section_suggestions,.section_credits,.section_cast,.section_crew,.section_addl_info{padding:1em .75em}.section_my_catalog.section_outer{padding:0}.my_review{width:100%;padding:0;background:transparent;border:none;overflow:none}.section_tracklisting{padding:0 .5em}}div.section_release_navigation{padding:12px;padding-left:20px;padding-right:20px;border-bottom:1px var(--mono-d) solid}.release_left_column{background:var(--mono-f0);padding:0!important;border-right:1px var(--mono-e) solid}.return_banner{height:32px;line-height:32px;font-size:16px;color:var(--mono-8);background:var(--mono-f0);margin-bottom:40px}.return_banner a{text-decoration:none}.buy_button{display:flex;flex-direction:row;justify-content:center;margin:0 auto 1.5em auto;background:var(--gen-blue-darker);color:var(--mono-abs-f)!important;text-decoration:none;padding-top:5px;padding-bottom:5px;font-size:1.1em}@media only screen and (min-width : 1300px){}ul.credits{background:var(--mono-f);padding:5px;border-radius:3px}ul.credits li{list-style:none;font-size:.9em;overflow:visible;padding:4px}ul.credits li div{display:inline-block}.credits_artist a,.credits_artist a:hover{font-weight:normal}.credits_artist.main a{font-weight:bold}.credits_roles{color:var(--mono-8);margin-left:3px}.guest{color:#888}.role_name{position:relative;color:var(--mono-1)}.role_tracks{display:none;position:absolute;top:14px;left:-5px;color:var(--text-primary);z-index:15;background:var(--mono-f);padding:6px;border-radius:3px;box-shadow:2px 2px rgba(0,0,0,.3);white-space:nowrap}.role_name:hover .role_tracks{display:inline-block}.role_name.has_tracks{color:var(--mono-8)}#minor_credits a.artist{font-weight:normal!important}.album_title{font-size:2em;color:var(--mono-0);margin-bottom:.1em;padding:0 .3em}.album_shortcut{float:right;font-size:.8em;background:transparent;border:none;outline:none;margin-top:8px;color:var(--mono-6);text-align:right}.album_title .album_shortcut{font-size:.5em;margin-top:0}.review_shortcut{float:right;font-size:1em;background:transparent;border:none;outline:none;margin-top:8px;color:var(--mono-6);text-align:right}.release_img{text-align:center}.release_left_col{background:var(--mono-f8)}.release_page_header,.page_object_section_discussion_header{font-size:1em;margin-bottom:.75em;height:1.2em;line-height:1.2em}.release_page_header h2,.page_object_section_discussion_header h2{font-size:1.2em;color:var(--mono-5);font-weight:bold;float:left;height:inherit}.release_pri_descriptors{font-size:.9em;color:var(--mono-6);line-height:1.4}#my_catalog{display:flex;flex-direction:column}.section_my_catalog div#release_touch_catalog_guidance{visibility:hidden;margin-top:5px;font-size:.8em;color:var(--mono-8)}.section_my_catalog:hover div#release_touch_catalog_guidance{visibility:visible}@media only screen and (max-width:48.1em){.release_right_column .section_my_catalog.section_outer{padding:.5em 1em}}#my_catalog .release_page_header span.subtext{font-size:.7em;color:var(--mono-8);margin-left:5px}.release_right_col{background:var(--mono-f)}.release_pri_genres a{text-decoration:none;font-weight:bold;font-size:.9em}.release_sec_genres a{text-decoration:none;font-size:.8em}div.release_nav_guidance_artist,div.release_nav_guidance_artist i{font-size:1em;line-height:1.8em!important}div.release_nav_guidance_artist i{xfont-size:1.1em}div.release_navigation{margin-top:5px;margin-bottom:5px}div.release_navigation a{text-decoration:none}div.release_navigation_guidance{border-bottom:1px var(--mono-d) solid;color:var(--mono-6)}div.release_navigation_links{height:2.9em;line-height:2.9em;border-radius:5px;overflow:hidden;display:flex;background:var(--mono-f8)}div.release_nav_guidance_left{float:left}div.release_nav_guidance_left a,div.release_nav_guidance_right a{color:var(--mono-6);text-decoration:none}div.release_nav_guidance_right{float:right}div.release_nav_guidance_artist{text-align:center;width:100%}div.prev_image{width:3em;height:3em}div.prev_link{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-left:10px}div.next_image{width:3em;height:3em;margin-left:10px}div.next_link{text-align:right;flex:1;padding-left:.5em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.release_nav_artist{border-bottom:1px solid var(--mono-d);font-size:.8em;margin-top:5px;color:var(--mono-5)}.genre_descriptor_vote_btn{float:right;font-size:1.1em;padding:.25em;color:var(--mono-c);padding-left:1em;padding-right:.75em}.release_genres:hover .genre_descriptor_vote_btn{color:var(--mono-6)}.release_descriptors:hover .genre_descriptor_vote_btn{color:var(--mono-6)}.genre_descriptor_vote_btn:hover{color:var(--gen-blue-med)}table.album_info,table.film_info{margin-top:10px;font-size:1.1em}table.album_info a,table.film_info a{text-decoration:none}div.release_image{float:left;display:block;height:3em;width:3em;margin-left:5px;border-radius:3px;cursor:pointer}div.release_info{height:3em;margin-left:4em}div.release_title,div.release_artist{height:1.5em;line-height:1.5em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:290px}@media only screen and (min-width : 1300px){}div.release_title{font-weight:bold}div.release_title .subtext{font-weight:normal;font-size:.9em;color:var(--mono-8)}div.release_artist a.artist{font-weight:normal}div.release_artist{color:var(--mono-6);font-size:.9em}div.release_artist .subtext{font-size:.9em;color:var(--mono-8)}ul.alt_titles{display:none}ul.alt_titles li{list-style-type:none}.non_featured_credit{display:none}ul.tracks.allcredits .non_featured_credit{display:block}.release_info_classifiers{font-size:.9em;color:var(--mono-8);margin-left:8px}.track_credit_show_link{float:right;display:inline-block;font-size:.8em;color:var(--gen-blue-dark);cursor:pointer;line-height:1.2em}li.track ul.credits{margin-top:0px;margin-bottom:4px;padding:0;background:transparent}ul.tracks li.track ul.credits{margin-top:.25em}li.track ul.credits li{background:none!important;padding:0px;margin-bottom:1px;border:none;margin-left:1.5em;background:none;padding-left:3px}ul.credits{margin-bottom:0;font-size:1.1em;padding:1em}ul.tracks{border:.3px var(--ui-divider-line) solid;xborder-radius:2px}ul.tracks li.track{min-height:2.5em;list-style:none;font-size:.9em;color:var(--text-primary);background:var(--surface-primary);padding:.25em;padding-bottom:.25em;padding-right:0;padding-left:.2em;margin-bottom:0px;xborder-bottom:.3px var(--ui-divider-line) solid;overflow:hidden;text-overflow:ellipsis}ul.tracks li:nth-child(even){background:var(--surface-secondary)}ul.tracks li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.tracks li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.tracks li:last-child{border-bottom-left-radius:5px;border-bottom-right-radius:5px;border-bottom:none;margin-bottom:0}.tracklist_num{min-width:3em;min-height:14px;margin-right:.3em;line-height:1.58;margin-top:auto;margin-bottom:auto;display:block;float:left;color:var(--mono-6);font-weight:bold;text-align:center}.tracklist_title{display:flex;word-break:break-word;align-items:center;flex-wrap:wrap;font-size:1.1em;max-width:250px;min-height:12px;margin-top:6px;margin-bottom:6px;min-width:100px;padding-right:3px}@media only screen and (min-width : 1300px){.tracklist_title{max-width:340px}}ul.tracks.allcredits .tracklist_title{font-size:1.3em}ul.tracks.allcredits .tracklist_duration{font-size:.7692em}.tracks_work_link_frame{xdisplay:flex}.tracks_work_link,.tracks_lyric_link{background:var(--surface-tertiary);font-size:.75em;color:var(--text-primary);border-radius:10px;line-height:1;padding:0 .66em;margin-left:.66em}.page_release .page_section_feature_image{width:40%;height:40%}.page_release .page_section_features_frame h2{font-size:1.4em;color:var(--mono-6);font-weight:bold}.page_release .page_section_features_frame{padding:1em;padding-bottom:2em}.page_release_tracks_score{float:right;width:4.3em}.tracklist_duration{display:inline-block;margin-left:7px;color:var(--mono-6);font-size:.9em}.track_preview{float:right;font-size:1.8em;border-radius:3px;color:var(--mono-6);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}.track_play{float:right;font-size:1.8em;border-radius:3px;color:var(--mono-5);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}.track_download a{float:right;font-size:.9em;border-radius:3px;color:var(--mono-6);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}#track_rating_success,#notes_success,#acq_date_success,#listening_success{color:#383;display:inline-block;display:none}.track_rating{float:right;display:inline-block;width:2.4em;text-align:left;padding-left:6px;padding-right:2px}.track_rating_disp{float:right;margin-right:5px}.track_rating_hide{display:none}span.track_rating.recommended div.track_rating_avg{font-weight:bold}span.track_rating.not_significant div.track_rating_avg{color:var(--mono-a);font-weight:normal!important}.track_rating_avg{line-height:1.5em;font-variant:tabular-nums}.ratings_bar{height:4px;background:var(--gen-blue-dark);border-radius:3px}span.track_rating.not_significant div.ratings_bar{background:var(--mono-a)}a.affiliate_link{text-decoration:none}#track_preview{text-align:center;margin-top:10px}th.info_hdr{width:105px;color:var(--mono-6);font-weight:normal;font-size:.9em;text-align:left;padding:5px;padding-right:10px;border:none}table.album_info td,table.film_info td{padding:3px}.avg_rating{font-size:1.2em;font-weight:bold}.avg_rating_friends{color:#383;font-weight:bold;font-size:1em}.max_rating{font-size:.9em;color:var(--mono-6)}.num_ratings{font-size:.95em;color:var(--mono-4)}.release_touch_guidance{font-size:.9em;color:var(--mono-6);display:none}.release_my_catalog{display:flex;flex-flow:row wrap;line-height:2.3}.my_catalog_rating{background-color:var(--mono-f8);border:1px var(--mono-d) solid;border-radius:3px;width:141px;height:32px;padding:6.5px;padding-left:10px;opacity:.8;margin-right:5px;cursor:pointer;outline:none}.my_catalog_rating.inrate{opacity:.6}div.rating_stars{background:url(https://e.snmc.io/2.5/img/star_sprite_4.png) no-repeat top left;display:block;float:left;width:90px;height:16px;margin-right:5px}div.rating_loading{display:none;float:left;width:90px;height:16px;margin-right:5px;line-height:17px}div.rating_num{display:block;float:left;width:24px;height:16px;line-height:16px;font-size:1.1em;color:var(--text-primary)}div.loading div.rating_stars,div.loading div.rating_num{display:none}div.loading div.rating_loading{display:block}.my_catalog_catalog{line-height:2.3}.my_catalog_tags,.my_catalog_review{position:relative;line-height:2.3}.my_catalog_tags .tag_dlg{position:absolute;display:none;left:0px;top:2.8em;padding:5px;padding-top:0;padding-bottom:5px;width:220px;background:var(--mono-f8);border:1px var(--mono-d) solid;z-index:10}.tag_dlg label{font-size:10px!important;font-weight:bold!important;line-height:10px!important;padding:0!important;margin:0!important}input.tag_tags{font-size:.9em;background:var(--mono-f);width:150px;border:1px solid var(--mono-c);border-radius:3px;padding:3px}a.tag_save{padding:3px;padding-left:5px;padding-right:5px;background:var(--gen-blue-darker);line-height:24px;margin-left:4px;border-radius:3px;color:var(--mono-f);text-decoration:none}.catalog_btn,.format_btn,.review_save_btn,.review_btn,.track_rating_btn,.listening_btn,.notes_btn,.more_btn,.tag_btn{min-width:3em;text-align:center;background-color:var(--mono-db);border-radius:4px;padding:.25em .8em .25em 3em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative}.more_btn{padding:.25em .8em}.format_btn{min-width:3em;line-height:2.2;text-align:center;background-color:var(--mono-ef);border-radius:4px;padding:.3em .8em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative}.listening_btn{cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_listening.png);background-size:2.3em auto;background-repeat:no-repeat;background-position:5% 50%}.bump_btn{min-width:3em;text-align:center;background-color:var(--mono-db);border-radius:4px;padding:.3em .8em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative;display:none;color:var(--mono-8)}.bump_btn.bumpable{background:var(--mono-db);cursor:pointer;color:var(--mono-4)}.track_rating_btn.has_ratings{background-image:url(https://e.snmc.io/2.5/img/line_icon_trackrating_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.more_btn.has_more{background-color:#dddcf3;font-weight:bold}.review_btn.has_review{background-image:url(https://e.snmc.io/2.5/img/line_icon_review_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.more_btn.has_more{background-color:#dddcf3;font-weight:bold}input.review_save_btn,a.review_save_btn{background-color:var(--gen-blue-darker);border:1px solid var(--gen-blue-darker);border-radius:3px;padding-left:1em;padding-right:1em;margin-right:3px;margin-top:8px;margin-bottom:2px;line-height:1.5;font-size:1em;color:var(--mono-f);cursor:pointer}#review_save_btn{padding-left:35px;padding-right:35px}.review_save_btn:disabled,.review_save_btn:disabled:hover{color:var(--mono-8);cursor:default;background:#e4e4e4;border:1px solid #e4e4e4}.tag_btn.has_tags{background-image:url(https://e.snmc.io/2.5/img/line_icon_tag_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.catalog_btn,.review_btn,.track_rating_btn,.notes_btn,.more_btn,.tag_btn{cursor:pointer}.review_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_review.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.track_rating_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_trackrating.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.catalog_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}#format_note{line-height:12px;color:var(--mono-6);background:var(--mono-e);padding:10px}.format_btn_options{position:absolute;display:none;left:0px;top:2.8em;width:180px;background:var(--mono-f8);border:1px var(--mono-d) solid;padding:0;z-index:10}.format_btn_option{padding-left:8px;padding-right:8px;color:var(--text-primary);cursor:pointer}.format_btn_option.default_format{background:var(--gen-bg-yellow)}.format_btn_option:hover{background:var(--mono-d8)}.format_btn{background:var(--gen-bg-lightgreen);border-top-left-radius:0;border-bottom-left-radius:0}.catalog_btn_options{position:absolute;display:none;left:0px;top:2.8em;width:120px;background:var(--mono-f8);border:1px var(--mono-d) solid;padding:0;z-index:10}.catalog_btn_option{padding-left:8px;padding-right:8px;color:var(--mono-6);cursor:pointer}.catalog_btn_option:hover{background:var(--mono-d8)}.catalog_btn.catalog_u{background:var(--mono-d8);color:var(--mono-0);border-top-right-radius:0;border-bottom-right-radius:0;margin-right:0;cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.catalog_btn.catalog_o,.catalog_btn.catalog_w{background:var(--gen-bg-lightgreen);color:var(--text-primary);border-top-right-radius:0;border-bottom-right-radius:0;margin-right:0;cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.tag_btn{cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_tag.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%}div.catalog_section{margin-right:6px;margin-left:0px;padding-bottom:20px;position:relative;min-height:300px}.catalog_list{margin-right:215px;padding-top:10px}.catalog_list span.navspan,.review_list{text-align:right;background:var(--mono-f3);border-radius:3px;padding-left:5px;padding-right:5px;display:block;margin-bottom:10px;line-height:2em}.catalog_list span.navlinkcurrent,.review_list span.navlinkcurrent{color:var(--mono-5);font-weight:bold}.catalog_list span.navspan a,.review_list span.navspan a{text-decoration:none}@media only screen and (max-width:48.1em){.catalog_list span.navspan a,.review_list span.navspan a,.catalog_list span.navlinkcurrent,.review_list span.navlinkcurrent{padding-left:.33em;padding-right:.33em;line-height:1.7}}.review_sort{float:left;color:var(--mono-6);font-size:.9em;margin-left:2px;line-height:15px;height:15px;margin-top:5px;margin-bottom:5px}.sort_choice{display:inline-block;padding-left:5px;padding-right:5px;text-align:center;border-right:1px var(--mono-a) solid;cursor:pointer}.sort_choice:hover{color:var(--mono-4)}.sort_choice.selected{font-weight:bold;color:var(--mono-4)}.sort_choice:last-child{border-right:none}.catalog_stats{width:200px;float:right;min-height:300px;padding-top:15px;position:absolute;right:0;top:0}.catalog_stats div.header{font-size:1.1em;color:var(--mono-3);background:var(--mono-e);border-radius:3px;text-align:center;line-height:20px;width:200px}.catalog_header{background:var(--mono-ef);height:25px;line-height:25px;padding-left:0px;padding-right:0px;border-radius:3px;margin-bottom:4px}.catalog_header a.user,.catalog_header a.useri,.catalog_header a.usero{font-weight:bold;text-decoration:none;font-size:.9em}.catalog_rating_system_comment{float:right;margin-right:5px;font-size:.9em;color:var(--mono-5);margin-left:8px}.catalog_track_ratings{float:right;cursor:pointer;width:24px;height:25px;margin-left:5px;font-size:.9em;font-weight:bold;color:var(--mono-8);text-align:center;background:rgba(0,0,0,.05)}.no_track_ratings{background:var(--mono-e);padding:10px;border-radius:3px;margin:10px}.catalog_no_track_ratings{float:right;width:24px;height:25px;margin-left:5px}.catalog_date{float:left;width:100px;height:25px;font-size:.9em;line-height:25px;background:var(--mono-f8);color:var(--mono-6)}.catalog_line.my_rating:hover .catalog_date{color:var(--mono-d8)}.catalog_line.my_rating .catalog_date_inner{background:var(--mono-f0);border-radius:3px;color:var(--mono-5);border:1px var(--mono-d) solid;line-height:24px;padding-right:12px}.catalog_date_inner{padding-right:12px;text-align:right}.catalog_line.my_rating .catalog_bump,.catalog_line.can_delete .catalog_delete{display:none;background:var(--mono-f0);border-radius:3px;margin-right:3px;margin-left:3px;color:var(--mono-5);border:1px var(--mono-d) solid;line-height:24px;text-align:center;cursor:pointer}.catalog_bump:hover{background:#f4f4ff!important;cursor:pointer}.catalog_line.my_rating:hover .catalog_date_inner,.catalog_line.can_delete:hover .catalog_date_inner{display:none}.catalog_line.can_delete:hover .catalog_delete{display:block}.catalog_line.my_rating:hover .catalog_bump{display:block}.catalog_line{position:relative}.catalog_year{font-size:1.1em;font-weight:bold;color:var(--mono-6);height:20px;line-height:20px;border-radius:3px;margin-bottom:5px;margin-top:3px}.catalog_ownership{font-size:.9em;color:var(--mono-6);margin-left:8px}.catalog_rating{float:right;width:90px;height:16px;margin-top:3px;margin-left:4px}.contributor_header{font-size:.9em;color:var(--mono-6)}.my_review label{display:inline-block;margin-top:5px}.my_review.edit_mode #saved_review{display:none}.my_review.view_mode #review_edit{display:none}.saved_review{background:var(--mono-f);border:1px solid var(--mono-d);border-radius:3px;padding:10px}label span.review_label{font-weight:normal;font-size:1.2em}label span.subtext{display:block;font-weight:normal;font-size:.95em;color:var(--mono-6);margin-top:4px;margin-left:10px;max-width:500px;margin-bottom:8px}label span.inline_subtext{font-weight:normal;font-size:.95em;color:var(--mono-4);margin-left:5px}.subtext ul{margin-left:24px;margin-top:5px;margin-bottom:9px}.subtext ul li{list-style:circle}.subtext a{text-decoration:none}#published_rules{display:none;color:var(--gen-blue-darker);font-weight:bold}.textarea_toolbar{height:21px;margin-top:4px;margin-bottom:1px}.textarea_toolbar a{padding:3px;padding-left:5px;padding-right:5px;border:1px solid var(--mono-c);background:var(--mono-d8);font-weight:bold;margin-left:3px;margin-top:6px;margin-bottom:4px;text-decoration:none;color:var(--mono-8);border-radius:2px;font-size:.8em}.textarea_toolbar a:hover{background:var(--gen-bg-yellow);color:var(--mono-6)}.track_rating_title_autosave_frame{font-size:.875em;max-width:500px;display:flex;justify-content:flex-end;padding-top:.25em;align-items:center}#page_release .track_rating_release_title{display:none}.track_ratings_autosave_frame{padding-left:1em}#track_ratings_autosave{margin-right:.125em}.track_rating_release_title{flex:1;font-size:1.25em;font-weight:bold}ul#track_ratings{max-width:500px;margin-top:10px;margin-bottom:10px}ul#track_ratings .my_catalog_rating{background-color:transparent;border:none}#my_track_ratings{display:none}#my_track_ratings.autosave_enabled .track_ratings_actions{display:none}#my_track_ratings:not(.autosave_enabled) .track_rating_status{display:none}#my_more_info{display:none;background:var(--mono-f8);padding:15px;width:auto;border-radius:5px}ul#discussion{border:1px solid var(--mono-b);border-radius:3px;background:var(--mono-f);overflow:hidden;padding:10px;padding-top:5px;padding-bottom:5px}ul#discussion li{list-style:none;font-size:1.2em;background:var(--mono-f);margin-bottom:0px;line-height:1.2em;max-width:325px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}@media only screen and (min-width : 1300px){ul#discussion li{max-width:390px}}.star-0m{background-position:0 0!important;width:90px;height:16px}.star-10m{background-position:0 -66px!important;width:90px;height:16px}.star-1m{background-position:0 -132px!important;width:90px;height:16px}.star-2m{background-position:0 -198px!important;width:90px;height:16px}.star-3m{background-position:0 -264px!important;width:90px;height:16px}.star-4m{background-position:0 -330px!important;width:90px;height:16px}.star-5m{background-position:0 -396px!important;width:90px;height:16px}.star-6m{background-position:0 -462px!important;width:90px;height:16px}.star-7m{background-position:0 -528px!important;width:90px;height:16px}.star-8m{background-position:0 -594px!important;width:90px;height:16px}.star-9m{background-position:0 -660px!important;width:90px;height:16px}.review{margin-bottom:10px;border-bottom:1px var(--mono-f0) solid}.review_featured_info{font-size:18px;margin-bottom:10px}.review_featured_info a.artist{font-weight:normal;color:#338}.review_body{word-wrap:break-word;word-break:break-word;display:inline-block;padding:5px;padding-top:12px;padding-right:38px;padding-left:38px;font-size:1.1em;color:var(--mono-4)!important;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;width:100%;line-height:1.4}@media only screen and (max-width:48.1em){.review_body{padding:1em .5em}}.review_body span{color:var(--mono-4)!important}.review_body.featured{background:var(--mono-f8);padding:12px}.review_body a.normal_link{color:var(--mono-6);text-decoration:none}.review_title{font-weight:bold;word-wrap:break-word;word-break:break-word;display:block;margin-bottom:4px;color:var(--mono-0)}.review_header{background:var(--mono-e);height:2.4em;line-height:2.4em;padding-left:0px;padding-right:0px;border-radius:3px;border-bottom-left-radius:0px;border-bottom-right-radius:0px;padding:0px}.review_header_no_img{float:left;margin-right:10px;width:2.4em;height:2.4em;border-radius:3px;background:var(--mono-d8)}.review_header_img{float:left;margin-right:10px;display:inline-block;border-radius:3px;width:2.4em;height:2.4em}.review_issue_label{font-size:.8em;color:var(--mono-6);margin-top:4px;margin-bottom:0px;text-align:right}.review_attribution{font-size:.8em;margin-top:5px;color:var(--mono-6)}.review_supplement{color:var(--mono-4);font-size:.9em;margin-top:8px}.review_supplement_expand{background:var(--mono-f4);padding:2px;padding-left:0;display:block;text-align:center;width:auto;font-size:.9em;cursor:pointer}.review_supplement.supplement_hidden{display:none}.review_publish_status{text-align:right;font-size:.7em;margin-top:5px;color:var(--mono-6)}.review_publish_status a{color:var(--mono-6);text-decoration:none}.review_header.friend,.catalog_header.friend{background:var(--gen-bg-lightgreen)}.review_header a.user,.review_header a.useri,.review_header a.usero{font-weight:bold;text-decoration:none}.review_featured{margin-left:.9em;color:var(--mono-6);font-style:italic}.review_date{font-size:.9em;color:var(--mono-8);margin-left:8px}.review_date a{text-decoration:none}.review_date a:hover{text-decoration:underline}.review_rating{float:right;width:90px;height:16px;margin-top:3px;margin-left:4px;margin-right:8px}.review_voting{position:relative;float:right;width:7.6em;height:2.4em;line-height:2.4em;margin-top:2px;margin-left:4px;margin-right:0px}.review_help{display:none;position:absolute;width:300px;right:0;top:25px;border-radius:3px;background:var(--mono-f);padding:15px;color:var(--mono-5);background:var(--mono-f);background:var(--mono-f);line-height:15px;font-size:.9em;border:4px solid rgba(0,0,0,.5);background-clip:padding-box}.review_vote_down,.review_vote_up,.review_vote_bookmark{position:relative;width:2.4em;border-radius:3px;display:inline-block;text-align:center;cursor:pointer}.voting_tip{display:none;position:absolute;background:rgba(0,0,0,.9);text-align:center;border-radius:3px;top:-24px;line-height:2.4em;width:100px;left:-40px;color:var(--mono-f);font-size:.8em}span.review_vote_down:hover span.voting_tip{display:block!important}span.review_vote_up:hover span.voting_tip{display:block!important}span.review_vote_bookmark:hover span.voting_tip{display:block!important}.review_vote_count{width:3.2em;height:2.4em;float:right;position:relative;font-size:.8em;color:var(--mono-6);display:inline-block;text-align:center;cursor:pointer;margin-left:0px;margin-right:2px}.review_vote_down:hover,.review_vote_up:hover,.review_vote_bookmark:hover{background:var(--mono-f4)}.review_voting i.fa-caret-down,.review_voting i.fa-caret-up{font-size:1.2em;color:var(--mono-a)}.review_vote_down.voted i{color:var(--gen-text-red)}.review_vote_bookmark.bookmarked i{color:#00f!important}.review_vote_up.voted i{color:green!important}.review_vote_up i{line-height:7px}.review_vote_down i{line-height:7px}.review_vote_bookmark{line-height:2em;height:2.4em;vertical-align:top}.review_vote_bookmark i{font-size:.7em;color:var(--mono-8)}.rating_info_table{height:30px;border-radius:5px}.rating_info_table div{cursor:pointer}.rating_info_table div.disabled{color:gray;cursor:default}.rating_info_table div.active{background:var(--mono-d);cursor:default}.rating_info_ratings,.rating_info_cataloged,.rating_info_track_ratings{width:33%;display:block;height:24px;line-height:24px;float:left;background:var(--mono-e);text-align:center}.rating_info_ratings{border-top-left-radius:3px;border-bottom-left-radius:3px;border-right:1px solid var(--mono-b)}.rating_info_cataloged{border-right:1px solid var(--mono-b)}.rating_info_track_ratings{border-top-right-radius:3px;border-bottom-right-radius:3px}div#searchsuggestions{margin:0;border:var(--mono-8) 1px solid;padding:0;width:188px}div.suggestion{font-size:.9em;background:var(--mono-f);color:var(--mono-6);padding-left:3px;padding-right:3px;margin:0}div.suggestionsel{font-size:.9em;background:var(--mono-f);color:var(--text-primary);padding-left:3px;padding-right:3px;margin:0;background:var(--gen-blue-lightest)}.album_artist_small{font-size:.6em;color:var(--mono-6);line-height:1.3em}@media only screen and (max-width:48.1em){.album_title{padding:.4em;padding-top:0px;padding-bottom:.3em;font-size:1.8em;margin-bottom:0em}.release_right_column .section_main_info.section_outer{padding:0px;padding-top:15px;padding-bottom:25px}div.catalog_list{width:100%}.rating_info_tab{font-size:11px}ul.issues{min-width:0px}}.bkg-metadata-star-bold{background-image:var(--metadata-star-bold)}img.metadata-star-bold{content:var(--metadata-star-bold)}.bkg-metadata-star{background-image:var(--metadata-star)}img.metadata-star{content:var(--metadata-star)}.page_release_tracks_score{opacity:.5}.page_release_tracks_score.significant{opacity:1}.page_release_section_tracks_songs_song_stats{xwidth:7.25em;float:right;text-align:center;align-items:flex-start;padding:0 .5em;padding-right:0;line-height:1;display:flex;xalign-self:flex-end;gap:.5em;position:relative}.page_release_section_tracks_track_stats_scores{font-size:1em;font-size:.925em;text-align:center;align-items:flex-start;padding:0;line-height:1.75;display:flex;gap:.5em;position:relative;justify-content:flex-end;border-radius:12px;display:flex;align-items:center}.page_release_section_tracks_track_stats_count{min-width:2.5em;padding-right:.5em;text-align:center;color:var(--text-secondary);font-size:.875em;display:flex;align-items:center}.page_release_section_tracks_track_stats_score_star{display:flex;align-items:center;gap:.25em}.page_release_section_tracks_has_lyrics,.page_release_section_tracks_has_work{background:var(--surface-tertiary);font-size:.75em;color:var(--text-primary);border-radius:10px;padding:0 .75em;margin-left:.5em}.page_release_section_tracks_track_stats_rating{font-weight:bold;margin-bottom:.0625em;width:1.8em;justify-content:center;display:flex}.page_release_section_tracks_track_stats img{width:.66em;height:.66em}html{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star_bold.svg)}html.theme_eve,html.theme_night{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star_bold.svg)}
+ul.issues{border-radius:5px;max-height:211px;background:var(--mono-fb);padding:5px;border:1px var(--mono-d) solid;overflow:hidden;overflow-y:scroll}ul.issues.expanded{max-height:inherit}ul.issues li{list-style:none;height:3em;font-size:.9em;color:#5e5b5b;background:var(--mono-fb);padding:0px;margin-bottom:3px;margin-top:3px;border-radius:3px;text-overflow:ellipsis;white-space:nowrap}ul.issues li:last-child{border-bottom:none}ul.issues li.release_view{text-align:center;height:3em;line-height:3em}ul.issues li.release_view a{color:var(--gen-blue-darkest);text-decoration:none}ul.issues li:hover{background:var(--mono-f)}ul.issues li.release_view{cursor:default;background:var(--mono-f2);color:var(--mono-3);font-size:.9em;border-radius:5px;margin-bottom:5px;text-align:center}ul.issues li.current .issue_info_top{font-weight:bold}ul.issues li.issue_info_release{background-color:var(--surface-secondary);font-weight:bold}span.primary_indicator{color:var(--gen-text-red)}ul.issues li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.issues li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.issues li:last-child{border-bottom-left-radius:5px;border-bottom-right-radius:5px}span.main_issue_info{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:500px}span.issue_countries,span.issue_label,span.issue_cat,span.issue_formats{display:block;float:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.issue_info_top{height:1.5em;line-height:1.5em;padding-left:5px;padding-right:5px}div.issue_info_bottom{height:1.5em;line-height:1.5em;padding-right:5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}span.issue_formats{display:inline-block;width:136px}span.issue_attributes{color:var(--mono-6);margin-left:5px}span.issue_attributes span.smallgray{font-size:9px}span.issue_countries{float:right;text-align:right;margin-right:10px;position:relative;display:inline-block;min-width:100px}div.additional_countries{display:none;position:absolute;right:0;background:var(--mono-f);border:1px solid var(--mono-c);padding:4px;top:-5px}span.issue_countries:hover div.additional_countries{display:block}span.issue_label{display:inline-block;width:200px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}span.issue_cat{display:inline-block;width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}span.issue_title a{font-size:1.1em;text-decoration:none;color:var(--gen-blue-darker)}span.issue_year.ymd{color:var(--mono-0)}span.issue_year.ym{color:var(--mono-6)}span.issue_year.y{color:var(--mono-8)}a.sametitle{color:var(--mono-4)!important}a.sametitle:hover{color:#33f!important}li.current a.sametitle:hover{color:var(--mono-4)!important}div.issue_no_img{display:block;width:35px;color:var(--mono-4);float:left;height:3em;width:3em;margin-right:10px;margin-left:0px;background:var(--mono-d8);border-radius:3px}div.issue_img{display:block;width:35px;color:var(--mono-4);float:left;height:3em;width:3em;margin-right:10px;margin-left:0px;border-radius:3px;background-size:cover!important;background-position:center center!important}span.issue_year{display:block;float:left;width:3em;color:var(--mono-4);font-size:.9em;margin-right:10px;margin-left:0px}
+.profile_listening_container{display:flex;flex-flow:row nowrap;justify-content:flex-start;align-items:center;flex-basis:100%;border:solid 1px rgba(0,0,0,.1);background-color:var(--mono-f);border-radius:6px;padding:.5em;margin:2em .4em .6em .4em;overflow:hidden}.profile_set_listening_box{display:flex;flex-flow:column nowrap;justify-content:flex-end;flex-basis:9em;align-items:center;font-size:.9em;line-height:1.7;margin-right:.8em}.profile_set_listening_btn .btn{padding:.5em 2em;margin-left:0}.profile_set_listening_btn .btn:hover{padding:.5em 2em;margin-left:0}#profile_play_history_container{display:flex;justify-content:flex-start}.profile_view_play_history_btn{display:flex;justify-content:flex-end;flex:1}.profile_view_play_history_btn .btn{line-height:1.5;text-align:center;padding:.7em .8em}.profile_view_play_history_btn .btn:hover{line-height:1.5;padding:.7em .8em}#play_history_edit_box{padding:.5em .2em;flex:1 1 50%}#profile_listening_input_container{display:flex;justify-content:flex-start;align-items:flex-start;flex:1;margin-right:.5em}#play_history_edit{flex-basis:100%;padding:.25em;margin-right:1em}#profile_listening_input_container .btn{line-height:1.5;margin-top:0em}#profile_listening_input_container .btn:hover{line-height:1.5;margin-top:0rem}.note.profile_listening_note{display:flex;flex-direction:row;margin-top:1em;font-size:.8em;padding:.4em;margin:.5em 1em 0em 0em}.fa.profile_listening_note_icon{display:flex;margin-right:.4em;font-size:1.1em;color:var(--gen-blue-darker)}#play_history_item_line{border-bottom:solid .5px rgba(0,0,0,.05);margin-left:4em}#play_history{display:flex;flex-flow:column nowrap;width:100%;margin-bottom:4em}.play_history_item{display:flex;flex-flow:row nowrap;justify-content:flex-start;align-items:first-baseline;padding-top:.4em}.play_history_artbox{display:flex;align-items:center;max-width:3em;margin-right:1em}.play_history_item_art{border-radius:.2em;max-width:100%}.play_history_infobox{display:flex;flex-flow:column nowrap;flex-basis:100%;overflow:hidden;padding:.4em 0 .6em 0}.play_history_item_date{color:var(--mono-9);font-size:.8em;margin-bottom:.3em;line-height:1.2}.play_history_infobox_lower{display:flex;flex-flow:row wrap}.play_history_interpunct{color:var(--gen-blue-darkest);font-size:1.5em;font-weight:bold;margin:0 .8em}.play_history_separator{margin:0em .4em}.play_history_comment{color:var(--mono-7);font-style:italic}.play_history_item_delete{justify-content:flex-end;align-self:center;margin-left:0em}.play_history_chart{display:table;width:100%;margin-bottom:5em}.play_history_chart_item{display:table-row;border:1px solid var(--mono-e);margin:.5em}.play_history_chart_item_col{display:table-cell;padding:.5em}.play_history_chart_item:nth-child(even){background:var(--mono-e)}.play_history_chart_col_pos{width:50px;text-align:center;vertical-align:middle;font-size:40px;font-weight:700;color:var(--mono-7)}#play_history_user_profile{display:table;width:100%;margin-bottom:5em}.play_history_user_profile_row{display:table-row;border:1px solid var(--mono-e);margin:.5em}.play_history_user_profile_col{display:table-cell;padding:.5em}#release_play_selection{display:none;background-color:var(--mono-f);padding:1.4em;margin-top:.8em;margin-bottom:1em;border:1px solid rgba(0,0,0,.1);border-radius:.4em}.listening_header{display:block;font-size:1.1em;margin-bottom:.6em}#listening_current{margin-top:0em;margin-bottom:2em;font-size:.9em}.listening_track{list-style:none;font-size:1em;color:var(--mono-2);overflow:hidden;text-overflow:ellipsis}.listening_tracklist_line{display:flex;flex-flow:row nowrap;align-items:baseline;padding:.8em 0 .4em 1em}.listening_tracklist_num{font-size:1em;padding-right:1.2em;color:var(--mono-6)}.listening_tracklist_title{display:block;font-size:.9em}.listening_tracks_dropdown{font-size:.9em;margin:.8em 0 .3em 1.2em;cursor:pointer;outline:none}.listening_entire_album{font-size:1em}.listening_comments_container{display:flex;flex-direction:column}.listening_comment_btns_container{display:flex;flex-direction:row;justify-content:flex-end}.listening_comments_inputbox{width:100%;margin-top:.8em;margin-bottom:.3em;padding:.3em 1em;box-sizing:border-box;border-radius:10em;border:1px solid var(--mono-c)}.listening_no_track_ratings{background:var(--mono-f3);font-size:.9em;font-style:italic;padding:.8em 0 .3em 1em;border-radius:3px;margin:.8em 0em}.track_select_btn{cursor:pointer}#listening_btn{cursor:pointer}.listening_selected{background:var(--mono-e)!important;font-weight:bold;color:var(--text-primary)}ul.listening_selector li:hover{background:var(--mono-f8)}
+ul.suggestions{min-height:500px;border:1px var(--mono-c) solid;border-radius:5px;padding:1em;padding-right:1.5em;background:var(--mono-f);font-size:.9em}ul.suggestions li{list-style:none;color:var(--mono-4);background:var(--mono-f);padding:0px;margin-top:5px;margin-bottom:5px}.page_suggestions_not_available{font-size:1.3em;padding:1em;padding-top:3em;text-align:center}.page_discography_line{margin-top:.25em;margin-bottom:.25em;border-radius:8px}.page_discography_line_detail{display:none}.page_discography_line:nth-child(odd){background:rgba(128,128,128,.1)}.page_discography_img{background-size:cover!important;background-position:center center!important;background-repeat:no-repeat!important;width:4.2em;height:4.2em;background-color:var(--mono-d)!important;float:left;box-shadow:1px 1px 0px var(--mono-d);margin-right:1em}.page_discography_line_1{font-size:1.2em;padding-top:.5em;padding-bottom:.125em}.page_discography_line_1.recommended a.release{font-weight:bold}.page_discography_line_1 a.release{margin-right:.25em}.page_discography_artist_names{margin-left:.25em;font-size:.9em}ul.suggestions .component_discography_item_stats{width:6em;font-size:.9em}ul.suggestions .component_discography_item_details_reviews{display:none}.page_discography_attribute{font-size:.8em;padding:.1em;padding-left:.6em;padding-right:.6em;border-radius:5px;background:var(--mono-e8);color:var(--mono-5);font-weight:bold;display:inline-block;margin-right:.3em}.page_discography_average{float:right;font-size:1.3em;width:3.3em;text-align:center;line-height:2.8}.page_discography_reviews,.page_discography_ratings{float:right;width:4.3em;font-size:.9em;text-align:center;color:var(--mono-6);line-height:4}.page_discography_line_2{font-size:.9em;padding-top:.25em;padding-bottom:.5em;margin-left:5.85em}.page_discography_date{font-weight:bold;color:var(--mono-6);margin-right:.5em}.page_discography_date_full{display:none}.page_object_section_suggestions_refresh{float:right;font-size:1.2em;color:var(--mono-8);padding-left:.5em;padding-right:.5em;line-height:1.5;cursor:pointer}
+.more_comments{margin:5px;padding:10px;border:1px var(--mono-c) solid;border-radius:5px;background:var(--mono-e);text-align:center;color:var(--text-primary);font-weight:bold}.more_comments:hover{background:var(--mono-f);cursor:pointer}.page_mentions_header{padding:1em;margin-top:1em}.page_mentions_header h1{margin-bottom:.5em}.page_reference_content{padding:.5em}.page_reference_discussion_title,.page_mentions_item_description{padding:.5em;padding-left:1.5em;padding-right:1.5em;background:var(--mono-f2);font-size:1.1em;border-bottom:1px solid var(--mono-d)}.page_reference_content .post_actions,.page_reference_content .post_shortcut{display:none}.page_mentions_none{padding:1em;font-size:1.2em;color:var(--mono-8)}div.comments{max-width:525px;background:var(--mono-f);border-radius:3px;border:1px solid var(--mono-e);position:relative}ul.comments_list{max-height:300px;overflow-y:auto;margin:10px;margin-bottom:0;-webkit-overflow-scrolling:touch}.comment_help{display:none;position:absolute;width:300px;right:0;top:25px;border-radius:3px;background:var(--mono-f);padding:15px;color:var(--mono-5);background:var(--mono-f);background:var(--mono-f);line-height:15px;font-size:.9em;border:4px solid rgba(0,0,0,.5);background-clip:padding-box;z-index:80}.comment_no_img{float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)}.comment_img{float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px;background-size:cover!important;background-color:var(--mono-0);background-position:center center!important}ul.comment_rules{margin-top:10px;margin-bottom:10px}ul.comment_rules li{list-style-type:circle;list-style-position:inside;margin-bottom:2px;margin-top:2px}li.comment{list-style:none;margin:0;margin-bottom:5px;margin-top:5px}.comment_header{background:var(--mono-f8);height:25px;line-height:25px;padding-left:0px;padding-right:0px;border-radius:3px;margin-bottom:0px}.comment_header a.user,.comment_header a.useri,.comment_header a.usero{font-weight:bold;text-decoration:none;font-size:.9em}.comment_date{font-size:.9em;color:var(--mono-6);margin-right:8px;float:right}.comment_body{padding:5px;padding-top:10px;font-size:1em;color:var(--mono-4);-webkit-text-size-adjust:100%;word-wrap:break-word;word-break:break-word;display:inline-block}.comment_post_btn,.comment_post_add_btn,.comment_cancel_btn{cursor:pointer;text-align:center;font-weight:bold;background:var(--mono-db);text-decoration:none;color:var(--text-primary);border-radius:3px;line-height:24px;margin-top:5px;font-size:11px!important;height:24px!important}.comment_post_btn{background:var(--mono-db);color:var(--text-primary);cursor:pointer}.comment_post_btn{float:right;width:45%}.comment_cancel_btn{float:left;width:45%}.comments_post{position:relative;background:var(--mono-f8);border-radius:4px;padding:0px}.comments_post_loading{position:absolute;display:none;background:rgba(168,168,168,.2);border-radius:4px;width:100%;height:100%}.comment_new{box-sizing:border-box;display:block;border-radius:3px;padding:3px;border:1px solid var(--mono-c);width:100%;margin-top:5px;margin-bottom:5px;height:60px;font-size:.9em;color:var(--mono-6)}.comment_mod{font-size:.8em;color:var(--mono-8);text-align:right}.comment_mod span:hover{cursor:pointer;color:var(--gen-blue-darkest)}.comment_new.loading{background:var(--mono-e8);border:1px var(--mono-e8) solid;color:var(--mono-8)}div.comments.view .comment_new{display:none}div.comments.view div.comment_post_btn,div.comments.view div.comment_cancel_btn{display:none}div.comments.edit div.comment_post_add_btn{display:none}
+ul.suggestions{min-height:500px;border:1px var(--mono-c) solid;border-radius:5px;padding:1em;padding-right:1.5em;background:var(--mono-f);font-size:.9em}ul.suggestions li{list-style:none;color:var(--mono-4);background:var(--mono-f);padding:0px;margin-top:5px;margin-bottom:5px}.page_suggestions_not_available{font-size:1.3em;padding:1em;padding-top:3em;text-align:center}.page_discography_line{margin-top:.25em;margin-bottom:.25em;border-radius:8px}.page_discography_line_detail{display:none}.page_discography_line:nth-child(odd){background:rgba(128,128,128,.1)}.page_discography_img{background-size:cover!important;background-position:center center!important;background-repeat:no-repeat!important;width:4.2em;height:4.2em;background-color:var(--mono-d)!important;float:left;box-shadow:1px 1px 0px var(--mono-d);margin-right:1em}.page_discography_line_1{font-size:1.2em;padding-top:.5em;padding-bottom:.125em}.page_discography_line_1.recommended a.release{font-weight:bold}.page_discography_line_1 a.release{margin-right:.25em}.page_discography_artist_names{margin-left:.25em;font-size:.9em}ul.suggestions .component_discography_item_stats{width:6em;font-size:.9em}ul.suggestions .component_discography_item_details_reviews{display:none}.page_discography_attribute{font-size:.8em;padding:.1em;padding-left:.6em;padding-right:.6em;border-radius:5px;background:var(--mono-e8);color:var(--mono-5);font-weight:bold;display:inline-block;margin-right:.3em}.page_discography_average{float:right;font-size:1.3em;width:3.3em;text-align:center;line-height:2.8}.page_discography_reviews,.page_discography_ratings{float:right;width:4.3em;font-size:.9em;text-align:center;color:var(--mono-6);line-height:4}.page_discography_line_2{font-size:.9em;padding-top:.25em;padding-bottom:.5em;margin-left:5.85em}.page_discography_date{font-weight:bold;color:var(--mono-6);margin-right:.5em}.page_discography_date_full{display:none}.page_object_section_suggestions_refresh{float:right;font-size:1.2em;color:var(--mono-8);padding-left:.5em;padding-right:.5em;line-height:1.5;cursor:pointer}
+ul.lists{border:1px var(--mono-e) solid;border-radius:5px;background:var(--mono-f);padding:5px;font-size:1.2em;margin-top:8px}ul.lists li{list-style:none;font-size:.8em;color:var(--mono-4);background:var(--mono-f);overflow:hidden;padding:0;padding:4px;border-radius:5px}ul.lists li.expand_button{background:var(--mono-e)}ul.lists li:hover{xbackground:var(--mono-e)}ul.lists li:last-child{border-bottom:none}div.list_image{float:left;width:3em;height:3em;background-color:var(--mono-d);border-radius:5px}div.list_info{margin-left:3.9em}div.list_name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}#addtolist{position:relative}#add_to_list_lists{position:absolute;top:1.2em;display:none;right:0;width:200px;height:200px;overflow-y:auto;overflow-x:hidden;background:var(--mono-f);border:1px solid var(--mono-d8);border-radius:3px;z-index:20}#add_to_list_lists a{display:inline-block;text-decoration:none;font-size:1em;width:180px;padding:5px;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;border-radius:3px}#add_to_list_lists a:hover{background:var(--mono-f8)}#addtolist:hover #add_to_list_lists{display:block}#add_to_list_btn{float:right;display:inline-block;cursor:pointer;margin-top:-.5em}@media only screen and (min-width : 1300px){div.list_name{xmax-width:370px}div.list_info{xmax-width:370px}}div.release_right_column div.list_name,div.release_right_column div.list_info{max-width:900px!important}div.list_author{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.list_name a{font-size:1.2em;line-height:1.5;text-decoration:none;font-weight:bold}div.list_author a{font-size:1.1em;line-height:1.4;text-decoration:none}
+.page_object_discussion_threads{list-style-type:none;margin-top:.75em}.page_object_discussion_thread{padding:.5em 1em}.page_object_discussion_group_name{font-size:.8em;color:var(--mono-6);margin-left:.5em}.page_object_discussion_thread:nth-child(odd){background:rgba(128,128,128,.1)}
+.component_discography_items_frame{position:relative}.component_discography_items_frame .ui_section_overlay{margin:-1em -2em;border-radius:10px}ul.component_discography_items{display:flex;flex-direction:column;list-style-type:none;counter-reset:component_discography_counter}li.component_discography_item:before{content:counter(component_discography_counter) ".";align-items:flex-start;width:2.5em;color:var(--text-primary);justify-content:center;padding-right:.5em;font-weight:bold;font-size:1em}li.component_discography_item:before{display:none}li.component_discography_item{counter-increment:component_discography_counter;display:flex;font-size:1.2em;flex-direction:row;align-items:center;padding:.33em 0;xborder-bottom:1px solid var(--ui-divider-line)}.component_discography_item_image{display:inline-flex}.component_discography_item_image img,.component_discography_item_image.no_image{display:inline-block;height:4em;width:4em;background-color:var(--surface-secondary);object-fit:cover;border-radius:3px}.component_discography_item_info{display:flex;flex:1;flex-direction:column;justify-content:center;padding:.1em 1em;line-height:1.2;font-size:.95em}.component_discography_items_heading{flex:1}.component_discography_items_header{display:flex;flex-direction:row;align-items:flex-start;margin-bottom:1em}.component_discography_navigation{align-self:flex-end;padding:.2em 0}.component_discography_navigation_bottom{margin-top:.75em;padding:.25em 0;border-top:1px solid var(--ui-divider-line);border-bottom:1px solid var(--ui-divider-line)}.component_discography_navigation .ui_pagination{display:flex}.component_discography_navigation .ui_pagination_pages{display:flex;justify-content:center;align-items:center;flex:1}@media only screen and (max-width:75em){.component_discography_items_header{flex-direction:column}.component_discography_navigation .ui_pagination{margin:0 -.66em;font-size:.9em}.component_discography_items_heading{margin-bottom:.5em}.component_discography_navigation{align-self:stretch}}.component_discography_item .separator:before{text-align:center;content:"|";color:var(--text-secondary);padding:0 .25em}.component_discography_item_link.game{font-size:1.125em}.component_discography_item_link,.component_discography_item_info a{xcolor:rgb(30,82,151);display:inline-block;padding:.1em 0;xfont-weight:bold}.component_discography_catalog_no{color:var(--text-primary);font-weight:bold}.component_discography_item_details{font-size:.9em;color:var(--text-primary);display:flex;align-items:center;margin-top:.2em;line-height:1.3;flex-wrap:wrap}.component_discography_item_genres{color:var(--text-secondary)}.component_discography_item_details span{margin-right:.2em}.component_discography_item_stats,.component_discography_item_header_stats{display:flex;align-items:center;width:11em}.component_discography_item_details_average{font-variant-numeric:tabular-nums}.component_discography_item_header_stats{width:13.333em}.component_discography_item_stats span,.component_discography_item_header_stats span{text-align:right;flex:1}.component_discography_item_header_stats span.component_discography_item_header_average{text-align:center}.component_discography_item_details_average{background:var(--average-rating);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:bold;color:var(--text-primary)}.component_discography_item_details_ratings,.component_discography_item_details_reviews{font-size:.9em;text-align:right}.component_discography_item_stats span.abbr{display:none}.component_discography_item_stats_compact{display:none}@media only screen and (max-width:48.1em){.component_discography_item_stats,.component_discography_item_header_stats{width:9.7em}.component_discography_item_stats span,.component_discography_item_header_stats span{text-align:center}.component_discography_item_stats span.abbr{display:inline}.component_discography_item_stats span.full{display:none}}.component_discography_item_header{display:flex;border-bottom:1px solid var(--ui-divider-line);border-top:1px solid var(--ui-divider-line);font-size:.9em;user-select:none;margin-bottom:.5em}.component_discography_count{color:var(--h1);font-weight:bold}.component_discography_item_header span{padding:.75em 0em}.component_discography_item_header_sort_item{padding:0 .25em;margin-left:.25em;cursor:pointer}.component_discography_item_header_sort_item.selected{font-weight:bold;cursor:default}.component_discography_item_header_sort{flex:1;display:flex;align-items:center;font-weight:bold;color:var(--text-secondary);cursor:pointer}.component_discography_item_header_sort i{margin-left:.5em}.component_discography_item_image_link{line-height:.5}.component_discography_item_exclude{display:none}.component_discography_item_exclude i{padding:1em 2em;cursor:pointer}.component_discography_item.exclude_show{opacity:1}.component_discography_item.exclude_hide{opacity:0;transition:opacity 300ms}@media only screen and (max-width:48.1em){li.component_discography_item{font-size:1.3em}.component_discography_item_header_stats{width:11em;font-size:.9em}.component_discography_item_stats{width:7.8em}.component_discography_item_image img,.component_discography_item_image.no_image{height:4em;width:4em}.component_discography_item_info{padding:0 .33em 0 .8em;font-size:.9em}.component_discography_item_stats{display:none;font-size:.75em}}
+</style><script id="base_script">window.rym_dist = '//cdn.sonemic.net/dist/rym25';
+var r=(a,o,i)=>new Promise((e,t)=>{var s=l=>{try{d(i.next(l))}catch(n){t(n)}},c=l=>{try{d(i.throw(l))}catch(n){t(n)}},d=l=>l.done?e(l.value):Promise.resolve(l.value).then(s,c);d((i=i.apply(a,o)).next())});window.RYMtemplate=window.RYMtemplate||{};function ensureTemplateLoaded(a){return r(this,null,function*(){if(RYMtemplate[a])return;let o=[];return yield import((window.rym_dist||"//e.snmc.io")+"/dist/template/"+a+".js?v="+window.rym_dist_version).then(e=>{o=e.compiledTemplate.dependencies.map(t=>ensureTemplateLoaded(t)),window.RYMtemplate[a]=e.compiledTemplate.template}),Promise.all(o)})}function getTemplate(a){return function(){return r(this,null,function*(){return window.RYMtemplate=window.RYMtemplate||{},RYMtemplate[a]||(yield ensureTemplateLoaded(a)),RYMtemplate[a]})}()}function renderTemplate(a,o){return function(){return r(this,null,function*(){return window.RYMtemplate=window.RYMtemplate||{},RYMtemplate[a]||(yield ensureTemplateLoaded(a)),RYMtemplate[a].render(o,RYMtemplate)})}()}function applyLazyLoadBehavior(a,o,i){a.classList.remove("lazyload-initialized"),a.classList.add("lazyload-complete");let e=[a,...a.children];for(var t of e)t.dataset.srcset&&(t.srcset=t.dataset.srcset,delete t.dataset.srcset),window.devicePixelRatio>1&&t.dataset.bkg2x?(t.style.backgroundImage=`url('${t.dataset.bkg2x}')`,delete t.dataset.bkg2x,delete t.dataset.bkg):t.dataset.bkg&&(t.style.backgroundImage=`url('${t.dataset.bkg}')`,delete t.dataset.bkg),t.dataset.src&&(t.src=t.dataset.src,delete t.dataset.src),t.dataset.connatixScriptId&&(a.classList.remove("lazyload-creative-initialized"),i&&!window.bscFound&&window.connatixScripts[t.dataset.connatixScriptId]&&(window.connatixScripts[t.dataset.connatixScriptId](),window.connatixScripts[t.dataset.connatixScriptId]=null,console.log("loaded connatix video"))),t.dataset.suggestions&&(console.log("loading suggestions"),RYMsuggestions.load($(t))),t.dataset.medialink&&(console.log("loading media link"),ui.media_links.loadUnit(t));!o&&a.dataset.adcode&&typeof adVisibilityChanged!="undefined"&&adVisibilityChanged(a.dataset.adcode,i)}window.refreshLazyLoadList=function(){const a=document.querySelectorAll(".lazyload");for(let e=0;e<a.length;e++)a[e].classList.remove("lazyload"),a[e].classList.add("lazyload-initialized"),typeof window.lazyloadObserver!="undefined"?window.lazyloadObserver.observe(a[e]):applyLazyLoadBehavior(a[e],!0);const o=document.querySelectorAll(".lazyload-creative");for(let e=0;e<o.length;e++)o[e].classList.remove("lazyload-creative"),o[e].classList.add("lazyload-creative-initialized"),typeof window.lazyloadObserverAds!="undefined"?window.lazyloadObserverAds.observe(o[e]):applyLazyLoadBehavior(o[e],!0);const i=document.querySelectorAll(".ui_section_nav_marker");for(let e=0;e<i.length;e++)i[e].classList.remove("lazyload-creative"),i[e].classList.add("lazyload-creative-initialized"),typeof window.sectionNavMarkerObserver!="undefined"&&window.sectionNavMarkerObserver.observe(i[e])},rymQ(function(){if(typeof IntersectionObserver=="undefined")return;window.lazyloadObserver=new IntersectionObserver(i=>{for(let e=0;e<i.length;e++)if(i[e].isIntersecting){const t=i[e].target;lazyloadObserver.unobserve(t),applyLazyLoadBehavior(t,!1)}},{rootMargin:"300px 50px 300px 50px"}),window.lazyloadObserverAds=new IntersectionObserver(i=>{console.log(i,i);for(let e=0;e<i.length;e++){const t=i[e].target;applyLazyLoadBehavior(t,!1,i[e].isIntersecting)}},{rootMargin:"100px 0px 100px 0px"});function a(i,e,t){var s=i.scrollLeft,c=e-s,d=0,l=5,n=function(){d+=l;var f;i.scrollLeft=f,d<t&&setTimeout(n,l)};n()}if(document.getElementById("ui_section_nav")){let i=parseInt(window.getComputedStyle(document.getElementById("ui_section_nav")).height)||0;i+=parseInt(window.getComputedStyle(document.getElementById("page_header")).height)||0,window.sectionNavMarkerObserver=new IntersectionObserver(e=>{let t=null;for(let s=0;s<e.length;s++){let c=null;console.log(e[s].target.id,e[s].isIntersecting);let d=document.getElementById(`ui_section_nav_${e[s].target.id}`);e[s].isIntersecting?(t=d,d.classList.add("active")):d.classList.remove("active")}t&&(console.log(`scrolling to ${t.offsetLeft}`),document.getElementById("ui_section_nav").scroll({left:t.offsetLeft,behavior:"smooth"}))},{rootMargin:`-${i}px 0px 0px 0px`})}}),rymQ(function(){refreshLazyLoadList()});
+</script><link id="css-bundle" rel="stylesheet" href="//cdn.sonemic.net/dist/rym25/css/bundle.css?v=48d17652-b15b-42b5-8f47-82aaba602ce7" type="text/css" />
+
+               <style>
+
+                  .ui_fundraiser_letter_date {
+                     text-align:right;
+                     margin-bottom:1em;
+                  }
+
+                  .ui_fundraiser_letter {
+                     background:linear-gradient(to bottom, var(--mono-f), var(--mono-f8));
+                     box-shadow:1px 1px 5px rgba(0,0,0,0.2);
+                     padding:2em 4em;
+                     font-size:1.1em;
+                  }
+
+                  .ui_fundraiser_letter_button_subtext {
+                     font-size:0.8em;
+                     font-weight:normal;
+                  }
+
+                  .ui_fundraiser_letter_button {
+                     height:3.5em;
+                     width:45%;
+                     line-height:1.2;
+                     margin-right:2%;
+                     margin-bottom:1em;
+                     float:left;
+                     display:flex;
+                     flex-direction:column;
+                     align-items:center;
+                     justify-content:center;
+                  }
+
+                  .ui_fundraiser_letter_button_subscribe, .ui_fundraiser_letter_button_subscribe:hover {
+                     background: var(--gen-blue-dark);
+                     color: var(--mono-abs-f);
+                  }
+
+
+                  .ui_fundraiser_letter_button_donate {
+
+                  }
+
+                  .ui_fundraiser_bar_outline {
+                     height:1em;
+                     width:100%;
+                     border-radius:1em;
+                     overflow:hidden;
+                     background:var(--background);
+                     position:relative;
+                  }
+
+                  header .ui_fundraiser_bar_outline {
+                     height:2px;
+                  }
+
+                  .ui_fundraiser_bar_frame {
+                     padding-right:6%;
+                     margin-bottom:2em;
+                  }
+
+                  .ui_fundraiser_bar_inner {
+                     position:absolute;
+                     top:0;
+                     left:0;
+                     height:1em;
+                     background:crimson;
+
+                     width:50%
+                  }
+
+                  header .ui_fundraiser_bar_inner {
+                     background:#ff8888
+                  }
+
+
+                  .ui_fundraiser_bar_legend {
+                     width:100%;
+                     height:3em;
+                     margin-top:0.2em;
+                     font-size:0.8em;
+                     color:var(--mono-5);
+                     position:relative;
+                  }
+
+                  .ui_fundraiser_bar_legend_item {
+                     position:absolute;
+                     top:0;
+                     z-index:1;
+                  }
+
+                  .ui_fundraiser_bar_legend_start {
+                     left:0;
+                  }
+
+                  .ui_fundraiser_bar_legend_fundraiser_goal {
+                      right:0;
+                      text-align:right;
+                  }
+
+                  .ui_fundraiser_bar_legend_longterm_goal {
+                     right:0;
+                     text-align:right;
+                  }
+
+                  .ui_fundraiser_bar_goal_divider {
+                     position:absolute;
+                     display:none;
+                     top:0;
+                      right:37.32%;
+                      height:1em;
+                      width:1px;
+                      background:var(--ui-detail-neutral)         
+                  }
+
+                  .ui_fundraiser_letter_contents {
+                     padding-right:3em;
+                  }
+
+                  .ui_fundraiser_letter_contents p {
+                     line-height:1.5;
+                  }
+
+                  .ui_fundraiser_current {
+                     xfloat:right;
+                     font-size:0.8em;
+                     line-height:1.2;
+                     color:var(--mono-6);
+                  }
+
+                  @media only screen and (max-width:48.1em) {
+
+
+                     .ui_fundraiser_letter {
+                        padding:2em 1.5em;
+                     }
+
+                     .ui_fundraiser_letter_contents {
+                        padding-right:0;
+                     }
+
+                  }
+
+               
+             .ui_fundraiser_bar_inner  { width: 100.0%; background: #595; } </style>
+         <!-- Playwire header tag --> 
+         <script data-cfasync="false">
+           window.ramp = window.ramp || {};
+           window.ramp.que = window.ramp.que || [];
+           window.ramp.override = {
+               settings: {
+                   multiSelect: true
+               }
+           };
+      
+         </script>         
+      
+         <script>
+
+            window.ramp.custom_tags = ["rateyourmusic","album","false"];
+
+            window.ramp.que.push( () => {
+
+               window.ramp.setCustomGamKvs({"artist_name":"King Gizzard & The Lizard Wizard","release_name":"12 Bar Bruise","site":"rateyourmusic","pagetype":"album","logged_in":false,"enable_floating":true,"enable_adhesions":true});
+            });
+         </script>
+      
+<script type="text/javascript">rymQ(function() { rym.session.init(0, '0', '', {});});</script><script> window.streamingPreferences = {"preferred_link":"sonemic","service_regions":{"applemusic":"US","bandcamp":"US","deezer":"US","qobuz":"US","soundcloud":"US","spotify":"US","tidal":"US","youtube":"US"},"prefer_open":false}</script></head><body id="page_body" class="has_background_image " style="background-image:url('//cdn.sonemic.net/i/25/s/df079ddb27ab7ab85adbbeaefc0da00c/4311196'); background-size:cover;">
+
+            <script>
+               window.themes = ['light', 'eve', 'night'];
+               window.themes_label = ['Light', 'Evening', 'Night'];
+            </script>
+          
+      <script>
+         if ( window.localStorage['size_mode'] ) {
+            document.body.parentElement.className += ' size_mode_' + window.localStorage['size_mode'];
+         }
+
+         if ( !window.localStorage['theme'] && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ) {
+            document.body.parentElement.className += ' theme_eve';
+         } else if ( !window.localStorage['theme'] || window.localStorage['theme'] === 'day') {
+            document.body.parentElement.className += ' theme_light';
+         } else {
+            if ( -1 != window.themes.indexOf(window.localStorage['theme']) ) {
+               document.body.parentElement.className += ' theme_' + window.localStorage['theme'];
+            } else {
+               document.body.parentElement.className += ' theme_light';
+            }
+         }
+
+         if ( window.matchMedia ) {
+
+             var listener = window.matchMedia('(prefers-color-scheme: dark)').addEventListener;
+
+             if ( listener ) {
+                listener('change', e => {
+                  updateTheme();
+                });               
+             }
+         }
+      </script>
+      <div id="top" class="breadcrumb_section_marker anchor"></div><script>
+            window.addEventListener('DOMContentLoaded', (event) => {
+                window.dom_loaded = true;
+      
+             console.log('DOM loaded');
+             if ( typeof (_adjustFillerColumns) !== 'undefined' ) {
+                _adjustFillerColumns() 
+             }
+
+             setTimeout(function () { 
+               if ( typeof (_closeAllStickyAds) !== 'undefined' ) {
+                  _closeAllStickyAds() 
+               }
+
+             }, 5000);
+         
+  
+         });
+      
+            rymQ(function() { updateStyleThemeLabels() });
+         </script>
+      
+<header id="page_header">
+<div class="header_inner logged_in">
+
+
+
+
+<div class="header_profile">
+
+      <div class="header_profile_logged_out">
+         <span>   
+            <a href="/account/login" class="header_item">sign in</a>
+         </span>
+      </div>
+</div>
+
+
+<div class="header_logo">
+  <a class="main header_item sonemic" href="/">
+     <div class="logo_header"></div>
+     <span class="logo_name">RYM</span>
+  </a>
+
+</div>
+
+
+
+<div class="header_links">
+  <div class="header_links_inner">
+      <div class="divider"></div>
+      <a class="header_item" href="/new-music/">new music</a>
+      <a class="header_item" href="/genres/">genres</a>
+      <div class="header_charts">
+      <a class="header_charts header_item" href="/charts/">charts</a>
+      </div>
+      <a class="header_item" href="/lists/">lists</a>
+
+
+
+
+      
+
+      <div class="divider"></div>
+    </div>
+  </div>
+  <div class="header_search">
+  <div id="ui_search_frame_outer_main_search"  class="ui_search_frame_outer"> <div id="ui_search_frame_main_search" class="ui_search_frame"> <div onclick="rymQ(function() {RYMsearch.onClickClose(event, 'main_search');})" class="ui_search_close"> <div class="ui_search_close_bar"> <i class="fa fa-times"></i> Close</div> <div id="ui_search_context_indicator_main_search" class="ui_search_context_indicator"> <div id="ui_search_context_indicator_inner_main_search" class="ui_search_context_indicator_inner"></div> </div> </div> <div class="ui_search_clear"></div> <div class="ui_search_frame_inner"> <div id="ui_search_main_search" class="ui_search" data-default-scope="music" data-callback="" data-callback-id=""> <i style="cursor:pointer" onClick="RYMsearch.redirSearch(event, 'main_search');" id="ui_search_icon_main_search" class="fa fa-search ui_search_icon"></i> <i id="ui_clear_icon_main_search" onclick="rymQ(function() {RYMsearch.onClickClearSearch(event, 'main_search');})" class="fa fa-times-circle ui_clear_icon"></i>
+
+
+   <form onSubmit="event.preventDefault(); RYMsearch.redirSearch(event, 'main_search');">
+   <input autocomplete="off" aria-label="Search" value="" id="ui_search_input_main_search" placeholder="Search..." class="ui_search_input" onfocus="rymQ(function() {RYMsearch.onFocus(event, 'main_search')})" onblur="rymQ(function() {RYMsearch.onBlur(event, 'main_search')})" 
+
+   onkeydown="rymQ(function() {RYMsearch.onKeyDown(event, 'main_search')})" 
+
+   oninput="rymQ(function() {RYMsearch.onInput(event, 'main_search')})">
+   </form> </div> <div class="ui_search_rest"> <div class="ui_search_type"> <div id="ui_search_debug_main_search" class="ui_search_debug"></div> <span class="ui_search_object_label">Search:</span> <span id="ui_search_scope_selector_main_search" class="ui_search_object_selector"> <input type="hidden" name="ui_search_scope_main_search" id="ui_search_scope_main_search" value="music"> <span id="ui_search_scope_selector_music_main_search" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'music');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_music selected"> Music
+  </span> <span id="ui_search_scope_selector_film_main_search" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'film');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_film"> Film
+  </span> <span id="ui_search_scope_selector_games_main_search" style="display:none" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'games');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_games"> Games
+  </span> </span> <span class="ui_search_object_label">for:</span> <span id="ui_search_object_select_frame_main_search" class="ui_search_object_select_frame selected"> <select onchange="rymQ(function() {RYMsearch.onChangeObject(event, 'main_search')})" id="ui_search_object_select_main_search" class="ui_search_object_select"> </select> </span>  </div> <div id="ui_search_info_frame_main_search" class="ui_search_info_frame"> </div> <div id="ui_search_results_frame_main_search" class="ui_search_results_frame"> <div id="ui_search_results_main_search" class="ui_search_results"> </div> </div> </div> </div> </div>
+  </div>
+
+</div>   
+
+
+
+
+</div>
+
+</header>
+
+
+<div class="header_error" onClick="$(this).fadeOut();" id="header_error">
+   <div class="header_error_close"><i class="fa fa-times-circle"></i></div>
+   <div id="header_error_text"></div>
+</div>
+
+<div class="header_message" onClick="$(this).fadeOut();" id="header_message">
+   <div class="header_message_close"><i class="fa fa-times-circle"></i></div>
+   <div id="header_message_text"></div>
+</div>
+
+<div id="mobile_header_menu" class="mobile_header_menu "><a href="/new-music/" class="mobile_header_menu_item mobile_header_menu_item_new_music">
+      <span>New Music</span>
+</a><a href="/genres/" class="mobile_header_menu_item mobile_header_menu_item_genres">
+      <span>Genres</span>
+</a><a href="/charts/" class="mobile_header_menu_item mobile_header_menu_item_charts">
+      <span>Charts</span>
+</a><a href="/lists/" class="mobile_header_menu_item mobile_header_menu_item_lists">
+   <span>Lists</span> 
+</a></div>
+        
+
+            <div id="content_wrapper_outer" class="content_wrapper_outer">
+            <div id="content_wrapper" class="content_wrapper" >
+            <div id="content">
+            <div id="content_cover"></div>
+            <div id="precontent" class="precontent lazyload" data-bkg="//cdn.sonemic.net/i/25/s/df079ddb27ab7ab85adbbeaefc0da00c/4311196"></div>
+         <div id="total_cover"></div>
+         <div id="content_total_cover"></div>          
+      
+
+         <script>
+              try {
+                new Function('import("")');
+              } catch (err) {
+                document.write('<div class=note style="margin-bottom:1em;"><b>Note:</b> Not all scripts could be loaded. You may need to upgrade to a newer browser version in order to use this site.</div>');
+              }
+         </script>
+      <style>div.prev_image img, div.next_image img {
+    width: 3em;
+}
+div.list_image {
+   background-size:cover !important;
+   background-position:center center !important;
+}
+</style>
+   <div id="dropheader" style="display:none;"> </div>
+   <div id="shortcut"  style="display:none;">
+    <div id="shortcutshell">
+      <div id="shortcutinner">
+         <div class="small">
+         <table><tr><td>
+<div class="musictoolbar"> <a id="btnshortcutartist" href="#shortcutartist" onclick="viewshortcut('shortcutartist', '');return false;">artist</a>
+             
+             <a id="btnshortcutrelease" href="#shortcutrelease" onclick="viewshortcut('shortcutrelease', '');return false;">release</a>
+             <a id="btnshortcutlabel" href="#shortcutlabel" onclick="viewshortcut('shortcutlabel', '');return false;">label</a>
+             <a id="btnshortcutwork" href="#shortcutwork" onclick="viewshortcut('shortcutwork', '');return false;">work</a>
+             <a id="btnshortcutfilm" href="#shortcutfilm" onclick="viewshortcut('shortcutfilm', '');return false;">film</a>
+             <a id="btnshortcutvideo" href="#shortcutvideo" onclick="viewshortcut('shortcutvideo', '');return false;">video</a>
+             <a id="btnshortcutpicture" href="#shortcutpicture" onclick="viewshortcut('shortcutpicture', '');return false;">pic</a>
+             
+            </div>
+
+  </td><td style="text-align:right;"><a href="javascript:closeShortcut();" class="btn darkred_btn btn_small">x</a></td></tr></table>
+         </div>
+         <div id="shortcutsearch">
+            <iframe src="about:blank" name="shortcutsearchframe" id="shortcutsearchframe"  width="99%" height="99%"></iframe>
+         </div>
+      </div>
+      
+    </div>
+   
+   </div>
+   
+   <script type="text/javascript">var shortcut_first_sc='shortcutartist', shortcut_first_func = '';</script> 
+<div id="searchsuggestions" style="visibility:hidden;position:absolute;z-index:500;max-height:150px;overflow-y:scroll" ></div>
+<script>
+  function openShortcut(element)
+  {
+      currentElement = element;
+      var pos = $(element).position();
+      var shortcutWidth = $('#shortcut').outerWidth();
+      var windowWidth = $(window).outerWidth();
+      var left = pos.left + $(element).outerWidth();
+
+      if ( (left + shortcutWidth) > windowWidth ) {
+         left = windowWidth - shortcutWidth;
+      }
+
+      $('#shortcut').css('top', pos.top + 'px').css('left', left + 'px').show();;
+      if ( shortcut_first_sc && shortcut_first_sc != "") {
+        viewshortcut(shortcut_first_sc, shortcut_first_func);
+      }
+
+ }
+ </script><style>
+      div.coverart_4111509 {
+         position:relative;
+         padding-bottom:calc( 100% / 1.0);
+      }
+
+      div.coverart_4111509 img {
+         position:absolute;
+         top:0;
+         left:0;
+         width:100%
+      }
+
+   </style>
+
+<div class="release_page"  itemprop="mainEntity" itemscope itemtype="http://schema.org/MusicAlbum">
+     <div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+     <meta itemprop="ratingValue" content="3.09" />
+     <meta itemprop="bestRating" content="5.0" />
+     <meta itemprop="worstRating" content="0.5" />
+     <meta itemprop="ratingCount" content="6596" /><meta  itemprop="reviewCount" content="50" /></div>
+   <meta content="12 Bar Bruise" itemprop="name" />
+   
+      <meta content="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+   
+   <div style="max-width:1700px; margin: 0px auto;">
+   <div class="row">
+
+    <div id="column_container_right" class="large-8 push-4 columns release_right_column">  <div class="section_main_info section_outer"><div class="page_section">          
+         <div class="album_title">12 Bar Bruise 
+               <input aria-label="album shortcut" class="album_shortcut" readonly onclick="focus();select();" value="[Album4111509]" />
+               <div class="show-for-small album_artist_small">By <a   href="/artist/king-gizzard-and-the-lizard-wizard" class="artist">King Gizzard &amp; The Lizard Wizard</a></div>
+            </div>
+
+         <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:2px;font-size:1px;padding:0;"><tr style="height:2px;padding:0;"><td style="background:#ba3339;height:2px;padding:0px;color:#ba3339">.</td><td style="background:#814334;height:2px;padding:0px;color:#814334">.</td><td style="background:#83201a;height:2px;padding:0px;color:#83201a">.</td><td style="background:#a8a292;height:2px;padding:0px;color:#a8a292">.</td></tr></table>
+
+         <div class="show-for-small" style="text-align:center;">
+            <div style="padding-top:0.3em;"> <a  href="buy/">
+      <div class="coverart_4111509" style="position:relative;">
+      
+      <img srcset ="//cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg,
+                     //cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg 2x"
+           src="//cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg"
+           alt="Cover art for 12 Bar Bruise by King Gizzard &amp; The Lizard Wizard"
+      />
+      <!-- <meta itemprop="image" content="//cdn.sonemic.net/i/300/s/493653a567fe2bea0b31c563d8ed3831/4311196" /> -->
+    </div></a>
+    
+            <div id="media_link_button_container_top" 
+                  
+                 data-medialink="true"
+                 data-support-open="true" 
+                 data-artists="King Gizzard &amp; The Lizard Wizard" 
+                 data-albums="12 Bar Bruise" 
+                 data-links="{&#34;applemusic&#34;:{&#34;1649045961&#34;:{&#34;default&#34;:true,&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;de&#34;},&#34;1523709493&#34;:{&#34;for&#34;:[&#34;IT&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;1687145226&#34;:{&#34;for&#34;:[&#34;MX&#34;,&#34;US&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;560007430&#34;:{&#34;for&#34;:[&#34;FI&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;}},&#34;soundcloud&#34;:{&#34;1092843280&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/king-gizzard-the-lizard-wizard/sets/12-bar-bruise-1&#34;},&#34;2196034&#34;:{&#34;for&#34;:[&#34;DE&#34;],&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/flightlessrecords/sets/12-bar-bruise&#34;}},&#34;bandcamp&#34;:{&#34;2765388374&#34;:{&#34;default&#34;:true,&#34;url&#34;:&#34;kinggizzard.bandcamp.com/album/12-bar-bruise&#34;}},&#34;youtube&#34;:{&#34;atgfVBvXpew&#34;:{&#34;default&#34;:true}},&#34;tidal&#34;:{&#34;294038177&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;deezer&#34;:{&#34;439470117&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;qobuz&#34;:{&#34;er4f6z3kvnula&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}}}" 
+                 data-placement="top" 
+                 data-allow-ads="true" 
+                 class="media_link_container link_sonemic allow_ads support_open lazyload">
+            </div>
+       </div>
+         </div>
+         <table class="album_info_outer">
+         <tr><td style="vertical-align:top;">
+            <table class="album_info">
+               <tr class="hide-for-small"><th class="info_hdr">Artist</td><td colspan="2"><span itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup"><a  itemprop="name" href="/artist/king-gizzard-and-the-lizard-wizard" class="artist">King Gizzard &amp; The Lizard Wizard</a></span>
+               <span class="release_info_classifiers"></span></td></tr>
+               <tr><th class="info_hdr">Type</td><td colspan="2">Album</td></tr>
+                  <tr><th class="info_hdr">Released</td><td colspan="2">7 September <a style="text-decoration:none;" href="/charts/top/album/2012/"><b>2012</b></a></td></tr><tr><th class="info_hdr">Recorded</td><td colspan="2">2012</td></tr>
+               <tr><th class="info_hdr">RYM Rating</td><td colspan="2" style="padding:4px;">
+                <span >
+                  <span class="avg_rating" >
+                     3.09
+                  </span> 
+                  <span class="max_rating">/ <span >5.0</span><span style="display:none">0.5</span></span>
+                  <span class="num_ratings">
+                     from <b><span >6,596</span></b> ratings
+                  </span>
+               </span>
+               </td></tr>
+               <tr><th class="info_hdr">Ranked</td><td colspan="2">#<b>1,176</b> for <a href="/charts/top/album/2012/30/#pos1176">2012</a></td></tr><tr class="release_genres">
+                        <th class="info_hdr">
+                           Genres
+                        </th>
+                        <td>   <div style="float:left;">
+                           <span class="release_pri_genres"><a  class="genre" href="/genre/garage-rock/">Garage Rock</a>, <a  class="genre" href="/genre/noise-rock/">Noise Rock</a>, <a  class="genre" href="/genre/garage-psych/">Garage Psych</a>, <a  class="genre" href="/genre/garage-punk/">Garage Punk</a></span>
+                           <br /><span class="release_sec_genres"><a  class="genre" href="/genre/surf-punk/">Surf Punk</a>, <a  class="genre" href="/genre/psychedelic-rock/">Psychedelic Rock</a>, <a  class="genre" href="/genre/garage-punk/">Garage Punk</a>, <a  class="genre" href="/genre/shitgaze/">Shitgaze</a></span>
+                           </div>
+                           </td>
+	
+                        </tr><tr class="release_descriptors">
+                        <th class="info_hdr">
+                           Descriptors
+                        </th>
+                        <td><meta content="noisy" /><meta content=" male vocalist" /><meta content=" manic" /><meta content=" psychedelic" /><meta content=" lo-fi" /><meta content=" raw" /><meta content=" energetic" /><meta content=" playful" /><meta content=" anthemic" /><meta content=" summer" /><meta content=" warm" /><meta content=" hypnotic" /><meta content=" rebellious" /><meta content=" alcohol" /><meta content=" fuzzy" />   <div style="float:left;">
+                           <span class="release_pri_descriptors">noisy,  male vocalist,  manic,  psychedelic,  lo-fi,  raw,  energetic,  playful,  anthemic,  summer,  warm,  hypnotic,  rebellious,  alcohol,  fuzzy</span>
+                           </div>
+                           </td>                
+           
+                        </tr><tr><th class="info_hdr">Language </th><td style="font-size:0.9em;color:var(--mono-5);" colspan="2">English</td></tr></table></td></tr></table></div></div><div style="width:645px; padding-left:1.5em; z-index:200"><!-- /31961696/Sonemic/main-300x250-video-float-bottom-right -->
+            <div data-nosnippet class='page_creative_frame pw-video-target
+               
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-203'  style='margin:0 auto;display: block; align-items: center;margin-bottom:1em;min-height:300px;min-width:305px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-203'>
+            </div></div></div><div class="show-for-small"><div class="section_tracklisting"><div class="release_page_header"><h2>Track listing</h2>
+            <div id="track_credit_show_link_tracks_mobile" class="track_credit_show_link" onClick="rymQ( function() { RYMmediaPage.toggleTrackCredits('tracks_mobile'); });">Show track credits</div>
+         </div>
+            <span id="track_credit_show_msg_tracks_mobile" style="display:none;">Show track credits</span>
+            <span id="track_credit_hide_msg_tracks_mobile" style="display:none;">Hide track credits</span>
+          
+       <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+       <ul id="tracks_mobile" class="tracks tracklisting"><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     1
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/elbow/" itemprop="name">Elbow</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     2
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/muckraker/" itemprop="name">Muckraker</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     3
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/nein/" itemprop="name">Nein</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     4
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="name">12 Bar Bruise</a><a  href="/song/king-gizzard-and-the-lizard-wizard/12-bar-bruise/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     5
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/garage-liddiard/" itemprop="name">Garage Liddiard</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     6
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/sam-cherrys-last-shot/" itemprop="name">Sam Cherry&#39;s Last Shot</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+         <div style="width:300px;padding-left:23px;"><ul class="credits">
+             <li class="credits non_featured_credit">
+               <div class="credits_artist "><a   href="/artist/broderick-smith" class="artist">Broderick Smith</a></div>
+               <div class="credits_roles">spoken word</div></ul></div>                  
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     7
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/high-hopes-low/" itemprop="name">High Hopes Low</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     8
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/cut-throat-boogie/" itemprop="name">Cut Throat Boogie</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     9
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/bloody-ripper/" itemprop="name">Bloody Ripper</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     10
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/uh-oh-i-called-mum/" itemprop="name">Uh Oh, I Called Mum</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     11
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/sea-of-trees/" itemprop="name">Sea of Trees</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     12
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/footy-footy/" itemprop="name">Footy Footy</a><span class="tracklist_duration" data-inseconds="0">
+                     
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li></ul><div id="track_preview_tracks_mobile">
+            
+         </div> </div></div><div class="show-for-small"><div class="section_release_navigation"><div class="release_navigation"><div class="release_navigation_guidance">
+                    <div class="release_nav_guidance_artist">
+                     <div class="release_nav_guidance_left">
+                      
+                     </div>                     
+                     <div class="release_nav_guidance_right">
+                     <a href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/">Next
+                      <i class="fa fa-caret-right"></i></a>
+                      
+                     </div></div>
+                     <div style="clear:both;"></div>
+                  </div>
+               
+                                 
+                  <div class="release_navigation_links">
+                    <div class="prev_image">
+                       
+                    </div>
+                    <div class="prev_link">
+                       
+                    </div>
+                    <div class="next_link">
+                       <a  href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/" class="small">Eyes Like the Sky</a>
+                    </div>
+                    <div class="next_image">
+                       <a href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/"><img alt="Next in discography: ..." src="//cdn.sonemic.net/i/75/s/649ed942f3f5a728192c7fe465879c76/14157319" /></a>
+                    </div>
+                    <div style="clear:both;"></div>
+                  </div>                
+               
+            </div></div></div><div class="section_my_catalog section_outer" style="padding-bottom: 5px;"><div class="page_section"><div id="my_catalog">
+      <div class="release_page_header"><h2>Rate/Catalog 
+      </h2></div>
+       <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+                  <div class="release_my_catalog">
+                     <div id="my_catalog_rating_l_4111509" tabIndex="0" class="my_catalog_rating" 
+                  onMouseMove="rating_l_4111509.onMouseMove(event,this);"
+                  onMouseOver="rating_l_4111509.onMouseOver(event,this);"
+                  onMouseOut="rating_l_4111509.onMouseOut(event,this);"
+
+                  onTouchStart="rating_l_4111509.onTouchStart(event,this);"
+                  onTouchMove="rating_l_4111509.onTouchMove(event,this);"
+                  onTouchEnd="rating_l_4111509.onTouchEnd(event,this);"
+
+                  onClick="rating_l_4111509.onClick(event,this);"
+            >
+               <div id="rating_stars_l_4111509" class="rating_stars star-0m">
+               </div>
+               <div class="rating_loading">Saving...
+               </div>
+               <div id="rating_num_l_4111509" class="rating_num">
+                  0.0
+               </div>
+            </div>
+            <script>
+              rymQ(function() {window.rating_l_4111509 = new RYMrating('l', 4111509, 0 );});
+            </script>
+                     
+                     <div class="my_catalog_catalog">
+               <div onMouseOver="$('#catalog_btn_options_l_4111509').show();" onMouseOut="$('#catalog_btn_options_l_4111509').hide();" id="catalog_l_4111509" class="catalog_btn catalog_n">
+                     <span id="catalog_text_l_4111509">Catalog</span>
+                  <div id="catalog_btn_options_l_4111509" class="catalog_btn_options">
+                     <div id="catalog_btn_o" onClick="catalog_l_4111509.setOwnership('o');" class="catalog_btn_option">In collection</div>
+                     <div id="catalog_btn_w" onClick="catalog_l_4111509.setOwnership('w');" class="catalog_btn_option">On wishlist</div>
+                     <div id="catalog_btn_u" onClick="catalog_l_4111509.setOwnership('u');" class="catalog_btn_option">Used to own</div>
+                     <div id="catalog_btn_n" onClick="catalog_l_4111509.setOwnership('n');" class="catalog_btn_option">(not cataloged)</div>
+                  </div>
+               </div>
+               <script>
+                  rymQ(function() { window.catalog_l_4111509 = new RYMcatalog('l', 4111509, 'n', '');});
+               </script>
+              </div>
+
+                     <div id="my_catalog_format_l_4111509" class="my_catalog_format" style="display:none;">
+               <div onMouseOver="$('#format_btn_options').show();" onMouseOut="$('#format_btn_options').hide();" id="catalog_l_4111509" class="format_btn">
+                     <span id="format_text_l_4111509">---</span>
+                     <div id="format_btn_options" class="format_btn_options">
+                        <div id="format_btn_x" onClick="catalog_l_4111509.setFormat('');" class="format_btn_option">(not set)</div>
+                        <div id="format_btn_a" onClick="catalog_l_4111509.setFormat('CD');" class="format_btn_option default_format">CD</div>
+                        <div id="format_btn_b" onClick="catalog_l_4111509.setFormat('LP');" class="format_btn_option ">Vinyl</div>
+                        <div id="format_btn_c" onClick="catalog_l_4111509.setFormat('MP3');" class="format_btn_option ">Digital</div>
+                        <div id="format_btn_d" onClick="catalog_l_4111509.setFormat('CD-R');" class="format_btn_option ">CD-R</div>
+                        <div id="format_btn_e" onClick="catalog_l_4111509.setFormat('Cassette');" class="format_btn_option ">Cassette</div>
+                        <div id="format_btn_f" onClick="catalog_l_4111509.setFormat('DVD-A');" class="format_btn_option ">DVD-A</div>
+                        <div id="format_btn_g" onClick="catalog_l_4111509.setFormat('SACD');" class="format_btn_option ">SACD</div>
+                        <div id="format_btn_h" onClick="catalog_l_4111509.setFormat('Minidisc');" class="format_btn_option ">Minidisc</div>
+                        <div id="format_btn_i" onClick="catalog_l_4111509.setFormat('Multiple');" class="format_btn_option ">Multiple</div>
+                        <div id="format_btn_j" onClick="catalog_l_4111509.setFormat('8-Track');" class="format_btn_option ">8-track</div>
+                        <div id="format_btn_k" onClick="catalog_l_4111509.setFormat('Other');" class="format_btn_option ">Other</div>
+                     </div>
+            
+               </div>
+               <script>
+                  rymQ(function() {window.catalog_l_4111509 = new RYMcatalog('l', 4111509, 'n', '');});
+               </script>
+              </div>
+
+                     <div class="my_catalog_listening">
+                     <div id="listening_btn" class="listening_btn" onclick="alert('please login to use the listening feature.');">Set listening</div>
+                  </div>
+
+                     <div class="my_catalog_tags" >
+               <div id="tag_btn_l_4111509" class="tag_btn " onClick="alert('please login to tag this release.');" >
+                  <span id="tags_text_l_4111509">Tags</span>
+                  <span id="tags_add_text" style="display:none">Tags</span>
+                  </div>
+               <div id="tag_dlg_l_4111509" class="tag_dlg">
+                     <label for="tags_l_4111509">Enter tags, separated by commas</label>
+                     <input onFocus="musictagattachSuggest(this.id);" id="tags_l_4111509" value="" class="tag_tags">
+                  <a href="javascript:void(0);" onClick="tags.save()" class="tag_save">Save</a>
+               </div>
+               <script>
+                  rymQ(function() {window.tags = new RYMtags('l', 4111509, []);});
+               </script>               
+            </div>
+
+                     <div class="my_catalog_review">
+                        <div id="review_btn" class="review_btn" onclick="alert('please login to review this release.')">Review</div>
+                     </div>
+
+                     <div class="my_catalog_rate_tracks">
+                        <div id="track_rating_btn" class="track_rating_btn" onclick="alert('please login to rate tracks for this release.')">Track ratings</div>
+                     </div>
+
+                  <div class="clear"> </div>
+                  <div class="release_touch_guidance">To rate, slide your finger across the stars from left to right.</div>
+                  </div>
+                  <div class="clear"> </div>
+
+
+                  </div>
+               </div></div><div class="show-for-small">
+      <div id="expand_full_issues" class="mobile_expandable_full ">
+
+            <div id="expand_full_header_issues" class="mobile_expandable_full_header" onClick="RYMmobile.mobileExpand.toggleFull('issues');">
+
+               <div class="mobile_expandable_full_icons">
+                  <div class="mobile_expandable_full_expand_icon_expanded">
+                     <i class="fa fa-caret-down"></i>
+                  </div>
+                  <div class="mobile_expandable_full_expand_icon_hidden">
+                     <i class="fa fa-caret-right"></i>
+                  </div>
+               </div>
+
+               <div id="expand_full_name_issues" class="mobile_expandable_full_name">
+                  Issues
+               </div>
+
+            </div>
+
+            <div id="expand_full_content_issues" class="mobile_expandable_full_content">
+               <div class="section_issues section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>10 Issues</h2></div>
+         <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <ul class="issues ">
+      <li  class="issue_info release_view current"><a >Release view [combined information for all issues]</a></li><li id="issue_4111509" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/493653a567fe2bea0b31c563d8ed3831/4311196>" style="background:url('//cdn.sonemic.net/i/75/s/06382b953dc45d0e05e6af9209215d68/4311196') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise.p/">12 Bar Bruise</a> 
+                        
+                        <span title="This is the primary issue." class="primary_indicator">[p]</span>
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="7 September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14252508" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-5/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/c77acda6052da79f7b6e4cec16d35e79/9645604>" style="background:url('//cdn.sonemic.net/i/75/s/8d34090ffb057753463556b9309878b0/9645604') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-5/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Colored Vinyl, Numbered Edition">Colored Vinyl, Numbered Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14252530" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-6/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7a72adfb6c198bd0a4317bebcad9c334/9645616>" data-bkg="//cdn.sonemic.net/i/75/s/adae392c070a8a0bd7aa2b1be8e6f7d9/9645616"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-6/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_4146956" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-2/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ecaac4e560e7bd242422c7e770190808/4347248>" data-bkg="//cdn.sonemic.net/i/75/s/be923f228b4119132d5aab4215e45b90/4347248"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-2/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digipak">Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ym" title="September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001CD" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001CD
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14769114" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-7/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/baafb4cd6095821232d3347be7045124/9982264>" data-bkg="//cdn.sonemic.net/i/75/s/a6b001dba35318da5a15924ce107fbef/9982264"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-7/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="7 September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="Flightless " >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9590606" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-4/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/e7debaf04a2b25c92f2501283919371e/7237731>" data-bkg="//cdn.sonemic.net/i/75/s/ce6039c4674d2f05c59db284706c7a83/7237731"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-4/">12 Bar Bruise</a> 
+                         <span class="addendum">Muckcraker Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="140 gram, 33 rpm, Colored Vinyl, Digital Download, Limited Edition">140 gram, 33 rpm, Colored Vinyl, Digital Download, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="14 September 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT-001R" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT-001R
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9770786" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-green-vinyl-1/" title="12 Bar Bruise [green vinyl]"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/b9566673936399c45cb3b8797a9c2dec/7250504>" data-bkg="//cdn.sonemic.net/i/75/s/0109d8fdaa58b2b63337c4caafb9212b/7250504"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-green-vinyl-1/">12 Bar Bruise [green vinyl]</a> 
+                         <span class="addendum">Indie Record Store Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="33 rpm, Colored Vinyl">33 rpm, Colored Vinyl</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="14 September 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001R" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001R
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9802719" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-3/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7a3f4d758d1e938bc0e170143dfb166c/7267561>" data-bkg="//cdn.sonemic.net/i/75/s/8d4d5ec973f0ad2cd0b7499af1b86bc4/7267561"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-3/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="2 November 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT-001RCD" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT-001RCD
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14952594" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-8/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/df8acbad02e1c0517e5842a8c14d2089/10332110>" data-bkg="//cdn.sonemic.net/i/75/s/eaddbaca35d9bc414f2257b8f426ea60/10332110"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-8/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="11 October 2022">
+                     2022&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="KGLW " >
+                     <a  href="/label/kglw/" class="label">KGLW</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_15351625" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-9/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/419f758ae3e366d2cb3f163e4607cd92/13560835>" data-bkg="//cdn.sonemic.net/i/75/s/628cf7e458d310d83abe20701c1af41a/13560835"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-9/">12 Bar Bruise</a> 
+                         <span class="addendum">Cherry Ripe Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Colored Vinyl, Limited Edition, Paper/Cardboard Sleeve">Colored Vinyl, Limited Edition, Paper/Cardboard Sleeve</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ym" title="June 2023">
+                     2023&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="KGLW / KGLW-019-LP" >
+                     <a  href="/label/kglw/" class="label">KGLW</a> 
+                     / KGLW-019-LP
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://cdn.sonemic.net/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li></ul><script>rymQ(function() {$('.issues').prop('scrollTop', 0);});</script><div id="expand_button" onClick="rymQ( function() { RYMmediaPage.toggleIssues(10); });" data-state="compact" class="expand_button">
+               Expand all 10 issues
+            </div>
+            <span style="display:none;" id="issue_expand_text_compact">Compact issues</span>
+            <span style="display:none;"  id="issue_expand_text_expand">Expand all 10 issues</span></div></div>
+            </div>
+         </div>
+      </div><div class="hide-for-small"><div class="section_issues section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>10 Issues</h2></div>
+         <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <ul class="issues ">
+      <li  class="issue_info release_view current"><a >Release view [combined information for all issues]</a></li><li id="issue_4111509" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/493653a567fe2bea0b31c563d8ed3831/4311196>" style="background:url('//cdn.sonemic.net/i/75/s/06382b953dc45d0e05e6af9209215d68/4311196') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise.p/">12 Bar Bruise</a> 
+                        
+                        <span title="This is the primary issue." class="primary_indicator">[p]</span>
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="7 September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14252508" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-5/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/c77acda6052da79f7b6e4cec16d35e79/9645604>" style="background:url('//cdn.sonemic.net/i/75/s/8d34090ffb057753463556b9309878b0/9645604') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-5/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Colored Vinyl, Numbered Edition">Colored Vinyl, Numbered Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14252530" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-6/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7a72adfb6c198bd0a4317bebcad9c334/9645616>" data-bkg="//cdn.sonemic.net/i/75/s/adae392c070a8a0bd7aa2b1be8e6f7d9/9645616"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-6/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_4146956" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-2/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ecaac4e560e7bd242422c7e770190808/4347248>" data-bkg="//cdn.sonemic.net/i/75/s/be923f228b4119132d5aab4215e45b90/4347248"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-2/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digipak">Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ym" title="September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001CD" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001CD
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14769114" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-7/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/baafb4cd6095821232d3347be7045124/9982264>" data-bkg="//cdn.sonemic.net/i/75/s/a6b001dba35318da5a15924ce107fbef/9982264"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-7/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="7 September 2012">
+                     2012&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="Flightless " >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9590606" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-4/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/e7debaf04a2b25c92f2501283919371e/7237731>" data-bkg="//cdn.sonemic.net/i/75/s/ce6039c4674d2f05c59db284706c7a83/7237731"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-4/">12 Bar Bruise</a> 
+                         <span class="addendum">Muckcraker Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="140 gram, 33 rpm, Colored Vinyl, Digital Download, Limited Edition">140 gram, 33 rpm, Colored Vinyl, Digital Download, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="14 September 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT-001R" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT-001R
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9770786" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-green-vinyl-1/" title="12 Bar Bruise [green vinyl]"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/b9566673936399c45cb3b8797a9c2dec/7250504>" data-bkg="//cdn.sonemic.net/i/75/s/0109d8fdaa58b2b63337c4caafb9212b/7250504"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-green-vinyl-1/">12 Bar Bruise [green vinyl]</a> 
+                         <span class="addendum">Indie Record Store Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="33 rpm, Colored Vinyl">33 rpm, Colored Vinyl</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="14 September 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT001R" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT001R
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://cdn.sonemic.net/3.0/img/flags/4x3/au.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_9802719" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-3/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7a3f4d758d1e938bc0e170143dfb166c/7267561>" data-bkg="//cdn.sonemic.net/i/75/s/8d4d5ec973f0ad2cd0b7499af1b86bc4/7267561"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-3/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="2 November 2018">
+                     2018&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Flightless / FLT-001RCD" >
+                     <a  href="/label/flightless/" class="label">Flightless</a> 
+                     / FLT-001RCD
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14952594" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-8/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/df8acbad02e1c0517e5842a8c14d2089/10332110>" data-bkg="//cdn.sonemic.net/i/75/s/eaddbaca35d9bc414f2257b8f426ea60/10332110"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-8/">12 Bar Bruise</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="11 October 2022">
+                     2022&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="KGLW " >
+                     <a  href="/label/kglw/" class="label">KGLW</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_15351625" class="issue_info ">
+                  <a href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-9/" title="12 Bar Bruise"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/419f758ae3e366d2cb3f163e4607cd92/13560835>" data-bkg="//cdn.sonemic.net/i/75/s/628cf7e458d310d83abe20701c1af41a/13560835"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise-9/">12 Bar Bruise</a> 
+                         <span class="addendum">Cherry Ripe Edition</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Colored Vinyl, Limited Edition, Paper/Cardboard Sleeve">Colored Vinyl, Limited Edition, Paper/Cardboard Sleeve</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ym" title="June 2023">
+                     2023&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="KGLW / KGLW-019-LP" >
+                     <a  href="/label/kglw/" class="label">KGLW</a> 
+                     / KGLW-019-LP
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://cdn.sonemic.net/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li></ul><script>rymQ(function() {$('.issues').prop('scrollTop', 0);});</script><div id="expand_button" onClick="rymQ( function() { RYMmediaPage.toggleIssues(10); });" data-state="compact" class="expand_button">
+               Expand all 10 issues
+            </div>
+            <span style="display:none;" id="issue_expand_text_compact">Compact issues</span>
+            <span style="display:none;"  id="issue_expand_text_expand">Expand all 10 issues</span></div></div></div><div class="show-for-small">
+      <div id="expand_full_credits_small" class="mobile_expandable_full ">
+
+            <div id="expand_full_header_credits_small" class="mobile_expandable_full_header" onClick="RYMmobile.mobileExpand.toggleFull('credits_small');">
+
+               <div class="mobile_expandable_full_icons">
+                  <div class="mobile_expandable_full_expand_icon_expanded">
+                     <i class="fa fa-caret-down"></i>
+                  </div>
+                  <div class="mobile_expandable_full_expand_icon_hidden">
+                     <i class="fa fa-caret-right"></i>
+                  </div>
+               </div>
+
+               <div id="expand_full_name_credits_small" class="mobile_expandable_full_name">
+                  Credits
+               </div>
+
+            </div>
+
+            <div id="expand_full_content_credits_small" class="mobile_expandable_full_content">
+               <div class="section_credits"><div class="release_page_header hide-for-small"><h2>Credits</h2></div>
+          <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+          <ul id="credits_credits_mobile" class="credits"><li><a title="[Artist1071275]"  href="/artist/stu-mackenzie" class="artist">Stu Mackenzie</a><br /> <span class="role_name ">vocals</span>,  <span class="role_name ">guitar</span></li>
+<li><a title="[Artist1071283]"  href="/artist/michael-cavanagh" class="artist">Michael Cavanagh</a><br /> <span class="role_name ">drums</span></li>
+<li><a title="[Artist1071277]"  href="/artist/cook-craig" class="artist">Cook Craig</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071278]"  href="/artist/ambrose-kenny-smith" class="artist">Ambrose Kenny-Smith</a><br /> <span class="role_name ">harmonica</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071279]"  href="/artist/eric-moore" class="artist">Eric Moore</a><br /> <span class="role_name ">theremin</span>,  <span class="role_name ">keyboards</span>,  <span class="role_name ">percussion</span></li>
+<li><a title="[Artist1071282]"  href="/artist/lucas-harwood" class="artist">Lucas Skinner</a><br /> <span class="role_name ">bass</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071280]"  href="/artist/joey-walker" class="artist">Joe Walker</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist738214]"  href="/artist/king-gizzard-and-the-lizard-wizard" class="artist">King Gizzard &amp; The Lizard Wizard</a><br /> <span class="role_name ">recording engineer</span>,  <span class="role_name "><span class="rendered_text">mixing</span></span></li>
+<li><a title="[Artist1071285]"  href="/artist/paul_maybury" class="artist">Paul Maybury</a><br /> <span class="role_name ">recording engineer</span>,  <span class="role_name "><span class="rendered_text">mixing</span></span></li>
+<li><a title="[Artist1066797]"  href="/artist/joseph-carra" class="artist">Joseph Carra</a><br /> <span class="role_name ">mastering engineer</span></li>
+<li><a title="[Artist1070483]"  href="/artist/jason-galea" class="artist">Jason Galea</a><br /> <span class="role_name ">cover art</span></li>
+             <div id="minor_credits_credits_mobile" style="display:none;"><li style="display:none;"></li> <!-- to keep nth-child even --><li><a title="[Artist134219]"  href="/artist/broderick-smith" class="artist">Broderick Smith</a><br /> <span class="role_name has_tracks">spoken word<span class="role_tracks">6</span></span></li></div><li onClick="$('#minor_credits_credits_mobile').slideToggle(100);$('#track_minor_hide_credits_mobile').toggle();$('#track_minor_show_credits_mobile').toggle();" class="expand_button"> <span id="track_minor_show_credits_mobile"> Expand credits <span style="font-weight:normal">[+1]</span></span> <span id="track_minor_hide_credits_mobile" style="display:none;"> Compact credits </span></li> </ul> </div>
+          
+            </div>
+         </div>
+      </div><div id="reviews_shell"><div class="section_reviews section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>50 Reviews
+         </h2></div>
+         <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <div class="review_list">  <span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/2/">2</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/3/">3</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/4/">4</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/5/">5</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/6/">6</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/7/">7</a> <a class="navlinknext" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/2/">&gt;&gt;</a></span>
+         <div style="clear:both;"></div></div>
+         <div id="review_shell_std_47757072"><div class="review" >
+               <div class="review_header "><a title="User aokiji" href="/~aokiji"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/422b823e4f6f3b6ebcdf2510531d9c78/4647936" data-bkg2x="//cdn.sonemic.net/i/75/s/422b823e4f6f3b6ebcdf2510531d9c78/4647936" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~aokiji">aokiji</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/aokiji/king-gizzard-and-the-lizard-wizard/12-bar-bruise/47757072">Sep 11 2012</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span></span><div style="float:right;" id="review_voting_47757072"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">The poor man&#39;s Oh Sees clearly, but proving that it doesn&#39;t necessarily suck to be a poor man.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating47757072]" /></div></div>
+             </div></div><!-- @@_review_47757072 --><div id="review_shell_std_287121914"><div class="review" >
+               <div class="review_header "><a title="User DJSTAYGOLD" href="/~DJSTAYGOLD"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/79973d6ddbe7fd6ffbd76d5d728d5c0a/14560227" data-bkg2x="//cdn.sonemic.net/i/75/s/79973d6ddbe7fd6ffbd76d5d728d5c0a/14560227" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~DJSTAYGOLD">DJSTAYGOLD</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/DJSTAYGOLD/king-gizzard-and-the-lizard-wizard/12-bar-bruise/287121914">Apr 30 2026</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span></span><div style="float:right;" id="review_voting_287121914"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <div class="review_title"  >As expected from what they released before</div><span ><span class="rendered_text">To one of their first projects released it&#39;s ok. It&#39;s their surf rock with more garage elements to it. <br />I don&#39;t really feel the mixing and mastering on this one. They were immature but fun to listen to one or other track some times</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating287121914]" /></div></div>
+             </div></div><!-- /31961696/release.case-a.728.mid-right -->
+            <div data-nosnippet class='page_creative_frame small-desk-leaderboard
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-22'  data-adcode='div-gpt-ad-1465817209349-22'   style='overflow:hidden;margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;margin-top:1em;min-height:138px;min-width:728px;' >
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-22'>
+            </div></div><div id="review_shell_std_279300435"><div class="review" >
+               <div class="review_header "><a title="User sadflowerMB" href="/~sadflowerMB"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/20ed8636e2c2825f088c5a40ad72f59b/14230423" data-bkg2x="//cdn.sonemic.net/i/75/s/20ed8636e2c2825f088c5a40ad72f59b/14230423" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~sadflowerMB">sadflowerMB</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/sadflowerMB/king-gizzard-and-the-lizard-wizard/12-bar-bruise/279300435">Feb 08 2026</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span></span><div style="float:right;" id="review_voting_279300435"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <div class="review_title"  >Sad-flower: Into the Gizzard-Verse.</div><span ><span class="rendered_text">That’s right! After all this time spent gawking at the sheer size of their catalog &amp; wondering about the staggering sense of musical diversity I’ve heard so much about, I’m finally diving into the discography of King Gizzard &amp; The Lizard Wizard. Starting all the way back in 2012 with what is, by almost all accounts, a very normal but still very solid psych/garage rock record. <br /><br />Most of the best songs here fit pretty cleanly into that psyche/garage rock category, complete with some enjoyably lo-fi aesthetics &amp; very engaging musicianship, but there’s still a fair bit of variety in terms of which individual elements make each track stand out. “Nein” feels a little more ominous than any of it’s counterparts, “Cut Throat Boogie” is performed in a uniquely unhinged &amp; wild way, “Uh Oh I Called Mom” has the album’s hookiest chorus BY FAR, and the riffs on “Sea Of Trees” feel particularly lush &amp; hard hitting.<br /><br />But the best song in this category, as well as the best song on the whole album, is undoubtedly “Muckraker”. It’s got the same great scuzzy aesthetics as everything else we’ve already talked about, but it also gives us a much sweeter in tone chorus that feels distinctly nostalgic in spite of me never having heard it before, as well as an invigoratingly badass tempo change in each post chorus that are impossible not to move to. This song is such a blast. <br /><br />There are some tracks here that genuinely stand out on a stylistic level though. “Sam Cherry’s Last Shot” is a very engaging piece of spoken word with a cool western narrative to it &amp; perfect accompanying instrumentation, “Bloopy Ripper” has a surprisingly optimistic vibe to it &amp; a chorus melody that feels straight out of the Weezer playbook, and then there’s The Title Track which… actually stands out in a pretty bad way. There’s a solid song at the core here, but I cannot fathom why they intentionally made this mix sound as though the mic was placed DOWN THE HALL from the actual recording room. There’s sounding “lo-fi”, and then there’s just sounding like shit. <br /><br />In spite of that song which shares it’s name, “12 Bar Bruise” is a very fun album all things considered. Honestly a lot better than I was expecting. It definitely falters at certain points, especially near the middle, but it still has mostly excellent performances, a mostly very satisfying sound palette, and brief flashes of the unexpected that serve as a solid foundation for what I already know is going to be a WILDLY varied discography.<br /><br />This review series is gonna take me 3 months AT LEAST. The funniest part is that by the time I reach the end of their current 25 album collection, they will almost certainly have released a 26th album that has yet to be announced at the time of me writing this. Can’t wait to continue.</span></span><div onClick="$('#review_supplement__279300435').slideToggle(100);$(this).hide()" class="review_supplement_expand">More ▾</div><div id="review_supplement__279300435" class="review_supplement supplement_hidden"><span class="rendered_text">Best Songs: Muckraker, Nein, &amp; Sea of Trees.<br /><br />Weakest Songs: 12 Bar Bruise, Garage Liddiard, &amp; Footy Footy.<br /><br />This album gets a light 8/10 from me.<br /><br />Originally written: 20/6/24</span></div><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating279300435]" /></div></div>
+             </div></div><!-- @@_review_279300435 --><div id="review_shell_std_278755706"><div class="review" >
+               <div class="review_header "><a title="User merton" href="/~merton"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/048ef964609701274a970b5c125c2adb/6451144" data-bkg2x="//cdn.sonemic.net/i/75/s/048ef964609701274a970b5c125c2adb/6451144" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~merton">merton</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/merton/king-gizzard-and-the-lizard-wizard/12-bar-bruise/278755706">Feb 02 2026</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/4m.png" width="90" height="16" style="border:0;" alt="2.00 stars" title="2.00 stars" /></span></span><div style="float:right;" id="review_voting_278755706"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">Stretching King Gizz&#39;s early garage-rock sound to album length leads to middling results.  This, like <i>Willoughby&#39;s Beach</i>, contains three good songs, those being the super-catchy prog-pop &#34;Muckraker&#34;, the almost new wave &#34;Bloody Ripper&#34;, and the goofy-ass pub-punk &#34;Footy Footy&#34;.  Only this album is much longer than the aforementioned EP so you have to wait through a bunch of pointless noise to get to those!  Sigh.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating278755706]" /></div></div>
+             </div></div><!-- /31961696/release.case-a.728.mid-right-2 -->
+            <div data-nosnippet class='page_creative_frame small-desk-leaderboard
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-93'  data-adcode='div-gpt-ad-1465817209349-93'   style='overflow:hidden;margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;margin-top:1em;min-height:138px;min-width:728px;' >
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-93'>
+            </div></div><div id="review_shell_std_268802379"><div class="review" >
+               <div class="review_header "><a title="User DaveGr0hl" href="/~DaveGr0hl"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/d05d80733da304d79f21ba3721bb4a07/14517460" data-bkg2x="//cdn.sonemic.net/i/75/s/d05d80733da304d79f21ba3721bb4a07/14517460" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~DaveGr0hl">DaveGr0hl</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/DaveGr0hl/king-gizzard-and-the-lizard-wizard/12-bar-bruise/268802379">Oct 16 2025</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span></span><div style="float:right;" id="review_voting_268802379"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">Mostly the same as the EP before it but I don&#39;t think it&#39;s unique enough to differentiate it that much.<br /><br /><b>6/10</b></span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating268802379]" /></div></div>
+             </div></div><!-- @@_review_268802379 --><div id="review_shell_std_259432763"><div class="review" >
+               <div class="review_header "><a title="User xerodawn" href="/~xerodawn"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/a4d2c203b5d422d2e6d74500e84426c3/14576996" data-bkg2x="//cdn.sonemic.net/i/75/s/a4d2c203b5d422d2e6d74500e84426c3/14576996" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~xerodawn">xerodawn</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/xerodawn/king-gizzard-and-the-lizard-wizard/12-bar-bruise/259432763">Jun 23 2025</a>
+                  </span>
+
+                  
+                  <span onClick="$('#review_track_rating_259432763').toggle();" class="catalog_track_ratings">▼</span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span></span><div style="float:right;" id="review_voting_259432763"></div>
+                 
+               </div><div class="review_body "><div id="review_track_rating_259432763" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Elbow</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Muckraker</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Nein</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">12 Bar Bruise</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Garage Liddiard</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sam Cherry&#39;s Last Shot</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">High Hopes Low</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Cut Throat Boogie</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Bloody Ripper</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">Uh Oh, I Called Mum</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sea of Trees</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">Footy Footy</span></span>
+                     </div>
+                   </li></ul></div>
+
+
+      <div class="review_title"  >One of the most fun debuts in modern music</div><span ><span class="rendered_text">King Gizzard &amp; The Lizard Wizard&#39;s debut album <i>12 Bar Bruise</i> is no short of creative, fun, and charming. The band known for constantly evolving and changing their sound radically, has a debut album that embodies that spirit perfectly. A combination of sounds from genres that are really fun, like surf punk, garage rock, and noise all come together as really unorthodox for a debut album. They waste no time dipping their toes into territory that is really creative and out of the box on their first ever album. It&#39;s clear from this first release, however, that it&#39;s as equally creative as it is somewhat slightly unengaging and not entirely complete. A great number of songs come and go with no real time to process them, some unfinished to an extent; cutting abruptly/sounding like a demo rather than a full song. Regardless, these songs only lack the full engagement of an above average song by small amount. A lot of them are carried by the aforementioned risk of genre combinations and a display of musicality that is genuinely incredible. No song is unengaging to the extent that it leaves you uninterested, just enough to notice that the songs don&#39;t quite feel complete. From start to finish, it&#39;s a fun time where the potential of the band is completely evident, and an impressive first work that&#39;ll leave you wanting more.</span></span><div onClick="$('#review_supplement__259432763').slideToggle(100);$(this).hide()" class="review_supplement_expand">More ▾</div><div id="review_supplement__259432763" class="review_supplement supplement_hidden"><span class="rendered_text">best songs: Muckraker, Elbow, Cut Throat Boogie<br />worst songs: 12 Bar Bruise, Sam Cherry&#39;s Last Shot</span></div><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating259432763]" /></div></div>
+             </div></div><!-- @@_review_259432763 --><div id="review_shell_std_257368455"><div class="review" >
+               <div class="review_header "><a title="User Mexicant314" href="/~Mexicant314"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/4388148aa7201e7a384a2acc0dfc0641/13397750" data-bkg2x="//cdn.sonemic.net/i/75/s/4388148aa7201e7a384a2acc0dfc0641/13397750" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Mexicant314">Mexicant314</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Mexicant314/king-gizzard-and-the-lizard-wizard/12-bar-bruise/257368455">May 29 2025</a>
+                  </span>
+
+                  
+                  <span onClick="$('#review_track_rating_257368455').toggle();" class="catalog_track_ratings">▼</span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span></span><div style="float:right;" id="review_voting_257368455"></div>
+                 
+               </div><div class="review_body "><div id="review_track_rating_257368455" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Elbow</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Muckraker</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Nein</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">12 Bar Bruise</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Garage Liddiard</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sam Cherry&#39;s Last Shot</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">High Hopes Low</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Cut Throat Boogie</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"> &nbsp; </span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Bloody Ripper</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">Uh Oh, I Called Mum</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sea of Trees</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">Footy Footy</span></span>
+                     </div>
+                   </li></ul></div>
+
+
+      <div class="review_title"  >hurling munt at the wall and making a masterpiece</div><span ><span class="rendered_text">It&#39;s really hard to come out the gate with an established sound on your very first record. Most bands have a early period of trying to find their sound before discovering what a record made by that band &#34;Sounds like.&#34; King gizzard has the good fortune of years of teaching music, playing AC/DC riffs on a childhood bed, and other various musical experiments that led to an unmistakable sound and energy. (iIheard this band before osees, sue me.) I think about how Stu says himself that gizzard started off as a recording project where the idea was to play shows with the simplest songs possible. No one needed to rehearse because the songs were so stupidly simple to play. These energetic surf-punk teenagers just so happened to make a fucking fantastic garage-rock and surf-punk record that sounds like it was recorded in a comedically sized metal garbage can. The ear-piercing feedback solos, insane delay sounds, and catchy melodies show the beginnings of greatness to come, and a hunger for more</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating257368455]" /></div></div>
+             </div></div><!-- @@_review_257368455 --><div id="review_shell_std_255237468"><div class="review" >
+               <div class="review_header "><a title="User Breaux" href="/~Breaux"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/81c72bd551a5a3368971ed63026fdee9/13316982" data-bkg2x="//cdn.sonemic.net/i/75/s/81c72bd551a5a3368971ed63026fdee9/13316982" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Breaux">Breaux</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Breaux/king-gizzard-and-the-lizard-wizard/12-bar-bruise/255237468">May 04 2025</a>
+                  </span>
+
+                  
+                  <span onClick="$('#review_track_rating_255237468').toggle();" class="catalog_track_ratings">▼</span><span >
+                      <span  class="review_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span></span><div style="float:right;" id="review_voting_255237468"></div>
+                 
+               </div><div class="review_body "><div id="review_track_rating_255237468" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Elbow</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Muckraker</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Nein</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/4m.png" width="90" height="16" style="border:0;" alt="2.00 stars" title="2.00 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">12 Bar Bruise</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Garage Liddiard</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sam Cherry&#39;s Last Shot</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">High Hopes Low</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Cut Throat Boogie</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Bloody Ripper</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">Uh Oh, I Called Mum</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sea of Trees</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">Footy Footy</span></span>
+                     </div>
+                   </li></ul></div>
+
+
+      <div class="review_title"  >ONE TWO THREE FOUR FIVE SIX SEVEN EIGHT</div><span ><span class="rendered_text">NEIN NEIN NEIN NEIN NEIN NEIN NEIN<br /><br />12 Bar Bruise shows King Gizzard &amp; the Lizard Wizard still in their infancy, testing the waters with their sound. There are some strong tracks here, but also a few that don’t land quite as well. The production isn’t nearly as polished and interesting as what we’d hear in later KGLW projects. The title track especially suffers, it has a muffled, lo-fi quality that may be intentional to convey a drunken, chaotic energy, but I don&#39;t like it. The closer, Footy Footy, is another miss for me.<br /><br />That said, there are moments throughout the album that hint at the band’s future brilliance. It has energy, rawness, and charm. Overall, it’s a very solid debut. 70/100.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating255237468]" /></div></div>
+             </div></div><!-- @@_review_255237468 --><div class="review_list"><span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/2/">2</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/3/">3</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/4/">4</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/5/">5</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/6/">6</a>  <a class="navlinknum" href = "/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/7/">7</a> <a class="navlinknext" href="/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/reviews/2/">&gt;&gt;</a></span></div><div class="review_help" id="review_help_l">
+         Votes are used to help determine the most interesting content on RYM.    
+         <br /><br />
+         Vote up content that is on-topic, within the rules/guidelines, and will likely stay relevant long-term.
+         <br />
+         Vote down content which breaks the rules.
+      </div></div></div></div><div class="section_catalog section_outer"><div class="page_section">
+         <script> 
+            var rating_info_album_id = 4111509;
+            var rating_info_show_all_issues = true;
+         </script>
+         <div class="release_page_header"><h2>Catalog</h2></div>
+         <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+
+         <div class="rating_info_table">
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 4111509, true, 'ratings'); });" id="rating_info_ratings" class="rating_info_tab rating_info_ratings active">
+                  <b>Ratings:</b> 6,596
+               </div>
+            
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 4111509, true, 'catalog'); });" id="rating_info_catalog"  class="rating_info_tab rating_info_cataloged">
+                  <b>Cataloged:</b> 1,039
+               </div>
+            
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 4111509, true, 'track_ratings'); });" id="rating_info_track_ratings" class="rating_info_tab rating_info_track_ratings">
+                  <b><span class="hide-for-small-inline">Track rating sets:</span><span class="show-for-small-inline">Track ratings:</span></b> 613
+               </div>
+            </div>
+
+         <div class="catalog_section">
+               <div class="catalog_stats hide-for-small">
+                  <div class="header">Rating distribution</div>
+                  <div id="chart_div" style="background:var(--mono-f);height:100px;width:200px;"></div>
+            <script>
+      
+               function drawChart1() {
+                 var data = new google.visualization.DataTable();
+                 data.addColumn('number', 'Rating');
+                 data.addColumn('number', '# of ratings');
+                 data.addRows([
+                   [0.5, 20],[1.0, 48],[1.5, 125],[2.0, 424],[2.5, 1039],[3.0, 2280],[3.5, 1775],[4.0, 664],[4.5, 147],[5.0, 74]
+                 ]);
+
+                 var options = {
+                     backgroundColor:'transparent',
+                     legend:{position:'none'},
+                     chartArea:{left:30,bottom:50,width:"80%",height:"60%"},
+                     colors:['#336fc6'],
+                     hAxis:{textStyle: {color: '#999'}, baselineColor: '#aaa'},
+                     vAxis:{textStyle: {color: '#999'}, baselineColor: '#aaa'},
+                     tooltip: {textStyle: {fontSize:12} }
+                 };
+
+                 var chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
+                 chart.draw(data, options);
+               }
+            </script>
+       
+
+                  
+
+                  <div class="header">Rating trend</div>
+            <div id="chart_div2" style="background:var(--mono-f);height:100px;width:200px;"></div>
+            <script>
+               function drawChart2() {
+                 var data = google.visualization.arrayToDataTable([
+                   ['Year', 'Differential'],
+                   ['2015', -0.22 ],['2016', -0.17 ],['2017', -0.27 ],['2018', -0.32 ],['2019', -0.31 ],['2020', -0.37 ],['2021', -0.45 ],['2022', -0.38 ],['2023', -0.42 ],['2024', -0.45 ],['2025', -0.41 ],['2026', -0.35 ]
+                 ]);
+
+                 var options = {
+                     backgroundColor:'transparent',
+                     legend:{position:'none'},
+                     chartArea:{left:30,bottom:20,width:"80%",height:"80%"},
+                     colors:['#677DD6'],
+                     hAxis:{textStyle: {color: '#999'}, baselineColor: '#999'},
+                     vAxis:{textStyle: {color: '#999'}, format:'+#.##;-#.##;avg', negativeColor:'#800', baselineColor: '#666' /*,viewWindow:{max:5.5,min:0.5} */},
+                     pointSize:'3',
+                     lineWidth:1,
+                     tooltip: {textStyle: {fontSize:12} }
+                 };
+
+                  var formatter = new google.visualization.NumberFormat(
+                     {negativeColor: 'red', negativeParens: false});
+                 formatter.format(data, 1); // Apply formatter to second column
+
+                 var chart = new google.visualization.LineChart(document.getElementById('chart_div2'));
+                 chart.draw(data, options);
+               }
+            </script>
+      
+               </div>
+               <div id="catalog_list" class="catalog_list"><span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/2');">2</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/44');">44</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/88');">88</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/132');">132</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/176');">176</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/220');">220</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/264');">264</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/308');">308</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/352');">352</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/396');">396</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/440');">440</a> <a class="navlinknext" href="javascript:RYMmediaPage.navCatalog('l', 4111509, true, 'ratings', '/2');">&gt;&gt;</a></span> <div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">15 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/fa942e14597053f568ce3788111cd038/13614136" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~8stringsamurai">8stringsamurai</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span onClick="$('#catalog_track_rating_288543980').toggle();" class="catalog_track_ratings">▼</span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">Cyclops king</span>
+               </div>
+         <div style="clear:both;"></div><div id="catalog_track_rating_288543980" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Elbow</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Muckraker</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Nein</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">12 Bar Bruise</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Garage Liddiard</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sam Cherry&#39;s Last Shot</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">High Hopes Low</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Cut Throat Boogie</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Bloody Ripper</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">Uh Oh, I Called Mum</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Sea of Trees</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">Footy Footy</span></span>
+                     </div>
+                   </li></ul></div><div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">14 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/9db65bc3d7d440ea01fba6ab864dd69e/14609417" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~taz1212">taz1212</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/5m.png" width="90" height="16" style="border:0;" alt="2.50 stars" title="2.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">Decent</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/82c3777b789d78b9af55301fee1a55a5/14573735" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~Irithyll">Irithyll</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/4m.png" width="90" height="16" style="border:0;" alt="2.00 stars" title="2.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">4/10</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">12 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/ac651da173950c2b91b86349338c4f6e/10008920" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~BlindHorse">BlindHorse</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/2m.png" width="90" height="16" style="border:0;" alt="1.00 stars" title="1.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">12 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/f432de33c3e07f0c80d0aabaff81ac95/14279425" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~fedos_devices">fedos_devices</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">11 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/b91bb1a9c521451a42b9b86a5ece51d7/9395719" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~FailAvenger">FailAvenger</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">11 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/8682853d46257a782bdabb2a851cfa96/11740751" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~EternalEpure">EternalEpure</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">Good</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">10 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/2c8c98d0574d733c6e5aa23197a0447d/7453298" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~arcrezio">arcrezio</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">10 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~doomsmann">doomsmann</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/4m.png" width="90" height="16" style="border:0;" alt="2.00 stars" title="2.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">9 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/35958d6aeb2df38d29c6b21a385048ff/14613480" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~2_515_px">2_515_px</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">9 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/06dffdd4d48a06c31bdfea79bb6d2d5b/14593931" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~sophist_ceo">sophist_ceo</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">9 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/a9694df058c6050a9a41893cab7c4655/14590562" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~rubytunes">rubytunes</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">9 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/43f09613d2e50fd642d46a158181a5d1/14506313" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~Rebis_">Rebis_</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">8 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~djdaly">djdaly</a></span>
+                  <span class="catalog_ownership">Digital</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_4111509">8 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~NapalmInTheMorning42">NapalmInTheMorning42</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//cdn.sonemic.net/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div></div></div></div></div><div style="clear:both;"></div><div class="column_filler" id="column_filler_right"></div>
+        </div> <div id="column_container_left" class="large-4 pull-8 columns release_left_column column_container_left"><div class="page_release_art_frame"><div class="hide-for-small"><a  href="buy/">
+      <div class="coverart_4111509" style="position:relative;">
+      
+      <img srcset ="//cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg,
+                     //cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg 2x"
+           src="//cdn.sonemic.net/i/600/s/1bc495ee71032dc338fdac1b728450e4/4311196/king-gizzard-and-the-lizard-wizard-12-bar-bruise-Cover-Art.jpg"
+           alt="Cover art for 12 Bar Bruise by King Gizzard &amp; The Lizard Wizard"
+      />
+      <!-- <meta itemprop="image" content="//cdn.sonemic.net/i/300/s/493653a567fe2bea0b31c563d8ed3831/4311196" /> -->
+    </div></a>
+    
+            <div id="media_link_button_container_top" 
+                  
+                 data-medialink="true"
+                 data-support-open="true" 
+                 data-artists="King Gizzard &amp; The Lizard Wizard" 
+                 data-albums="12 Bar Bruise" 
+                 data-links="{&#34;applemusic&#34;:{&#34;1649045961&#34;:{&#34;default&#34;:true,&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;de&#34;},&#34;1523709493&#34;:{&#34;for&#34;:[&#34;IT&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;1687145226&#34;:{&#34;for&#34;:[&#34;MX&#34;,&#34;US&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;560007430&#34;:{&#34;for&#34;:[&#34;FI&#34;],&#34;album&#34;:&#34;12-bar-bruise&#34;,&#34;loc&#34;:&#34;us&#34;}},&#34;soundcloud&#34;:{&#34;1092843280&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/king-gizzard-the-lizard-wizard/sets/12-bar-bruise-1&#34;},&#34;2196034&#34;:{&#34;for&#34;:[&#34;DE&#34;],&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/flightlessrecords/sets/12-bar-bruise&#34;}},&#34;bandcamp&#34;:{&#34;2765388374&#34;:{&#34;default&#34;:true,&#34;url&#34;:&#34;kinggizzard.bandcamp.com/album/12-bar-bruise&#34;}},&#34;youtube&#34;:{&#34;atgfVBvXpew&#34;:{&#34;default&#34;:true}},&#34;tidal&#34;:{&#34;294038177&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;deezer&#34;:{&#34;439470117&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;qobuz&#34;:{&#34;er4f6z3kvnula&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}}}" 
+                 data-placement="top" 
+                 data-allow-ads="true" 
+                 class="media_link_container link_sonemic allow_ads support_open lazyload">
+            </div>
+       </div></div>
+<table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:4px;font-size:1px;padding:0;"><tr style="height:4px;padding:0;"><td style="background:#ba3339;height:4px;padding:0px;color:#ba3339">.</td><td style="background:#814334;height:4px;padding:0px;color:#814334">.</td><td style="background:#83201a;height:4px;padding:0px;color:#83201a">.</td><td style="background:#a8a292;height:4px;padding:0px;color:#a8a292">.</td></tr></table>
+<div style="padding:0px;padding-top:0;"><div class="hide-for-small"><div class="section_release_navigation"><div class="release_navigation"><div class="release_navigation_guidance">
+                    <div class="release_nav_guidance_artist">
+                     <div class="release_nav_guidance_left">
+                      
+                     </div>                     
+                     <div class="release_nav_guidance_right">
+                     <a href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/">Next
+                      <i class="fa fa-caret-right"></i></a>
+                      
+                     </div></div>
+                     <div style="clear:both;"></div>
+                  </div>
+               
+                                 
+                  <div class="release_navigation_links">
+                    <div class="prev_image">
+                       
+                    </div>
+                    <div class="prev_link">
+                       
+                    </div>
+                    <div class="next_link">
+                       <a  href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/" class="small">Eyes Like the Sky</a>
+                    </div>
+                    <div class="next_image">
+                       <a href="/release/album/king-gizzard-and-the-lizard-wizard/eyes-like-the-sky/"><img alt="Next in discography: ..." src="//cdn.sonemic.net/i/75/s/649ed942f3f5a728192c7fe465879c76/14157319" /></a>
+                    </div>
+                    <div style="clear:both;"></div>
+                  </div>                
+               
+            </div></div></div><!-- /31961696/release.case-a.300-336.top-left -->
+            <div data-nosnippet class='page_creative_frame big-rectangle
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-19'  data-adcode='div-gpt-ad-1465817209349-19'  style='margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;min-height:300px;min-width:305px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-19'>
+            </div></div><div class="hide-for-small"><div class="section_tracklisting"><div class="release_page_header"><h2>Track listing</h2>
+            <div id="track_credit_show_link_tracks" class="track_credit_show_link" onClick="rymQ( function() { RYMmediaPage.toggleTrackCredits('tracks'); });">Show track credits</div>
+         </div>
+            <span id="track_credit_show_msg_tracks" style="display:none;">Show track credits</span>
+            <span id="track_credit_hide_msg_tracks" style="display:none;">Hide track credits</span>
+         <meta content="12" itemprop="numTracks" /> 
+       <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+       <ul id="tracks" class="tracks tracklisting"><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     1
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/elbow/" itemprop="name">Elbow</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     2
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/muckraker/" itemprop="name">Muckraker</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     3
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/nein/" itemprop="name">Nein</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     4
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="name">12 Bar Bruise</a><a  href="/song/king-gizzard-and-the-lizard-wizard/12-bar-bruise/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     5
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/garage-liddiard/" itemprop="name">Garage Liddiard</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     6
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/sam-cherrys-last-shot/" itemprop="name">Sam Cherry&#39;s Last Shot</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+         <div style="width:300px;padding-left:23px;"><ul class="credits">
+             <li class="credits non_featured_credit">
+               <div class="credits_artist "><a   href="/artist/broderick-smith" class="artist">Broderick Smith</a></div>
+               <div class="credits_roles">spoken word</div></ul></div>                  
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     7
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/high-hopes-low/" itemprop="name">High Hopes Low</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     8
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/cut-throat-boogie/" itemprop="name">Cut Throat Boogie</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     9
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/bloody-ripper/" itemprop="name">Bloody Ripper</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     10
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/uh-oh-i-called-mum/" itemprop="name">Uh Oh, I Called Mum</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     11
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/sea-of-trees/" itemprop="name">Sea of Trees</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     12
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/king-gizzard-and-the-lizard-wizard/footy-footy/" itemprop="name">Footy Footy</a></span><span class="tracklist_duration" data-inseconds="0" itemprop="duration" content="PT0M00S">
+                     
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/king-gizzard-and-the-lizard-wizard/12-bar-bruise/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li></ul><div id="track_preview_tracks">
+            
+         </div> </div></div><div class="hide-for-small"><div class="section_credits"><div class="release_page_header hide-for-small"><h2>Credits</h2></div>
+          <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+          <ul id="credits_" class="credits"><li><a title="[Artist1071275]"  href="/artist/stu-mackenzie" class="artist">Stu Mackenzie</a><br /> <span class="role_name ">vocals</span>,  <span class="role_name ">guitar</span></li>
+<li><a title="[Artist1071283]"  href="/artist/michael-cavanagh" class="artist">Michael Cavanagh</a><br /> <span class="role_name ">drums</span></li>
+<li><a title="[Artist1071277]"  href="/artist/cook-craig" class="artist">Cook Craig</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071278]"  href="/artist/ambrose-kenny-smith" class="artist">Ambrose Kenny-Smith</a><br /> <span class="role_name ">harmonica</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071279]"  href="/artist/eric-moore" class="artist">Eric Moore</a><br /> <span class="role_name ">theremin</span>,  <span class="role_name ">keyboards</span>,  <span class="role_name ">percussion</span></li>
+<li><a title="[Artist1071282]"  href="/artist/lucas-harwood" class="artist">Lucas Skinner</a><br /> <span class="role_name ">bass</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist1071280]"  href="/artist/joey-walker" class="artist">Joe Walker</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">vocals</span></li>
+<li><a title="[Artist738214]"  href="/artist/king-gizzard-and-the-lizard-wizard" class="artist">King Gizzard &amp; The Lizard Wizard</a><br /> <span class="role_name ">recording engineer</span>,  <span class="role_name "><span class="rendered_text">mixing</span></span></li>
+<li><a title="[Artist1071285]"  href="/artist/paul_maybury" class="artist">Paul Maybury</a><br /> <span class="role_name ">recording engineer</span>,  <span class="role_name "><span class="rendered_text">mixing</span></span></li>
+<li><a title="[Artist1066797]"  href="/artist/joseph-carra" class="artist">Joseph Carra</a><br /> <span class="role_name ">mastering engineer</span></li>
+<li><a title="[Artist1070483]"  href="/artist/jason-galea" class="artist">Jason Galea</a><br /> <span class="role_name ">cover art</span></li>
+             <div id="minor_credits_" style="display:none;"><li style="display:none;"></li> <!-- to keep nth-child even --><li><a title="[Artist134219]"  href="/artist/broderick-smith" class="artist">Broderick Smith</a><br /> <span class="role_name has_tracks">spoken word<span class="role_tracks">6</span></span></li></div><li onClick="$('#minor_credits_').slideToggle(100);$('#track_minor_hide_').toggle();$('#track_minor_show_').toggle();" class="expand_button"> <span id="track_minor_show_"> Expand credits <span style="font-weight:normal">[+1]</span></span> <span id="track_minor_hide_" style="display:none;"> Compact credits </span></li> </ul> </div>
+          </div><div class="section_lists"><div class="release_page_header">
+         <h2 style="float:left;">
+            390 Lists
+         </h2>
+
+         </div><div class="clearfix"></div>
+       
+          <ul class="lists not_expanded">
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/4537aa6893aea04efc54d39865870c5b/10092602" data-bkg2x="//e.snmc.io/i/150/s/918e0f32ab878d61e00e7366d4b94e5e/10092602" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Bluemountains/albums-i-listened-to-in-2018/">Albums I listened to in 2018</a></div>
+                        <div class="list_author"><a class="user" href="/~Bluemountains">Bluemountains</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/a4a35b03319581547c5b44e9da13ef05/11627745" data-bkg2x="//e.snmc.io/i/150/s/6a137550c00dcf6c4e560d7ec9f5d63b/11627745" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/should/rym-if-there-was-tertiary-genres-and-quarternary-genres-and-quinary-genres/">RYM if there was tertiary genres and quarternary genres and quinary genres</a></div>
+                        <div class="list_author"><a class="user" href="/~should">should</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/d046841cc155615c6b9f4e3c25d96200/9781107" data-bkg2x="//e.snmc.io/i/150/s/a09c16d48722acf41cd9ed989a4efed4/9781107" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/shutuperic/king-gizzard-and-the-lizard-wizard-albums-ranked/">King Gizzard and the Lizard Wizard Albums Ranked</a></div>
+                        <div class="list_author"><a class="user" href="/~shutuperic">shutuperic</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/310b7bcc343d045f065114f6caafe3cd/6308625" data-bkg2x="//e.snmc.io/i/150/s/bf5d59f535201c8a88ec795d3da6c609/6308625" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/charnsuka/cool-album-art/">cool album art</a></div>
+                        <div class="list_author"><a class="user" href="/~charnsuka">charnsuka</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/2b2fba0a452ccd6c970fc01f2afc6914/13626123" data-bkg2x="//e.snmc.io/i/150/s/237a2e0cb5a4962ccfde9879e922b101/13626123" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/9TheLogan/favorite-albums/">Favorite albums</a></div>
+                        <div class="list_author"><a class="user" href="/~9TheLogan">9TheLogan</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/2eff8925f3230636fc75e675532ac65b/7006881" data-bkg2x="//e.snmc.io/i/150/s/97239a6efd2e0dfa2633e21f66ae5c3d/7006881" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Vito_/adult-swim-for-gen-y-from-here-to-tallahassee—-2010-2014/">Adult Swim for Gen Y (From Here to Tallahassee—  2010-2014)</a></div>
+                        <div class="list_author"><a class="user" href="/~Vito_">Vito_</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/a3032632b419c8ca9285ff95d70b1a08/9173526" data-bkg2x="//e.snmc.io/i/150/s/b90faec39bc40d23dc8f1a4147900da6/9173526" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/captaingoosehead/stuff-i-gotta-listen-to-or-back-log-as-they-say/">Stuff I gotta listen to (or &#34;back log&#34;, as they say)</a></div>
+                        <div class="list_author"><a class="user" href="/~captaingoosehead">captaingoosehead</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/arcimboldo/illustration-2010-19/">illustration 2010-19</a></div>
+                        <div class="list_author"><a class="user" href="/~arcimboldo">arcimboldo</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/b9d17ca67b264d15ac4b3fdf11c63c71/14218483" data-bkg2x="//e.snmc.io/i/150/s/8268adc89cf96f78bfc07dc092a946d6/14218483" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/merton/by-the-time-i-finish-writing-this-they-probably-will-have-released-another-one-33-albums-by-king-gizzard-and-the-lizard-wizard/">By the Time I Finish Writing This They Probably Will Have Released Another One: 33 Albums by King Gizzard &amp; The Lizard Wizard</a></div>
+                        <div class="list_author"><a class="user" href="/~merton">merton</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/a80b47f0d863fb78774ccc4796d489d1/7427326" data-bkg2x="//e.snmc.io/i/150/s/b52466dcda98376bf58cc0a5a70de98f/7427326" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/sabbouma10/favourite-australian-debut-albums/">Favourite Australian Debut Albums</a></div>
+                        <div class="list_author"><a class="user" href="/~sabbouma10">sabbouma10</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/zspaceboy/2010s-ranked/">2010s RANKED</a></div>
+                        <div class="list_author"><a class="user" href="/~zspaceboy">zspaceboy</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Sodajerk/top-100-albums-of-2012/">Top 100 Albums of 2012</a></div>
+                        <div class="list_author"><a class="user" href="/~Sodajerk">Sodajerk</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/5e319bace5da983d52ae1a9329b57672/7714987" data-bkg2x="//e.snmc.io/i/150/s/e749b6651b143448ba7b9e4efc48a4da/7714987" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/acidbrat/f҉u҉c҉k҉-҉n҉o҉t҉-҉h҉a҉v҉i҉n҉g҉-҉a҉-҉g҉a҉r҉a҉g҉e҉/">f҉u҉c҉k҉ ҉n҉o҉t҉ ҉h҉a҉v҉i҉n҉g҉ ҉a҉ ҉g҉a҉r҉a҉g҉e҉</a></div>
+                        <div class="list_author"><a class="user" href="/~acidbrat">acidbrat</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/62ac8d2855bef217b5fb2d7dace72a09/10042922" data-bkg2x="//e.snmc.io/i/150/s/5a6111d6ab21a3d61eed4c3fa4dd633c/10042922" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Scaruffi_Drone/the-total-scaruffi-catalogue-ranked-work-in-progress/">The Total Scaruffi Catalogue: Ranked (work in progress)</a></div>
+                        <div class="list_author"><a class="user" href="/~Scaruffi_Drone">Scaruffi_Drone</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/64686d48847a5f0313e58d0bc59a2735/11740172" data-bkg2x="//e.snmc.io/i/150/s/77f83817d2ab6959713230d59197adba/11740172" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/killergrl/things-i-listened-to-in-2023/">things i listened to in 2023</a></div>
+                        <div class="list_author"><a class="user" href="/~thedanceofmaya">thedanceofmaya</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/d27cdfe96ec5412f7969e85168ba1bee/12076620" data-bkg2x="//e.snmc.io/i/150/s/5243cb77474a1f54eb8d273144c7ec0d/12076620" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/EverySproutingTree/king-gistard-and-the-listard-wistard/">King Gistard and the Listard Wistard</a></div>
+                        <div class="list_author"><a class="user" href="/~EverySproutingTree">EverySproutingTree</a></div>
+                     </div>
+                  </li><li class="expand_button"><a href="lists/">See all 390 lists</a></li></ul>       
+               </div><div class="section_videos"><div class="release_page_header"><h2>Video</h2></div>
+                <table class="color_bar" style="xborder:1px #333 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table><div class="youtube_container" id="youtube_container_8d4fddab2870691d22683249d857a09e" data-youtube-id="atgfVBvXpew"><a class="youtube_embed" id="youtube_video_8d4fddab2870691d22683249d857a09e" target="_blank" 
+               rel="nofollow noopener" data-youtube-id="atgfVBvXpew" 
+               href="//www.youtube.com/watch?v=atgfVBvXpew">
+
+               <div class="youtube_img lazyload" data-bkg="//img.youtube.com/vi/atgfVBvXpew/hqdefault.jpg"  data-bkg2x="//img.youtube.com/vi/atgfVBvXpew/hqdefault.jpg"></div>
+               <div class="youtube_playbutton"></div>
+               <div class="youtube_title">Elbow</div>
+               </a></div></div><a name="suggestions" class="anchor"></a><div 
+            style="text-align:center;padding:0.5em;
+            margin-top:1em;display:block;font-size:1em;">
+             <a style="text-decoration:none;color:var(--gen-blue-darkest);" href="/subscribe/"><i class="fa fa-star"></i> Subscribe to see similar release suggestions</a> 
+            </div><!-- /31961696/Sonemic/main-300x600-mid-1 -->
+            <div data-nosnippet class='page_creative_frame large-desk-leaderboard-multisize
+               lazyload-creative
+               
+               
+               desktop-sticky-persist-ad
+               
+               ' id='frame-div-gpt-ad-1465817209349-222'  data-adcode='div-gpt-ad-1465817209349-222'  style='margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;min-height:360px;min-width:165px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-222'>
+            </div></div><div class="column_filler" id="column_filler_left"></div>
+    </div></div>
+      </div>
+      </div>
+
+<div style="border-top:1px solid var(--mono-d);padding:15px;padding-left:50px;padding-right:50px;padding-bottom:20px;"><div style=""><div class="release_page_header"><h2>Contributions</h2></div>
+       <table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table><span class="contributor_header">Contributors to this release: </span><a class="user" href = "/~aokiji">aokiji</a>, <a class="user" href = "/~k_dawg">k_dawg</a>, <a class="user" href = "/~paulemiko">paulemiko</a>, <a class="user" href = "/~mynamajeff">mynamajeff</a>, <a class="user" href = "/~Meervo">Meervo</a><div style="margin-top:5px;margin-left:15px;margin-bottom:10px;"><a href="/login">Log in</a> to submit a correction or upload art for this release</a></div></div></div></div><div style="height:4px;width:100%;overflow:hidden;"><table class="color_bar" style="xborder:1px #ba3339 solid; width:100%;height:4px;font-size:1px;padding:0;"><tr style="height:4px;padding:0;"><td style="background:#ba3339;height:4px;padding:0px;color:#ba3339">.</td><td style="background:#814334;height:4px;padding:0px;color:#814334">.</td><td style="background:#83201a;height:4px;padding:0px;color:#83201a">.</td><td style="background:#a8a292;height:4px;padding:0px;color:#a8a292">.</td></tr></table></div>
+         <div class="clearfix"></div>
+         <!-- end content and content_wrapper -->
+               </div>
+             </div>
+          </div>
+
+
+
+          <div class="overlay_invisible" id="overlay_invisible"></div>
+
+          <div class="ui_cropper_frame" id="ui_cropper_frame"></div>
+
+          <div class="modal_parent_frame" id="modal_parent_frame">
+             <div onClick="rym.closeModal();" id="modal_overlay" class="modal_overlay" style="">Close <i class="fa fa-times"></i></div>
+             <div onClick="rym.closeModal();" id="modal_overlay_invisible" class="modal_overlay_invisible" style=""></div>
+             <div id="modal_parent_frame_inner" class="modal_parent_frame_inner">
+                    <div id="modal_content" class="modal_content">
+                    </div>
+             </div>
+          </div>
+
+          <div class="modal_parent_frame_level_2" id="modal_parent_frame_level_2">
+             <div onClick="rym.closeModal2();" id="modal_overlay_level_2" class="modal_overlay" style="">Close <i class="fa fa-times"></i></div>
+             <div onClick="rym.closeModal2();" id="modal_overlay_invisible_level_2" class="modal_overlay_invisible" style=""></div>
+             <div id="modal_parent_frame_inner_level_2" class="modal_parent_frame_inner_level_2">
+                    <div id="modal_content_level_2" class="modal_content">
+                    </div>
+             </div>
+          </div>
+
+
+
+             <!-- ~~~~~~~~ end content ~~~~~~~~~~~~~~~ -->
+            <div class="ui_chooser_results_frame" id="ui_chooser_results_frame">
+                <div class="ui_chooser_results bg-fff alternate" id="ui_chooser_results">
+                </div>
+            </div>  
+
+
+
+             <div id="voting_ui_frame"></div>
+
+          <div style="clear:both;"></div>
+      
+         <!-- Playwire footer tag -->
+         <script data-cfasync="false" defer src="//cdn.intergient.com/1025628/76421/ramp.js"></script>         
+      
+               <script> 
+                   document.querySelectorAll('.mobile-sticky-ad').forEach( item => {
+                     console.log ('setting sticky timer for ' + item.id)
+                     setTimeout(function () {
+                        item.classList.add('seen')
+                     }, 2000);
+                   });
+               </script>
+         
+<footer>
+  <div class="footer_inner">
+
+     <div class="footer_main_section"><div class="minilogo_frame"><div class="minilogo"> <div class="logo_sonemic_bw_24"></div>
+                        <span class="minilogo_text">Rate Your Music</span>
+                        
+                    </div></div>
+
+
+        <div class="copyright">&copy; 2000-2026 Sonemic, Inc.</div>
+          
+
+
+        <div class="clearfix"></div>
+
+        <div class="clearfix"></div>
+
+        <div class="social_icons"> 
+           <a rel="noopener" title="Follow us on Facebook" href="https://facebook.com/sonemic.network/" target="_blank"><i class="fab fa-facebook-square"></i></a> 
+           <a rel="noopener" title="Follow us on Twitter" href="https://twitter.com/sonemic/" target="_blank"><i class="fab fa-twitter-square"></i></a> 
+           <a rel="noopener" title="Follow us on Instagram" href="https://instagram.com/sonemic/" target="_blank"><i class="fab fa-instagram-square"></i></a> 
+           <a rel="noopener" title="Follow us on Spotify" href="https://open.spotify.com/user/sonemic.com" target="_blank"><i class="fab fa-spotify"></i></a> 
+           <a rel="noopener" title="Subscribe to our weekly newsletter"  href="https://mailchi.mp/sonemic-selects/newsletter" target="_blank"><i class="fa fa-envelope"></i></a> 
+     
+        </div>
+
+
+     </div> 
+  
+  <div id="expand_full_footer" class="mobile_expandable_full mobile_expand_footer">
+
+        <div id="expand_full_header_footer" class="mobile_expandable_full_header" onclick="RYMmobile.mobileExpand.toggleFull('footer');">
+
+           <div class="mobile_expandable_full_icons">
+              <div class="mobile_expandable_full_expand_icon_expanded">
+                 <i class="fa fa-caret-down"></i>
+              </div>
+              <div class="mobile_expandable_full_expand_icon_hidden">
+                 <i class="fa fa-caret-right"></i>
+              </div>
+           </div>
+
+           <div id="expand_full_name_footer" class="mobile_expandable_full_name">
+              Site links
+           </div>
+
+        </div>
+
+        <div id="expand_full_content_footer" class="mobile_expandable_full_content">
+           
+     <div class="footer_sections">
+
+        <div class="footer_section" id="section_network">
+           <div class="footer_header">RYM Network</div>
+           <div class="footer_sub_links">
+              <a class="asonemic" href="https://rateyourmusic.com/">
+                  RYM
+                  
+                  <span class="sub">music</span></a>
+              <a class="asonemic" href="https://sonemic.com/">Sonemic <span class="sub">roadmap</span></a>
+              <a class="aglitchwave" href="https://glitchwave.com/">Glitchwave <span class="sub">video games (beta)</span></a>
+              <a class="aforum" href="https://rym.fm/">Discussion <span class="sub">rym.fm</span></a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Info</div>
+           <div class="footer_sub_links">
+              <a href="/wiki/RYM:FAQ">FAQ</a>
+              <a href="/development/">Development status</a>
+              <a href="/rymzilla/" class="has_tip" data-tiptip="Report bugs and request features">RYMzilla</a>
+              <a href="/submissions/">Submissions</a>
+              <a href="/data-access/register-interest/">Data access / API</a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Policy</div>
+           <div class="footer_sub_links">
+              
+              <a href="/wiki/">Database standards</a>
+              <a class="" href="/privacy">Privacy <span style="font-size:0.875em;"><br />(Updated: 29 Sep 2025)</span></a>
+              <a class="" href="/tos">Terms of service <span style="display:none;font-size:0.875em;">(Updated: 12 Aug 2024)</span></a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Contact us</div>
+           <div class="footer_sub_links">
+              <a href="/contact">Support / Feedback</a>
+              
+           </div>
+        </div>
+     </div>
+  
+        </div>
+     </div>
+  
+ 
+     <div style="clear:both;"></div>
+  </div>
+
+</footer></body></html><script src="https://cdn.sonemic.net/2.5/js/jquery.min.2.js"></script><script src="//cdn.sonemic.net/dist/rym25/js/bundle.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script><script src="//cdn.sonemic.net/dist/rym25/js/page/release.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script><script src="//cdn.sonemic.net/dist/rym25/js/component/suggestions.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script><script src="//cdn.sonemic.net/dist/rym25/js/component/play_history.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script><script src="//cdn.sonemic.net/dist/rym25/js/ui/comments.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script><script src="//cdn.sonemic.net/dist/rym25/js/component/content.js?v=48d17652-b15b-42b5-8f47-82aaba602ce7"></script>
+            <script  type="module" id="module_dep_media_links">
+                import * as media_links from 'https://cdn.sonemic.net/dist/rym25/js/ui/media_links.mjs?v=48d17652-b15b-42b5-8f47-82aaba602ce7';
+                window.ui = window.ui || {};
+                window.ui.media_links = media_links;
+
+
+            if ( window.ui.media_links._initPage !== undefined ) {
+               rymQ(window.ui.media_links._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_contributions">
+                import * as contributions from 'https://cdn.sonemic.net/dist/rym25/js/page/section/contributions.mjs?v=48d17652-b15b-42b5-8f47-82aaba602ce7';
+                window.page = window.page || {};
+                window.page.section = window.page.section || {};
+                window.page.section.contributions = contributions;
+
+
+            if ( window.page.section.contributions._initPage !== undefined ) {
+               rymQ(window.page.section.contributions._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_release">
+                import * as release from 'https://cdn.sonemic.net/dist/rym25/js/page/release.mjs?v=48d17652-b15b-42b5-8f47-82aaba602ce7';
+                window.page = window.page || {};
+                window.page.release = release;
+
+
+            if ( window.page.release._initPage !== undefined ) {
+               rymQ(window.page.release._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_community">
+                import * as community from 'https://cdn.sonemic.net/dist/rym25/js/core/community.mjs?v=48d17652-b15b-42b5-8f47-82aaba602ce7';
+                window.core = window.core || {};
+                window.core.community = community;
+
+
+            if ( window.core.community._initPage !== undefined ) {
+               rymQ(window.core.community._initPage);
+            }
+            </script>
+
+         <script>
+
+           window.addEventListener('DOMContentLoaded', (event) => {
+
+               for ( var i in window.ryminit ) {
+                  var fn = window.ryminit[i];
+                  window.ryminit[i] = null;
+                  if ( fn ) {
+                     fn();
+                  }
+               }
+
+               window.ryminit = null;
+            });
+
+         </script>
+      
+
+
+      <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+      <script type="text/javascript">
+
+         rymQ(function () {
+             function drawChart() {
+               if (typeof(drawChart1) != 'undefined') {
+                  drawChart1();
+               }
+               if (typeof(drawChart2) != 'undefined') {
+                  drawChart2();
+               }
+            }
+           google.charts.load('42', {packages: ['corechart']});
+           google.charts.setOnLoadCallback(drawChart);
+         });
+      </script>
+
+    <script type="text/javascript">rymQ(function () {
+      
+      $(".has_tip").tipTip();
+
+
+
+      });
+
+     </script>

--- a/test_data/https___rateyourmusic_com_release_album_radiohead_ok_computer_
+++ b/test_data/https___rateyourmusic_com_release_album_radiohead_ok_computer_
@@ -1,0 +1,4802 @@
+<!DOCTYPE html>
+<html lang="en" id="page_release" class="rym page_release scope_music nonsubscriber logged-out ">
+<head>
+
+      
+<link rel="preconnect" href="//e.snmc.io" />
+<link rel="preconnect" href="//www.googletagmanager.com" />
+<link rel="dns-prefetch" href="//lit.connatix.com" />
+<link rel="dns-prefetch" href="//csi.gstatic.com" />
+<link rel="dns-prefetch" href="//cm.g.doubleclick.net" />
+<link rel="dns-prefetch" href="//vid.connatix.com" />
+<link rel="dns-prefetch" href="//capi.connatix.com" />
+<link rel="dns-prefetch" href="//cds.connatix.com" />
+<link rel="dns-prefetch" href="//imasdk.googleapis.com" />
+<link rel="dns-prefetch" href="//aax.amazon-adsystem.com" />
+<link rel="dns-prefetch" href="//ib.adnxs.com" />
+<link rel="dns-prefetch" href="//securepubads.g.doubleclick.net" />
+<link rel="dns-prefetch" href="//tpc.googlesyndication.com" />
+<link rel="dns-prefetch" href="//pagead2.googlesyndication.com" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="icon" href="//e.snmc.io/2.5/img/sonemic.png" type="image/png" />
+<title>OK Computer by Radiohead (Album, Alternative Rock): Reviews, Ratings, Credits, Song list - Rate Your Music</title>
+      <meta name="description" content="OK Computer, an Album by Radiohead. Released 16 June 1997 on Parlophone (catalog no. 7243 8 55229 2 5; CD). Genres: Alternative Rock, Art Rock.  Rated #1 in the best albums of 1997, and #2 of all time album..  Featured peformers: Radiohead (songwriting, string arrangements, producer), Thom Yorke (vocals, guitar, piano, programming, songwriter), Jonny Greenwood (guitar, keyboards, piano, Mellotron, organ, glockenspiel, songwriter), Philip Selway (drums, percussion, songwriter), Ed O&#39;Brien (guitar, percussion, backing vocals, songwriter), Colin Greenwood (bass guitar, bass synthesizer, percussion, songwriter), Nigel Godrich (producer, mixing engineer), Nick Ingman (conductor), Chris Blair (mastering engineer), Gerard Navarro (assistant engineer), Jon Bailey (assistant engineer), Chris Scard (assistant engineer), Stanley Donwood (sleeve design, artwork, online editor), Thom Yorke (sleeve design, artwork), Matt Bale (artwork), Mr. Barry (artwork), Adam Cummings (guitar technician, additional guitar), Charlie Myatt (booking), Jim Warren (engineer), Andi Watson (stage design), Keith Wozencroft (management), Peregrine Watts-Russell (management), Tony Wadsworth (management), Big Al (management), Carol Baxter (international marketing), Julie Calland (management), Brian Message (management), Chris Hufford (management), Bryce Edge (management), Caffy St Luce (media management), Duncan Swift (instrument maintenance), Plank (instrument technician, equipment), David Tordoff (sound technician), Tim Greaves (tour manager), Dilly Gent (video editor)." /><meta name="robots" content="max-image-preview:large" /> <meta name="twitter:card" content="summary_large_image" />
+                <meta name="twitter:site" content="@Sonemic" />
+                <meta property="og:site_name" content="Rate Your Music">
+
+                <meta property="og:url" content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" />
+                <meta property="og:type" content="music.album">
+                <meta property="og:title" content="OK Computer by Radiohead - RYM/Sonemic" /><meta property="og:description" content="OK Computer, an Album by Radiohead. Released 16 June 1997 on Parlophone (catalog no. 7243 8 55229 2 5; CD). Genres: Alternative Rock, Art Rock.  Rated #1 in the best albums of 1997, and #2 of all time album..  Featured peformers: Radiohead (songwriting, string arrangements, producer), Thom Yorke (vocals, guitar, piano, programming, songwriter), Jonny Greenwood (guitar, keyboards, piano, Mellotron, organ, glockenspiel, songwriter), Philip Selway (drums, percussion, songwriter), Ed O&#39;Brien (guitar, percussion, backing vocals, songwriter), Colin Greenwood (bass guitar, bass synthesizer, percussion, songwriter), Nigel Godrich (producer, mixing engineer), Nick Ingman (conductor), Chris Blair (mastering engineer), Gerard Navarro (assistant engineer), Jon Bailey (assistant engineer), Chris Scard (assistant engineer), Stanley Donwood (sleeve design, artwork, online editor), Thom Yorke (sleeve design, artwork), Matt Bale (artwork), Mr. Barry (artwork), Adam Cummings (guitar technician, additional guitar), Charlie Myatt (booking), Jim Warren (engineer), Andi Watson (stage design), Keith Wozencroft (management), Peregrine Watts-Russell (management), Tony Wadsworth (management), Big Al (management), Carol Baxter (international marketing), Julie Calland (management), Brian Message (management), Chris Hufford (management), Bryce Edge (management), Caffy St Luce (media management), Duncan Swift (instrument maintenance), Plank (instrument technician, equipment), David Tordoff (sound technician), Tim Greaves (tour manager), Dilly Gent (video editor)." />
+<meta property="og:image" content="https://cdn.sonemic.net/i/1200/s/525428ba12182239eb506dfb76751ad5/11993756" />
+
+         <!-- Global site tag (gtag.js) - Google Analytics -->
+         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-59057-1"></script>
+         <script>
+           window.dataLayer = window.dataLayer || [];
+           function gtag(){dataLayer.push(arguments);}
+
+      
+           console.log('rym.analytics: Google analytics pageview event sent.');
+           gtag('js', new Date());
+           gtag('config', 'UA-59057-1');
+            
+      </script><script> window.rym_dist_version = '2cc494f3-2fa1-4b99-b59a-df5f51baca87';</script> 
+      <script>
+         ryminit = window.ryminit || [];
+
+         function rymQ( a ) {
+            if ( !ryminit ) {
+               a();
+            } else {
+               ryminit.push(a);
+            }
+         }
+        if ( 'ontouchstart' in window ) {
+          document.documentElement.className += ' touch';
+        } else {
+          document.documentElement.className += ' noTouch';
+        }
+
+      </script>
+      <style id="inline-resources">html.noTouch .show-for-touch{display:none}html.touch .hide-for-touch{display:none}.grid-row-33-66{display:grid;grid-template-columns:34% 66%}.grid-row-reverse .grid-column:first-child{order:2}@media only screen and (max-width:48.1em){.grid-row-33-66{grid-template-columns:100%}.grid-row-reverse .grid-column:first-child{order:1}.grid-row-reverse .grid-column:last-child{order:2}}.column_filler{width:100%;height:1px}@media only screen and (max-width:48.1em){.column_filler{display:none}}.row,.columns,.column{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}.row{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0}.row:before,.row:after{content:" ";display:table}.row:after{clear:both}.row .column,.row .columns{position:relative;padding-left:.9375em;padding-right:.9375em;width:100%}.row .row{width:auto;margin-left:-.9375em;margin-right:-.9375em;margin-top:0;margin-bottom:0;max-width:none}.row .row:before,.row .row:after{content:" ";display:table}.row .row:after{clear:both}@media only screen{.row .column,.row .columns{position:relative;padding-left:0em;padding-right:0em;float:left}.row .small-4{position:relative;width:33.33333%}.row .small-6{position:relative;width:50%}.row .small-8{position:relative;width:66.66667%}.row .small-9{position:relative;width:75%}[class*=column]+[class*=column]:last-child{float:right}[class*=column]+[class*=column].end{float:left}.column.small-centered,.columns.small-centered{position:relative;margin-left:auto;margin-right:auto;float:none}}@media only screen and (min-width: 48.1em){.row .large-2{position:relative;width:16.66667%}.row .large-3{position:relative;width:25%}.row .large-4{position:relative;width:33.33333%}.row .large-5{position:relative;width:41.66667%}.row .large-6{position:relative;width:50%}.row .large-7{position:relative;width:58.33333%}.row .large-8{position:relative;width:66.66667%}.row .large-9{position:relative;width:75%}.row .large-10{position:relative;width:83.33333%}.row .large-12{position:relative;width:100%}.push-4{position:relative;left:33.33333%;right:auto}.pull-8{position:relative;right:66.66667%;left:auto}}
+.icon_globe{font-size:1.2em;position:relative;display:inline-block;width:1.5em;height:.8em}.icon_globe .fa-circle{color:#157d15}.icon_globe .globe{color:#add8e6}.fa-align-justify:before{content:"\f039"}.fa-apple:before{content:"\f179"}.fa-ban:before{content:"\f05e"}.fa-bandcamp:before{content:"\f2d5"}.fa-bars:before{content:"\f0c9"}.fa-bell:before{content:"\f0f3"}.fa-bold:before{content:"\f032"}.fa-bookmark:before{content:"\f02e"}.fa-calendar:before{content:"\f133"}.fa-caret-down:before{content:"\f0d7"}.fa-caret-left:before{content:"\f0d9"}.fa-caret-right:before{content:"\f0da"}.fa-caret-square-down:before{content:"\f150"}.fa-caret-square-left:before{content:"\f191"}.fa-caret-square-right:before{content:"\f152"}.fa-caret-square-up:before{content:"\f151"}.fa-caret-up:before{content:"\f0d8"}.fa-check:before{content:"\f00c"}.fa-check-circle:before{content:"\f058"}.fa-check-double:before{content:"\f560"}.fa-check-square:before{content:"\f14a"}.fa-chevron-circle-down:before{content:"\f13a"}.fa-chevron-circle-left:before{content:"\f137"}.fa-chevron-circle-right:before{content:"\f138"}.fa-chevron-circle-up:before{content:"\f139"}.fa-chevron-down:before{content:"\f078"}.fa-chevron-left:before{content:"\f053"}.fa-chevron-right:before{content:"\f054"}.fa-chevron-up:before{content:"\f077"}.fa-circle:before{content:"\f111"}.fa-circle-notch:before{content:"\f1ce"}.fa-clock:before{content:"\f017"}.fa-cog:before{content:"\f013"}.fa-copy:before{content:"\f0c5"}.fa-download:before{content:"\f019"}.fa-edit:before{content:"\f044"}.fa-ellipsis-h:before{content:"\f141"}.fa-ellipsis-v:before{content:"\f142"}.fa-envelope:before{content:"\f0e0"}.fa-exclamation:before{content:"\f12a"}.fa-exclamation-circle:before{content:"\f06a"}.fa-exclamation-triangle:before{content:"\f071"}.fa-expand:before{content:"\f065"}.fa-expand-alt:before{content:"\f424"}.fa-expand-arrows-alt:before{content:"\f31e"}.fa-external-link:before{content:"\f08e"}.fa-external-link-alt:before{content:"\f35d"}.fa-eye:before{content:"\f06e"}.fa-facebook:before{content:"\f09a"}.fa-facebook-f:before{content:"\f39e"}.fa-facebook-messenger:before{content:"\f39f"}.fa-facebook-square:before{content:"\f082"}.fa-flag:before{content:"\f024"}.fa-globe:before{content:"\f0ac"}.fa-globe-africa:before{content:"\f57c"}.fa-globe-americas:before{content:"\f57d"}.fa-globe-asia:before{content:"\f57e"}.fa-globe-europe:before{content:"\f7a2"}.fa-home-alt:before{content:"\f80a"}.fa-image:before{content:"\f03e"}.fa-images:before{content:"\f302"}.fa-info:before{content:"\f129"}.fa-info-circle:before{content:"\f05a"}.fa-instagram:before{content:"\f16d"}.fa-instagram-square:before{content:"\e055"}.fa-italic:before{content:"\f033"}.fa-key:before{content:"\f084"}.fa-link:before{content:"\f0c1"}.fa-list:before{content:"\f03a"}.fa-list-music:before{content:"\f8c9"}.fa-list-ol:before{content:"\f0cb"}.fa-list-ul:before{content:"\f0ca"}.fa-lock:before{content:"\f023"}.fa-map-marker-alt:before{content:"\f3c5"}.fa-play:before{content:"\f04b"}.fa-plus:before{content:"\f067"}.fa-plus-circle:before{content:"\f055"}.fa-plus-square:before{content:"\f0fe"}.fa-poll:before{content:"\f681"}.fa-poll-h:before{content:"\f682"}.fa-question:before{content:"\f128"}.fa-question-circle:before{content:"\f059"}.fa-question-square:before{content:"\f2fd"}.fa-quote-left:before{content:"\f10d"}.fa-quote-right:before{content:"\f10e"}.fa-random:before{content:"\f074"}.fa-rectangle-landscape:before{content:"\f2fa"}.fa-rectangle-portrait:before{content:"\f2fb"}.fa-rectangle-wide:before{content:"\f2fc"}.fa-reddit:before{content:"\f1a1"}.fa-search:before{content:"\f002"}.fa-share:before{content:"\f064"}.fa-share-alt:before{content:"\f1e0"}.fa-share-alt-square:before{content:"\f1e1"}.fa-share-square:before{content:"\f14d"}.fa-soundcloud:before{content:"\f1be"}.fa-spinner:before{content:"\f110"}.fa-spinner-third:before{content:"\f3f4"}.fa-spotify:before{content:"\f1bc"}.fa-square:before{content:"\f0c8"}.fa-square-full:before{content:"\f45c"}.fa-star:before{content:"\f005"}.fa-star-half:before{content:"\f089"}.fa-star-half-alt:before{content:"\f5c0"}.fa-step-backward:before{content:"\f048"}.fa-step-forward:before{content:"\f051"}.fa-sticky-note:before{content:"\f249"}.fa-sync:before{content:"\f021"}.fa-sync-alt:before{content:"\f2f1"}.fa-th-large:before{content:"\f009"}.fa-th-list:before{content:"\f00b"}.fa-thumbtack:before{content:"\f08d"}.fa-times:before{content:"\f00d"}.fa-times-circle:before{content:"\f057"}.fa-twitter:before{content:"\f099"}.fa-twitter-square:before{content:"\f081"}.fa-user-friends:before{content:"\f500"}.fa-video:before{content:"\f03d"}.fa-whatsapp:before{content:"\f232"}.fa-whatsapp-square:before{content:"\f40c"}.fa-youtube:before{content:"\f167"}.fa-youtube-square:before{content:"\f431"}
+html{line-height:1.15;-webkit-text-size-adjust:100%}body{margin:0}main{display:block}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}img{border-style:none}button,input,optgroup,select,textarea{font-family:inherit;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}button,[type=button],[type=reset],[type=submit]{-webkit-appearance:button}button::-moz-focus-inner,[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner{border-style:none;padding:0}button:-moz-focusring,[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em;border:none}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details{display:block}summary{display:list-item}template{display:none}[hidden]{display:none}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}html{font-size:62.5%}body{font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;font-feature-settings:"ss05" 1,"ss06" 1,"ss09" 1;font-size:12px}h1,h2,h3,h4,h5{font-weight:normal;margin:0;margin-bottom:.25em}h1{font-size:2.5em;font-weight:bold}h2{font-size:2.2em}h3{font-size:1.9em}h4{font-size:1.6em}h5{font-size:1.5em}@media only screen and (max-width:48.1em){h1{font-size:2em;font-weight:bold}h2{font-size:1.9em}h3{font-size:1.8em}h4{font-size:1.7em}h5{font-size:1.5em}}p{line-height:1.6em;margin-bottom:1em}blockquote{margin:0 1.5em}table{width:100%;border-collapse:collapse}td{border-collapse:collapse;padding:5px}tr{border-collapse:collapse}.anchor{scroll-margin-top:3em}a{text-decoration:none;color:var(--gen-blue-darker)}a.artist,.artist,a.game,a.work.major,a.user,a.film,a.film_artist{font-weight:bold}a.action{padding:.4em 0em;display:inline-block;text-transform:uppercase;font-size:.9em;font-weight:bold}img.lazyload:not([src]),picture.lazyload img:not([src]){visibility:hidden}img{object-fit:cover}img.cover{width:2.8em;height:2.8em;float:left;object-fit:cover;border-radius:4px;margin-right:.75em}img.size_2{width:2em;height:2em}img.image_release{width:2.8em;height:2.8em;float:left;object-fit:cover;border-radius:4px;margin-right:.75em;overflow:hidden}.image_aspect_padded_frame{position:relative;flex:1}.image_aspect_padded_frame img{position:absolute;width:100%;height:100%;top:0;left:0;right:0;bottom:0}.image_aspect_padded_frame a{display:flex}input,select,textarea,.input_auto_resize_frame,.input_auto_resize_frame::after{font-size:16px;font-weight:normal;padding:.15em;border-radius:3px;background:var(--surface-primary);color:var(--text-primary);border:1px solid var(--ui-detail-neutral);font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss05" 1,"ss06" 1,"ss09" 1}textarea{width:100%}input:disabled,select:disabled,textarea:disabled{color:var(--mono-8);background:var(--mono-e)}select{min-width:8em}label{font-weight:bold}.ui_section_overlay{background:var(--background);opacity:.7;z-index:30;position:absolute;top:0;left:0;right:0;bottom:0;margin:-.5em -1.5em;border-radius:10px;display:none}.show_overlay .ui_section_overlay{display:block}.show_overlay .component_discography_item{filter:saturate(70%)}.overlay_invisible{background:rgba(0,0,0,.1);z-index:105;position:fixed;top:0;left:0;right:0;bottom:0;display:none}.content_wrapper_outer{xbackground:var(--mono-f2);background-repeat:no-repeat;background-size:cover!important;background-position:center center!important}.preload{opacity:.05;position:absolute;top:-5000em;left:-5000em;pointer-events:none}.precontent{-webkit-transform:scale3d(1,1,1);position:absolute;top:-100vh;left:0;height:100vh;background-size:cover!important;width:100%;z-index:-1}#content_cover{position:absolute;z-index:7000;background:rgba(0,0,15,.6);display:none}#content_total_cover{position:fixed: top:0;left:0;right:0;bottom:0;z-index:50;background:rgba(0,0,0,.1)}body.has_background_image #content_wrapper{background:rgba(49,49,49,.2);margin:0 auto;max-width:132.5em;padding-left:2px;padding-right:2px}#content_cover{z-index:900}#content{padding:3em;font-size:1.25em;line-height:1.3;min-height:calc(100vh);max-width:106em;margin:0 auto;margin-top:4rem}html.size_mode_smaller #content{font-size:1.15em;line-height:1.25;max-width:115em}@media only screen and (max-width:48.1em){#content{margin-top:0;padding:.5em;padding-top:1em}}@media only screen and (min-width:48.125em){group{display:flex;flex-direction:column}.group_filler{flex:1;order:32767}}.smallgray,a.smallgray{font-size:.9em}.error{padding:.5em 1.5em;margin-bottom:1em}.code{font-family:"Courier new",monospace;border-left:5px solid;padding:1em}.note{border:1px solid;padding:1em 2em}.warning{padding:1em 2em;margin-bottom:1em}.warning p{margin:0}.notice{padding:1em 1.25em;font-size:.9em;margin-bottom:1em}.notice p{margin:0}.quote_user{margin-bottom:.2em}.quote{font-size:1.33rem;margin-bottom:1em;border-left:12px solid rgba(128,128,128,.4);padding:1.7em;padding-top:1.2em;padding-bottom:1.2em}.quote_link,.quote a.quote_link{float:right;font-weight:normal;font-size:1.2em}.quote .quote .quote .quote .quote{display:none}.quote .quote{border:none;border-radius:0;border-left:12px solid rgba(128,128,128,.3);margin-left:0em;margin-right:0em;margin-top:.6em}.quote_author{font-weight:bold;margin-left:-.7em;margin-bottom:.4em}.rendered_text{position:relative}.rendered_text_url_hidden{clip-path:inset(100%);clip:rect(1px,1px,1px,1px);height:1px;overflow:hidden;position:absolute;white-space:nowrap;width:1px}.rendered_text_url_pre_hidden:after{content:"..."}.clear,.clearfix{clear:both}.comma_separated:after{content:", "}.comma_separated:last-child:after{content:""}.pipe_separated:after{content:" | "}.pipe_separated:last-child:after{content:""}.slash_separated:after{content:"/ "}.slash_separated:last-child:after{content:""}.show-for-small-table-row{display:none}.show-for-small-inline{display:none}.hide-for-small-block{display:none}.hide-for-small-inline{display:none}.show-for-small{display:none}.hide-for-small{display:none}.rym_shortcut{font-size:.9em;border:none}.fa,.fas,.far,.fal,.fad,.fab{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;display:inline-block;font-style:normal;font-variant:normal;text-rendering:auto;line-height:1}.fa-spin{-webkit-animation:fa-spin 2s infinite linear;animation:fa-spin 2s infinite linear}@keyframes fa-spin{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}to{-webkit-transform:rotate(360deg);transform:rotate(360deg)}}.fa-stack{display:inline-block;height:1em;line-height:1.25em;position:relative;width:1em}.fa-stack-1x,.fa-stack-2x{left:0;position:absolute;text-align:center;width:100%}.fa-stack-1x{line-height:inherit}.fa-stack-2x{font-size:2em}.fa-inverse{color:#fff}.fab{font-family:"Font Awesome 5 Brands";font-weight:400}.far{font-family:"Font Awesome 5 Free";font-weight:400}.fa,.fas{font-family:"Font Awesome 5 Free";font-weight:900}.fad{position:relative;font-family:"Font Awesome 5 Duotone";font-weight:900}.fad{position:relative;font-family:"Font Awesome 5 Duotone";font-weight:900}.fal{font-family:"Font Awesome 5 Pro";font-weight:300}.fad:before{position:absolute;color:var(--fa-primary-color, inherit);opacity:1;opacity:var(--fa-primary-opacity, 1)}.fad:after{color:var(--fa-secondary-color, inherit);opacity:.4;opacity:var(--fa-secondary-opacity, .4)}.fa-swap-opacity .fad:before,.fad.fa-swap-opacity:before{opacity:.4;opacity:var(--fa-secondary-opacity, .4)}.fa-swap-opacity .fad:after,.fad.fa-swap-opacity:after{opacity:1;opacity:var(--fa-primary-opacity, 1)}.fad.fa-inverse{color:#fff}.fad.fa-stack-1x,.fad.fa-stack-2x{position:absolute}.fad.fa-stack-1x:before,.fad.fa-stack-2x:before,.fad.fa-fw:before{left:50%;-webkit-transform:translateX(-50%);transform:translateX(-50%)}.ui_flag{xfont-size:1.33em;line-height:.5}.ui_flag img{width:1.2em;height:.9em;border-bottom:.5px solid rgba(128,128,128,.4);border-right:.5px solid rgba(128,128,128,.4)}.rendered_text .documentation_sel_section li{margin-top:.5em;margin-bottom:.5em}.rendered_text .documentation_sel_section ul{margin-bottom:0;margin:1em 0}.documentation_sel_text{text-decoration:underline;text-decoration-color:rgba(128,128,128,.302)}.selectable .documentation_sel_text{text-decoration:underline;text-decoration-color:var(--ui-divider-line)}.selectable .documentation_sel_text.selected{color:var(--alert-error-background);font-weight:bold;text-decoration:none}.documentation_sel_section{display:block;padding:1em 0}.selectable .documentation_sel_section{padding:.5em .75em;margin:.33em 0;xborder:3px solid var(--ui-divider-line);xbackground:var(--surface-primary);border-radius:9px;display:block}.selectable .documentation_sel_section.search_hidden{display:none}.selectable .documentation_sel_section{user-select:none}.selectable .documentation_sel_section.selected{xbackground:linear-gradient(to bottom,var(--surface-primary),var(--surface-secondary));background:rgba(88,88,88,.14);xborder:3px solid var(--alert-error-background)}blockquote.rules,.page_documentation_item_frame blockquote.rules{margin:1em 0;padding:.5em 1em;background:transparent;color:var(--alert-error-background)}.documentation_sel_section_handle{font-weight:bold;margin-bottom:.25em;display:block;xdisplay:inline-block}.page_moderation_restriction_name{font-weight:bold;display:block;margin-bottom:.25em}.selectable .documentation_sel_section_handle{margin-bottom:.25em;display:block;cursor:pointer}.documentation_sel_section_handle i{display:none}.selectable .documentation_sel_section_handle i{color:var(--text-secondary);margin-right:.5em;display:inline}.selectable .documentation_sel_section_handle .fa-check-circle{display:none}.selectable .documentation_sel_section.selected .fa-check-circle{display:inline;color:var(--alert-error-background)}.selectable .documentation_sel_section.selected .fa-circle{display:none}blockquote.rules,.page_documentation_item_frame blockquote.rules{margin:1em 0;padding:.5em 1em;background:transparent;color:var(--alert-error-background)}@media only screen and (min-width: 48.063em){.hide-for-small-block{display:block}.hide-for-small{display:inherit}.hide-for-small-inline{display:inline}tr.hide-for-small{display:table-row}}@media only screen and (max-width: 48.1em){.show-for-small{display:inherit!important}.show-for-small-inline{display:inline!important}.show-for-small-table-row{display:table-row}}.adhesion_bottom{height:110px}@media only screen and (max-width:48em){.adhesion_bottom{height:78px}}html{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star_bold.svg)}html.theme_eve,html.theme_night,html.theme_darkgray{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star_bold.svg)}.bkg-metadata-star-bold{background-image:var(--metadata-star-bold)}img.metadata-star-bold{content:var(--metadata-star-bold)}.bkg-metadata-star{background-image:var(--metadata-star)}img.metadata-star{content:var(--metadata-star)}#track_rating_status{height:1.5em;display:flex;align-items:center;color:var(--text-secondary);margin-bottom:.5em;font-size:.875em}#track_rating_status .saving{display:none}#track_rating_status .saved{display:none}#track_rating_status.saving .saving{display:inline}#track_rating_status.saved .saved{display:inline}
+@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/Regular.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/Regular.woff?d) format("woff");font-weight:normal;font-style:normal;font-display:swap;font-feature-settings:"ss06" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/Bold.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/Bold.woff?d) format("woff");font-weight:700;font-display:swap;font-style:normal;font-feature-settings:"ss06" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/RegularIt.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/RegularIt.woff?d) format("woff");font-weight:normal;font-display:swap;font-style:italic;font-feature-settings:"ss06" 1,"ss05" 1,"ss09" 1}@font-face{font-family:"ProximaNova";src:url(https://e.snmc.io/3.0/font/Proxima-Nova/BoldIt.woff2?d) format("woff2"),url(https://e.snmc.io/3.0/font/Proxima-Nova/BoldIt.woff?d) format("woff");font-weight:700;font-display:swap;font-style:italic;font-feature-settings:"ss06" 1,"ss05" 1,"ss09" 1}@font-face{font-family:"Font Awesome 5 Pro";font-style:normal;font-weight:300;font-display:block;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-light-300.woff2) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-light-300.woff) format("woff")}@font-face{font-family:"Font Awesome 5 Free";font-style:normal;font-weight:400;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-regular-400.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-regular-400.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Brands";font-style:normal;font-weight:400;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-brands-400.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-brands-400.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Free";font-style:normal;font-weight:900;font-display:swap;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-solid-900.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-solid-900.woff?b) format("woff")}@font-face{font-family:"Font Awesome 5 Duotone";font-style:normal;font-weight:900;font-display:block;src:url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-duotone-900.woff2?b) format("woff2"),url(https://e.snmc.io/3.0/font/fa-2022-04-10/fa-duotone-900.woff?b) format("woff")}
+.media_link_container{min-height:2.9em;margin:.5em 0;display:flex;justify-content:center}.media_link_container.link_linkfire{min-height:3.2em}.media_link_container.link_linkfire.support_open{min-height:8em}.media_link_container.link_linkfire.support_open.allow_ads{min-height:12em}.page_features_secondary_metadata_field .linkfire_container{margin-left:-2em}.lnk-player,.lnk-dropdown-area{justify-content:center!important}.lnk-dropdown-title{white-space:nowrap;overflow:hidden;text-overflow:ellipsis!important;padding-right:.5em!important}.logo_header{width:2.22222em;height:2.22222em}html.scope_film .logo_header{width:2.22222em;height:2.22222em}.logo_sonemic_32,.logo_cinemos_32,.logo_glitchwave_32{width:2.22222em;height:2.22222em}.logo_name{float:left}.logo_header{float:left;margin-top:.35rem;margin-right:.7em;border-radius:50%}header{font-size:1.4em;line-height:2.41em;height:2.5em;text-align:left;padding-left:1.25em;padding-right:1.25em;position:fixed;background:linear-gradient(to bottom,#555,#666);background:var(--header-background);top:0;left:0;right:0;z-index:1000}div.badge_count_bubble{font-size:1rem;line-height:1.6em;padding-left:.3em;padding-right:.3em;border-radius:50%;font-weight:bold;top:.1em;position:absolute;right:.2em;text-align:center;z-index:5;min-width:1.7em;border-radius:3.7px}div.badge_count_pending{position:absolute;left:0;bottom:.2em;right:0;font-size:.6em;padding:0;line-height:1.3}.header_extended_section div.badge_count_pending{left:auto;right:1em;padding:.2em .8em;font-size:.7em;top:.9em;bottom:.8em}a.header_item .badge_count_bubble{left:auto;right:1em;top:1em;font-size:1.1rem}.header_item i.fa-circle{font-size:.7em}a.header_icon_link,.header_icon_link{line-height:2.3;position:relative;float:right;padding-left:.7em;font-size:1.1em;padding-right:.75em;display:none}.header_inner.logged_in .header_icon_link{display:block}a.header_icon_link_artist_profiles{font-size:1em;line-height:2.4}.header_items_spillover{display:none}@media only screen and (max-width:48.1em){.header_icon_link.hide-for-small,.header_inner.logged_in .header_icon_link.hide-for-small{display:none}}@media only screen and (max-width:1000px){header{padding-left:.25em;padding-right:.25em}.header_icon_link.header_icon_link_artist_profiles,.header_icon_link.header_icon_link_notepad,.header_icon_link_friends,.header_icon_link_requests{display:none!important}.header_items_spillover{display:block}a.header_item .badge_count_bubble{top:.7em}}.header_user_img{float:left;margin-top:.25em;display:inline-block;border-radius:3px;width:2em;height:2em}.header_inner{max-width:95em}.header_inner,.footer_inner{margin:0 auto;padding-left:.25em;padding-right:0em;margin:0 auto;text-align:center}.header_inner.logged_in{padding-right:0em}.header_menu{float:right}header img.logo{width:2.5em;height:2em;margin-right:.2em}.header_search{overflow:hidden}.header_search .ui_search_frame_inner{padding:.5em .25em}.header_extended_section{position:absolute;top:2.3em;border-top:3px;width:13.5em;left:0;z-index:1500;display:none}@media only screen and (max-width:48.1em){.header_extended_section{top:4em}}.header_extended_more_menu{left:auto;right:0em}.header_extended_section a{display:block;text-align:left;font-size:.9em;width:100%;border-bottom:1px}.header_profile_main{float:left;margin-left:.75em}.header_profile .header_extended_section{width:9.2em}a.header_profile_link{padding-left:1em;padding-right:.5em}.header_profile_logged_out a{margin-left:1em}.header_links{float:left}.header_links_inner{display:flex}.header_links i,.header_profile i{line-height:1.2;padding-left:.5em;padding-right:.5em}.header_exp{display:block;float:right}.header_item_icon{position:relative}a.header_item,.header_item,.header_mod_roles,.header_theme_buttons{display:block;float:left;text-decoration:none;padding-left:.5em;padding-right:.5em;position:relative}.subscribe_label_small{display:none}@media only screen and (max-width:70em){span.subscribe_label_large{display:none}span.subscribe_label_small{display:inline}a.header_item,.header_item,.header_mod_roles,.header_theme_buttons{font-size:.75em;line-height:2.84em}}#header_profile_username{font-weight:bold}.header_extended_section a.header_item,.header_extended_section .header_item{padding-left:1em;padding-right:1em;line-height:2.33;width:100%}div.header_mod_roles{width:100%;padding:0}a.header_mod_role{width:33.333%;font-size:.9em;float:left;text-align:center}div.header_theme_buttons{width:100%;padding:0}.header_theme_button{width:50%;min-height:1em;float:left;text-align:center;font-size:.9em;padding-top:.3em;padding-bottom:.3em}.header_theme_button_label{line-height:1.2;padding-top:.3em}.header_theme_button_mode{line-height:1.2;padding-bottom:.2em;font-size:1em;font-weight:bold}a.header_mod_role:last-child{border-right:none}.header_logo{font-weight:bold;font-size:.9em;text-transform:uppercase;position:relative;float:left}header .divider{display:block;float:left;width:1px;margin-top:.6em;height:1.45em;margin-right:.5em;margin-left:.5em}header .mobile_divider{display:none}header a.main{line-height:2.78em;text-transform:uppercase;font-weight:bold;font-size:1em;letter-spacing:0}header .menu_btn{margin-top:.45em;width:1.5em;height:1.5em;float:right;margin-left:1em}.header_search{overflow:hidden}.header_search input{width:100%;line-height:1.9}.header_profile{float:right;position:relative}.header_profile_mobile{float:right;position:relative;margin-left:.4em}@media only screen and (max-width: 48em){header{padding-left:0;padding-right:0}header .mobile_divider{display:block;float:left}.header_profile_main{margin-left:.25em}.header_links{display:none}.header_menu{display:block}.header_search{margin-left:5.75em}.header_profile_link{display:none!important}.header_exp{display:none}}.header_error,.header_message{display:none;position:fixed;z-index:60000;top:3.3333em;left:0;right:0;line-height:2.5em;border:1px solid #ecc;text-align:center}.header_error_close,.header_message_close{float:right;margin-right:.8em;font-size:1.2em;opacity:.7}@media only screen and (max-width:48.1em){.header_error,.header_message{left:0;right:0}}.mobile_header_menu{display:none;margin-top:3.3em}.mobile_header_menu.fixed{position:fixed;z-index:1001;width:100%}@media only screen and (max-width:48.1em){.mobile_header_menu{display:block}}a.mobile_header_menu_item{display:inline-block;line-height:2.7em;text-align:center;margin:0;font-size:1em;font-weight:bold}.mobile_header_menu_item_new_music{width:25%}.mobile_header_menu_item_charts{width:25%}.mobile_header_menu_item_genres{width:25%}.mobile_header_menu_item_lists{width:25%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_new_music{width:23%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_charts{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_genres{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_lists{width:18%}.mobile_header_menu.has_forum_link .mobile_header_menu_item_community{width:23%}.mobile_header_menu_item_more{width:10%}.footer_inner{padding:0em;padding-top:.8em;padding-bottom:.8em;margin:0 auto;max-width:75em}.footer_main_section{width:15em;float:left;text-align:center;display:block}.minilogo{margin-top:.4em;margin-right:1em;text-transform:uppercase;font-weight:bold;font-size:1em;display:inline-block}.minilogo div{float:left}.minilogo_text{line-height:1.7rem;margin-left:.5em}.minilogo_frame{height:3em}.copyright{display:block;margin-bottom:.3em;line-height:1.42}.trademark{margin-top:.3em;margin-bottom:.9em}.othersites{margin-top:.3em;margin-bottom:.5em}.minilogo img{width:2.5em}.footer_sections{padding:.8em;padding-left:8em;padding-right:2em;margin:0 auto;font-size:1.1em;text-align:left}.footer_header{text-transform:uppercase;font-size:1em;margin-bottom:.5em}.footer_sub_links a{display:block;font-size:.9em;line-height:1.5em}.footer_sub_links .updated{font-size:.7em;margin-top:-.2em;margin-bottom:.2em}.footer_sub_links .sub{font-size:.8em;float:right}.footer_section{width:9em;float:left;margin-left:1em;margin-right:1em}#section_network{margin-right:2.5em;width:13em}.social_icons{font-size:1.3em}.social_icons i{width:2em;height:2em;line-height:2em;text-align:center;transition:color .1s}footer{color:var(--mono-abs-d);border-top:3px solid var(--mono-abs-9);background:var(--mono-abs-3);font-size:1.25em;width:100%;position:relative;padding-bottom:2em;padding-bottom:130px}footer .mobile_expandable_full{margin:0}.mobile_expand_footer .mobile_expandable_full_header{background:transparent;color:var(--mono-abs-d)!important}@media only screen and (min-width:48.063em){#expand_full_header_footer{display:none}}#expand_full_content_footer{overflow:inherit;padding:0}.server_info{position:absolute;font-size:.8em;color:var(--mono-8);right:1em;bottom:1em}@media only screen and (max-width:48.1em){.footer_main_section{margin:0 auto;float:none;margin-bottom:1em}.footer_sections{margin:0 auto;margin-top:1em;padding:.8em;float:none;clear:both}.footer_section{width:21em;padding:0;margin:0 auto;margin-top:1em;float:none;clear:both}.footer_sub_links a{font-size:1.1em;line-height:1.8em}#section_network{width:21em;margin:0 auto}}
+.ui_button{line-height:1.5em;font-size:1em;padding:.5em 1em;min-width:1.5em;font-weight:bold;font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss06" 1,"ss09" 1;text-align:center;text-decoration:none;display:inline-block;margin-right:.25em;cursor:pointer;background:var(--btn-primary-background-default);color:var(--btn-primary-text);border-radius:3px;border:none}.ui_button_text_plain{background:none;border:none;padding:0;margin:0;font-weight:normal;color:var(--surface-primary);display:inline;font-size:1em;touch-action:manipulation}.ui_button_text{background:none;border:none;padding:0;margin:0;font-weight:normal;color:var(--link-text-default);display:inline;cursor:pointer;font-size:1em;user-select:none;touch-action:manipulation}.ui_button_text:hover{color:var(--link-text-hover)}.ui_button_text:disabled{color:var(--link-text-disabled);cursor:default}.ui_button_text.primary{font-weight:bold}.ui_button:hover{background:var(--btn-primary-background-hover);color:var(--btn-primary-text)}.ui_button:active{background:var(--btn-primary-background-active)}.ui_button:disabled{cursor:default;color:var(--btn-primary-text-disabled);background:var(--btn-primary-background-disabled)}.ui_button.secondary{background:var(--btn-secondary-background-default);color:var(--btn-secondary-text)}.ui_button.secondary:hover{background:var(--btn-secondary-background-hover)}.ui_button.secondary:active{background:var(--btn-secondary-background-active)}.ui_button.secondary:disabled{cursor:default;background:var(--btn-secondary-background-disabled)}.ui_button.button_expand{width:100%;margin-right:0;font-size:1em;background:var(--btn-expand-background-default);color:var(--btn-expand-text);border-radius:3px;line-height:1.75;border:none;cursor:pointer;user-select:none;text-align:center}.ui_button.button_expand .ui_button_expand_text_expanded{display:none}.section_expanded .ui_button.button_expand .ui_button_expand_text_expanded{display:block}.section_expanded .ui_button.button_expand .ui_button_expand_text_default{display:none}.ui_button.button_expand:hover{background:var(--btn-expand-background-hover)}.ui_button.button_expand:active{background:var(--btn-expand-background-active)}.ui_button.button_expand:disabled{background:var(--btn-expand-background-disabled);color:var(--btn-expand-text-disabled)}.ui_button.button_create_playlist{background:var(--btn-secondary-background-selected);border:3px solid var(--btn-secondary-background-hover);color:var(--btn-secondary-text);border-radius:25px;padding:.5em 2em}.ui_button.button_create_playlist:hover{background:var(--btn-secondary-background-hover)}.btn,input[type=button],input[type=submit]{line-height:1.4em;font-size:1em;padding:.25em .8em;min-width:1.5em;font-weight:bold;font-family:"ProximaNova",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial;font-feature-settings:"ss06" 1,"ss09" 1;text-align:center;text-decoration:none;display:inline-block;margin-right:.25em}.btn_small{font-size:.9em}@media only screen and (max-width:48.1em){.btn_small{font-size:1em}}.btn_xsmall{padding:.25em .5em;font-size:.9em}.btn.blue_btn,.darkgray_btn,.red_btn,.darkred_btn{width:auto;max-width:25em;text-align:center;border:1px solid transparent}.flat_btn{border:1px solid var(--ui-detail-neutral)}.flat_btn.disabled,.flat_btn.disabled:hover{border:1px solid var(--ui-detail-neutral)}.flat_btn:hover{border:1px solid var(--ui-detail-neutral)}.blue_btn:hover{text-decoration:none}.blue_btn.disabled,.blue_btn.disabled:hover{text-decoration:none}.expand_button,a.expand_button,li.expand_button{display:block;line-height:2.5em;font-weight:bold;text-align:center;border-radius:3px;margin-top:.5em;margin-bottom:.5em;text-decoration:none}
+.ui_search{background:var(--surface-secondary);border-radius:25px;position:relative;display:inline-block}header .ui_search{display:block}.ui_search_icon,.ui_clear_icon{position:absolute;top:.5em;font-size:1.2em;color:var(--text-secondary);z-index:2}.ui_search_icon{margin-left:.7em}i.ui_clear_icon{top:0;right:0;cursor:pointer;width:2.3em;text-align:center;line-height:2!important;display:none}.ui_search_frame.active i.ui_clear_icon{display:inline}.ui_search_frame.has_content i.ui_clear_icon{display:inline}.ui_search_debug{float:right;margin-left:.5em;line-height:2.5;font-size:.9em}.ui_search_debug a{color:var(--text-secondary)}.ui_clear_icon:hover{color:var(--text-secondary)}.ui_search_input{width:100%;color:var(--text-primary);outline:none;border:none;background:transparent;padding:0;padding-left:2.5em;padding-right:2.5em}.ui_search_object_category_label{text-align:right;font-size:1.3em;line-height:2;color:var(--text-secondary);padding-right:.5em}.ui_search_close{max-width:40em;margin:0 auto;display:none}.ui_search_close_bar{cursor:pointer;float:right;line-height:2em;font-size:2em;text-align:right;padding-right:.5em;color:var(--secondary-text)}.ui_search_rest{margin-top:.5em;width:40em;background:var(--background);box-shadow:1px 1px 3px rgba(0,0,0,.3);border-radius:3px;display:none}.ui_search_frame.active .ui_search_rest{display:block;position:absolute}.ui_search_type,.ui_search_results_frame{background:var(--surface-primary);padding:.5em 0}.ui_search_results_frame{height:28em;overflow-y:auto}@media only screen and (max-width:48.1em){header .ui_search_results_frame{height:calc(90vh - 5em)}}.ui_search_frame_inner{max-width:80em;margin:0 auto;font-size:.75em;padding:.5em;line-height:1.3;text-align:left;z-index:50}.ui_search_results_help{padding:1em;text-align:center;font-size:1.2em;line-height:1.3;color:var(--text-secondary)}.ui_search_results_help p{color:var(--text-secondary)}.ui_search_results_help i.fa{margin-left:.5em;margin-right:.5em}.ui_search_type{color:var(--text-secondary);padding:.5em;padding-left:1em;padding-right:1em;font-size:1.2em;border-bottom:1px solid var(--ui-detail-neutral);display:none}.ui_search_results{display:none;flex-direction:column;align-items:stretch}.ui_search_frame.active .ui_search_type,.ui_search_frame.active .ui_search_results{display:block}.ui_search_object_label{color:var(--text-secondary);font-size:.9em;margin-right:.25em;margin-left:.25em}.ui_search_scope_selector_item.selected{border-bottom:3px solid var(--background);font-weight:bold}.ui_search_scope_selector_item{min-width:2em;padding-left:.25em;padding-right:.25em;color:var(--text-secondary);line-height:2em;text-align:center;display:inline-block;cursor:pointer;user-select:none}.ui_search_object_category_only_btn{float:right;margin-left:.5em;font-size:.7em;background:var(--background);margin-top:.6em;font-weight:bold;line-height:1.6em;padding-left:1em;border-radius:3px;padding-right:1em;cursor:pointer}.ui_search_scope_selector_item.selected{cursor:default}.ui_search_scope_selector_item_music:hover{color:#207bbf!important}.ui_search_scope_selector_item_film:hover{color:#b96f00!important}.ui_search_scope_selector_item_games:hover{color:#c21c1c!important}.ui_search_scope_selector_item_music.selected{color:#207bbf;border-color:#207bbf!important}.ui_search_scope_selector_item_film.selected{color:#b96f00;border-color:#b96f00!important}.ui_search_scope_selector_item_games.selected{color:#c21c1c;border-color:#c21c1c!important}.ui_search_object_select_frame{position:relative;display:inline-block}.ui_search_object_select{background:var(--surface-primary);border:none;font-weight:bold;color:var(--text-primary);font-size:1em}.ui_search_configure{float:right;margin-left:1em;min-width:2em;padding-left:.25em;padding-right:.25em;color:var(--mono-8);line-height:2em;cursor:pointer;position:relative}.ui_search_configure:hover{background:var(--mono-f8)}.ui_search_result{display:flex;align-items:center;justify-content:center;border-radius:1px;background:var(--mono-f8);cursor:pointer;margin-bottom:.33em;padding-left:.5em;padding-right:.5em}.ui_search_result:hover{background:var(--mono-f0)}.ui_search_result_info{margin-top:.2em;margin-bottom:.2em;margin-left:1em;flex-grow:1}.ui_search_result_info_subtext,.ui_search_result_date_loc_info,.ui_search_result_hint,.ui_search_result_genres{margin-bottom:.15em}.ui_search_result_info_name{padding-top:.25em;font-size:1.2em;color:#207bbf}.ui_search_result_info_subtext{font-size:.9em;font-weight:bold;color:var(--mono-6)}.ui_search_result_date_loc_info .flag{float:left;margin-right:.4em}.ui_search_result_music_performers,.ui_search_result_music_composers{margin-top:.1em;font-weight:bold;color:var(--mono-5)}.ui_search_result_open_external,.ui_search_result_shortcut_frame{text-align:right;color:var(--mono-9);font-size:1.1em;min-height:2em;cursor:pointer;padding:.4em;padding-right:.6em;padding-left:.6em}.ui_search_result_open_external:hover,.ui_search_result_shortcut_frame:hover{background:var(--mono-d);color:var(--mono-6)}.ui_search_result_relevant_aka,.ui_search_result_name_display_original{font-size:.8em;color:var(--mono-8);margin-left:.3em}.ui_search_result_date_loc_info{font-size:.9em;color:var(--mono-6)}.ui_search_result_hint,.ui_search_result_debug{color:var(--mono-8);font-size:.9em;display:none}.ui_search_result_debug{display:none}.ui_search_result_image_bkg{width:5em;height:5em;background-color:var(--mono-f0)!important;box-shadow:1px 1px 0px var(--mono-c);background-position:center center!important;background-size:cover!important}.ui_search_result.result_film .ui_search_result_image_bkg{width:5em;height:7em}.ui_search_result.result_descriptor .ui_search_result_image_bkg{visibility:hidden;height:1px}.ui_search_result_action{align-self:flex-start;text-align:right}.ui_search_result_genres,.ui_search_result_genre_details{font-size:.9em;color:var(--mono-8)}.ui_search_result_film_directors,.ui_search_result_film_starring{margin-right:.25em;font-size:.9em;color:var(--mono-8)}.ui_search_context_indicator{margin-right:10em;color:var(--mono-9);line-height:4;padding-left:2em;padding-right:1em;overflow:hidden;text-align:right;white-space:nowrap;font-style:italic}.ui_search_context_indicator_inner{pointer-events:none;float:right}.ui_search_result_shortcut{font-size:.7em;width:98%;padding:1%;display:none}.ui_search_result_shortcut_frame.clicked .ui_search_result_shortcut{display:inline}.ui_search_result_shortcut_frame.clicked i{display:none}.ui_search_frame_outer{position:relative;height:2.5em;display:inline-block}header .ui_search_frame.active{position:initial;width:100%}header .ui_search_frame_outer{position:initial;display:block}.ui_search_frame.active{position:absolute;width:40em;z-index:3000}.ui_search_autocomplete_result{font-size:1.4em;font-weight:bold;padding:.33em 1em;display:block;width:100%;text-align:left;scroll-margin-top:3em;color:var(--text-primary)}.ui_search_autocomplete_result:hover,.ui_search_autocomplete_result:active,.ui_search_autocomplete_result:focus{background:var(--surface-secondary)}@media only screen and (max-width:48.1em){.ui_search_frame.active,header .ui_search_frame.active{background:var(--mono-f);position:fixed;top:0;left:0;right:0;bottom:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:0em;z-index:3000}.ui_search_clear{clear:both}.ui_search_rest{border:none;box-shadow:none;padding:0;width:100%}.ui_search_frame.active .ui_search_rest{position:relative}.ui_search_frame.active .ui_search_close{display:block}.ui_search_results_frame{position:relative;overflow-y:visible}.ui_search_frame.active .ui_search_frame_inner{padding:0}}
+.ui_page_nav_frame{white-space:nowrap;z-index:3;display:none}.ui_page_nav{text-align:left;margin:0 auto;font-size:1.2em;list-style-type:none;padding-left:.5em;text-align:left;padding:.25em;overflow-x:auto}.ui_page_nav li{display:inline-block;padding:.55em .55em;margin:.25em;border-radius:.25em;background:var(--mono-f8);min-width:8em;text-align:center;color:var(--gen-blue-med)}@media only screen and (max-width:48.1em){.ui_page_nav li{min-width:27%}}
+.page_section_features_frame h2{margin-bottom:.5em}.page_section_feature_image{width:15em;height:15em;object-fit:contain}@media only screen and (max-width:48.1em){.page_section_feature_image{width:9em;height:9em}}.page_section_feature{display:flex}.page_section_feature:hover{background:var(--mono-f8)}.page_section_feature_info{padding:0 1.5em;flex:1;display:flex;flex-direction:column;justify-content:center}.page_section_feature_info h3{font-size:1.6em;color:var(--mono-0);font-weight:bold;color:var(--gen-blue-dark);line-height:1.3}.page_section_feature_info p{color:var(--text-primary);font-size:1.1em;line-height:1.3;margin:0}
+.page_section_contributions_supported_page{background:var(--surface-secondary);padding:1em;margin:1em 0;display:inline-flex;flex-direction:row;align-items:center;border-radius:3px}.page_section_contributions_supported_page_actions{margin-left:1.66em}.page_section_contributions_supported_page_text{flex:1;padding:0 .66em;line-height:1.5}.page_section_contributions_supported_page_text_anonymous{display:none}.page_section_contributions_supported_page.is_anonymous .page_section_contributions_supported_page_text_anonymous{display:inline}.page_section_contributions_supported_page.is_anonymous .page_section_contributions_supported_page_text_user{display:none}.page_section_contributions_supported_page_actions a{font-size:.9em;color:var(--text-secondary);margin-right:1em}i.sponsor-star{background:var(--average-rating);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:bold;color:var(--text-primary);margin:0 .2em;cursor:pointer}h2 i.sponsor-star{font-size:.6em;float:right;line-height:2.2;padding:0 .2em}.page_section_contributions_supported_page img{border-radius:3px;object-fit:cover;width:3em;height:3em}#page_section_contributions_supported_page_thanks_count{font-weight:bold;margin:0 .5em;color:var(--text-primary)}.page_section_contributions_supported_page_intro{padding:1em 1.15em;max-width:35em;margin:0 auto}.page_section_contributions_supported_page_free_select{padding:.5em 1em;background:var(--surface-secondary);font-size:.9em}.page_section_contributions_supported_page_form{display:flex;align-items:center;margin-top:.5em}.page_section_contributions_supported_page_btn{flex:1;text-align:right}.page_section_contributions_sponsorship_intro{padding:1.25em 2em;background:var(--surface-secondary);color:var(--text-secondary)}.page_section_contributions_sponsorship_form{line-height:2.2;padding-top:1em;border-top:1px solid var(--ui-detail-neutral)}.page_section_contributions_sponsorship_btn{float:right}@media only screen and (max-width:48.1em){.page_section_contributions_supported_page_actions{margin:0}.page_section_contributions_supported_page_actions a{display:block;padding:.5em 0}.page_section_contributions_supported_page img{margin-right:1em}}
+.page_release #content{padding:0;background:var(--background)}.sub_text{font-size:.6em;color:var(--mono-8);margin-left:10px}.page_release body.has_background_image #content_wrapper_outer{background:var(--overlay)}.page_release .media_link_container{margin-top:1em;margin-bottom:0}a.song.bolded{font-weight:bold}.ui_media_links_container{xheight:4.3em}#page_release .ui_media_link_btn{height:2em;width:2em}.ui_media_links{display:flex;flex-flow:row wrap;justify-content:center;align-content:space-between;gap:.15em}@media screen and (max-width: 688px){.ui_media_links{max-width:31rem}}.page_object_section{padding:1.25em}@media only screen and (max-width: 48.1em){.page_object_section{padding:.5em}}.release_right_column,.film_right_column{background:var(--mono-f)}.no_content_message{background:var(--mono-f8);text-align:center;border:1px var(--mono-d8) solid;color:var(--mono-8);padding:5px;padding-left:15px;padding-right:15px;border-radius:3px}.release_right_column .page_section{max-width:82.5em;margin:0 auto}.my_review{height:auto;width:520px;overflow:hidden;display:none;background:var(--mono-f8);border:1px var(--mono-c) solid;padding:10px;padding-left:35px;padding-right:35px;margin-bottom:8px}.release_right_column .section_reviews.section_outer{padding:30px;padding-top:25px;padding-bottom:15px;border-top:1px var(--mono-e) solid;border-bottom:1px var(--mono-e) solid}.release_right_column .section_catalog.section_outer{padding:30px;padding-top:25px;padding-bottom:15px}.section_tracklisting{padding:10px;padding-top:15px;padding-left:20px;padding-right:20px}.section_lists,.section_videos,.section_discussion,.section_comments,.section_suggestions,.section_credits,.section_cast,.section_crew,.section_addl_info{padding:1em;padding-left:20px;padding-right:20px}.page_release .page_object_section_discussion{padding:1em;padding-left:20px;padding-right:20px}.release_right_column .section_main_info.section_outer{padding:1.5em;padding-right:.75em;padding-top:25px;padding-bottom:25px}.release_right_column .section_issues.section_outer{padding:30px;padding-top:25px;padding-bottom:15px}.release_right_column .section_my_catalog.section_outer{padding:30px;padding-top:25px;padding-bottom:15px;border-top:1px var(--mono-e) solid;border-bottom:1px var(--mono-e) solid}.page_release_art_frame{text-align:center;background:var(--mono-e);padding:20px;padding-top:20px;padding-bottom:12px}@media only screen and (max-width:1500px){.release_right_column .section_main_info.section_outer{padding:1em}}@media only screen and (max-width:1200px){#frame-div-gpt-ad-1465817209349-19{max-width:100%;overflow:hidden}.release_right_column .section_main_info.section_outer{padding:.5em}.page_release_art_frame{padding:.5em}.page_release .section_main_info{padding:1em}.release_right_column .section_main_info.section_outer{padding:2em .75em}#frame-div-gpt-ad-1465817209349-21{margin-right:-2.5em!important;margin-left:0em!important}}@media only screen and (max-width:48.1em){.release_right_column .section_reviews.section_outer,.section_issues.section_outer,.release_right_column .section_catalog.section_outer{padding-left:.5em;padding-right:.5em}.page_release .page_object_section_discussion{padding:1em .75em}.section_lists,.section_videos,.section_discussion,.section_comments,.section_suggestions,.section_credits,.section_cast,.section_crew,.section_addl_info{padding:1em .75em}.section_my_catalog.section_outer{padding:0}.my_review{width:100%;padding:0;background:transparent;border:none;overflow:none}.section_tracklisting{padding:0 .5em}}div.section_release_navigation{padding:12px;padding-left:20px;padding-right:20px;border-bottom:1px var(--mono-d) solid}.release_left_column{background:var(--mono-f0);padding:0!important;border-right:1px var(--mono-e) solid}.return_banner{height:32px;line-height:32px;font-size:16px;color:var(--mono-8);background:var(--mono-f0);margin-bottom:40px}.return_banner a{text-decoration:none}.buy_button{display:flex;flex-direction:row;justify-content:center;margin:0 auto 1.5em auto;background:var(--gen-blue-darker);color:var(--mono-abs-f)!important;text-decoration:none;padding-top:5px;padding-bottom:5px;font-size:1.1em}@media only screen and (min-width : 1300px){}ul.credits{background:var(--mono-f);padding:5px;border-radius:3px}ul.credits li{list-style:none;font-size:.9em;overflow:visible;padding:4px}ul.credits li div{display:inline-block}.credits_artist a,.credits_artist a:hover{font-weight:normal}.credits_artist.main a{font-weight:bold}.credits_roles{color:var(--mono-8);margin-left:3px}.guest{color:#888}.role_name{position:relative;color:var(--mono-1)}.role_tracks{display:none;position:absolute;top:14px;left:-5px;color:var(--text-primary);z-index:15;background:var(--mono-f);padding:6px;border-radius:3px;box-shadow:2px 2px rgba(0,0,0,.3);white-space:nowrap}.role_name:hover .role_tracks{display:inline-block}.role_name.has_tracks{color:var(--mono-8)}#minor_credits a.artist{font-weight:normal!important}.album_title{font-size:2em;color:var(--mono-0);margin-bottom:.1em;padding:0 .3em}.album_shortcut{float:right;font-size:.8em;background:transparent;border:none;outline:none;margin-top:8px;color:var(--mono-6);text-align:right}.album_title .album_shortcut{font-size:.5em;margin-top:0}.review_shortcut{float:right;font-size:1em;background:transparent;border:none;outline:none;margin-top:8px;color:var(--mono-6);text-align:right}.release_img{text-align:center}.release_left_col{background:var(--mono-f8)}.release_page_header,.page_object_section_discussion_header{font-size:1em;margin-bottom:.75em;height:1.2em;line-height:1.2em}.release_page_header h2,.page_object_section_discussion_header h2{font-size:1.2em;color:var(--mono-5);font-weight:bold;float:left;height:inherit}.release_pri_descriptors{font-size:.9em;color:var(--mono-6);line-height:1.4}#my_catalog{display:flex;flex-direction:column}.section_my_catalog div#release_touch_catalog_guidance{visibility:hidden;margin-top:5px;font-size:.8em;color:var(--mono-8)}.section_my_catalog:hover div#release_touch_catalog_guidance{visibility:visible}@media only screen and (max-width:48.1em){.release_right_column .section_my_catalog.section_outer{padding:.5em 1em}}#my_catalog .release_page_header span.subtext{font-size:.7em;color:var(--mono-8);margin-left:5px}.release_right_col{background:var(--mono-f)}.release_pri_genres a{text-decoration:none;font-weight:bold;font-size:.9em}.release_sec_genres a{text-decoration:none;font-size:.8em}div.release_nav_guidance_artist,div.release_nav_guidance_artist i{font-size:1em;line-height:1.8em!important}div.release_nav_guidance_artist i{xfont-size:1.1em}div.release_navigation{margin-top:5px;margin-bottom:5px}div.release_navigation a{text-decoration:none}div.release_navigation_guidance{border-bottom:1px var(--mono-d) solid;color:var(--mono-6)}div.release_navigation_links{height:2.9em;line-height:2.9em;border-radius:5px;overflow:hidden;display:flex;background:var(--mono-f8)}div.release_nav_guidance_left{float:left}div.release_nav_guidance_left a,div.release_nav_guidance_right a{color:var(--mono-6);text-decoration:none}div.release_nav_guidance_right{float:right}div.release_nav_guidance_artist{text-align:center;width:100%}div.prev_image{width:3em;height:3em}div.prev_link{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-left:10px}div.next_image{width:3em;height:3em;margin-left:10px}div.next_link{text-align:right;flex:1;padding-left:.5em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.release_nav_artist{border-bottom:1px solid var(--mono-d);font-size:.8em;margin-top:5px;color:var(--mono-5)}.genre_descriptor_vote_btn{float:right;font-size:1.1em;padding:.25em;color:var(--mono-c);padding-left:1em;padding-right:.75em}.release_genres:hover .genre_descriptor_vote_btn{color:var(--mono-6)}.release_descriptors:hover .genre_descriptor_vote_btn{color:var(--mono-6)}.genre_descriptor_vote_btn:hover{color:var(--gen-blue-med)}table.album_info,table.film_info{margin-top:10px;font-size:1.1em}table.album_info a,table.film_info a{text-decoration:none}div.release_image{float:left;display:block;height:3em;width:3em;margin-left:5px;border-radius:3px;cursor:pointer}div.release_info{height:3em;margin-left:4em}div.release_title,div.release_artist{height:1.5em;line-height:1.5em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:290px}@media only screen and (min-width : 1300px){}div.release_title{font-weight:bold}div.release_title .subtext{font-weight:normal;font-size:.9em;color:var(--mono-8)}div.release_artist a.artist{font-weight:normal}div.release_artist{color:var(--mono-6);font-size:.9em}div.release_artist .subtext{font-size:.9em;color:var(--mono-8)}ul.alt_titles{display:none}ul.alt_titles li{list-style-type:none}.non_featured_credit{display:none}ul.tracks.allcredits .non_featured_credit{display:block}.release_info_classifiers{font-size:.9em;color:var(--mono-8);margin-left:8px}.track_credit_show_link{float:right;display:inline-block;font-size:.8em;color:var(--gen-blue-dark);cursor:pointer;line-height:1.2em}li.track ul.credits{margin-top:0px;margin-bottom:4px;padding:0;background:transparent}ul.tracks li.track ul.credits{margin-top:.25em}li.track ul.credits li{background:none!important;padding:0px;margin-bottom:1px;border:none;margin-left:1.5em;background:none;padding-left:3px}ul.credits{margin-bottom:0;font-size:1.1em;padding:1em}ul.tracks{border:.3px var(--ui-divider-line) solid;xborder-radius:2px}ul.tracks li.track{min-height:2.5em;list-style:none;font-size:.9em;color:var(--text-primary);background:var(--surface-primary);padding:.25em;padding-bottom:.25em;padding-right:0;padding-left:.2em;margin-bottom:0px;xborder-bottom:.3px var(--ui-divider-line) solid;overflow:hidden;text-overflow:ellipsis}ul.tracks li:nth-child(even){background:var(--surface-secondary)}ul.tracks li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.tracks li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.tracks li:last-child{border-bottom-left-radius:5px;border-bottom-right-radius:5px;border-bottom:none;margin-bottom:0}.tracklist_num{min-width:3em;min-height:14px;margin-right:.3em;line-height:1.58;margin-top:auto;margin-bottom:auto;display:block;float:left;color:var(--mono-6);font-weight:bold;text-align:center}.tracklist_title{display:flex;word-break:break-word;align-items:center;flex-wrap:wrap;font-size:1.1em;max-width:250px;min-height:12px;margin-top:6px;margin-bottom:6px;min-width:100px;padding-right:3px}@media only screen and (min-width : 1300px){.tracklist_title{max-width:340px}}ul.tracks.allcredits .tracklist_title{font-size:1.3em}ul.tracks.allcredits .tracklist_duration{font-size:.7692em}.tracks_work_link_frame{xdisplay:flex}.tracks_work_link,.tracks_lyric_link{background:var(--surface-tertiary);font-size:.75em;color:var(--text-primary);border-radius:10px;line-height:1;padding:0 .66em;margin-left:.66em}.page_release .page_section_feature_image{width:40%;height:40%}.page_release .page_section_features_frame h2{font-size:1.4em;color:var(--mono-6);font-weight:bold}.page_release .page_section_features_frame{padding:1em;padding-bottom:2em}.page_release_tracks_score{float:right;width:4.3em}.tracklist_duration{display:inline-block;margin-left:7px;color:var(--mono-6);font-size:.9em}.track_preview{float:right;font-size:1.8em;border-radius:3px;color:var(--mono-6);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}.track_play{float:right;font-size:1.8em;border-radius:3px;color:var(--mono-5);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}.track_download a{float:right;font-size:.9em;border-radius:3px;color:var(--mono-6);cursor:pointer;width:18px;height:12px;text-align:center;margin-left:10px}#track_rating_success,#notes_success,#acq_date_success,#listening_success{color:#383;display:inline-block;display:none}.track_rating{float:right;display:inline-block;width:2.4em;text-align:left;padding-left:6px;padding-right:2px}.track_rating_disp{float:right;margin-right:5px}.track_rating_hide{display:none}span.track_rating.recommended div.track_rating_avg{font-weight:bold}span.track_rating.not_significant div.track_rating_avg{color:var(--mono-a);font-weight:normal!important}.track_rating_avg{line-height:1.5em;font-variant:tabular-nums}.ratings_bar{height:4px;background:var(--gen-blue-dark);border-radius:3px}span.track_rating.not_significant div.ratings_bar{background:var(--mono-a)}a.affiliate_link{text-decoration:none}#track_preview{text-align:center;margin-top:10px}th.info_hdr{width:105px;color:var(--mono-6);font-weight:normal;font-size:.9em;text-align:left;padding:5px;padding-right:10px;border:none}table.album_info td,table.film_info td{padding:3px}.avg_rating{font-size:1.2em;font-weight:bold}.avg_rating_friends{color:#383;font-weight:bold;font-size:1em}.max_rating{font-size:.9em;color:var(--mono-6)}.num_ratings{font-size:.95em;color:var(--mono-4)}.release_touch_guidance{font-size:.9em;color:var(--mono-6);display:none}.release_my_catalog{display:flex;flex-flow:row wrap;line-height:2.3}.my_catalog_rating{background-color:var(--mono-f8);border:1px var(--mono-d) solid;border-radius:3px;width:141px;height:32px;padding:6.5px;padding-left:10px;opacity:.8;margin-right:5px;cursor:pointer;outline:none}.my_catalog_rating.inrate{opacity:.6}div.rating_stars{background:url(https://e.snmc.io/2.5/img/star_sprite_4.png) no-repeat top left;display:block;float:left;width:90px;height:16px;margin-right:5px}div.rating_loading{display:none;float:left;width:90px;height:16px;margin-right:5px;line-height:17px}div.rating_num{display:block;float:left;width:24px;height:16px;line-height:16px;font-size:1.1em;color:var(--text-primary)}div.loading div.rating_stars,div.loading div.rating_num{display:none}div.loading div.rating_loading{display:block}.my_catalog_catalog{line-height:2.3}.my_catalog_tags,.my_catalog_review{position:relative;line-height:2.3}.my_catalog_tags .tag_dlg{position:absolute;display:none;left:0px;top:2.8em;padding:5px;padding-top:0;padding-bottom:5px;width:220px;background:var(--mono-f8);border:1px var(--mono-d) solid;z-index:10}.tag_dlg label{font-size:10px!important;font-weight:bold!important;line-height:10px!important;padding:0!important;margin:0!important}input.tag_tags{font-size:.9em;background:var(--mono-f);width:150px;border:1px solid var(--mono-c);border-radius:3px;padding:3px}a.tag_save{padding:3px;padding-left:5px;padding-right:5px;background:var(--gen-blue-darker);line-height:24px;margin-left:4px;border-radius:3px;color:var(--mono-f);text-decoration:none}.catalog_btn,.format_btn,.review_save_btn,.review_btn,.track_rating_btn,.listening_btn,.notes_btn,.more_btn,.tag_btn{min-width:3em;text-align:center;background-color:var(--mono-db);border-radius:4px;padding:.25em .8em .25em 3em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative}.more_btn{padding:.25em .8em}.format_btn{min-width:3em;line-height:2.2;text-align:center;background-color:var(--mono-ef);border-radius:4px;padding:.3em .8em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative}.listening_btn{cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_listening.png);background-size:2.3em auto;background-repeat:no-repeat;background-position:5% 50%}.bump_btn{min-width:3em;text-align:center;background-color:var(--mono-db);border-radius:4px;padding:.3em .8em;margin:0em .3em .3em .3em;font-size:.8em;color:var(--mono-4);position:relative;display:none;color:var(--mono-8)}.bump_btn.bumpable{background:var(--mono-db);cursor:pointer;color:var(--mono-4)}.track_rating_btn.has_ratings{background-image:url(https://e.snmc.io/2.5/img/line_icon_trackrating_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.more_btn.has_more{background-color:#dddcf3;font-weight:bold}.review_btn.has_review{background-image:url(https://e.snmc.io/2.5/img/line_icon_review_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.more_btn.has_more{background-color:#dddcf3;font-weight:bold}input.review_save_btn,a.review_save_btn{background-color:var(--gen-blue-darker);border:1px solid var(--gen-blue-darker);border-radius:3px;padding-left:1em;padding-right:1em;margin-right:3px;margin-top:8px;margin-bottom:2px;line-height:1.5;font-size:1em;color:var(--mono-f);cursor:pointer}#review_save_btn{padding-left:35px;padding-right:35px}.review_save_btn:disabled,.review_save_btn:disabled:hover{color:var(--mono-8);cursor:default;background:#e4e4e4;border:1px solid #e4e4e4}.tag_btn.has_tags{background-image:url(https://e.snmc.io/2.5/img/line_icon_tag_white.png);background-color:var(--gen-blue-darker);color:var(--mono-f)}.catalog_btn,.review_btn,.track_rating_btn,.notes_btn,.more_btn,.tag_btn{cursor:pointer}.review_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_review.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.track_rating_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_trackrating.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.catalog_btn{background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}#format_note{line-height:12px;color:var(--mono-6);background:var(--mono-e);padding:10px}.format_btn_options{position:absolute;display:none;left:0px;top:2.8em;width:180px;background:var(--mono-f8);border:1px var(--mono-d) solid;padding:0;z-index:10}.format_btn_option{padding-left:8px;padding-right:8px;color:var(--text-primary);cursor:pointer}.format_btn_option.default_format{background:var(--gen-bg-yellow)}.format_btn_option:hover{background:var(--mono-d8)}.format_btn{background:var(--gen-bg-lightgreen);border-top-left-radius:0;border-bottom-left-radius:0}.catalog_btn_options{position:absolute;display:none;left:0px;top:2.8em;width:120px;background:var(--mono-f8);border:1px var(--mono-d) solid;padding:0;z-index:10}.catalog_btn_option{padding-left:8px;padding-right:8px;color:var(--mono-6);cursor:pointer}.catalog_btn_option:hover{background:var(--mono-d8)}.catalog_btn.catalog_u{background:var(--mono-d8);color:var(--mono-0);border-top-right-radius:0;border-bottom-right-radius:0;margin-right:0;cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.catalog_btn.catalog_o,.catalog_btn.catalog_w{background:var(--gen-bg-lightgreen);color:var(--text-primary);border-top-right-radius:0;border-bottom-right-radius:0;margin-right:0;cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_catalog.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%;position:relative}.tag_btn{cursor:pointer;background-image:url(https://e.snmc.io/2.5/img/line_icon_tag.png);background-size:2.2em auto;background-repeat:no-repeat;background-position:5% 50%}div.catalog_section{margin-right:6px;margin-left:0px;padding-bottom:20px;position:relative;min-height:300px}.catalog_list{margin-right:215px;padding-top:10px}.catalog_list span.navspan,.review_list{text-align:right;background:var(--mono-f3);border-radius:3px;padding-left:5px;padding-right:5px;display:block;margin-bottom:10px;line-height:2em}.catalog_list span.navlinkcurrent,.review_list span.navlinkcurrent{color:var(--mono-5);font-weight:bold}.catalog_list span.navspan a,.review_list span.navspan a{text-decoration:none}@media only screen and (max-width:48.1em){.catalog_list span.navspan a,.review_list span.navspan a,.catalog_list span.navlinkcurrent,.review_list span.navlinkcurrent{padding-left:.33em;padding-right:.33em;line-height:1.7}}.review_sort{float:left;color:var(--mono-6);font-size:.9em;margin-left:2px;line-height:15px;height:15px;margin-top:5px;margin-bottom:5px}.sort_choice{display:inline-block;padding-left:5px;padding-right:5px;text-align:center;border-right:1px var(--mono-a) solid;cursor:pointer}.sort_choice:hover{color:var(--mono-4)}.sort_choice.selected{font-weight:bold;color:var(--mono-4)}.sort_choice:last-child{border-right:none}.catalog_stats{width:200px;float:right;min-height:300px;padding-top:15px;position:absolute;right:0;top:0}.catalog_stats div.header{font-size:1.1em;color:var(--mono-3);background:var(--mono-e);border-radius:3px;text-align:center;line-height:20px;width:200px}.catalog_header{background:var(--mono-ef);height:25px;line-height:25px;padding-left:0px;padding-right:0px;border-radius:3px;margin-bottom:4px}.catalog_header a.user,.catalog_header a.useri,.catalog_header a.usero{font-weight:bold;text-decoration:none;font-size:.9em}.catalog_rating_system_comment{float:right;margin-right:5px;font-size:.9em;color:var(--mono-5);margin-left:8px}.catalog_track_ratings{float:right;cursor:pointer;width:24px;height:25px;margin-left:5px;font-size:.9em;font-weight:bold;color:var(--mono-8);text-align:center;background:rgba(0,0,0,.05)}.no_track_ratings{background:var(--mono-e);padding:10px;border-radius:3px;margin:10px}.catalog_no_track_ratings{float:right;width:24px;height:25px;margin-left:5px}.catalog_date{float:left;width:100px;height:25px;font-size:.9em;line-height:25px;background:var(--mono-f8);color:var(--mono-6)}.catalog_line.my_rating:hover .catalog_date{color:var(--mono-d8)}.catalog_line.my_rating .catalog_date_inner{background:var(--mono-f0);border-radius:3px;color:var(--mono-5);border:1px var(--mono-d) solid;line-height:24px;padding-right:12px}.catalog_date_inner{padding-right:12px;text-align:right}.catalog_line.my_rating .catalog_bump,.catalog_line.can_delete .catalog_delete{display:none;background:var(--mono-f0);border-radius:3px;margin-right:3px;margin-left:3px;color:var(--mono-5);border:1px var(--mono-d) solid;line-height:24px;text-align:center;cursor:pointer}.catalog_bump:hover{background:#f4f4ff!important;cursor:pointer}.catalog_line.my_rating:hover .catalog_date_inner,.catalog_line.can_delete:hover .catalog_date_inner{display:none}.catalog_line.can_delete:hover .catalog_delete{display:block}.catalog_line.my_rating:hover .catalog_bump{display:block}.catalog_line{position:relative}.catalog_year{font-size:1.1em;font-weight:bold;color:var(--mono-6);height:20px;line-height:20px;border-radius:3px;margin-bottom:5px;margin-top:3px}.catalog_ownership{font-size:.9em;color:var(--mono-6);margin-left:8px}.catalog_rating{float:right;width:90px;height:16px;margin-top:3px;margin-left:4px}.contributor_header{font-size:.9em;color:var(--mono-6)}.my_review label{display:inline-block;margin-top:5px}.my_review.edit_mode #saved_review{display:none}.my_review.view_mode #review_edit{display:none}.saved_review{background:var(--mono-f);border:1px solid var(--mono-d);border-radius:3px;padding:10px}label span.review_label{font-weight:normal;font-size:1.2em}label span.subtext{display:block;font-weight:normal;font-size:.95em;color:var(--mono-6);margin-top:4px;margin-left:10px;max-width:500px;margin-bottom:8px}label span.inline_subtext{font-weight:normal;font-size:.95em;color:var(--mono-4);margin-left:5px}.subtext ul{margin-left:24px;margin-top:5px;margin-bottom:9px}.subtext ul li{list-style:circle}.subtext a{text-decoration:none}#published_rules{display:none;color:var(--gen-blue-darker);font-weight:bold}.textarea_toolbar{height:21px;margin-top:4px;margin-bottom:1px}.textarea_toolbar a{padding:3px;padding-left:5px;padding-right:5px;border:1px solid var(--mono-c);background:var(--mono-d8);font-weight:bold;margin-left:3px;margin-top:6px;margin-bottom:4px;text-decoration:none;color:var(--mono-8);border-radius:2px;font-size:.8em}.textarea_toolbar a:hover{background:var(--gen-bg-yellow);color:var(--mono-6)}.track_rating_title_autosave_frame{font-size:.875em;max-width:500px;display:flex;justify-content:flex-end;padding-top:.25em;align-items:center}#page_release .track_rating_release_title{display:none}.track_ratings_autosave_frame{padding-left:1em}#track_ratings_autosave{margin-right:.125em}.track_rating_release_title{flex:1;font-size:1.25em;font-weight:bold}ul#track_ratings{max-width:500px;margin-top:10px;margin-bottom:10px}ul#track_ratings .my_catalog_rating{background-color:transparent;border:none}#my_track_ratings{display:none}#my_track_ratings.autosave_enabled .track_ratings_actions{display:none}#my_track_ratings:not(.autosave_enabled) .track_rating_status{display:none}#my_more_info{display:none;background:var(--mono-f8);padding:15px;width:auto;border-radius:5px}ul#discussion{border:1px solid var(--mono-b);border-radius:3px;background:var(--mono-f);overflow:hidden;padding:10px;padding-top:5px;padding-bottom:5px}ul#discussion li{list-style:none;font-size:1.2em;background:var(--mono-f);margin-bottom:0px;line-height:1.2em;max-width:325px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}@media only screen and (min-width : 1300px){ul#discussion li{max-width:390px}}.star-0m{background-position:0 0!important;width:90px;height:16px}.star-10m{background-position:0 -66px!important;width:90px;height:16px}.star-1m{background-position:0 -132px!important;width:90px;height:16px}.star-2m{background-position:0 -198px!important;width:90px;height:16px}.star-3m{background-position:0 -264px!important;width:90px;height:16px}.star-4m{background-position:0 -330px!important;width:90px;height:16px}.star-5m{background-position:0 -396px!important;width:90px;height:16px}.star-6m{background-position:0 -462px!important;width:90px;height:16px}.star-7m{background-position:0 -528px!important;width:90px;height:16px}.star-8m{background-position:0 -594px!important;width:90px;height:16px}.star-9m{background-position:0 -660px!important;width:90px;height:16px}.review{margin-bottom:10px;border-bottom:1px var(--mono-f0) solid}.review_featured_info{font-size:18px;margin-bottom:10px}.review_featured_info a.artist{font-weight:normal;color:#338}.review_body{word-wrap:break-word;word-break:break-word;display:inline-block;padding:5px;padding-top:12px;padding-right:38px;padding-left:38px;font-size:1.1em;color:var(--mono-4)!important;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;width:100%;line-height:1.4}@media only screen and (max-width:48.1em){.review_body{padding:1em .5em}}.review_body span{color:var(--mono-4)!important}.review_body.featured{background:var(--mono-f8);padding:12px}.review_body a.normal_link{color:var(--mono-6);text-decoration:none}.review_title{font-weight:bold;word-wrap:break-word;word-break:break-word;display:block;margin-bottom:4px;color:var(--mono-0)}.review_header{background:var(--mono-e);height:2.4em;line-height:2.4em;padding-left:0px;padding-right:0px;border-radius:3px;border-bottom-left-radius:0px;border-bottom-right-radius:0px;padding:0px}.review_header_no_img{float:left;margin-right:10px;width:2.4em;height:2.4em;border-radius:3px;background:var(--mono-d8)}.review_header_img{float:left;margin-right:10px;display:inline-block;border-radius:3px;width:2.4em;height:2.4em}.review_issue_label{font-size:.8em;color:var(--mono-6);margin-top:4px;margin-bottom:0px;text-align:right}.review_attribution{font-size:.8em;margin-top:5px;color:var(--mono-6)}.review_supplement{color:var(--mono-4);font-size:.9em;margin-top:8px}.review_supplement_expand{background:var(--mono-f4);padding:2px;padding-left:0;display:block;text-align:center;width:auto;font-size:.9em;cursor:pointer}.review_supplement.supplement_hidden{display:none}.review_publish_status{text-align:right;font-size:.7em;margin-top:5px;color:var(--mono-6)}.review_publish_status a{color:var(--mono-6);text-decoration:none}.review_header.friend,.catalog_header.friend{background:var(--gen-bg-lightgreen)}.review_header a.user,.review_header a.useri,.review_header a.usero{font-weight:bold;text-decoration:none}.review_featured{margin-left:.9em;color:var(--mono-6);font-style:italic}.review_date{font-size:.9em;color:var(--mono-8);margin-left:8px}.review_date a{text-decoration:none}.review_date a:hover{text-decoration:underline}.review_rating{float:right;width:90px;height:16px;margin-top:3px;margin-left:4px;margin-right:8px}.review_voting{position:relative;float:right;width:7.6em;height:2.4em;line-height:2.4em;margin-top:2px;margin-left:4px;margin-right:0px}.review_help{display:none;position:absolute;width:300px;right:0;top:25px;border-radius:3px;background:var(--mono-f);padding:15px;color:var(--mono-5);background:var(--mono-f);background:var(--mono-f);line-height:15px;font-size:.9em;border:4px solid rgba(0,0,0,.5);background-clip:padding-box}.review_vote_down,.review_vote_up,.review_vote_bookmark{position:relative;width:2.4em;border-radius:3px;display:inline-block;text-align:center;cursor:pointer}.voting_tip{display:none;position:absolute;background:rgba(0,0,0,.9);text-align:center;border-radius:3px;top:-24px;line-height:2.4em;width:100px;left:-40px;color:var(--mono-f);font-size:.8em}span.review_vote_down:hover span.voting_tip{display:block!important}span.review_vote_up:hover span.voting_tip{display:block!important}span.review_vote_bookmark:hover span.voting_tip{display:block!important}.review_vote_count{width:3.2em;height:2.4em;float:right;position:relative;font-size:.8em;color:var(--mono-6);display:inline-block;text-align:center;cursor:pointer;margin-left:0px;margin-right:2px}.review_vote_down:hover,.review_vote_up:hover,.review_vote_bookmark:hover{background:var(--mono-f4)}.review_voting i.fa-caret-down,.review_voting i.fa-caret-up{font-size:1.2em;color:var(--mono-a)}.review_vote_down.voted i{color:var(--gen-text-red)}.review_vote_bookmark.bookmarked i{color:#00f!important}.review_vote_up.voted i{color:green!important}.review_vote_up i{line-height:7px}.review_vote_down i{line-height:7px}.review_vote_bookmark{line-height:2em;height:2.4em;vertical-align:top}.review_vote_bookmark i{font-size:.7em;color:var(--mono-8)}.rating_info_table{height:30px;border-radius:5px}.rating_info_table div{cursor:pointer}.rating_info_table div.disabled{color:gray;cursor:default}.rating_info_table div.active{background:var(--mono-d);cursor:default}.rating_info_ratings,.rating_info_cataloged,.rating_info_track_ratings{width:33%;display:block;height:24px;line-height:24px;float:left;background:var(--mono-e);text-align:center}.rating_info_ratings{border-top-left-radius:3px;border-bottom-left-radius:3px;border-right:1px solid var(--mono-b)}.rating_info_cataloged{border-right:1px solid var(--mono-b)}.rating_info_track_ratings{border-top-right-radius:3px;border-bottom-right-radius:3px}div#searchsuggestions{margin:0;border:var(--mono-8) 1px solid;padding:0;width:188px}div.suggestion{font-size:.9em;background:var(--mono-f);color:var(--mono-6);padding-left:3px;padding-right:3px;margin:0}div.suggestionsel{font-size:.9em;background:var(--mono-f);color:var(--text-primary);padding-left:3px;padding-right:3px;margin:0;background:var(--gen-blue-lightest)}.album_artist_small{font-size:.6em;color:var(--mono-6);line-height:1.3em}@media only screen and (max-width:48.1em){.album_title{padding:.4em;padding-top:0px;padding-bottom:.3em;font-size:1.8em;margin-bottom:0em}.release_right_column .section_main_info.section_outer{padding:0px;padding-top:15px;padding-bottom:25px}div.catalog_list{width:100%}.rating_info_tab{font-size:11px}ul.issues{min-width:0px}}.bkg-metadata-star-bold{background-image:var(--metadata-star-bold)}img.metadata-star-bold{content:var(--metadata-star-bold)}.bkg-metadata-star{background-image:var(--metadata-star)}img.metadata-star{content:var(--metadata-star)}.page_release_tracks_score{opacity:.5}.page_release_tracks_score.significant{opacity:1}.page_release_section_tracks_songs_song_stats{xwidth:7.25em;float:right;text-align:center;align-items:flex-start;padding:0 .5em;padding-right:0;line-height:1;display:flex;xalign-self:flex-end;gap:.5em;position:relative}.page_release_section_tracks_track_stats_scores{font-size:1em;font-size:.925em;text-align:center;align-items:flex-start;padding:0;line-height:1.75;display:flex;gap:.5em;position:relative;justify-content:flex-end;border-radius:12px;display:flex;align-items:center}.page_release_section_tracks_track_stats_count{min-width:2.5em;padding-right:.5em;text-align:center;color:var(--text-secondary);font-size:.875em;display:flex;align-items:center}.page_release_section_tracks_track_stats_score_star{display:flex;align-items:center;gap:.25em}.page_release_section_tracks_has_lyrics,.page_release_section_tracks_has_work{background:var(--surface-tertiary);font-size:.75em;color:var(--text-primary);border-radius:10px;padding:0 .75em;margin-left:.5em}.page_release_section_tracks_track_stats_rating{font-weight:bold;margin-bottom:.0625em;width:1.8em;justify-content:center;display:flex}.page_release_section_tracks_track_stats img{width:.66em;height:.66em}html{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/light/svg/star_bold.svg)}html.theme_eve,html.theme_night{--metadata-star: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star.svg);--metadata-star-bold: url(//e.snmc.io/3.0/img/ui/catalog/metadata/eve/svg/star_bold.svg)}
+ul.issues{border-radius:5px;max-height:211px;background:var(--mono-fb);padding:5px;border:1px var(--mono-d) solid;overflow:hidden;overflow-y:scroll}ul.issues.expanded{max-height:inherit}ul.issues li{list-style:none;height:3em;font-size:.9em;color:#5e5b5b;background:var(--mono-fb);padding:0px;margin-bottom:3px;margin-top:3px;border-radius:3px;text-overflow:ellipsis;white-space:nowrap}ul.issues li:last-child{border-bottom:none}ul.issues li.release_view{text-align:center;height:3em;line-height:3em}ul.issues li.release_view a{color:var(--gen-blue-darkest);text-decoration:none}ul.issues li:hover{background:var(--mono-f)}ul.issues li.release_view{cursor:default;background:var(--mono-f2);color:var(--mono-3);font-size:.9em;border-radius:5px;margin-bottom:5px;text-align:center}ul.issues li.current .issue_info_top{font-weight:bold}ul.issues li.issue_info_release{background-color:var(--surface-secondary);font-weight:bold}span.primary_indicator{color:var(--gen-text-red)}ul.issues li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.issues li:first-child{border-top-left-radius:5px;border-top-right-radius:5px}ul.issues li:last-child{border-bottom-left-radius:5px;border-bottom-right-radius:5px}span.main_issue_info{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:500px}span.issue_countries,span.issue_label,span.issue_cat,span.issue_formats{display:block;float:left;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.issue_info_top{height:1.5em;line-height:1.5em;padding-left:5px;padding-right:5px}div.issue_info_bottom{height:1.5em;line-height:1.5em;padding-right:5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}span.issue_formats{display:inline-block;width:136px}span.issue_attributes{color:var(--mono-6);margin-left:5px}span.issue_attributes span.smallgray{font-size:9px}span.issue_countries{float:right;text-align:right;margin-right:10px;position:relative;display:inline-block;min-width:100px}div.additional_countries{display:none;position:absolute;right:0;background:var(--mono-f);border:1px solid var(--mono-c);padding:4px;top:-5px}span.issue_countries:hover div.additional_countries{display:block}span.issue_label{display:inline-block;width:200px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}span.issue_cat{display:inline-block;width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}span.issue_title a{font-size:1.1em;text-decoration:none;color:var(--gen-blue-darker)}span.issue_year.ymd{color:var(--mono-0)}span.issue_year.ym{color:var(--mono-6)}span.issue_year.y{color:var(--mono-8)}a.sametitle{color:var(--mono-4)!important}a.sametitle:hover{color:#33f!important}li.current a.sametitle:hover{color:var(--mono-4)!important}div.issue_no_img{display:block;width:35px;color:var(--mono-4);float:left;height:3em;width:3em;margin-right:10px;margin-left:0px;background:var(--mono-d8);border-radius:3px}div.issue_img{display:block;width:35px;color:var(--mono-4);float:left;height:3em;width:3em;margin-right:10px;margin-left:0px;border-radius:3px;background-size:cover!important;background-position:center center!important}span.issue_year{display:block;float:left;width:3em;color:var(--mono-4);font-size:.9em;margin-right:10px;margin-left:0px}
+.profile_listening_container{display:flex;flex-flow:row nowrap;justify-content:flex-start;align-items:center;flex-basis:100%;border:solid 1px rgba(0,0,0,.1);background-color:var(--mono-f);border-radius:6px;padding:.5em;margin:2em .4em .6em .4em;overflow:hidden}.profile_set_listening_box{display:flex;flex-flow:column nowrap;justify-content:flex-end;flex-basis:9em;align-items:center;font-size:.9em;line-height:1.7;margin-right:.8em}.profile_set_listening_btn .btn{padding:.5em 2em;margin-left:0}.profile_set_listening_btn .btn:hover{padding:.5em 2em;margin-left:0}#profile_play_history_container{display:flex;justify-content:flex-start}.profile_view_play_history_btn{display:flex;justify-content:flex-end;flex:1}.profile_view_play_history_btn .btn{line-height:1.5;text-align:center;padding:.7em .8em}.profile_view_play_history_btn .btn:hover{line-height:1.5;padding:.7em .8em}#play_history_edit_box{padding:.5em .2em;flex:1 1 50%}#profile_listening_input_container{display:flex;justify-content:flex-start;align-items:flex-start;flex:1;margin-right:.5em}#play_history_edit{flex-basis:100%;padding:.25em;margin-right:1em}#profile_listening_input_container .btn{line-height:1.5;margin-top:0em}#profile_listening_input_container .btn:hover{line-height:1.5;margin-top:0rem}.note.profile_listening_note{display:flex;flex-direction:row;margin-top:1em;font-size:.8em;padding:.4em;margin:.5em 1em 0em 0em}.fa.profile_listening_note_icon{display:flex;margin-right:.4em;font-size:1.1em;color:var(--gen-blue-darker)}#play_history_item_line{border-bottom:solid .5px rgba(0,0,0,.05);margin-left:4em}#play_history{display:flex;flex-flow:column nowrap;width:100%;margin-bottom:4em}.play_history_item{display:flex;flex-flow:row nowrap;justify-content:flex-start;align-items:first-baseline;padding-top:.4em}.play_history_artbox{display:flex;align-items:center;max-width:3em;margin-right:1em}.play_history_item_art{border-radius:.2em;max-width:100%}.play_history_infobox{display:flex;flex-flow:column nowrap;flex-basis:100%;overflow:hidden;padding:.4em 0 .6em 0}.play_history_item_date{color:var(--mono-9);font-size:.8em;margin-bottom:.3em;line-height:1.2}.play_history_infobox_lower{display:flex;flex-flow:row wrap}.play_history_interpunct{color:var(--gen-blue-darkest);font-size:1.5em;font-weight:bold;margin:0 .8em}.play_history_separator{margin:0em .4em}.play_history_comment{color:var(--mono-7);font-style:italic}.play_history_item_delete{justify-content:flex-end;align-self:center;margin-left:0em}.play_history_chart{display:table;width:100%;margin-bottom:5em}.play_history_chart_item{display:table-row;border:1px solid var(--mono-e);margin:.5em}.play_history_chart_item_col{display:table-cell;padding:.5em}.play_history_chart_item:nth-child(even){background:var(--mono-e)}.play_history_chart_col_pos{width:50px;text-align:center;vertical-align:middle;font-size:40px;font-weight:700;color:var(--mono-7)}#play_history_user_profile{display:table;width:100%;margin-bottom:5em}.play_history_user_profile_row{display:table-row;border:1px solid var(--mono-e);margin:.5em}.play_history_user_profile_col{display:table-cell;padding:.5em}#release_play_selection{display:none;background-color:var(--mono-f);padding:1.4em;margin-top:.8em;margin-bottom:1em;border:1px solid rgba(0,0,0,.1);border-radius:.4em}.listening_header{display:block;font-size:1.1em;margin-bottom:.6em}#listening_current{margin-top:0em;margin-bottom:2em;font-size:.9em}.listening_track{list-style:none;font-size:1em;color:var(--mono-2);overflow:hidden;text-overflow:ellipsis}.listening_tracklist_line{display:flex;flex-flow:row nowrap;align-items:baseline;padding:.8em 0 .4em 1em}.listening_tracklist_num{font-size:1em;padding-right:1.2em;color:var(--mono-6)}.listening_tracklist_title{display:block;font-size:.9em}.listening_tracks_dropdown{font-size:.9em;margin:.8em 0 .3em 1.2em;cursor:pointer;outline:none}.listening_entire_album{font-size:1em}.listening_comments_container{display:flex;flex-direction:column}.listening_comment_btns_container{display:flex;flex-direction:row;justify-content:flex-end}.listening_comments_inputbox{width:100%;margin-top:.8em;margin-bottom:.3em;padding:.3em 1em;box-sizing:border-box;border-radius:10em;border:1px solid var(--mono-c)}.listening_no_track_ratings{background:var(--mono-f3);font-size:.9em;font-style:italic;padding:.8em 0 .3em 1em;border-radius:3px;margin:.8em 0em}.track_select_btn{cursor:pointer}#listening_btn{cursor:pointer}.listening_selected{background:var(--mono-e)!important;font-weight:bold;color:var(--text-primary)}ul.listening_selector li:hover{background:var(--mono-f8)}
+ul.suggestions{min-height:500px;border:1px var(--mono-c) solid;border-radius:5px;padding:1em;padding-right:1.5em;background:var(--mono-f);font-size:.9em}ul.suggestions li{list-style:none;color:var(--mono-4);background:var(--mono-f);padding:0px;margin-top:5px;margin-bottom:5px}.page_suggestions_not_available{font-size:1.3em;padding:1em;padding-top:3em;text-align:center}.page_discography_line{margin-top:.25em;margin-bottom:.25em;border-radius:8px}.page_discography_line_detail{display:none}.page_discography_line:nth-child(odd){background:rgba(128,128,128,.1)}.page_discography_img{background-size:cover!important;background-position:center center!important;background-repeat:no-repeat!important;width:4.2em;height:4.2em;background-color:var(--mono-d)!important;float:left;box-shadow:1px 1px 0px var(--mono-d);margin-right:1em}.page_discography_line_1{font-size:1.2em;padding-top:.5em;padding-bottom:.125em}.page_discography_line_1.recommended a.release{font-weight:bold}.page_discography_line_1 a.release{margin-right:.25em}.page_discography_artist_names{margin-left:.25em;font-size:.9em}ul.suggestions .component_discography_item_stats{width:6em;font-size:.9em}ul.suggestions .component_discography_item_details_reviews{display:none}.page_discography_attribute{font-size:.8em;padding:.1em;padding-left:.6em;padding-right:.6em;border-radius:5px;background:var(--mono-e8);color:var(--mono-5);font-weight:bold;display:inline-block;margin-right:.3em}.page_discography_average{float:right;font-size:1.3em;width:3.3em;text-align:center;line-height:2.8}.page_discography_reviews,.page_discography_ratings{float:right;width:4.3em;font-size:.9em;text-align:center;color:var(--mono-6);line-height:4}.page_discography_line_2{font-size:.9em;padding-top:.25em;padding-bottom:.5em;margin-left:5.85em}.page_discography_date{font-weight:bold;color:var(--mono-6);margin-right:.5em}.page_discography_date_full{display:none}.page_object_section_suggestions_refresh{float:right;font-size:1.2em;color:var(--mono-8);padding-left:.5em;padding-right:.5em;line-height:1.5;cursor:pointer}
+.more_comments{margin:5px;padding:10px;border:1px var(--mono-c) solid;border-radius:5px;background:var(--mono-e);text-align:center;color:var(--text-primary);font-weight:bold}.more_comments:hover{background:var(--mono-f);cursor:pointer}.page_mentions_header{padding:1em;margin-top:1em}.page_mentions_header h1{margin-bottom:.5em}.page_reference_content{padding:.5em}.page_reference_discussion_title,.page_mentions_item_description{padding:.5em;padding-left:1.5em;padding-right:1.5em;background:var(--mono-f2);font-size:1.1em;border-bottom:1px solid var(--mono-d)}.page_reference_content .post_actions,.page_reference_content .post_shortcut{display:none}.page_mentions_none{padding:1em;font-size:1.2em;color:var(--mono-8)}div.comments{max-width:525px;background:var(--mono-f);border-radius:3px;border:1px solid var(--mono-e);position:relative}ul.comments_list{max-height:300px;overflow-y:auto;margin:10px;margin-bottom:0;-webkit-overflow-scrolling:touch}.comment_help{display:none;position:absolute;width:300px;right:0;top:25px;border-radius:3px;background:var(--mono-f);padding:15px;color:var(--mono-5);background:var(--mono-f);background:var(--mono-f);line-height:15px;font-size:.9em;border:4px solid rgba(0,0,0,.5);background-clip:padding-box;z-index:80}.comment_no_img{float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)}.comment_img{float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px;background-size:cover!important;background-color:var(--mono-0);background-position:center center!important}ul.comment_rules{margin-top:10px;margin-bottom:10px}ul.comment_rules li{list-style-type:circle;list-style-position:inside;margin-bottom:2px;margin-top:2px}li.comment{list-style:none;margin:0;margin-bottom:5px;margin-top:5px}.comment_header{background:var(--mono-f8);height:25px;line-height:25px;padding-left:0px;padding-right:0px;border-radius:3px;margin-bottom:0px}.comment_header a.user,.comment_header a.useri,.comment_header a.usero{font-weight:bold;text-decoration:none;font-size:.9em}.comment_date{font-size:.9em;color:var(--mono-6);margin-right:8px;float:right}.comment_body{padding:5px;padding-top:10px;font-size:1em;color:var(--mono-4);-webkit-text-size-adjust:100%;word-wrap:break-word;word-break:break-word;display:inline-block}.comment_post_btn,.comment_post_add_btn,.comment_cancel_btn{cursor:pointer;text-align:center;font-weight:bold;background:var(--mono-db);text-decoration:none;color:var(--text-primary);border-radius:3px;line-height:24px;margin-top:5px;font-size:11px!important;height:24px!important}.comment_post_btn{background:var(--mono-db);color:var(--text-primary);cursor:pointer}.comment_post_btn{float:right;width:45%}.comment_cancel_btn{float:left;width:45%}.comments_post{position:relative;background:var(--mono-f8);border-radius:4px;padding:0px}.comments_post_loading{position:absolute;display:none;background:rgba(168,168,168,.2);border-radius:4px;width:100%;height:100%}.comment_new{box-sizing:border-box;display:block;border-radius:3px;padding:3px;border:1px solid var(--mono-c);width:100%;margin-top:5px;margin-bottom:5px;height:60px;font-size:.9em;color:var(--mono-6)}.comment_mod{font-size:.8em;color:var(--mono-8);text-align:right}.comment_mod span:hover{cursor:pointer;color:var(--gen-blue-darkest)}.comment_new.loading{background:var(--mono-e8);border:1px var(--mono-e8) solid;color:var(--mono-8)}div.comments.view .comment_new{display:none}div.comments.view div.comment_post_btn,div.comments.view div.comment_cancel_btn{display:none}div.comments.edit div.comment_post_add_btn{display:none}
+ul.suggestions{min-height:500px;border:1px var(--mono-c) solid;border-radius:5px;padding:1em;padding-right:1.5em;background:var(--mono-f);font-size:.9em}ul.suggestions li{list-style:none;color:var(--mono-4);background:var(--mono-f);padding:0px;margin-top:5px;margin-bottom:5px}.page_suggestions_not_available{font-size:1.3em;padding:1em;padding-top:3em;text-align:center}.page_discography_line{margin-top:.25em;margin-bottom:.25em;border-radius:8px}.page_discography_line_detail{display:none}.page_discography_line:nth-child(odd){background:rgba(128,128,128,.1)}.page_discography_img{background-size:cover!important;background-position:center center!important;background-repeat:no-repeat!important;width:4.2em;height:4.2em;background-color:var(--mono-d)!important;float:left;box-shadow:1px 1px 0px var(--mono-d);margin-right:1em}.page_discography_line_1{font-size:1.2em;padding-top:.5em;padding-bottom:.125em}.page_discography_line_1.recommended a.release{font-weight:bold}.page_discography_line_1 a.release{margin-right:.25em}.page_discography_artist_names{margin-left:.25em;font-size:.9em}ul.suggestions .component_discography_item_stats{width:6em;font-size:.9em}ul.suggestions .component_discography_item_details_reviews{display:none}.page_discography_attribute{font-size:.8em;padding:.1em;padding-left:.6em;padding-right:.6em;border-radius:5px;background:var(--mono-e8);color:var(--mono-5);font-weight:bold;display:inline-block;margin-right:.3em}.page_discography_average{float:right;font-size:1.3em;width:3.3em;text-align:center;line-height:2.8}.page_discography_reviews,.page_discography_ratings{float:right;width:4.3em;font-size:.9em;text-align:center;color:var(--mono-6);line-height:4}.page_discography_line_2{font-size:.9em;padding-top:.25em;padding-bottom:.5em;margin-left:5.85em}.page_discography_date{font-weight:bold;color:var(--mono-6);margin-right:.5em}.page_discography_date_full{display:none}.page_object_section_suggestions_refresh{float:right;font-size:1.2em;color:var(--mono-8);padding-left:.5em;padding-right:.5em;line-height:1.5;cursor:pointer}
+ul.lists{border:1px var(--mono-e) solid;border-radius:5px;background:var(--mono-f);padding:5px;font-size:1.2em;margin-top:8px}ul.lists li{list-style:none;font-size:.8em;color:var(--mono-4);background:var(--mono-f);overflow:hidden;padding:0;padding:4px;border-radius:5px}ul.lists li.expand_button{background:var(--mono-e)}ul.lists li:hover{xbackground:var(--mono-e)}ul.lists li:last-child{border-bottom:none}div.list_image{float:left;width:3em;height:3em;background-color:var(--mono-d);border-radius:5px}div.list_info{margin-left:3.9em}div.list_name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}#addtolist{position:relative}#add_to_list_lists{position:absolute;top:1.2em;display:none;right:0;width:200px;height:200px;overflow-y:auto;overflow-x:hidden;background:var(--mono-f);border:1px solid var(--mono-d8);border-radius:3px;z-index:20}#add_to_list_lists a{display:inline-block;text-decoration:none;font-size:1em;width:180px;padding:5px;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;border-radius:3px}#add_to_list_lists a:hover{background:var(--mono-f8)}#addtolist:hover #add_to_list_lists{display:block}#add_to_list_btn{float:right;display:inline-block;cursor:pointer;margin-top:-.5em}@media only screen and (min-width : 1300px){div.list_name{xmax-width:370px}div.list_info{xmax-width:370px}}div.release_right_column div.list_name,div.release_right_column div.list_info{max-width:900px!important}div.list_author{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}div.list_name a{font-size:1.2em;line-height:1.5;text-decoration:none;font-weight:bold}div.list_author a{font-size:1.1em;line-height:1.4;text-decoration:none}
+.page_object_discussion_threads{list-style-type:none;margin-top:.75em}.page_object_discussion_thread{padding:.5em 1em}.page_object_discussion_group_name{font-size:.8em;color:var(--mono-6);margin-left:.5em}.page_object_discussion_thread:nth-child(odd){background:rgba(128,128,128,.1)}
+.component_discography_items_frame{position:relative}.component_discography_items_frame .ui_section_overlay{margin:-1em -2em;border-radius:10px}ul.component_discography_items{display:flex;flex-direction:column;list-style-type:none;counter-reset:component_discography_counter}li.component_discography_item:before{content:counter(component_discography_counter) ".";align-items:flex-start;width:2.5em;color:var(--text-primary);justify-content:center;padding-right:.5em;font-weight:bold;font-size:1em}li.component_discography_item:before{display:none}li.component_discography_item{counter-increment:component_discography_counter;display:flex;font-size:1.2em;flex-direction:row;align-items:center;padding:.33em 0;xborder-bottom:1px solid var(--ui-divider-line)}.component_discography_item_image{display:inline-flex}.component_discography_item_image img,.component_discography_item_image.no_image{display:inline-block;height:4em;width:4em;background-color:var(--surface-secondary);object-fit:cover;border-radius:3px}.component_discography_item_info{display:flex;flex:1;flex-direction:column;justify-content:center;padding:.1em 1em;line-height:1.2;font-size:.95em}.component_discography_items_heading{flex:1}.component_discography_items_header{display:flex;flex-direction:row;align-items:flex-start;margin-bottom:1em}.component_discography_navigation{align-self:flex-end;padding:.2em 0}.component_discography_navigation_bottom{margin-top:.75em;padding:.25em 0;border-top:1px solid var(--ui-divider-line);border-bottom:1px solid var(--ui-divider-line)}.component_discography_navigation .ui_pagination{display:flex}.component_discography_navigation .ui_pagination_pages{display:flex;justify-content:center;align-items:center;flex:1}@media only screen and (max-width:75em){.component_discography_items_header{flex-direction:column}.component_discography_navigation .ui_pagination{margin:0 -.66em;font-size:.9em}.component_discography_items_heading{margin-bottom:.5em}.component_discography_navigation{align-self:stretch}}.component_discography_item .separator:before{text-align:center;content:"|";color:var(--text-secondary);padding:0 .25em}.component_discography_item_link.game{font-size:1.125em}.component_discography_item_link,.component_discography_item_info a{xcolor:rgb(30,82,151);display:inline-block;padding:.1em 0;xfont-weight:bold}.component_discography_catalog_no{color:var(--text-primary);font-weight:bold}.component_discography_item_details{font-size:.9em;color:var(--text-primary);display:flex;align-items:center;margin-top:.2em;line-height:1.3;flex-wrap:wrap}.component_discography_item_genres{color:var(--text-secondary)}.component_discography_item_details span{margin-right:.2em}.component_discography_item_stats,.component_discography_item_header_stats{display:flex;align-items:center;width:11em}.component_discography_item_details_average{font-variant-numeric:tabular-nums}.component_discography_item_header_stats{width:13.333em}.component_discography_item_stats span,.component_discography_item_header_stats span{text-align:right;flex:1}.component_discography_item_header_stats span.component_discography_item_header_average{text-align:center}.component_discography_item_details_average{background:var(--average-rating);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:bold;color:var(--text-primary)}.component_discography_item_details_ratings,.component_discography_item_details_reviews{font-size:.9em;text-align:right}.component_discography_item_stats span.abbr{display:none}.component_discography_item_stats_compact{display:none}@media only screen and (max-width:48.1em){.component_discography_item_stats,.component_discography_item_header_stats{width:9.7em}.component_discography_item_stats span,.component_discography_item_header_stats span{text-align:center}.component_discography_item_stats span.abbr{display:inline}.component_discography_item_stats span.full{display:none}}.component_discography_item_header{display:flex;border-bottom:1px solid var(--ui-divider-line);border-top:1px solid var(--ui-divider-line);font-size:.9em;user-select:none;margin-bottom:.5em}.component_discography_count{color:var(--h1);font-weight:bold}.component_discography_item_header span{padding:.75em 0em}.component_discography_item_header_sort_item{padding:0 .25em;margin-left:.25em;cursor:pointer}.component_discography_item_header_sort_item.selected{font-weight:bold;cursor:default}.component_discography_item_header_sort{flex:1;display:flex;align-items:center;font-weight:bold;color:var(--text-secondary);cursor:pointer}.component_discography_item_header_sort i{margin-left:.5em}.component_discography_item_image_link{line-height:.5}.component_discography_item_exclude{display:none}.component_discography_item_exclude i{padding:1em 2em;cursor:pointer}.component_discography_item.exclude_show{opacity:1}.component_discography_item.exclude_hide{opacity:0;transition:opacity 300ms}@media only screen and (max-width:48.1em){li.component_discography_item{font-size:1.3em}.component_discography_item_header_stats{width:11em;font-size:.9em}.component_discography_item_stats{width:7.8em}.component_discography_item_image img,.component_discography_item_image.no_image{height:4em;width:4em}.component_discography_item_info{padding:0 .33em 0 .8em;font-size:.9em}.component_discography_item_stats{display:none;font-size:.75em}}
+</style><script id="base_script">window.rym_dist = '//e.snmc.io';
+var r=(a,o,i)=>new Promise((e,t)=>{var s=l=>{try{d(i.next(l))}catch(n){t(n)}},c=l=>{try{d(i.throw(l))}catch(n){t(n)}},d=l=>l.done?e(l.value):Promise.resolve(l.value).then(s,c);d((i=i.apply(a,o)).next())});window.RYMtemplate=window.RYMtemplate||{};function ensureTemplateLoaded(a){return r(this,null,function*(){if(RYMtemplate[a])return;let o=[];return yield import((window.rym_dist||"//e.snmc.io")+"/dist/template/"+a+".js?v="+window.rym_dist_version).then(e=>{o=e.compiledTemplate.dependencies.map(t=>ensureTemplateLoaded(t)),window.RYMtemplate[a]=e.compiledTemplate.template}),Promise.all(o)})}function getTemplate(a){return function(){return r(this,null,function*(){return window.RYMtemplate=window.RYMtemplate||{},RYMtemplate[a]||(yield ensureTemplateLoaded(a)),RYMtemplate[a]})}()}function renderTemplate(a,o){return function(){return r(this,null,function*(){return window.RYMtemplate=window.RYMtemplate||{},RYMtemplate[a]||(yield ensureTemplateLoaded(a)),RYMtemplate[a].render(o,RYMtemplate)})}()}function applyLazyLoadBehavior(a,o,i){a.classList.remove("lazyload-initialized"),a.classList.add("lazyload-complete");let e=[a,...a.children];for(var t of e)t.dataset.srcset&&(t.srcset=t.dataset.srcset,delete t.dataset.srcset),window.devicePixelRatio>1&&t.dataset.bkg2x?(t.style.backgroundImage=`url('${t.dataset.bkg2x}')`,delete t.dataset.bkg2x,delete t.dataset.bkg):t.dataset.bkg&&(t.style.backgroundImage=`url('${t.dataset.bkg}')`,delete t.dataset.bkg),t.dataset.src&&(t.src=t.dataset.src,delete t.dataset.src),t.dataset.connatixScriptId&&(a.classList.remove("lazyload-creative-initialized"),i&&!window.bscFound&&window.connatixScripts[t.dataset.connatixScriptId]&&(window.connatixScripts[t.dataset.connatixScriptId](),window.connatixScripts[t.dataset.connatixScriptId]=null,console.log("loaded connatix video"))),t.dataset.suggestions&&(console.log("loading suggestions"),RYMsuggestions.load($(t))),t.dataset.medialink&&(console.log("loading media link"),ui.media_links.loadUnit(t));!o&&a.dataset.adcode&&typeof adVisibilityChanged!="undefined"&&adVisibilityChanged(a.dataset.adcode,i)}window.refreshLazyLoadList=function(){const a=document.querySelectorAll(".lazyload");for(let e=0;e<a.length;e++)a[e].classList.remove("lazyload"),a[e].classList.add("lazyload-initialized"),typeof window.lazyloadObserver!="undefined"?window.lazyloadObserver.observe(a[e]):applyLazyLoadBehavior(a[e],!0);const o=document.querySelectorAll(".lazyload-creative");for(let e=0;e<o.length;e++)o[e].classList.remove("lazyload-creative"),o[e].classList.add("lazyload-creative-initialized"),typeof window.lazyloadObserverAds!="undefined"?window.lazyloadObserverAds.observe(o[e]):applyLazyLoadBehavior(o[e],!0);const i=document.querySelectorAll(".ui_section_nav_marker");for(let e=0;e<i.length;e++)i[e].classList.remove("lazyload-creative"),i[e].classList.add("lazyload-creative-initialized"),typeof window.sectionNavMarkerObserver!="undefined"&&window.sectionNavMarkerObserver.observe(i[e])},rymQ(function(){if(typeof IntersectionObserver=="undefined")return;window.lazyloadObserver=new IntersectionObserver(i=>{for(let e=0;e<i.length;e++)if(i[e].isIntersecting){const t=i[e].target;lazyloadObserver.unobserve(t),applyLazyLoadBehavior(t,!1)}},{rootMargin:"300px 50px 300px 50px"}),window.lazyloadObserverAds=new IntersectionObserver(i=>{console.log(i,i);for(let e=0;e<i.length;e++){const t=i[e].target;applyLazyLoadBehavior(t,!1,i[e].isIntersecting)}},{rootMargin:"100px 0px 100px 0px"});function a(i,e,t){var s=i.scrollLeft,c=e-s,d=0,l=5,n=function(){d+=l;var f;i.scrollLeft=f,d<t&&setTimeout(n,l)};n()}if(document.getElementById("ui_section_nav")){let i=parseInt(window.getComputedStyle(document.getElementById("ui_section_nav")).height)||0;i+=parseInt(window.getComputedStyle(document.getElementById("page_header")).height)||0,window.sectionNavMarkerObserver=new IntersectionObserver(e=>{let t=null;for(let s=0;s<e.length;s++){let c=null;console.log(e[s].target.id,e[s].isIntersecting);let d=document.getElementById(`ui_section_nav_${e[s].target.id}`);e[s].isIntersecting?(t=d,d.classList.add("active")):d.classList.remove("active")}t&&(console.log(`scrolling to ${t.offsetLeft}`),document.getElementById("ui_section_nav").scroll({left:t.offsetLeft,behavior:"smooth"}))},{rootMargin:`-${i}px 0px 0px 0px`})}}),rymQ(function(){refreshLazyLoadList()});
+</script><link id="css-bundle" rel="stylesheet" href="//e.snmc.io/dist/css/bundle.css?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87" type="text/css" />
+
+               <style>
+
+                  .ui_fundraiser_letter_date {
+                     text-align:right;
+                     margin-bottom:1em;
+                  }
+
+                  .ui_fundraiser_letter {
+                     background:linear-gradient(to bottom, var(--mono-f), var(--mono-f8));
+                     box-shadow:1px 1px 5px rgba(0,0,0,0.2);
+                     padding:2em 4em;
+                     font-size:1.1em;
+                  }
+
+                  .ui_fundraiser_letter_button_subtext {
+                     font-size:0.8em;
+                     font-weight:normal;
+                  }
+
+                  .ui_fundraiser_letter_button {
+                     height:3.5em;
+                     width:45%;
+                     line-height:1.2;
+                     margin-right:2%;
+                     margin-bottom:1em;
+                     float:left;
+                     display:flex;
+                     flex-direction:column;
+                     align-items:center;
+                     justify-content:center;
+                  }
+
+                  .ui_fundraiser_letter_button_subscribe, .ui_fundraiser_letter_button_subscribe:hover {
+                     background: var(--gen-blue-dark);
+                     color: var(--mono-abs-f);
+                  }
+
+
+                  .ui_fundraiser_letter_button_donate {
+
+                  }
+
+                  .ui_fundraiser_bar_outline {
+                     height:1em;
+                     width:100%;
+                     border-radius:1em;
+                     overflow:hidden;
+                     background:var(--background);
+                     position:relative;
+                  }
+
+                  header .ui_fundraiser_bar_outline {
+                     height:2px;
+                  }
+
+                  .ui_fundraiser_bar_frame {
+                     padding-right:6%;
+                     margin-bottom:2em;
+                  }
+
+                  .ui_fundraiser_bar_inner {
+                     position:absolute;
+                     top:0;
+                     left:0;
+                     height:1em;
+                     background:crimson;
+
+                     width:50%
+                  }
+
+                  header .ui_fundraiser_bar_inner {
+                     background:#ff8888
+                  }
+
+
+                  .ui_fundraiser_bar_legend {
+                     width:100%;
+                     height:3em;
+                     margin-top:0.2em;
+                     font-size:0.8em;
+                     color:var(--mono-5);
+                     position:relative;
+                  }
+
+                  .ui_fundraiser_bar_legend_item {
+                     position:absolute;
+                     top:0;
+                     z-index:1;
+                  }
+
+                  .ui_fundraiser_bar_legend_start {
+                     left:0;
+                  }
+
+                  .ui_fundraiser_bar_legend_fundraiser_goal {
+                      right:0;
+                      text-align:right;
+                  }
+
+                  .ui_fundraiser_bar_legend_longterm_goal {
+                     right:0;
+                     text-align:right;
+                  }
+
+                  .ui_fundraiser_bar_goal_divider {
+                     position:absolute;
+                     display:none;
+                     top:0;
+                      right:37.32%;
+                      height:1em;
+                      width:1px;
+                      background:var(--ui-detail-neutral)         
+                  }
+
+                  .ui_fundraiser_letter_contents {
+                     padding-right:3em;
+                  }
+
+                  .ui_fundraiser_letter_contents p {
+                     line-height:1.5;
+                  }
+
+                  .ui_fundraiser_current {
+                     xfloat:right;
+                     font-size:0.8em;
+                     line-height:1.2;
+                     color:var(--mono-6);
+                  }
+
+                  @media only screen and (max-width:48.1em) {
+
+
+                     .ui_fundraiser_letter {
+                        padding:2em 1.5em;
+                     }
+
+                     .ui_fundraiser_letter_contents {
+                        padding-right:0;
+                     }
+
+                  }
+
+               
+             .ui_fundraiser_bar_inner  { width: 100.0%; background: #595; } </style>
+         <!-- Playwire header tag --> 
+         <script data-cfasync="false">
+           window.ramp = window.ramp || {};
+           window.ramp.que = window.ramp.que || [];
+           window.ramp.override = {
+               settings: {
+                   multiSelect: true
+               }
+           };
+      
+         </script>         
+      
+         <script>
+
+            window.ramp.custom_tags = ["rateyourmusic","album","false"];
+
+            window.ramp.que.push( () => {
+
+               window.ramp.setCustomGamKvs({"artist_name":"Radiohead","release_name":"OK Computer","site":"rateyourmusic","pagetype":"album","logged_in":false,"enable_floating":true,"enable_adhesions":true});
+            });
+         </script>
+      <script>
+          var ts = new Date().valueOf();
+
+          var cx='cf98b3be146703013111dfb80ef96e6e';
+         rymQ(function() { $("body").on("mousemove touchend",function(n){$("body").off("mousemove touchend");var o,t=!!window.opr&&!!opr.addons||!!window.opera||navigator.userAgent.indexOf(" OPR/")>=0,e="undefined"!=typeof InstallTrigger,i=Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor")>0,r=!!document.documentMode,d=!r&&!!window.StyleMedia,a=!!window.chrome&&!!window.chrome.webstore,c=(a||t)&&!!window.CSS,s=!1;navigator.webdriver;a&&window.chrome;try{navigator.permissions.query({name:"notifications"}).then(function(n){"denied"===Notification.permission&&"prompt"===n.state&&!0})}catch(n){o=n}try{null[0]()}catch(n){o=n}o.stack.indexOf("phantomjs")>-1&&(s=!0);var u=window.outerHeight,w=window.innerHeight,m=window.outerWidth,h=window.innerWidth,p=document.documentElement.hasAttribute("webdriver"),v=document.documentElement.hasAttribute("hola_ext_inject"),l=!!("ontouchstart"in window)||"ontouchstart"in document.documentElement,f=navigator.hardwareConcurrency,g=navigator.appCodeName,y=navigator.plugins,b=new Array;for(var x in y){var j=y[x];if(j)for(var C in j){var O=j[C];O&&O.description&&b.push(O.description.substr(0,12))}}var S={a:t,b:e,c:i,d:r,e:d,f:a,g:c,h:s,i:u,j:p,l:l,m:f,n:g,o:b.join(":"),p:w,q:m,r:h,s:v,t:s,cx:cx,ts:ts};rym.request.post("SecChk",S,null,"script")}); });
+      </script>
+<script type="text/javascript">rymQ(function() { rym.session.init(0, '0', '', {});});</script><script> window.streamingPreferences = {"preferred_link":"sonemic","service_regions":{"applemusic":"US","bandcamp":"US","deezer":"US","qobuz":"US","soundcloud":"US","spotify":"US","tidal":"US","youtube":"US"},"prefer_open":false}</script></head><body id="page_body" class="has_background_image " style="background-image:url('//cdn.sonemic.net/i/25/s/22d41de2b2842623fbaf99129b89ecad/11993756'); background-size:cover;">
+
+            <script>
+               window.themes = ['light', 'eve', 'night'];
+               window.themes_label = ['Light', 'Evening', 'Night'];
+            </script>
+          
+      <script>
+         if ( window.localStorage['size_mode'] ) {
+            document.body.parentElement.className += ' size_mode_' + window.localStorage['size_mode'];
+         }
+
+         if ( !window.localStorage['theme'] && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ) {
+            document.body.parentElement.className += ' theme_eve';
+         } else if ( !window.localStorage['theme'] || window.localStorage['theme'] === 'day') {
+            document.body.parentElement.className += ' theme_light';
+         } else {
+            if ( -1 != window.themes.indexOf(window.localStorage['theme']) ) {
+               document.body.parentElement.className += ' theme_' + window.localStorage['theme'];
+            } else {
+               document.body.parentElement.className += ' theme_light';
+            }
+         }
+
+         if ( window.matchMedia ) {
+
+             var listener = window.matchMedia('(prefers-color-scheme: dark)').addEventListener;
+
+             if ( listener ) {
+                listener('change', e => {
+                  updateTheme();
+                });               
+             }
+         }
+      </script>
+      <div id="top" class="breadcrumb_section_marker anchor"></div><script>
+            window.addEventListener('DOMContentLoaded', (event) => {
+                window.dom_loaded = true;
+      
+             console.log('DOM loaded');
+             if ( typeof (_adjustFillerColumns) !== 'undefined' ) {
+                _adjustFillerColumns() 
+             }
+
+             setTimeout(function () { 
+               if ( typeof (_closeAllStickyAds) !== 'undefined' ) {
+                  _closeAllStickyAds() 
+               }
+
+             }, 5000);
+         
+  
+         });
+      
+            rymQ(function() { updateStyleThemeLabels() });
+         </script>
+      
+<header id="page_header">
+<div class="header_inner logged_in">
+
+
+
+
+<div class="header_profile">
+
+      <div class="header_profile_logged_out">
+         <span>   
+            <a href="/account/login" class="header_item">sign in</a>
+         </span>
+      </div>
+</div>
+
+
+<div class="header_logo">
+  <a class="main header_item sonemic" href="/">
+     <div class="logo_header"></div>
+     <span class="logo_name">RYM</span>
+  </a>
+
+</div>
+
+
+
+<div class="header_links">
+  <div class="header_links_inner">
+      <div class="divider"></div>
+      <a class="header_item" href="/new-music/">new music</a>
+      <a class="header_item" href="/genres/">genres</a>
+      <div class="header_charts">
+      <a class="header_charts header_item" href="/charts/">charts</a>
+      </div>
+      <a class="header_item" href="/lists/">lists</a>
+
+
+
+
+      
+
+      <div class="divider"></div>
+    </div>
+  </div>
+  <div class="header_search">
+  <div id="ui_search_frame_outer_main_search"  class="ui_search_frame_outer"> <div id="ui_search_frame_main_search" class="ui_search_frame"> <div onclick="rymQ(function() {RYMsearch.onClickClose(event, 'main_search');})" class="ui_search_close"> <div class="ui_search_close_bar"> <i class="fa fa-times"></i> Close</div> <div id="ui_search_context_indicator_main_search" class="ui_search_context_indicator"> <div id="ui_search_context_indicator_inner_main_search" class="ui_search_context_indicator_inner"></div> </div> </div> <div class="ui_search_clear"></div> <div class="ui_search_frame_inner"> <div id="ui_search_main_search" class="ui_search" data-default-scope="music" data-callback="" data-callback-id=""> <i style="cursor:pointer" onClick="RYMsearch.redirSearch(event, 'main_search');" id="ui_search_icon_main_search" class="fa fa-search ui_search_icon"></i> <i id="ui_clear_icon_main_search" onclick="rymQ(function() {RYMsearch.onClickClearSearch(event, 'main_search');})" class="fa fa-times-circle ui_clear_icon"></i>
+
+
+   <form onSubmit="event.preventDefault(); RYMsearch.redirSearch(event, 'main_search');">
+   <input autocomplete="off" aria-label="Search" value="" id="ui_search_input_main_search" placeholder="Search..." class="ui_search_input" onfocus="rymQ(function() {RYMsearch.onFocus(event, 'main_search')})" onblur="rymQ(function() {RYMsearch.onBlur(event, 'main_search')})" 
+
+   onkeydown="rymQ(function() {RYMsearch.onKeyDown(event, 'main_search')})" 
+
+   oninput="rymQ(function() {RYMsearch.onInput(event, 'main_search')})">
+   </form> </div> <div class="ui_search_rest"> <div class="ui_search_type"> <div id="ui_search_debug_main_search" class="ui_search_debug"></div> <span class="ui_search_object_label">Search:</span> <span id="ui_search_scope_selector_main_search" class="ui_search_object_selector"> <input type="hidden" name="ui_search_scope_main_search" id="ui_search_scope_main_search" value="music"> <span id="ui_search_scope_selector_music_main_search" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'music');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_music selected"> Music
+  </span> <span id="ui_search_scope_selector_film_main_search" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'film');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_film"> Film
+  </span> <span id="ui_search_scope_selector_games_main_search" style="display:none" onclick="rymQ(function() {RYMsearch.onClickSearchScope(event, 'main_search', 'games');})" class="ui_search_scope_selector_item ui_search_scope_selector_item_games"> Games
+  </span> </span> <span class="ui_search_object_label">for:</span> <span id="ui_search_object_select_frame_main_search" class="ui_search_object_select_frame selected"> <select onchange="rymQ(function() {RYMsearch.onChangeObject(event, 'main_search')})" id="ui_search_object_select_main_search" class="ui_search_object_select"> </select> </span>  </div> <div id="ui_search_info_frame_main_search" class="ui_search_info_frame"> </div> <div id="ui_search_results_frame_main_search" class="ui_search_results_frame"> <div id="ui_search_results_main_search" class="ui_search_results"> </div> </div> </div> </div> </div>
+  </div>
+
+</div>   
+
+
+
+
+</div>
+
+</header>
+
+
+<div class="header_error" onClick="$(this).fadeOut();" id="header_error">
+   <div class="header_error_close"><i class="fa fa-times-circle"></i></div>
+   <div id="header_error_text"></div>
+</div>
+
+<div class="header_message" onClick="$(this).fadeOut();" id="header_message">
+   <div class="header_message_close"><i class="fa fa-times-circle"></i></div>
+   <div id="header_message_text"></div>
+</div>
+
+<div id="mobile_header_menu" class="mobile_header_menu "><a href="/new-music/" class="mobile_header_menu_item mobile_header_menu_item_new_music">
+      <span>New Music</span>
+</a><a href="/genres/" class="mobile_header_menu_item mobile_header_menu_item_genres">
+      <span>Genres</span>
+</a><a href="/charts/" class="mobile_header_menu_item mobile_header_menu_item_charts">
+      <span>Charts</span>
+</a><a href="/lists/" class="mobile_header_menu_item mobile_header_menu_item_lists">
+   <span>Lists</span> 
+</a></div>
+        
+
+            <div id="content_wrapper_outer" class="content_wrapper_outer">
+            <div id="content_wrapper" class="content_wrapper" >
+            <div id="content">
+            <div id="content_cover"></div>
+            <div id="precontent" class="precontent lazyload" data-bkg="//cdn.sonemic.net/i/25/s/22d41de2b2842623fbaf99129b89ecad/11993756"></div>
+         <div id="total_cover"></div>
+         <div id="content_total_cover"></div>          
+      
+
+         <script>
+              try {
+                new Function('import("")');
+              } catch (err) {
+                document.write('<div class=note style="margin-bottom:1em;"><b>Note:</b> Not all scripts could be loaded. You may need to upgrade to a newer browser version in order to use this site.</div>');
+              }
+         </script>
+      <style>div.prev_image img, div.next_image img {
+    width: 3em;
+}
+div.list_image {
+   background-size:cover !important;
+   background-position:center center !important;
+}
+</style>
+   <div id="dropheader" style="display:none;"> </div>
+   <div id="shortcut"  style="display:none;">
+    <div id="shortcutshell">
+      <div id="shortcutinner">
+         <div class="small">
+         <table><tr><td>
+<div class="musictoolbar"> <a id="btnshortcutartist" href="#shortcutartist" onclick="viewshortcut('shortcutartist', '');return false;">artist</a>
+             
+             <a id="btnshortcutrelease" href="#shortcutrelease" onclick="viewshortcut('shortcutrelease', '');return false;">release</a>
+             <a id="btnshortcutlabel" href="#shortcutlabel" onclick="viewshortcut('shortcutlabel', '');return false;">label</a>
+             <a id="btnshortcutwork" href="#shortcutwork" onclick="viewshortcut('shortcutwork', '');return false;">work</a>
+             <a id="btnshortcutfilm" href="#shortcutfilm" onclick="viewshortcut('shortcutfilm', '');return false;">film</a>
+             <a id="btnshortcutvideo" href="#shortcutvideo" onclick="viewshortcut('shortcutvideo', '');return false;">video</a>
+             <a id="btnshortcutpicture" href="#shortcutpicture" onclick="viewshortcut('shortcutpicture', '');return false;">pic</a>
+             
+            </div>
+
+  </td><td style="text-align:right;"><a href="javascript:closeShortcut();" class="btn darkred_btn btn_small">x</a></td></tr></table>
+         </div>
+         <div id="shortcutsearch">
+            <iframe src="about:blank" name="shortcutsearchframe" id="shortcutsearchframe"  width="99%" height="99%"></iframe>
+         </div>
+      </div>
+      
+    </div>
+   
+   </div>
+   
+   <script type="text/javascript">var shortcut_first_sc='shortcutartist', shortcut_first_func = '';</script> 
+<div id="searchsuggestions" style="visibility:hidden;position:absolute;z-index:500;max-height:150px;overflow-y:scroll" ></div>
+<script>
+  function openShortcut(element)
+  {
+      currentElement = element;
+      var pos = $(element).position();
+      var shortcutWidth = $('#shortcut').outerWidth();
+      var windowWidth = $(window).outerWidth();
+      var left = pos.left + $(element).outerWidth();
+
+      if ( (left + shortcutWidth) > windowWidth ) {
+         left = windowWidth - shortcutWidth;
+      }
+
+      $('#shortcut').css('top', pos.top + 'px').css('left', left + 'px').show();;
+      if ( shortcut_first_sc && shortcut_first_sc != "") {
+        viewshortcut(shortcut_first_sc, shortcut_first_func);
+      }
+
+ }
+ </script><style>
+      div.coverart_45 {
+         position:relative;
+         padding-bottom:calc( 100% / 1.0008340283569641);
+      }
+
+      div.coverart_45 img {
+         position:absolute;
+         top:0;
+         left:0;
+         width:100%
+      }
+
+   </style>
+
+<div class="release_page"  itemprop="mainEntity" itemscope itemtype="http://schema.org/MusicAlbum">
+     <div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+     <meta itemprop="ratingValue" content="4.30" />
+     <meta itemprop="bestRating" content="5.0" />
+     <meta itemprop="worstRating" content="0.5" />
+     <meta itemprop="ratingCount" content="135396" /><meta  itemprop="reviewCount" content="2033" /></div>
+   <meta content="OK Computer" itemprop="name" />
+   
+      <meta content="/release/album/radiohead/ok-computer/" itemprop="url" />
+   
+   <div style="max-width:1700px; margin: 0px auto;">
+   <div class="row">
+
+    <div id="column_container_right" class="large-8 push-4 columns release_right_column">  <div class="section_main_info section_outer"><div class="page_section">          
+         <div class="album_title">OK Computer 
+               <input aria-label="album shortcut" class="album_shortcut" readonly onclick="focus();select();" value="[Album45]" />
+               <div class="show-for-small album_artist_small">By <a   href="/artist/radiohead" class="artist">Radiohead</a></div>
+            </div>
+
+         <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:2px;font-size:1px;padding:0;"><tr style="height:2px;padding:0;"><td style="background:#a8b7c0;height:2px;padding:0px;color:#a8b7c0">.</td><td style="background:#a9b8bc;height:2px;padding:0px;color:#a9b8bc">.</td><td style="background:#7694a2;height:2px;padding:0px;color:#7694a2">.</td><td style="background:#636468;height:2px;padding:0px;color:#636468">.</td><td style="background:#be855b;height:2px;padding:0px;color:#be855b">.</td><td style="background:#9e9ea6;height:2px;padding:0px;color:#9e9ea6">.</td><td style="background:#c8b497;height:2px;padding:0px;color:#c8b497">.</td><td style="background:#54bcec;height:2px;padding:0px;color:#54bcec">.</td></tr></table>
+
+         <div class="show-for-small" style="text-align:center;">
+            <div style="padding-top:0.3em;"> <a  href="buy/">
+      <div class="coverart_45" style="position:relative;">
+      
+      <img srcset ="//cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg,
+                     //cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg 2x"
+           src="//cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg"
+           alt="Cover art for OK Computer by Radiohead"
+      />
+      <!-- <meta itemprop="image" content="//cdn.sonemic.net/i/300/s/0fa37201b199941562f3078dedf5caae/11993756" /> -->
+    </div></a>
+    
+            <div id="media_link_button_container_top" 
+                  
+                 data-medialink="true"
+                 data-support-open="true" 
+                 data-artists="Radiohead" 
+                 data-albums="OK Computer" 
+                 data-links="{&#34;spotify&#34;:{&#34;7dxKtc08dYeRVHt3p9CZJn&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;},&#34;6dVIqQ8qmQ5GBnJ9shOYGE&#34;:{&#34;for&#34;:[&#34;AU&#34;,&#34;DE&#34;,&#34;GB&#34;,&#34;MX&#34;],&#34;type&#34;:&#34;album&#34;},&#34;2fGCAYUMssLKiUAoNdxGLx&#34;:{&#34;for&#34;:[&#34;VE&#34;],&#34;type&#34;:&#34;album&#34;},&#34;4ENxWWkPImVwAle9cpJ12I&#34;:{&#34;for&#34;:[&#34;FI&#34;,&#34;FR&#34;,&#34;HU&#34;],&#34;type&#34;:&#34;album&#34;}},&#34;applemusic&#34;:{&#34;1097861387&#34;:{&#34;default&#34;:true,&#34;album&#34;:&#34;ok-computer&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;1239489060&#34;:{&#34;for&#34;:[&#34;AU&#34;,&#34;FI&#34;,&#34;FR&#34;,&#34;HU&#34;],&#34;album&#34;:&#34;ok-computer-oknotok-1997-2017&#34;,&#34;loc&#34;:&#34;fr&#34;}},&#34;soundcloud&#34;:{&#34;242606955&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/radiohead/sets/ok-computer-3&#34;}},&#34;tidal&#34;:{&#34;58990510&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;deezer&#34;:{&#34;14879699&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;qobuz&#34;:{&#34;0634904078164&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}}}" 
+                 data-placement="top" 
+                 data-allow-ads="true" 
+                 class="media_link_container link_sonemic allow_ads support_open lazyload">
+            </div>
+       </div>
+         </div>
+         <table class="album_info_outer">
+         <tr><td style="vertical-align:top;">
+            <table class="album_info">
+               <tr class="hide-for-small"><th class="info_hdr">Artist</td><td colspan="2"><span itemprop="byArtist" itemscope itemtype="http://schema.org/MusicGroup"><a  itemprop="name" href="/artist/radiohead" class="artist">Radiohead</a></span>
+               <span class="release_info_classifiers"></span></td></tr>
+               <tr><th class="info_hdr">Type</td><td colspan="2">Album</td></tr>
+                  <tr><th class="info_hdr">Released</td><td colspan="2">16 June <a style="text-decoration:none;" href="/charts/top/album/1997/"><b>1997</b></a></td></tr><tr><th class="info_hdr">Recorded</td><td colspan="2">4 September 1995 - 6 March 1997</td></tr>
+               <tr><th class="info_hdr">RYM Rating</td><td colspan="2" style="padding:4px;">
+                <span >
+                  <span class="avg_rating" >
+                     4.30
+                  </span> 
+                  <span class="max_rating">/ <span >5.0</span><span style="display:none">0.5</span></span>
+                  <span class="num_ratings">
+                     from <b><span >135,396</span></b> ratings
+                  </span>
+               </span>
+               </td></tr>
+               <tr><th class="info_hdr">Ranked</td><td colspan="2">#<b>1</b> for <a href="/charts/top/album/1997/#pos1">1997</a>, #<b>2</b> <a href="/charts/top/album/all-time/#pos2">overall</a></td></tr><tr class="release_genres">
+                        <th class="info_hdr">
+                           Genres
+                        </th>
+                        <td>   <div style="float:left;">
+                           <span class="release_pri_genres"><a  class="genre" href="/genre/alternative-rock/">Alternative Rock</a>, <a  class="genre" href="/genre/art-rock/">Art Rock</a></span>
+                           <br /><span class="release_sec_genres"><a  class="genre" href="/genre/post-britpop/">Post-Britpop</a>, <a  class="genre" href="/genre/space-rock-revival/">Space Rock Revival</a></span>
+                           </div>
+                           </td>
+	
+                        </tr><tr class="release_descriptors">
+                        <th class="info_hdr">
+                           Descriptors
+                        </th>
+                        <td><meta content="melancholic" /><meta content=" anxious" /><meta content=" alienation" /><meta content=" male vocalist" /><meta content=" futuristic" /><meta content=" existential" /><meta content=" lonely" /><meta content=" atmospheric" /><meta content=" cold" /><meta content=" pessimistic" /><meta content=" introspective" /><meta content=" depressive" /><meta content=" longing" /><meta content=" dense" /><meta content=" urban" /><meta content=" progressive" /><meta content=" serious" /><meta content=" sarcastic" /><meta content=" dystopian" /><meta content=" passionate" /><meta content=" paranoia" /><meta content=" melodic" /><meta content=" anti-authoritarian" /><meta content=" technology" /><meta content=" sad" /><meta content=" insecure" /><meta content=" mental health" /><meta content=" poetic" /><meta content=" cynical" /><meta content=" falsetto" /><meta content=" political" /><meta content=" concept album" /><meta content=" vehicles" /><meta content=" cars" /><meta content=" travel" />   <div style="float:left;">
+                           <span class="release_pri_descriptors">melancholic,  anxious,  alienation,  male vocalist,  futuristic,  existential,  lonely,  atmospheric,  cold,  pessimistic,  introspective,  depressive,  longing,  dense,  urban,  progressive,  serious,  sarcastic,  dystopian,  passionate,  paranoia,  melodic,  anti-authoritarian,  technology,  sad,  insecure,  mental health,  poetic,  cynical,  falsetto,  political,  concept album,  vehicles,  cars,  travel</span>
+                           </div>
+                           </td>                
+           
+                        </tr><tr><th class="info_hdr">Language </th><td style="font-size:0.9em;color:var(--mono-5);" colspan="2">English</td></tr></table></td></tr></table></div></div><div style="width:645px; padding-left:1.5em; z-index:200"><!-- /31961696/Sonemic/main-300x250-video-float-bottom-right -->
+            <div data-nosnippet class='page_creative_frame pw-video-target
+               
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-203'  style='margin:0 auto;display: block; align-items: center;margin-bottom:1em;min-height:300px;min-width:305px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-203'>
+            </div></div></div><div class="show-for-small"><div class="section_tracklisting"><div class="release_page_header"><h2>Track listing</h2></div> 
+       <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+       <ul id="tracks_mobile" class="tracks tracklisting"><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     1
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/airbag/" itemprop="name">Airbag</a><a  href="/song/radiohead/airbag/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="284">
+                     4:44
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     2
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/paranoid-android/" itemprop="name">Paranoid Android</a><a  href="/song/radiohead/paranoid-android/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="383">
+                     6:23
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     3
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/subterranean-homesick-alien-1/" itemprop="name">Subterranean Homesick Alien</a><a  href="/song/radiohead/subterranean-homesick-alien-1/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="267">
+                     4:27
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     4
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/exit-music-for-a-film/" itemprop="name">Exit Music (For a Film)</a><a  href="/song/radiohead/exit-music-for-a-film/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="264">
+                     4:24
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     5
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/let-down/" itemprop="name">Let Down</a><a  href="/song/radiohead/let-down/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="299">
+                     4:59
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     6
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/karma-police/" itemprop="name">Karma Police</a><a  href="/song/radiohead/karma-police/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="261">
+                     4:21
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     7
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/radiohead/fitter-happier/" itemprop="name">Fitter Happier</a><a  href="/song/radiohead/fitter-happier/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="117">
+                     1:57
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     8
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/radiohead/electioneering-1/" itemprop="name">Electioneering</a><a  href="/song/radiohead/electioneering-1/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="230">
+                     3:50
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     9
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/climbing-up-the-walls/" itemprop="name">Climbing Up the Walls</a><a  href="/song/radiohead/climbing-up-the-walls/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="285">
+                     4:45
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     10
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/no-surprises/" itemprop="name">No Surprises</a><a  href="/song/radiohead/no-surprises/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="228">
+                     3:48
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     11
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/lucky/" itemprop="name">Lucky</a><a  href="/song/radiohead/lucky/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="259">
+                     4:19
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     12
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/the-tourist/" itemprop="name">The Tourist</a><a  href="/song/radiohead/the-tourist/#lyrics"  class="tracks_lyric_link">lyrics</a><span class="tracklist_duration" data-inseconds="324">
+                     5:24
+                  </span>
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track" style="text-align:right;padding-top:0.25em"><span style="line-height: 2.6em;color: var(--mono-6);margin-right:0.8em;" class="tracklist_total">Total length: 53:21</span></li></ul><div id="track_preview_tracks_mobile">
+            
+         </div> </div></div><div class="show-for-small"><div class="section_release_navigation"><div class="release_navigation"><div class="release_navigation_guidance">
+                    <div class="release_nav_guidance_artist">
+                     <div class="release_nav_guidance_left">
+                      <a href="/release/album/radiohead/the-bends/"><i class="fa fa-caret-left"></i>
+                      Previous</a>
+                     </div>                     
+                     <div class="release_nav_guidance_right">
+                     <a href="/release/album/radiohead/kid-a/">Next
+                      <i class="fa fa-caret-right"></i></a>
+                      
+                     </div></div>
+                     <div style="clear:both;"></div>
+                  </div>
+               
+                                 
+                  <div class="release_navigation_links">
+                    <div class="prev_image">
+                       <a href="/release/album/radiohead/the-bends/"><img alt="Previous in discography: The Bends" src="//cdn.sonemic.net/i/75/s/cc9173268ad1a610f71dbfb7d3a0ee04/14043991" /></a>
+                    </div>
+                    <div class="prev_link">
+                       <a  href="/release/album/radiohead/the-bends/" class="small">The Bends</a>
+                    </div>
+                    <div class="next_link">
+                       <a  href="/release/album/radiohead/kid-a/" class="small">Kid A</a>
+                    </div>
+                    <div class="next_image">
+                       <a href="/release/album/radiohead/kid-a/"><img alt="Next in discography: The Bends" src="//cdn.sonemic.net/i/75/s/84704ca8b24adf06888eb22aa82d69f0/12580450" /></a>
+                    </div>
+                    <div style="clear:both;"></div>
+                  </div>                
+               
+            </div></div></div><div class="section_my_catalog section_outer" style="padding-bottom: 5px;"><div class="page_section"><div id="my_catalog">
+      <div class="release_page_header"><h2>Rate/Catalog 
+      </h2></div>
+       <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+                  <div class="release_my_catalog">
+                     <div id="my_catalog_rating_l_45" tabIndex="0" class="my_catalog_rating" 
+                  onMouseMove="rating_l_45.onMouseMove(event,this);"
+                  onMouseOver="rating_l_45.onMouseOver(event,this);"
+                  onMouseOut="rating_l_45.onMouseOut(event,this);"
+
+                  onTouchStart="rating_l_45.onTouchStart(event,this);"
+                  onTouchMove="rating_l_45.onTouchMove(event,this);"
+                  onTouchEnd="rating_l_45.onTouchEnd(event,this);"
+
+                  onClick="rating_l_45.onClick(event,this);"
+            >
+               <div id="rating_stars_l_45" class="rating_stars star-0m">
+               </div>
+               <div class="rating_loading">Saving...
+               </div>
+               <div id="rating_num_l_45" class="rating_num">
+                  0.0
+               </div>
+            </div>
+            <script>
+              rymQ(function() {window.rating_l_45 = new RYMrating('l', 45, 0 );});
+            </script>
+                     
+                     <div class="my_catalog_catalog">
+               <div onMouseOver="$('#catalog_btn_options_l_45').show();" onMouseOut="$('#catalog_btn_options_l_45').hide();" id="catalog_l_45" class="catalog_btn catalog_n">
+                     <span id="catalog_text_l_45">Catalog</span>
+                  <div id="catalog_btn_options_l_45" class="catalog_btn_options">
+                     <div id="catalog_btn_o" onClick="catalog_l_45.setOwnership('o');" class="catalog_btn_option">In collection</div>
+                     <div id="catalog_btn_w" onClick="catalog_l_45.setOwnership('w');" class="catalog_btn_option">On wishlist</div>
+                     <div id="catalog_btn_u" onClick="catalog_l_45.setOwnership('u');" class="catalog_btn_option">Used to own</div>
+                     <div id="catalog_btn_n" onClick="catalog_l_45.setOwnership('n');" class="catalog_btn_option">(not cataloged)</div>
+                  </div>
+               </div>
+               <script>
+                  rymQ(function() { window.catalog_l_45 = new RYMcatalog('l', 45, 'n', '');});
+               </script>
+              </div>
+
+                     <div id="my_catalog_format_l_45" class="my_catalog_format" style="display:none;">
+               <div onMouseOver="$('#format_btn_options').show();" onMouseOut="$('#format_btn_options').hide();" id="catalog_l_45" class="format_btn">
+                     <span id="format_text_l_45">---</span>
+                     <div id="format_btn_options" class="format_btn_options">
+                        <div id="format_btn_x" onClick="catalog_l_45.setFormat('');" class="format_btn_option">(not set)</div>
+                        <div id="format_btn_a" onClick="catalog_l_45.setFormat('CD');" class="format_btn_option default_format">CD</div>
+                        <div id="format_btn_b" onClick="catalog_l_45.setFormat('LP');" class="format_btn_option ">Vinyl</div>
+                        <div id="format_btn_c" onClick="catalog_l_45.setFormat('MP3');" class="format_btn_option ">Digital</div>
+                        <div id="format_btn_d" onClick="catalog_l_45.setFormat('CD-R');" class="format_btn_option ">CD-R</div>
+                        <div id="format_btn_e" onClick="catalog_l_45.setFormat('Cassette');" class="format_btn_option ">Cassette</div>
+                        <div id="format_btn_f" onClick="catalog_l_45.setFormat('DVD-A');" class="format_btn_option ">DVD-A</div>
+                        <div id="format_btn_g" onClick="catalog_l_45.setFormat('SACD');" class="format_btn_option ">SACD</div>
+                        <div id="format_btn_h" onClick="catalog_l_45.setFormat('Minidisc');" class="format_btn_option ">Minidisc</div>
+                        <div id="format_btn_i" onClick="catalog_l_45.setFormat('Multiple');" class="format_btn_option ">Multiple</div>
+                        <div id="format_btn_j" onClick="catalog_l_45.setFormat('8-Track');" class="format_btn_option ">8-track</div>
+                        <div id="format_btn_k" onClick="catalog_l_45.setFormat('Other');" class="format_btn_option ">Other</div>
+                     </div>
+            
+               </div>
+               <script>
+                  rymQ(function() {window.catalog_l_45 = new RYMcatalog('l', 45, 'n', '');});
+               </script>
+              </div>
+
+                     <div class="my_catalog_listening">
+                     <div id="listening_btn" class="listening_btn" onclick="alert('please login to use the listening feature.');">Set listening</div>
+                  </div>
+
+                     <div class="my_catalog_tags" >
+               <div id="tag_btn_l_45" class="tag_btn " onClick="alert('please login to tag this release.');" >
+                  <span id="tags_text_l_45">Tags</span>
+                  <span id="tags_add_text" style="display:none">Tags</span>
+                  </div>
+               <div id="tag_dlg_l_45" class="tag_dlg">
+                     <label for="tags_l_45">Enter tags, separated by commas</label>
+                     <input onFocus="musictagattachSuggest(this.id);" id="tags_l_45" value="" class="tag_tags">
+                  <a href="javascript:void(0);" onClick="tags.save()" class="tag_save">Save</a>
+               </div>
+               <script>
+                  rymQ(function() {window.tags = new RYMtags('l', 45, []);});
+               </script>               
+            </div>
+
+                     <div class="my_catalog_review">
+                        <div id="review_btn" class="review_btn" onclick="alert('please login to review this release.')">Review</div>
+                     </div>
+
+                     <div class="my_catalog_rate_tracks">
+                        <div id="track_rating_btn" class="track_rating_btn" onclick="alert('please login to rate tracks for this release.')">Track ratings</div>
+                     </div>
+
+                  <div class="clear"> </div>
+                  <div class="release_touch_guidance">To rate, slide your finger across the stars from left to right.</div>
+                  </div>
+                  <div class="clear"> </div>
+
+
+                  </div>
+               </div></div><div class="show-for-small">
+      <div id="expand_full_issues" class="mobile_expandable_full ">
+
+            <div id="expand_full_header_issues" class="mobile_expandable_full_header" onClick="RYMmobile.mobileExpand.toggleFull('issues');">
+
+               <div class="mobile_expandable_full_icons">
+                  <div class="mobile_expandable_full_expand_icon_expanded">
+                     <i class="fa fa-caret-down"></i>
+                  </div>
+                  <div class="mobile_expandable_full_expand_icon_hidden">
+                     <i class="fa fa-caret-right"></i>
+                  </div>
+               </div>
+
+               <div id="expand_full_name_issues" class="mobile_expandable_full_name">
+                  Issues
+               </div>
+
+            </div>
+
+            <div id="expand_full_content_issues" class="mobile_expandable_full_content">
+               <div class="section_issues section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>35 Issues</h2></div>
+         <table class="color_bar" style="xborder:1px #333 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <ul class="issues ">
+      <li  class="issue_info release_view current"><a >Release view [combined information for all issues]</a></li><li id="issue_45" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer/" title="OK Computer"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/0fa37201b199941562f3078dedf5caae/11993756>" style="background:url('//cdn.sonemic.net/i/75/s/92dd35ce1e293a2a0cb4ec913bea4826/11993756') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer.p/">OK Computer</a> 
+                        
+                        <span title="This is the primary issue." class="primary_indicator">[p]</span>
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 2 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> <span class="ui_flag" title="Brazil"><img alt="Brazil" src="https://e.snmc.io/3.0/img/flags/4x3/br.svg" /></span> <span class="ui_flag" title="Canada"><img alt="Canada" src="https://e.snmc.io/3.0/img/flags/4x3/ca.svg" /></span> <span class="ui_flag" title="Colombia"><img alt="Colombia" src="https://e.snmc.io/3.0/img/flags/4x3/co.svg" /></span>  +5 <div class="additional_countries"><span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> <span class="ui_flag" title="Brazil"><img alt="Brazil" src="https://e.snmc.io/3.0/img/flags/4x3/br.svg" /></span> <span class="ui_flag" title="Canada"><img alt="Canada" src="https://e.snmc.io/3.0/img/flags/4x3/ca.svg" /></span> <span class="ui_flag" title="Colombia"><img alt="Colombia" src="https://e.snmc.io/3.0/img/flags/4x3/co.svg" /></span> <span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> <span class="ui_flag" title="Ukraine"><img alt="Ukraine" src="https://e.snmc.io/3.0/img/flags/4x3/ua.svg" /></span> <span class="ui_flag" title="Indonesia"><img alt="Indonesia" src="https://e.snmc.io/3.0/img/flags/4x3/id.svg" /></span> <span class="ui_flag" title="Mexico"><img alt="Mexico" src="https://e.snmc.io/3.0/img/flags/4x3/mx.svg" /></span> <span class="ui_flag" title="Australia"><img alt="Australia" src="https://e.snmc.io/3.0/img/flags/4x3/au.svg" /></span> </div></span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_4307978" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-24/" title="OK Computer"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9d6c86544a8ee2dc0e0e8932d673e176/5852865>" style="background:url('//cdn.sonemic.net/i/75/s/13ac16854eb9d9b759e33e1f6b4e5194/5852865') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-24/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 2 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8419639" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-7/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/616d4d33e4f21978c150e34bb73ab06a/8331457>" data-bkg="//cdn.sonemic.net/i/75/s/6184e6ed094bb97184cdb84bfaeedcd6/8331457"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-7/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Numbered Edition, Promo">Numbered Edition, Promo</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / CDPP 005" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / CDPP 005
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_16673148" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-34/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/da322d2553cef5c50d8185b8392619d6/13761553>" data-bkg="//cdn.sonemic.net/i/75/s/df035ae3d98c94101ab6e2507b1c7655/13761553"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-34/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Limited Edition, Slipcase / O-Card">Bonus CD, Limited Edition, Slipcase / O-Card</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 21338 2 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 21338 2 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1799595" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-17/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/723b6d03025f7ef01bda282ea15c8428/9272568>" data-bkg="//cdn.sonemic.net/i/75/s/308675f1787652eaaa3aa6439acfa414/9272568"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-17/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="21 May 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-50201" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-50201
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_675769" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-18/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ca005743f22490fbbbe91c0f94fcb12c/2740194>" data-bkg="//cdn.sonemic.net/i/75/s/4233b43c8dc7cd94d4525f266dcd7ba9/2740194"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-18/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold">180 gram, 33 rpm, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 1 8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2248873" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-21/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ac0e313010d805868a6fefa74241dd74/2641711>" data-bkg="//cdn.sonemic.net/i/75/s/bcfc6f04782cb84fd2716c82763223da/2641711"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-21/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 4 9" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 4 9
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_11537905" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-13/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/206c9b9784c00df049341c7b861f1553/8208062>" data-bkg="//cdn.sonemic.net/i/75/s/e50918c0a7dd14970a778ec0dc7292d1/8208062"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-13/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="MiniDisc ">
+                     MiniDisc 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 8 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 8 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1059714" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-30/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/59880d5e7797670cf31d9be3f034d961/2273926>" data-bkg="//cdn.sonemic.net/i/75/s/f3c8b8827f20adbef7b5fdb2635e0498/2273926"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-30/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="30 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 4 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 4 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Indonesia"><img alt="Indonesia" src="https://e.snmc.io/3.0/img/flags/4x3/id.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_650135" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-14/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/cf1ca6c24812bf84bd2e14ad37cbc5a8/12350109>" data-bkg="//cdn.sonemic.net/i/75/s/4de520e0c5a1c5d9f48de4d86aea5eb1/12350109"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-14/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 July 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / CDP 7243 8 55229 2 5" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / CDP 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_13563229" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-23/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/23352fe8596b1700a4f3125e43e20a38/9272584>" data-bkg="//cdn.sonemic.net/i/75/s/2d8890df78d7e0346f9fa427a8e45b72/9272584"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-23/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2006">
+                     2006&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / TOCP-53834" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / TOCP-53834
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_6333691" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-15/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/6b9ad88003292bd3f72995bb6869abdd/5890140>" data-bkg="//cdn.sonemic.net/i/75/s/ae84bdc3ac6e856f8fb206eecff74829/5890140"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-15/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold">180 gram, 33 rpm, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / NODATA 02 7243 8 55229 1 8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / NODATA 02 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1744901" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-19/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/82a33fd12f106e34116269bc42ef4d39/2410478>" data-bkg="//cdn.sonemic.net/i/75/s/c7758342a9dfdf67b1d05a03d748b167/2410478"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-19/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="11 June 2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / TOCP-53834" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / TOCP-53834
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1781833" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-27/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/336950ef77441d1ac47c05570cd939f2/2400438>" data-bkg="//cdn.sonemic.net/i/75/s/58e08f119a8ede92ae2cee12ffc4fa9a/2400438"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-27/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold, Limited Edition">180 gram, 33 rpm, Gatefold, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="2 September 2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 7243 8 55229 1 8" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2296837" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-25/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/f8c4e552d5438a06422c860241862bc0/3591269>" data-bkg="//cdn.sonemic.net/i/75/s/1e8f804a27d0a0172ca2eae1798ffc7e/3591269"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-25/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Box Set, Limited Edition">Bonus CD, Bonus DVD, Box Set, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999 6 93626 2 0" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999 6 93626 2 0
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="France"><img alt="France" src="https://e.snmc.io/3.0/img/flags/4x3/fr.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_16061944" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-33/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/4efd44a1f5540aea78a7fdbe14bd5693/12539203>" data-bkg="//cdn.sonemic.net/i/75/s/3c83ea454fe0eb14602259f29a211b67/12539203"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-33/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Box Set, Collector&#39;s Edition">Bonus CD, Bonus DVD, Box Set, Collector&#39;s Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999 6 93629 2 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999 6 93629 2 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> <span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2051525" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-29/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/50a4ce29cd788ac748ca1d5dc1a80963/2617012>" data-bkg="//cdn.sonemic.net/i/75/s/adfa4c1136fecf51378d1c76cea3163e/2617012"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-29/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Collector&#39;s Edition">Bonus CD, Bonus DVD, Collector&#39;s Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="24 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 5099969362927" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 5099969362927
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2153783" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-28/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/fab33dd88c3ca62c8a91b2f8f58aca5b/2612223>" data-bkg="//cdn.sonemic.net/i/75/s/230fb14c18c47f85a55a53988b7d2a4c/2612223"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-28/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Collector&#39;s Edition, Digipak">Bonus CD, Collector&#39;s Edition, Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="24 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 509996 93623 2 3" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 509996 93623 2 3
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2229942" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-16/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/361e270ea10c84ae27b8e3ab115580e1/2631839>" data-bkg="//cdn.sonemic.net/i/75/s/2f8dcee9b1ffa5daee5fbf1174440477/2631839"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-16/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Collector&#39;s Edition, Digipak">Bonus CD, Collector&#39;s Edition, Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="27 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999-6-95462-8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999-6-95462-8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://e.snmc.io/3.0/img/flags/4x3/au.svg" /></span> <span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2115060" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-20/" title="OK Computer [Special Edition]"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/20841b3bac64a1fe94ddf0eb252d16fa/13630454>" data-bkg="//cdn.sonemic.net/i/75/s/8cb5467d8062500022ccaef4ed8655e2/13630454"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-20/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Collector&#39;s Edition, Limited Edition">Bonus CD, Bonus DVD, Collector&#39;s Edition, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-70727" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-70727
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2115063" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-26/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ba03a67cb480f11b1b066a79cc83d2cb/2572398>" data-bkg="//cdn.sonemic.net/i/75/s/4a65a0500ef9c69a1a78dc2d1ced8487/2572398"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-26/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD">Bonus CD</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-70715" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-70715
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_7956905" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-1/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/259d515aa92e955a1cbb826856cf354c/7737229>" data-bkg="//cdn.sonemic.net/i/75/s/7fbbca61a939393aff015060a73b59d1/7737229"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-1/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8032139" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-2/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9883cb0fd4bea1b001a5b0bea14c94cf/6579595>" data-bkg="//cdn.sonemic.net/i/75/s/31d2397a791f2eff5c51aab78d42ad4e/6579595"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-2/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8273836" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-6/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/be50b9cad6da0831da478928fdfce228/6960753>" data-bkg="//cdn.sonemic.net/i/75/s/400fa5793007991773c80adc6826ae40/6960753"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-6/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCD781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCD781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_13776090" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-31/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/919957eb41f345a67bd375ae38e56880/9839085>" data-bkg="//cdn.sonemic.net/i/75/s/ec6fb99036ddd7e405e3a4634663aa95/9839085"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-31/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLDA781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLDA781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_10768293" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-11/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/a443245f351b107f0776545cb7aa1e49/14210554>" data-bkg="//cdn.sonemic.net/i/75/s/e893a6a5c51a2939ff2af1207fd12b05/14210554"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-11/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Союз / XLCD868" >
+                     <a  href="/label/союз_мьюзик/" class="label">Союз</a> 
+                     / XLCD868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Russian Federation"><img alt="Russian Federation" src="https://e.snmc.io/3.0/img/flags/4x3/ru.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254749" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-3/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/75b6b997183b2c01fef1c87e8c7b255c/11612091>" data-bkg="//cdn.sonemic.net/i/75/s/912de5a9f48fe9f3706e088a283d10c2/11612091"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-3/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCD868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCD868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254793" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-5/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7145bb034d18ec896206a22d49b0c103/6607766>" data-bkg="//cdn.sonemic.net/i/75/s/0d8c100b93e3f660b0b052b719d6ec35/6607766"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-5/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997-2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Anniversary Edition, Bonus Tracks, Box Set, Digital Download, Remastered">180 gram, 33 rpm, Anniversary Edition, Bonus Tracks, Box Set, Digital Download, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLMX868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLMX868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> <span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_10258609" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-10/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/c7eeea889a5ba8ac458dea2f884774f7/13232272>" data-bkg="//cdn.sonemic.net/i/75/s/ff463f8d978b8552bbc29b28734000f8/13232272"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-10/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCDJP868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCDJP868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254773" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-2/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/e917c0cf94680b976a6d76ab3a06116e/9454275>" data-bkg="//cdn.sonemic.net/i/75/s/aaf43a8ce165fdaa2f56da7ea80df9b5/9454275"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-2/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Bonus Tracks, Digital Download, Gatefold, Remastered">180 gram, 33 rpm, Bonus Tracks, Digital Download, Gatefold, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8376503" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-3/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9d36dcc7be53e5f5bbe6d7e907055cdd/6572041>" data-bkg="//cdn.sonemic.net/i/75/s/0f8925207d7c6e963ccfc942321e0842/6572041"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-3/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus Tracks, Digital file, Remastered">Anniversary Edition, Bonus Tracks, Digital file, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Digital File ">
+                     Digital File 
+                  </span>
+
+                  <span class="issue_label" title="XL " >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8389481" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-1/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/29ed13d6272fd0fde064a3fdf356c3ff/6579974>" data-bkg="//cdn.sonemic.net/i/75/s/74a48dd95fa54c889d4e4b3e7ce1d125/6579974"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-1/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Bonus Tracks, Colored Vinyl, Digital Download, Gatefold, Limited Edition">180 gram, 33 rpm, Bonus Tracks, Colored Vinyl, Digital Download, Gatefold, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP868X" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP868X
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8438553" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-8/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/83224ec742ddb5fdf2b8f3a64306938e/6610516>" data-bkg="//cdn.sonemic.net/i/75/s/2ec0e6d5950f8070b77fcb9839a22edf/6610516"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-8/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997-2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 July 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="S-Music / 5454682" >
+                     <a  href="/label/s_music_records/" class="label">S-Music</a> 
+                     / 5454682
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14759756" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-32/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/1ddfcc08f8f30053b65f762df0c8c116/10329606>" data-bkg="//cdn.sonemic.net/i/75/s/a7a6180d39d86e9ff8d086118cef4ba9/10329606"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-32/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2022">
+                     2022&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1755575" class="issue_info ">
+                  <a href="/release/unauth/radiohead/ok-computer-1/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/3118808cd57bc708dc16ae08d7f48854/2386738>" data-bkg="//cdn.sonemic.net/i/75/s/3af0d607694e21723842f8c8beed695d/2386738"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/unauth/radiohead/ok-computer-1/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="33 rpm, Abridged, Picture Disc, Promo">33 rpm, Abridged, Picture Disc, Promo</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year " title="">
+                     &nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl 12&#34; ">
+                     Vinyl 12&#34; 
+                  </span>
+
+                  <span class="issue_label" title="(Counterfeit) / Parlophone: NODATA PROLP02" >
+                     <a  href="/label/_counterfeit_/" class="label">(Counterfeit)</a> 
+                     / Parlophone: NODATA PROLP02
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li></ul><script>rymQ(function() {$('.issues').prop('scrollTop', 0);});</script><div id="expand_button" onClick="rymQ( function() { RYMmediaPage.toggleIssues(35); });" data-state="compact" class="expand_button">
+               Expand all 35 issues
+            </div>
+            <span style="display:none;" id="issue_expand_text_compact">Compact issues</span>
+            <span style="display:none;"  id="issue_expand_text_expand">Expand all 35 issues</span></div></div>
+            </div>
+         </div>
+      </div><div class="hide-for-small"><div class="section_issues section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>35 Issues</h2></div>
+         <table class="color_bar" style="xborder:1px #333 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <ul class="issues ">
+      <li  class="issue_info release_view current"><a >Release view [combined information for all issues]</a></li><li id="issue_45" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer/" title="OK Computer"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/0fa37201b199941562f3078dedf5caae/11993756>" style="background:url('//cdn.sonemic.net/i/75/s/92dd35ce1e293a2a0cb4ec913bea4826/11993756') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer.p/">OK Computer</a> 
+                        
+                        <span title="This is the primary issue." class="primary_indicator">[p]</span>
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 2 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> <span class="ui_flag" title="Brazil"><img alt="Brazil" src="https://e.snmc.io/3.0/img/flags/4x3/br.svg" /></span> <span class="ui_flag" title="Canada"><img alt="Canada" src="https://e.snmc.io/3.0/img/flags/4x3/ca.svg" /></span> <span class="ui_flag" title="Colombia"><img alt="Colombia" src="https://e.snmc.io/3.0/img/flags/4x3/co.svg" /></span>  +5 <div class="additional_countries"><span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> <span class="ui_flag" title="Brazil"><img alt="Brazil" src="https://e.snmc.io/3.0/img/flags/4x3/br.svg" /></span> <span class="ui_flag" title="Canada"><img alt="Canada" src="https://e.snmc.io/3.0/img/flags/4x3/ca.svg" /></span> <span class="ui_flag" title="Colombia"><img alt="Colombia" src="https://e.snmc.io/3.0/img/flags/4x3/co.svg" /></span> <span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> <span class="ui_flag" title="Ukraine"><img alt="Ukraine" src="https://e.snmc.io/3.0/img/flags/4x3/ua.svg" /></span> <span class="ui_flag" title="Indonesia"><img alt="Indonesia" src="https://e.snmc.io/3.0/img/flags/4x3/id.svg" /></span> <span class="ui_flag" title="Mexico"><img alt="Mexico" src="https://e.snmc.io/3.0/img/flags/4x3/mx.svg" /></span> <span class="ui_flag" title="Australia"><img alt="Australia" src="https://e.snmc.io/3.0/img/flags/4x3/au.svg" /></span> </div></span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_4307978" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-24/" title="OK Computer"><div 
+                     class="has_tip issue_img" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9d6c86544a8ee2dc0e0e8932d673e176/5852865>" style="background:url('//cdn.sonemic.net/i/75/s/13ac16854eb9d9b759e33e1f6b4e5194/5852865') center center no-repeat;" 
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-24/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 2 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8419639" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-7/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/616d4d33e4f21978c150e34bb73ab06a/8331457>" data-bkg="//cdn.sonemic.net/i/75/s/6184e6ed094bb97184cdb84bfaeedcd6/8331457"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-7/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Numbered Edition, Promo">Numbered Edition, Promo</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / CDPP 005" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / CDPP 005
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_16673148" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-34/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/da322d2553cef5c50d8185b8392619d6/13761553>" data-bkg="//cdn.sonemic.net/i/75/s/df035ae3d98c94101ab6e2507b1c7655/13761553"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-34/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Limited Edition, Slipcase / O-Card">Bonus CD, Limited Edition, Slipcase / O-Card</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 21338 2 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 21338 2 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1799595" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-17/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/723b6d03025f7ef01bda282ea15c8428/9272568>" data-bkg="//cdn.sonemic.net/i/75/s/308675f1787652eaaa3aa6439acfa414/9272568"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-17/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="21 May 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-50201" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-50201
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_675769" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-18/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ca005743f22490fbbbe91c0f94fcb12c/2740194>" data-bkg="//cdn.sonemic.net/i/75/s/4233b43c8dc7cd94d4525f266dcd7ba9/2740194"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-18/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold">180 gram, 33 rpm, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 1 8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2248873" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-21/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ac0e313010d805868a6fefa74241dd74/2641711>" data-bkg="//cdn.sonemic.net/i/75/s/bcfc6f04782cb84fd2716c82763223da/2641711"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-21/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 4 9" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 4 9
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_11537905" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-13/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/206c9b9784c00df049341c7b861f1553/8208062>" data-bkg="//cdn.sonemic.net/i/75/s/e50918c0a7dd14970a778ec0dc7292d1/8208062"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-13/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="16 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="MiniDisc ">
+                     MiniDisc 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 8 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 8 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1059714" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-30/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/59880d5e7797670cf31d9be3f034d961/2273926>" data-bkg="//cdn.sonemic.net/i/75/s/f3c8b8827f20adbef7b5fdb2635e0498/2273926"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-30/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="30 June 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Cassette ">
+                     Cassette 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 7243 8 55229 4 5" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 7243 8 55229 4 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Indonesia"><img alt="Indonesia" src="https://e.snmc.io/3.0/img/flags/4x3/id.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_650135" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-14/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/cf1ca6c24812bf84bd2e14ad37cbc5a8/12350109>" data-bkg="//cdn.sonemic.net/i/75/s/4de520e0c5a1c5d9f48de4d86aea5eb1/12350109"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-14/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 July 1997">
+                     1997&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / CDP 7243 8 55229 2 5" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / CDP 7243 8 55229 2 5
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_13563229" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-23/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/23352fe8596b1700a4f3125e43e20a38/9272584>" data-bkg="//cdn.sonemic.net/i/75/s/2d8890df78d7e0346f9fa427a8e45b72/9272584"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-23/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2006">
+                     2006&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / TOCP-53834" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / TOCP-53834
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_6333691" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-15/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/6b9ad88003292bd3f72995bb6869abdd/5890140>" data-bkg="//cdn.sonemic.net/i/75/s/ae84bdc3ac6e856f8fb206eecff74829/5890140"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-15/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold">180 gram, 33 rpm, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / NODATA 02 7243 8 55229 1 8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / NODATA 02 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1744901" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-19/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/82a33fd12f106e34116269bc42ef4d39/2410478>" data-bkg="//cdn.sonemic.net/i/75/s/c7758342a9dfdf67b1d05a03d748b167/2410478"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-19/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Limited Edition">Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="11 June 2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / TOCP-53834" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / TOCP-53834
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1781833" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-27/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/336950ef77441d1ac47c05570cd939f2/2400438>" data-bkg="//cdn.sonemic.net/i/75/s/58e08f119a8ede92ae2cee12ffc4fa9a/2400438"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-27/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Gatefold, Limited Edition">180 gram, 33 rpm, Gatefold, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="2 September 2008">
+                     2008&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 7243 8 55229 1 8" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 7243 8 55229 1 8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2296837" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-25/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/f8c4e552d5438a06422c860241862bc0/3591269>" data-bkg="//cdn.sonemic.net/i/75/s/1e8f804a27d0a0172ca2eae1798ffc7e/3591269"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-25/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Box Set, Limited Edition">Bonus CD, Bonus DVD, Box Set, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999 6 93626 2 0" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999 6 93626 2 0
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="France"><img alt="France" src="https://e.snmc.io/3.0/img/flags/4x3/fr.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_16061944" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-33/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/4efd44a1f5540aea78a7fdbe14bd5693/12539203>" data-bkg="//cdn.sonemic.net/i/75/s/3c83ea454fe0eb14602259f29a211b67/12539203"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-33/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Box Set, Collector&#39;s Edition">Bonus CD, Bonus DVD, Box Set, Collector&#39;s Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999 6 93629 2 7" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999 6 93629 2 7
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> <span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2051525" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-29/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/50a4ce29cd788ac748ca1d5dc1a80963/2617012>" data-bkg="//cdn.sonemic.net/i/75/s/adfa4c1136fecf51378d1c76cea3163e/2617012"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-29/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Collector&#39;s Edition">Bonus CD, Bonus DVD, Collector&#39;s Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="24 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 5099969362927" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 5099969362927
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2153783" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-28/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/fab33dd88c3ca62c8a91b2f8f58aca5b/2612223>" data-bkg="//cdn.sonemic.net/i/75/s/230fb14c18c47f85a55a53988b7d2a4c/2612223"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-28/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Collector&#39;s Edition, Digipak">Bonus CD, Collector&#39;s Edition, Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="24 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Capitol / 509996 93623 2 3" >
+                     <a  href="/label/capitol_records/" class="label">Capitol</a> 
+                     / 509996 93623 2 3
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2229942" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-16/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/361e270ea10c84ae27b8e3ab115580e1/2631839>" data-bkg="//cdn.sonemic.net/i/75/s/2f8dcee9b1ffa5daee5fbf1174440477/2631839"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-16/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Collector&#39;s Edition, Digipak">Bonus CD, Collector&#39;s Edition, Digipak</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="27 March 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Parlophone / 50999-6-95462-8" >
+                     <a  href="/label/parlophone/" class="label">Parlophone</a> 
+                     / 50999-6-95462-8
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Australia"><img alt="Australia" src="https://e.snmc.io/3.0/img/flags/4x3/au.svg" /></span> <span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2115060" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-20/" title="OK Computer [Special Edition]"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/20841b3bac64a1fe94ddf0eb252d16fa/13630454>" data-bkg="//cdn.sonemic.net/i/75/s/8cb5467d8062500022ccaef4ed8655e2/13630454"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-20/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD, Bonus DVD, Collector&#39;s Edition, Limited Edition">Bonus CD, Bonus DVD, Collector&#39;s Edition, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-70727" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-70727
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_2115063" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-26/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/ba03a67cb480f11b1b066a79cc83d2cb/2572398>" data-bkg="//cdn.sonemic.net/i/75/s/4a65a0500ef9c69a1a78dc2d1ced8487/2572398"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-26/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Bonus CD">Bonus CD</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2009">
+                     2009&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="EMI / TOCP-70715" >
+                     <a  href="/label/emi-records/" class="label">EMI</a> 
+                     / TOCP-70715
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_7956905" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-1/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/259d515aa92e955a1cbb826856cf354c/7737229>" data-bkg="//cdn.sonemic.net/i/75/s/7fbbca61a939393aff015060a73b59d1/7737229"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-1/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8032139" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-2/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9883cb0fd4bea1b001a5b0bea14c94cf/6579595>" data-bkg="//cdn.sonemic.net/i/75/s/31d2397a791f2eff5c51aab78d42ad4e/6579595"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-2/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8273836" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-6/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/be50b9cad6da0831da478928fdfce228/6960753>" data-bkg="//cdn.sonemic.net/i/75/s/400fa5793007991773c80adc6826ae40/6960753"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-6/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title=""></span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCD781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCD781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_13776090" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-31/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/919957eb41f345a67bd375ae38e56880/9839085>" data-bkg="//cdn.sonemic.net/i/75/s/ec6fb99036ddd7e405e3a4634663aa95/9839085"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-31/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Digital file, Streaming">Digital file, Streaming</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 April 2016">
+                     2016&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Lossless Digital ">
+                     Lossless Digital 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLDA781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLDA781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_10768293" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-11/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/a443245f351b107f0776545cb7aa1e49/14210554>" data-bkg="//cdn.sonemic.net/i/75/s/e893a6a5c51a2939ff2af1207fd12b05/14210554"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-11/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="Союз / XLCD868" >
+                     <a  href="/label/союз_мьюзик/" class="label">Союз</a> 
+                     / XLCD868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Russian Federation"><img alt="Russian Federation" src="https://e.snmc.io/3.0/img/flags/4x3/ru.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254749" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-3/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/75b6b997183b2c01fef1c87e8c7b255c/11612091>" data-bkg="//cdn.sonemic.net/i/75/s/912de5a9f48fe9f3706e088a283d10c2/11612091"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-3/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCD868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCD868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254793" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-5/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/7145bb034d18ec896206a22d49b0c103/6607766>" data-bkg="//cdn.sonemic.net/i/75/s/0d8c100b93e3f660b0b052b719d6ec35/6607766"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-5/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997-2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Anniversary Edition, Bonus Tracks, Box Set, Digital Download, Remastered">180 gram, 33 rpm, Anniversary Edition, Bonus Tracks, Box Set, Digital Download, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLMX868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLMX868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="EU"><img alt="EU" src="https://e.snmc.io/3.0/img/flags/4x3/eu.svg" /></span> <span class="ui_flag" title="United States"><img alt="United States" src="https://e.snmc.io/3.0/img/flags/4x3/us.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_10258609" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-10/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/c7eeea889a5ba8ac458dea2f884774f7/13232272>" data-bkg="//cdn.sonemic.net/i/75/s/ff463f8d978b8552bbc29b28734000f8/13232272"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-10/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997 2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="XL / XLCDJP868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLCDJP868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Japan"><img alt="Japan" src="https://e.snmc.io/3.0/img/flags/4x3/jp.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8254773" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-2/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/e917c0cf94680b976a6d76ab3a06116e/9454275>" data-bkg="//cdn.sonemic.net/i/75/s/aaf43a8ce165fdaa2f56da7ea80df9b5/9454275"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-2/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Bonus Tracks, Digital Download, Gatefold, Remastered">180 gram, 33 rpm, Bonus Tracks, Digital Download, Gatefold, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP868" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP868
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8376503" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-3/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/9d36dcc7be53e5f5bbe6d7e907055cdd/6572041>" data-bkg="//cdn.sonemic.net/i/75/s/0f8925207d7c6e963ccfc942321e0842/6572041"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-3/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus Tracks, Digital file, Remastered">Anniversary Edition, Bonus Tracks, Digital file, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Digital File ">
+                     Digital File 
+                  </span>
+
+                  <span class="issue_label" title="XL " >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8389481" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-oknotok-1997-2017-1/" title="OK Computer OKNOTOK 1997 2017"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/29ed13d6272fd0fde064a3fdf356c3ff/6579974>" data-bkg="//cdn.sonemic.net/i/75/s/74a48dd95fa54c889d4e4b3e7ce1d125/6579974"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="" href="/release/album/radiohead/ok-computer-oknotok-1997-2017-1/">OK Computer OKNOTOK 1997 2017</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Bonus Tracks, Colored Vinyl, Digital Download, Gatefold, Limited Edition">180 gram, 33 rpm, Bonus Tracks, Colored Vinyl, Digital Download, Gatefold, Limited Edition</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="23 June 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP868X" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP868X
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_8438553" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-8/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/83224ec742ddb5fdf2b8f3a64306938e/6610516>" data-bkg="//cdn.sonemic.net/i/75/s/2ec0e6d5950f8070b77fcb9839a22edf/6610516"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-8/">OK Computer</a> 
+                         <span class="addendum">OKNOTOK 1997-2017</span> 
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered">Anniversary Edition, Bonus CD, Gatefold, Paper/Cardboard Sleeve, Remastered</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year ymd" title="1 July 2017">
+                     2017&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="CD ">
+                     CD 
+                  </span>
+
+                  <span class="issue_label" title="S-Music / 5454682" >
+                     <a  href="/label/s_music_records/" class="label">S-Music</a> 
+                     / 5454682
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="Argentina"><img alt="Argentina" src="https://e.snmc.io/3.0/img/flags/4x3/ar.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_14759756" class="issue_info ">
+                  <a href="/release/album/radiohead/ok-computer-32/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/1ddfcc08f8f30053b65f762df0c8c116/10329606>" data-bkg="//cdn.sonemic.net/i/75/s/a7a6180d39d86e9ff8d086118cef4ba9/10329606"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/album/radiohead/ok-computer-32/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="180 gram, 33 rpm, Digital Download, Gatefold">180 gram, 33 rpm, Digital Download, Gatefold</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year y" title="2022">
+                     2022&nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl LP">
+                     Vinyl LP
+                  </span>
+
+                  <span class="issue_label" title="XL / XLLP781" >
+                     <a  href="/label/xl_recordings/" class="label">XL</a> 
+                     / XLLP781
+                  </span>
+
+                  <span class="issue_countries">&nbsp;</span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li><li id="issue_1755575" class="issue_info ">
+                  <a href="/release/unauth/radiohead/ok-computer-1/" title="OK Computer"><div 
+                     class="has_tip issue_img lazyload" data-tiptip="<img class=large_tip_img src=//cdn.sonemic.net/i/300/s/3118808cd57bc708dc16ae08d7f48854/2386738>" data-bkg="//cdn.sonemic.net/i/75/s/3af0d607694e21723842f8c8beed695d/2386738"  
+                  >
+         
+               </div></a>
+
+               <div class="issue_info_top">
+                  <span class="main_issue_info">
+                     <span class="issue_title">
+                        <a class="sametitle" href="/release/unauth/radiohead/ok-computer-1/">OK Computer</a> 
+                        
+                        
+                        <span class="issue_attributes" style="font-weight:normal;">
+                           <span class="attribute" title="33 rpm, Abridged, Picture Disc, Promo">33 rpm, Abridged, Picture Disc, Promo</span>
+                        </span>
+                     </span>
+                  </span>
+               </div>
+
+               <div class="issue_info_bottom">
+                  <span class="issue_year " title="">
+                     &nbsp;
+                  </span>
+
+                  <span class="issue_formats" title="Vinyl 12&#34; ">
+                     Vinyl 12&#34; 
+                  </span>
+
+                  <span class="issue_label" title="(Counterfeit) / Parlophone: NODATA PROLP02" >
+                     <a  href="/label/_counterfeit_/" class="label">(Counterfeit)</a> 
+                     / Parlophone: NODATA PROLP02
+                  </span>
+
+                  <span class="issue_countries">&nbsp;<span class="ui_flag" title="United Kingdom"><img alt="United Kingdom" src="https://e.snmc.io/3.0/img/flags/4x3/gb.svg" /></span> </span>
+                  <div class="clearfix"></div>
+               </div>
+
+
+              </li></ul><script>rymQ(function() {$('.issues').prop('scrollTop', 0);});</script><div id="expand_button" onClick="rymQ( function() { RYMmediaPage.toggleIssues(35); });" data-state="compact" class="expand_button">
+               Expand all 35 issues
+            </div>
+            <span style="display:none;" id="issue_expand_text_compact">Compact issues</span>
+            <span style="display:none;"  id="issue_expand_text_expand">Expand all 35 issues</span></div></div></div><div class="show-for-small">
+      <div id="expand_full_credits_small" class="mobile_expandable_full ">
+
+            <div id="expand_full_header_credits_small" class="mobile_expandable_full_header" onClick="RYMmobile.mobileExpand.toggleFull('credits_small');">
+
+               <div class="mobile_expandable_full_icons">
+                  <div class="mobile_expandable_full_expand_icon_expanded">
+                     <i class="fa fa-caret-down"></i>
+                  </div>
+                  <div class="mobile_expandable_full_expand_icon_hidden">
+                     <i class="fa fa-caret-right"></i>
+                  </div>
+               </div>
+
+               <div id="expand_full_name_credits_small" class="mobile_expandable_full_name">
+                  Credits
+               </div>
+
+            </div>
+
+            <div id="expand_full_content_credits_small" class="mobile_expandable_full_content">
+               <div class="section_credits"><div class="release_page_header hide-for-small"><h2>Credits</h2></div>
+          <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+          <ul id="credits_credits_mobile" class="credits"><li><a title="[Artist42]"  href="/artist/radiohead" class="artist">Radiohead</a><br /> <span class="role_name "><span class="rendered_text">songwriting</span></span>,  <span class="role_name ">string arrangements</span>,  <span class="role_name ">producer</span></li>
+<li><a title="[Artist72630]"  href="/artist/thom-yorke" class="artist">Thom Yorke</a><br /> <span class="role_name ">vocals</span>,  <span class="role_name ">guitar</span>,  <span class="role_name ">piano</span>,  <span class="role_name ">programming</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist21860]"  href="/artist/jonny-greenwood" class="artist">Jonny Greenwood</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">keyboards</span>,  <span class="role_name ">piano</span>,  <span class="role_name ">Mellotron</span>,  <span class="role_name ">organ</span>,  <span class="role_name ">glockenspiel</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist521869]"  href="/artist/philip-selway" class="artist">Philip Selway</a><br /> <span class="role_name ">drums</span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist521870]"  href="/artist/ed-obrien" class="artist">Ed O&#39;Brien</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">backing vocals</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist703643]"  href="/artist/colin-greenwood" class="artist">Colin Greenwood</a><br /> <span class="role_name ">bass guitar</span>,  <span class="role_name "><span class="rendered_text">bass synthesizer</span></span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist427029]"  href="/artist/nigel-godrich" class="artist">Nigel Godrich</a><br /> <span class="role_name ">producer</span>,  <span class="role_name ">mixing engineer</span></li>
+<li><a title="[Artist27082]"  href="/artist/nick-ingman" class="artist">Nick Ingman</a><br /> <span class="role_name ">conductor</span></li>
+<li><a title="[Artist954146]"  href="/artist/chris_blair" class="artist">Chris &#34;King Fader&#34; Blair</a><br /> <span class="role_name ">mastering engineer</span></li>
+<li><a title="[Artist954574]"  href="/artist/gerard_navarro" class="artist">Gerard Navarro</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist1062583]"  href="/artist/jon_bailey" class="artist">Jon Bailey</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist1062585]"  href="/artist/chris_scard" class="artist">Chris Scard</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist995128]"  href="/artist/stanley-donwood" class="artist">Stanley Donwood</a><br /> <span class="role_name ">sleeve design</span>,  <span class="role_name "><span class="rendered_text">artwork</span></span>,  <span class="role_name "><span class="rendered_text">online editor</span></span></li>
+<li><a title="[Artist72630]"  href="/artist/thom-yorke" class="artist">The White Chocolate Farm</a><br /> <span class="role_name ">sleeve design</span>,  <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist1697068]"  href="/artist/matt-bale" class="artist">Matt Bale</a><br /> <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist1697072]"  href="/artist/mr-barry" class="artist">Mr. Barry</a><br /> <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist2003472]"  href="/artist/adam-cummings" class="artist">Adam Cummings</a><br /> <span class="role_name ">guitar technician</span>,  <span class="role_name ">additional guitar</span></li>
+<li><span>Charlie Myatt</span><br /> <span class="role_name "><span class="rendered_text">booking</span></span></li>
+<li><a title="[Artist954139]"  href="/artist/jim_warren" class="artist">Jim Warren</a><br /> <span class="role_name ">engineer</span></li>
+<li><span>Andi Watson</span><br /> <span class="role_name "><span class="rendered_text">stage design</span></span></li>
+<li><span>Keith Wozencroft</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist1562967]"  href="/artist/peregrine-watts-russell" class="artist">Perry Watts-Russell</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Tony Wadsworth</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Big Al</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Carol Baxter</span><br /> <span class="role_name ">international marketing</span></li>
+<li><span>Julie Calland</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist1054980]"  href="/artist/brian_message" class="artist">Brian Message</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist972381]"  href="/artist/chris_hufford" class="artist">Chris Hufford</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Bryce Edge</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Caffy St Luce</span><br /> <span class="role_name "><span class="rendered_text">media management</span></span></li>
+<li><span>Duncan Swift</span><br /> <span class="role_name ">instrument maintenance</span></li>
+<li><a title="[Artist2029817]"  href="/artist/plank-6" class="artist">Plank</a><br /> <span class="role_name ">instrument technician</span>,  <span class="role_name "><span class="rendered_text">equipment</span></span></li>
+<li><a title="[Artist2003473]"  href="/artist/david-tordoff" class="artist">Tree</a><br /> <span class="role_name "><span class="rendered_text">sound technician</span></span></li>
+<li><a title="[Artist2064328]"  href="/artist/tim-greaves" class="artist">Tim Greaves</a><br /> <span class="role_name ">tour manager</span></li>
+<li><a title="[Artist817099]"  href="/artist/dilly-gent" class="artist">Dilly Gent</a><br /> <span class="role_name "><span class="rendered_text">video editor</span></span></li> </ul> </div>
+          
+            </div>
+         </div>
+      </div><div id="reviews_shell"><div class="section_reviews section_outer"><div class="page_section">
+         <div class="release_page_header"><h2>2,033 Reviews
+         </h2></div>
+         <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+         <div class="review_list"> 
+            <style>
+               #include_all_languages { 
+                  border:none 
+               }
+               #include_all_languages_label { 
+                  margin-right:1em;
+                  margin-left:1em;
+                  font-weight:normal;
+                  color:var(--text-secondary);
+               }
+            </style>
+         <label 
+                           onClick="rym.request.post('SetReviewShowAllLanguages', 
+                                       {show:document.getElementById('include_all_languages').checked}, 
+                                       null, 'script');"
+                            id="include_all_languages_label" 
+                            for="include_all_languages">
+                            <input id="include_all_languages" 
+                            aria-label="include all languages" 
+                            type=checkbox > Include all languages</label> <span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/2/">2</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/22/">22</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/45/">45</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/67/">67</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/90/">90</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/113/">113</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/135/">135</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/158/">158</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/180/">180</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/203/">203</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/226/">226</a> <a class="navlinknext" href="/release/album/radiohead/ok-computer/reviews/2/">&gt;&gt;</a></span>
+         <div style="clear:both;"></div></div>
+         <div id="review_shell_std_1181052"><div class="review" >
+               <div class="review_header "><a title="User Iai" href="/~Iai"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/b30cb55212386e2c4331cfc40b2da307/5653759" data-bkg2x="//cdn.sonemic.net/i/75/s/b30cb55212386e2c4331cfc40b2da307/5653759" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Iai">Iai</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Iai/radiohead/ok-computer/1181052">Apr 05 2022</a>
+                  </span>
+
+                  
+                  <span onClick="$('#review_track_rating_1181052').toggle();" class="catalog_track_ratings">▼</span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span></span><div style="float:right;" id="review_voting_1181052"></div>
+                 
+               </div><div class="review_body "><div id="review_track_rating_1181052" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Airbag</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Paranoid Android</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Subterranean Homesick Alien</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">Exit Music (For a Film)</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Let Down</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Karma Police</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">Fitter Happier</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Electioneering</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Climbing Up the Walls</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">No Surprises</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Lucky</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">The Tourist</span></span>
+                     </div>
+                   </li></ul></div>
+
+
+      <span ><span class="rendered_text">I think I actually under-rate <i>OK Computer</i>, if anything.  That&#39;s bonkers, right?  It&#39;s been my favourite album for over two decades now - but that right there is exactly the problem.  I heard it when I was 15, and it was maybe the fourth or fifth album of any kind I&#39;d ever truly paid attention to front-to-back, and the first that wasn&#39;t essentially forced upon me by my parents or general peer pressure at school.  It was the first time I&#39;d ever decided it might be worth actually trying out music for real, and the very first album I ever landed on just so happened to be the best one?  Nah.  It&#39;s far too <i>convenient</i>.  I keep side-eyeing it uneasily when I see it sitting at the top of my favourite albums list.  Surely the rush of hearing it now can&#39;t be the same as it was when I was hearing it as a teenager.  Surely at least one of the 3,500 albums I&#39;ve heard since has surpassed it.  Right?!<br /><br />And yet I&#39;ve been having this thought repeatedly for well over a decade now, and every time I come back to it I&#39;m absolutely blown away.  I think to myself that surely &#34;Paranoid Android&#34; won&#39;t have that power when the shock of the multi-part song structure has worn off.  Surely &#34;Subterranean Homesick Alien&#34; won&#39;t sound as profoundly spacious, distant, and yearning as it did back in those long distant days when it was my favourite song.  Surely &#34;Exit Music (For a Film)&#34; won&#39;t still send those shivers flying up my spine.  Surely &#34;Let Down&#34; won&#39;t be so emotionally overwhelming.  Surely &#34;Climbing Up the Walls&#34; won&#39;t still feel so terrifying.  Surely at some point &#34;No Surprises&#34; will stop sounding so damn pretty and feeling so damn desolate.  Surely &#34;Lucky&#34; won&#39;t soar so high.  And yet every time I go back and check, I find that all of those things are true and more.  The other songs have only grown in my estimation since; &#34;The Tourist&#34; has stopped feeling like one of the weak points here and screamed all the way up to becoming one of my favourite songs in their catalogue, and the surprising coldness of &#34;Electioneering&#34; has really started to draw me in.  It just somehow keeps getting better every time I hear it.  So yes: it turns out that by total fluke, my first ever attempt to find a favourite album was the only one I ever needed, and as much as I&#39;ve loved spending so long trying to find something better, and as much as I will probably continue to do so for as long as I&#39;m alive, it&#39;s probably a fruitless endeavour.  <i>OK Computer</i>, man.  What a fucking album.<br /><br />So yeah.  Apologies if you&#39;re one of the many, many people who favourited the previous version of this review, but it was a complete load of shite and frankly you should have known better.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating1181052]" /></div></div>
+             </div></div><!-- /31961696/release.case-a.728.mid-right -->
+            <div data-nosnippet class='page_creative_frame small-desk-leaderboard
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-22'  data-adcode='div-gpt-ad-1465817209349-22'   style='overflow:hidden;margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;margin-top:1em;min-height:138px;min-width:728px;' >
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-22'>
+            </div></div><div id="review_shell_std_20261844"><div class="review" >
+               <div class="review_header "><a title="User finulanu" href="/~finulanu"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/aad33ea551b7fb62026dfa568a8e9b81/14476882" data-bkg2x="//cdn.sonemic.net/i/75/s/aad33ea551b7fb62026dfa568a8e9b81/14476882" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~finulanu">finulanu</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/finulanu/radiohead/ok-computer/20261844">Feb 16 2020</a>
+                  </span>
+
+                  
+                  <span onClick="$('#review_track_rating_20261844').toggle();" class="catalog_track_ratings">▼</span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span></span><div style="float:right;" id="review_voting_20261844"></div>
+                 
+               </div><div class="review_body "><div id="review_track_rating_20261844" class="track_rating_hide"><ul class="tracks" style="margin:10px;"><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                        <span class="tracklist_num">1</span>
+                        <span class="tracklist_title"><span class="rendered_text">Airbag</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">2</span>
+                        <span class="tracklist_title"><span class="rendered_text">Paranoid Android</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">3</span>
+                        <span class="tracklist_title"><span class="rendered_text">Subterranean Homesick Alien</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">4</span>
+                        <span class="tracklist_title"><span class="rendered_text">Exit Music (For a Film)</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">5</span>
+                        <span class="tracklist_title"><span class="rendered_text">Let Down</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">6</span>
+                        <span class="tracklist_title"><span class="rendered_text">Karma Police</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                        <span class="tracklist_num">7</span>
+                        <span class="tracklist_title"><span class="rendered_text">Fitter Happier</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                        <span class="tracklist_num">8</span>
+                        <span class="tracklist_title"><span class="rendered_text">Electioneering</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                        <span class="tracklist_num">9</span>
+                        <span class="tracklist_title"><span class="rendered_text">Climbing Up the Walls</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                        <span class="tracklist_num">10</span>
+                        <span class="tracklist_title"><span class="rendered_text">No Surprises</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                        <span class="tracklist_num">11</span>
+                        <span class="tracklist_title"><span class="rendered_text">Lucky</span></span>
+                     </div>
+                   </li><li class="track">
+                     <div class="tracklist_line">
+                        <span class="track_rating_disp"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                        <span class="tracklist_num">12</span>
+                        <span class="tracklist_title"><span class="rendered_text">The Tourist</span></span>
+                     </div>
+                   </li></ul></div>
+
+
+      <span ><span class="rendered_text">I get why Radiohead rub a lot of people the wrong way. A lot of people just find them too <i>cold</i>, and Thom Yorke has one of those voices that&#39;ll drive a lot of people batty. They&#39;re also such an enormously acclaimed band that a little backlash was just inevitable. Plus, even I find their image as the self-ordained Darkest Weirdest Band On Earth a little excessive, and I gave this album five stars! Oh, and did I mentioned how widely imitated they are? We live in a world where bands like Coldplay and Muse and Keane diluted this sound into something a little more radio-friendly and made buckets of money off it. In cases like that, you couldn&#39;t be blamed if you wonder: does the original stand up after all?<br /><br />Well, I&#39;ve got some nitpicks of my own. &#34;Electioneering&#34; isn&#39;t quite the headbanger&#39;s extravaganza it clearly wants to be (great guitars at the end, though), while &#34;Fitter Happier&#34; still sounds a little too edgy-&#39;90s for my liking (isn&#39;t there a Nine Inch Nails b-side called &#34;A Pig In a Cage On Antibiotics?&#34;). If I ever bust this score down to a 4.5, it&#39;s probably because they put these two right in a row. My opinion on &#34;Exit Music (For a Film)&#34; depends on my mood; sometimes I get caught up in the gothic drama of the whole thing, and other times, it just seems like a whole lot of overheated nothing. In other words, I&#39;m not quite ready to go out and say OK Computer is a perfect album. I would&#39;ve said that at one point, a less mature point in my life indeed, but you know how it is. You get older, and that album you loved so much shows a few of its rough edges.<br /><br />Yet the best songs on this album really are as good as you&#39;ve heard. Pretty much all of them. I&#39;d hesitate to call &#34;Subterranean Homesick Alien&#34; a masterpiece, but its subtly tricky arrangement and much-needed humor make it an important addition to the album. You&#39;ve just got to lighten things up sometimes, because this record gets heavy. Sometimes in terms of the guitars (they tear some shit up in the loud parts of &#34;Paranoid Android&#34;), but more in terms of the emotions. This album is one negative trip, my friends. &#34;Android&#34; lurches between queasy acoustic guitars, wall-rattling riffs, and goth-prog creepiness, in brilliant fashion - think how &#34;Happiness is a Warm Gun&#34; constantly keeps you off your kilter, but the release is much different. &#34;Climbing Up the Walls&#34; plunges you deep into some horror-movie shit, with huge drums, processed vocals (Yorke lets some bloodcurdling screams loose), and some of Greenwood&#39;s earliest string arrangements. Even &#34;No Surprises,&#34; which musically is almost McCartney-esque in its mellow lull, has some dark fucking lyrics. Radiohead plunges you into a dark and alienating world with this album, is what I&#39;m saying here.<br /><br />Normally this kind of relentless grimness puts me off (pretty sure I&#39;ve raised this complaint about Pink Floyd), but Radiohead <i>knows their way around a song</i>. The tunes I mentioned above are spectacularly well-crafted. &#34;Android&#39;s&#34; multipart structure is no mere grab bag - each part not only flows with but builds onto the one before it. &#34;Climbing Up the Walls&#34; earns its explosive ending - the fireworks is always just waiting there, so when they finally hit, they feel like the most natural development. &#34;No Surprises&#34; is plenty lovely, but with an ominous edge. And hey, there&#39;s more where that came from. Take my personal favorite, &#34;Let Down.&#34; This one&#39;s best known for its third verse, where Thom Yorke duets with himself. It&#39;s a soaring and spectacular moment, the album at its most emotional and yearning, and it gets there by way of a tense but lovely keyboard solo. Even before all that kicks in, check out the blend of icy guitars and Ringo-style drums that move the verses and choruses. There is, in short, a real attention to sonic detail here. The detail&#39;s why I never minded the Beatles lift on &#34;Karma Police.&#34; Not only does the piano part fit in with the song&#39;s soft chorus beautifully, but the textures in the coda are pure Radiohead.<br /><br />Those five are the biggies for most people, but the cool thing about this album is there&#39;s a lot going on here. Somehow I&#39;ve made it alll this way without even mentioning the opener, &#34;Airbag.&#34; Shame on me! What a great song. The atmospheric guitar, sprinkles of keyboards, and cello hook might not surprise you, but the song is also kinda <i>funky</i>. Great beat here, and a great bassline, too. Radiohead&#39;s rhythm section doesn&#39;t get a lot of attention, but they deserve a lot of credit for shaping their sound. They don&#39;t get as much attention on the closer, the waltzing &#34;Tourist,&#34; but that&#39;s also a feast of sound. Check out the dreamy country guitars, the mellotron choir, even the little ding of a triangle at the end. While we&#39;re in the album&#39;s closing stretch, I&#39;ve always really enjoyed &#34;Lucky.&#34; Yorke&#39;s soaring vocal and Greenwood&#39;s most balls-out bombastic guitar make a great pair on this one.<br /><br />I guess my only question is what to do about those two weaker tracks. They had some great material in the vaults - the trip-hoppy instrumental &#34;Meeting in the Aisle&#34; would&#39;ve made a much better transition than &#34;Fitter Happier,&#34; and &#34;Pearly&#34; rocks much better than &#34;Electioneering.&#34; I also wish &#34;Polyethylene&#34; had found a home on an album - to my ears, it&#39;s one of Radiohead&#39;s better tracks, with a big tonal shift I&#39;ve always really loved. Still, we got the album we got. Not one of those albums where every song is a total gem, but an album whose high points are so dazzling I can&#39;t help but go the full five.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating20261844]" /></div></div>
+             </div></div><!-- /31961696/release.case-a.728.mid-right-2 -->
+            <div data-nosnippet class='page_creative_frame small-desk-leaderboard
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-93'  data-adcode='div-gpt-ad-1465817209349-93'   style='overflow:hidden;margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;margin-top:1em;min-height:138px;min-width:728px;' >
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-93'>
+            </div></div><div id="review_shell_std_8413216"><div class="review" >
+               <div class="review_header "><a title="User FlintGF" href="/~FlintGF"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/cd696547f0f4faabc53313c4f6dd26df/14399725" data-bkg2x="//cdn.sonemic.net/i/75/s/cd696547f0f4faabc53313c4f6dd26df/14399725" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~FlintGF">FlintGF</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/FlintGF/radiohead/ok-computer/8413216">Jun 04 2019</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span></span><div style="float:right;" id="review_voting_8413216"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">I&#39;d like to think I&#39;m good about not letting the wider critical world affect my own amateur reviews. Rather than saying this or that is overrated or underrated, or making parallels about my opinions vs everyone else&#39;s, I prefer looking at things within my own bubble - after all, it&#39;s my opinion that matters the most to my listening habits and I imagine someone would read my thoughts to learn what I personally think. With some records that&#39;s harder than others. There&#39;s a number of albums that are so universal that they form a part of our collective consciousness even if we don&#39;t care about them: albums which have been discussed and analysed so often and in such great detail due to their importance and place in the canon that there is literally nothing new to say. Most of the time, I can still comfortably get by. Enough time has passed from <b>The Beatles, Pink Floyd, Led Zeppelin</b> and other sacred cows that the old canon narratives are actively being argued against while new ones are established and there&#39;s a wider variety of opinions challenging the old classics, and somewhere between those lines I&#39;m able to place my own opinion without feeling like I&#39;m better off just linking to the relevant Wikipedia section. <br /><br /><a  href="/release/album/radiohead/ok-computer/" class="album">OK Computer</a> is a curveball for me in this regard. It&#39;s a landmark album, and even I agree with that - to a degree that it feels like an actual challenge to start dissecting it apart. You&#39;re not going to find unique angles to view this album through from me, is what I am saying. It&#39;s my generation&#39;s <i>Sgt Peppers</i>, and I&#39;m saying that without a single ounce of hyperbole. It&#39;s a cultural milestone that has affected so much of the other music I enjoy, inspired countless other musicians and shifted genre trends. To this day it causes so much discussion, analysis and over-analysis that we are all absolutely sick of it. We can all recite from memory the story of Thom Yorke &amp; co becoming increasingly fatigued by society and music industry at the same time as they felt their ambitions limited by their early sound, and in turn exploding in fame and finding themselves even more fatigued through the record they made to channel all of that frustration and ambition through. And if you don&#39;t, you&#39;re pretending - because <i>OK Computer</i> transcends any genre barrier knowledge if you&#39;re even remotely passionate about music. It&#39;s omnipresent.You can&#39;t avoid it, no matter how much you want.<br /><br />Even now, <i>OK Computer</i> is a prime example of a band reaching for their lofty ambitions and realising the breadth of their own skill set, and taking a boundary-breaking leap within their own path. Comparing <a  href="/release/album/radiohead/pablo-honey/" class="album">Pablo Honey</a> and <a  href="/release/album/radiohead/the-bends/" class="album">The Bends</a> to it is practically pointless because the change is so vast: there&#39;s enough hints on both albums, particularly <i>The Bends</i>, to point out where <i>OK Computer</i> came from but the narrative is loose, the familiarities superficial at best. <i>OK Computer</i> effectively re-introduces <a   href="/artist/radiohead" class="artist">Radiohead</a> from scratch: the urban angst of grunge-era guitar walls has evolved into pre-millennial apathy and depression, and the band are musically thinking outside their own box to the point that the tropes introduced here are now aspects the band are forever associated with. Not just that, but they&#39;re also elements that are echoed within the particular kind of rock music that followed in <i>OK Computer</i>&#39;s wake. You can trace a direct genealogy from it to nearly everything that has been happening in indie and alternative rock since. You think of angst-laden, introspective guitars and you&#39;ll be able to trace them here.<br /><br />Like all the very best progenitors, <i>OK Computer</i> still sounds like its own thing even now. Despite how many times its tricks have been repeated, there&#39;s nothing that combines them quite like here. Part of it is due to Radiohead&#39;s own uniqueness, the very specific traits its members have: Yorke&#39;s falsetto wailing (oft imitated, never bettered) and characteristic lyrical style most obviously, but also Jonny Greenwood&#39;s flourishes inspired by modern classical and Phil Selway&#39;s razor-sharp drumming. There&#39;s also the neurotic flair that <i>OK Computer</i> is powered by that has never really been captured by its followers in quite this way. Yorke was very obviously not having a good time, the band as a whole found inspiration through it and traces of it are all over the album, whether it&#39;s the resigned exhaustion of &#34;No Surprises&#34;, the anger of &#34;Electioneering&#34; or the downright crippling paranoia of &#34;Climbing Up the Walls&#34;. <i>OK Computer</i> frequently sounds like its suffocating within its own four walls creeping closer together, only to push them periodically away to reveal something hopeful for a fleeting moment.<br /><br /><i>OK Computer</i> isn&#39;t Radiohead&#39;s best album. I understand why &#34;Paranoid Android&#34; is iconic and as admirable as its multi-suite progression is, I&#39;ve never seen it as a particular discography highlight and its first part towers above the others to the point I wish it was the blueprint for the entire song, and &#34;Electioneering&#34; meanwhile is basically an attempt to re-do <b>R.E.M.</b>&#39;s &#34;Ignoreland&#34; but quite simply not as good. They&#39;re good but neither are songs I could say lifts the album for me. I also just think that Radiohead started to get <i>really interesting</i> after they decided to deconstruct and reassemble themselves in <i>OK Computer</i>&#39;s aftermath, which is when their skitterish neuroses found a sound that perfectly suited it. But, I understand why it&#39;s such a revered album, and it wouldn&#39;t need a great stretch to make me into a true believer too. After all, many of their best songs are here. &#34;Let Down&#34; is in some days is in fact the best song they ever wrote, period, making the world-weary desire to disappear into the most gorgeous thing when in its final minutes the song jumps off a cliff and soars into the sunset on the wings of its layered vocal parts and intensifying instrumental section. &#34;Karma Police&#34; is one of Radiohead&#39;s most haunting but bottles a quietly churning rage, and it twists that dagger deeper with each new section it offers. The finale for &#34;Exit Music (For a Film)&#34; is like that bottled rage finally breaking through, igniting into a wall of distressed sound of the like the band&#39;s rarely tried since.<br /><br />The final stretch of the album is also probably one of the all-time best closing runs: &#34;Climbing Up the Walls&#34; makes an orchestral section sound distressingly claustrophobic (it&#39;s phenomenal, by the way); the simple but endlessly beautiful &#34;No Surprises&#34; is the other big contender for the band&#39;s best song and in fact its quiet but powerful fragility is what converted me into thinking there&#39;s something to this band after all; &#34;Lucky&#34; is as atmospheric a rock anthem as the band would ever do and the second verse&#39;s introduction of the simple keyboard texture is one of my pet favourite moments of simple instrumental additions making a real difference; and &#34;The Tourist&#34; achingly floats in its own world, giving the paranoia of the album a calm breathe out in the end. <i>OK Computer </i>has throughout its length hit with some big punches and overall high quality miserablist rock, but it concludes like a real iconic moment in music history.<br /><br />Furthermore, <i>OK Computer</i> still feels just as relevant as it always was as well, maybe even moreso in this modern society that&#39;s growing more cynical and fatigued by the month. It&#39;s just as evocative and its songs are still impactful, proving their strengths despite every single one of them having been picked to their bones over the years; including the &#34;Fitter Happier&#34; interlude, which genuinely has its own important slot in the overall flow and Greater Thematics of the album. <i>OK Computer</i> is a truly great album, often stunningly so, and very audibly a moment where a band realised their own capabilities towards greatness and made them a reality. That so many people in the world agree with me, a lot of them way more passionately than I do, is a happy coincidence. This is all to say that out of all the albums in my collection, <i>OK Computer</i> is probably the one record I find the most difficult to discuss, but you&#39;re in luck: in a matter of seconds you can find thousands of reviews, articles and in-depth essays that say what I&#39;d likely think anyway. This must be what Beatles fans feel like.<br /><br />It&#39;s not one of my personal all-time greats but its place among the canon is more than justified.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating8413216]" /></div></div>
+             </div></div><!-- @@_review_8413216 --><div id="review_shell_std_45547715"><div class="review" >
+               <div class="review_header "><a title="User seagull59" href="/~seagull59"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/3be65614be1e1b59424efa512d44bbc8/7519298" data-bkg2x="//cdn.sonemic.net/i/75/s/3be65614be1e1b59424efa512d44bbc8/7519298" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~seagull59">seagull59</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/seagull59/radiohead/ok-computer/45547715">May 31 2012</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span></span><div style="float:right;" id="review_voting_45547715"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">There are Radiohead devotees like there were once Bowie devotees. Those who find the unexpected change in direction exciting rather than disconcerting. Those who discover a little more meaning in it all than the rest of us think necessary to enquire into. It&#39;s an admirable tradition that goes back at least as far as the Beatles. OK Computer draws a little from the Beatles, as from Pink Floyd and even U2. The 60&#39;s, 70&#39;s and 80&#39;s...man, if you could put those big names into a successful mix, then you&#39;re on to a winner! OK Computer does just that, with a sound production that does justice to its prestigious forerunners.<br />Quintessential art-rock, song based but sufficiently removed from any stifling Grunge influence and liberated by a laissez-faire, neo-progressive experimentalism, it&#39;s no wonder that this is their most celebrated release - it reaches back to earlier generations rather than alienating them.<br />There&#39;s no denying that Radiohead&#39;s instincts for grand theatrics  - combining biting self-analysis and semi-bombastic instrumental innovation - are artistically convincing and Yorke&#39;s vocal style probably summed up a generation of angst-ridden youngsters. What&#39;s more, the music can scale some frightening heights, carefully crafted to be sure, yet with a natural band feel. But under closer scrutiny some of the patching up can be a little irritating. Where songs aren&#39;t arranged to segue seamlessly, they often resort to silly effects driven bridges. And not every song stands up, some are given artificial support that isn&#39;t always successfully integrated - pulling out all the stops begins to sound like damage limitation. On Climbing Up The Walls it seems to work splendidly, Airbag too, goes full tilt with breath-taking confidence, but a song like Lucky seems too slight to be dressed up that way, likewise Let Down and Electioneering. Fortunately Subterranean Homesick Blues and Paranoid Android more than make up.<br />But if the album is only slightly over-ambitious, that&#39;s not a crime and, to be fair, all the songs hang together and add up to one seminal rock album...perhaps one of the last in this age of downloading and playlisting.<br />But I do miss something to make me smile - rather than just nod - and it&#39;s odd perhaps, that something so downbeat could have made such an impression....much like Floyd in the 70&#39;s I suppose, taking themselves so depressingly seriously. And I miss a strong back-beat or a funky jazz for all its dazzle and guile.<br />As always, it comes down to personal tastes. This album means an awful lot to a great many people. It&#39;s easy to see why.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating45547715]" /></div></div>
+             </div></div><!-- @@_review_45547715 --><div id="review_shell_std_42916435"><div class="review" >
+               <div class="review_header "><a title="User Zephos" href="/~Zephos"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/46a031cc85448393faa8e336a0f8ddea/7210903" data-bkg2x="//cdn.sonemic.net/i/75/s/46a031cc85448393faa8e336a0f8ddea/7210903" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Zephos">Zephos</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Zephos/radiohead/ok-computer/42916435">Apr 19 2012</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span></span><div style="float:right;" id="review_voting_42916435"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">I wrote a shining excellent review for this album, and then the browser went nuts, froze, and somehow logged me out and the review was destroyed. I&#39;m still pissed the fuck off just having to redo it all (you know how much crap I write). But in spite of this it&#39;s almost horribly fitting. Because that&#39;s what OK Computer is kind of &#34;about&#34;. And what is that? Well first what do you think might be the leading reason for a sort of revitalization in rock music with this year? Because it&#39;s undeniably the most ALIVE year in the genre since basically 1991, easily. Not that anything was wrong with the 90&#39;s, I hear tell electronic music from this time was strong. And 91-96? The golden age of Hip-Hop right there, some of the finest material ever dropped. But for rock? Kind of a dry time, not BAD or anything, just....dry. Stagnate. Heck the last time Rock was this dry was ages ago, the mid-70&#39;s, and that was much briefer, AND 1975 kicked ass anyway. So this is easily the biggest drought in the genre&#39;s history so far. Sure part of the reason may have been how many awesome bands died or fell off prematurely right before it (MBV, Jane&#39;s Addiction, Slint, Guns N Roses, Stone Roses, Pixies). But mostly it felt strapped for direction and ideas, only Post-Rock truly excited, and even that only really starts taking off with 97&#39; anyway. 97&#39; solved the identity crisis, because Rock finally realized what was going on in the world around it and how to start putting that into music. Around 97&#39; if you&#39;re old enough to recall was when the digital age really started to happened, when information economy swung in for real, a new technological and social world began. Lots of bands started processing that, and the rewards were plenty. And no one better synthesized it into a sound than Radiohead did with OK Computer. Except this isn&#39;t the good sides of all that, not the super sleek and clean aesthetics that graced much of the late 90&#39;s art world. Radiohead became obsessed with the dark sides, the strange furious frustrations not with humans like the Hippies and Punks before them, but with the claustrophobia and plastic of the inanimate around us. This is in the lyrics, and VERY much in the songs. The music here is wonderful stuff, a complete realization not only of everything they&#39;d been playing at since the start but of every single new thing they tried out too. Their old obsession with slow burning songs on Bends didn&#39;t all the way convince me in it&#39;s execution. In fact one of the main things that made me weary of them from far off was all their slow songs, The Bends didn&#39;t make me unscared either. But here that side of them is made real, doubtlessly great and worth it&#39;s time. The more anthemic and energetic songs are astounding works here. With all the simple Britpop anthems running around at the time (including virtually the whole of Be Here Now) it&#39;s easy to forget what a truly exciting and forward thinking rock anthem would sound like. You know, one that isn&#39;t overly indebted to some past form of music. And in comes songs like Airbag, Karma Police, and Climbing Up the Walls, sounding like nothing else before them...and sweeping you away in their sad grandeur. The mood of the album is worth noting too. It&#39;s at turns hopeful and despairing, sometimes seemingly at the same time. It&#39;s an odd sort of melancholy that seems almost disengaged in it&#39;s own fate. The melodies are beautifully sad, like The Smiths before them, but Yorke sees no strut in his breed of misery like Morrissey did. Instead it&#39;s almost resigned and passive about crumbling world, very Millennial in a way. That music video of Thom Yorke calmly singing in a tube as water fills up around him is pretty damn apt I&#39;d say wouldn&#39;t you? And due to all this OK Computer is perhaps still the one record modern rock lives in the shadow of. Not Nevermind. Nevermind cast it&#39;s shadow deep into the 00&#39;s, but mostly on irrelevant crap, it&#39;s real legacy sadly being &#34;Teenage angst has paid off well&#34; rather than any meaningful cultural imprint (aside from killing off much of the old mainstream anyway). Instead it&#39;s OK Computer that has informed subsequent rock, mostly the Brits with bands like Muse and Coldplay, but also North Americans like Interpol and Arcade Fire. This is 2000&#39;s music being born here, far more important than people give it credit for, and people give it a ton of credit as is.<br /><br />Rating: 5<br />Highlights: Airbag, Paranoid Android, Karma Police, Climbing Up the Walls</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating42916435]" /></div></div>
+             </div></div><!-- @@_review_42916435 --><div id="review_shell_std_9943695"><div class="review" >
+               <div class="review_header "><a title="User Communique" href="/~Communique"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/95f57468c76180b2350f868052ebba84/14588853" data-bkg2x="//cdn.sonemic.net/i/75/s/95f57468c76180b2350f868052ebba84/14588853" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Communique">Communique</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Communique/radiohead/ok-computer/9943695">Jan 18 2008</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/5m.png" width="90" height="16" style="border:0;" alt="2.50 stars" title="2.50 stars" /></span></span><div style="float:right;" id="review_voting_9943695"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">Hurrah, finally I had my first Radiohead experience after all these years! <i>OK Computer</i> on a burned CD! Hurrah! I had to wait so long.<br /><br />In earnest: How can anybody really <i>enjoy</i> a record like this? These ever meandering &#39;songs&#39;, that sometimes start auspicious or have some decent middle part, before or after mostly presenting some nerve-wrecking noise? This whining &#39;singer&#39;, whose voice is even more bugging than <a   href="/artist/bono" class="artist">Bono</a>&#39;s?<br /><br />Where do these lads have their &#39;ideas&#39; from? Is it <a   href="/artist/u2" class="artist">U2</a>&#39;s misled <a  href="/release/album/u2/achtung-baby/" class="album">Achtung Baby</a>? Is it some unknown, troubled, psychedelic trip jazz prog combo from Finland or so? I don&#39;t know, and to be honest, it doesn&#39;t interest me at all.<br /><br />Maybe in the end Radiohead are some paranoid androids? <a  href="/release/album/ultravox/ha-ha-ha/" class="album">Ha! Ha! Ha!</a><br /><br />PS: There is one track, that somehow appeals to me throughout its very length. It&#39;s called &#34;Lucky&#34;. And another one almost manages the same achievement. It&#39;s called &#34;Exit Music (For a Film)&#34;. Nevertheless even these songs probably wouldn&#39;t make it on one of my mix CD&#39;s for the car stereo.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating9943695]" /></div></div>
+             </div></div><!-- @@_review_9943695 --><div id="review_shell_std_58606"><div class="review" >
+               <div class="review_header "><a title="User Roy_Pearl" href="/~Roy_Pearl"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/530b19a275c6d922fa05a449968a08e5/10590" data-bkg2x="//cdn.sonemic.net/i/75/s/530b19a275c6d922fa05a449968a08e5/10590" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~Roy_Pearl">Roy_Pearl</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/Roy_Pearl/radiohead/ok-computer/58606">Aug 12 2002</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/5m.png" width="90" height="16" style="border:0;" alt="2.50 stars" title="2.50 stars" /></span></span><div style="float:right;" id="review_voting_58606"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">So let me get this straight. A bunch of one-hit-wonder grunge copyists (&#34;Pablo Honey&#34;) bottom out after flitting over to overly-precious Britpop (&#34;The Bends&#34;), and then decide that song structure is what&#39;s holding them back. The melodies and words on OK Computer sound like Thom Yorke is making them up as he sings them. The thematic conceit is retarded. The music - while not wholly unlikeable - trades bombast for pretension. And some people find this challenging and out-there? It&#39;s avant-garde for people who&#39;ve never heard anything avant-garde - much closer to the meandering, tuneless, self-important prog bullshit that made punk rock necessary. <br /><br />Unfortunately - though predictably - this psuedo-intellectual, gussied-up Britpop approach to experimentalism proved safe enough that _OK Computer_ tapped into the zeitgeist. In other words, it&#39;s just _out there_ enough to give a conservative mainstream audience a fleeting sense of being hip. Now, get back in your cages.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating58606]" /></div></div>
+             </div></div><!-- @@_review_58606 --><div id="review_shell_std_16874923"><div class="review" >
+               <div class="review_header "><a title="User dt2" href="/~dt2"><div class="review_header_img lazyload" data-bkg="//cdn.sonemic.net/i/75/s/9208868d37155b1ec503a235d07d8dfc/5506943" data-bkg2x="//cdn.sonemic.net/i/75/s/9208868d37155b1ec503a235d07d8dfc/5506943" style="background-position:center !important; background-repeat:no-repeat !important ;background-size:cover !important;background-color:var(--mono-0);"></div></a>
+                  <span class="review_user" ><a class="user" href = "/~dt2">dt2</a></span>
+                  <span class="review_date"  >
+                  <a href="/music-review/dt2/radiohead/ok-computer-14/16874923">Jul 28 2008</a>
+                  </span>
+
+                  
+                  <span class="catalog_no_track_ratings"></span><span >
+                      <span  class="review_rating"><img src = "//e.snmc.io/2.5/img/images/4m.png" width="90" height="16" style="border:0;" alt="2.00 stars" title="2.00 stars" /></span></span><div style="float:right;" id="review_voting_16874923"></div>
+                 
+               </div><div class="review_body ">
+
+
+      <span ><span class="rendered_text">I can sort of understand the praise this album gets. The execution is really pretty good, and if you&#39;re buying what they&#39;re selling I can see the attraction, I am not, however, buying. <br />I hadn&#39;t intended ever owning this as every Radiohead song I&#39;d heard has left me cold, but after a lengthy discussion with a friend who couldn&#39;t understand how anyone couldn&#39;t like this he gave me a copy assuring me that I would come around. I tried, I really did, but I just can&#39;t enjoy this at all. The biggest sticking point is probably the annoyingly whiny &#34;I&#39;m just so fucking profound&#34; vocals, but not far behind is all the cliché studio gimmickry, the weak songwriting, and uninteresting arrangements. The band does play well from a technical standpoint, but that stopped being enough for me when I was about 14.</span></span><div class="review_publish_status">Published <input aria-label="review shortcut" class="review_shortcut" readonly style="width:150px;margin-top:0;float:none;" onclick="focus();select();" value="[Rating16874923]" /></div><div class="review_issue_label">CDP 7243 8 55229 2 5 CD  (1997)</div></div>
+             </div></div><!-- @@_review_16874923 --><div class="review_list"><span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/2/">2</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/22/">22</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/45/">45</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/67/">67</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/90/">90</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/113/">113</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/135/">135</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/158/">158</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/180/">180</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/203/">203</a> <span class="navdot">..</span> <a class="navlinknum" href = "/release/album/radiohead/ok-computer/reviews/226/">226</a> <a class="navlinknext" href="/release/album/radiohead/ok-computer/reviews/2/">&gt;&gt;</a></span></div><div class="review_help" id="review_help_l">
+         Votes are used to help determine the most interesting content on RYM.    
+         <br /><br />
+         Vote up content that is on-topic, within the rules/guidelines, and will likely stay relevant long-term.
+         <br />
+         Vote down content which breaks the rules.
+      </div></div></div></div><div class="section_catalog section_outer"><div class="page_section">
+         <script> 
+            var rating_info_album_id = 45;
+            var rating_info_show_all_issues = true;
+         </script>
+         <div class="release_page_header"><h2>Catalog</h2></div>
+         <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+
+         <div class="rating_info_table">
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 45, true, 'ratings'); });" id="rating_info_ratings" class="rating_info_tab rating_info_ratings active">
+                  <b>Ratings:</b> 135,396
+               </div>
+            
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 45, true, 'catalog'); });" id="rating_info_catalog"  class="rating_info_tab rating_info_cataloged">
+                  <b>Cataloged:</b> 39,505
+               </div>
+            
+               <div onClick="rymQ( function() { RYMmediaPage.selectCatalogPane('l', 45, true, 'track_ratings'); });" id="rating_info_track_ratings" class="rating_info_tab rating_info_track_ratings">
+                  <b><span class="hide-for-small-inline">Track rating sets:</span><span class="show-for-small-inline">Track ratings:</span></b> 18,463
+               </div>
+            </div>
+
+         <div class="catalog_section">
+               <div class="catalog_stats hide-for-small">
+                  <div class="header">Rating distribution</div>
+                  <div id="chart_div" style="background:var(--mono-f);height:100px;width:200px;"></div>
+            <script>
+      
+               function drawChart1() {
+                 var data = new google.visualization.DataTable();
+                 data.addColumn('number', 'Rating');
+                 data.addColumn('number', '# of ratings');
+                 data.addRows([
+                   [0.5, 1184],[1.0, 531],[1.5, 586],[2.0, 1460],[2.5, 2290],[3.0, 5522],[3.5, 10103],[4.0, 24536],[4.5, 35144],[5.0, 54040]
+                 ]);
+
+                 var options = {
+                     backgroundColor:'transparent',
+                     legend:{position:'none'},
+                     chartArea:{left:30,bottom:50,width:"80%",height:"60%"},
+                     colors:['#336fc6'],
+                     hAxis:{textStyle: {color: '#999'}, baselineColor: '#aaa'},
+                     vAxis:{textStyle: {color: '#999'}, baselineColor: '#aaa'},
+                     tooltip: {textStyle: {fontSize:12} }
+                 };
+
+                 var chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
+                 chart.draw(data, options);
+               }
+            </script>
+       
+
+                  
+
+                  <div class="header">Rating trend</div>
+            <div id="chart_div2" style="background:var(--mono-f);height:100px;width:200px;"></div>
+            <script>
+               function drawChart2() {
+                 var data = google.visualization.arrayToDataTable([
+                   ['Year', 'Differential'],
+                   ['2004', 0.61 ],['2005', 0.71 ],['2006', 0.73 ],['2007', 0.72 ],['2008', 0.74 ],['2009', 0.74 ],['2010', 0.76 ],['2011', 0.70 ],['2012', 0.70 ],['2013', 0.74 ],['2014', 0.80 ],['2015', 0.77 ],['2016', 0.82 ],['2017', 0.85 ],['2018', 0.83 ],['2019', 0.80 ],['2020', 0.80 ],['2021', 0.82 ],['2022', 0.85 ],['2023', 0.87 ],['2024', 0.86 ],['2025', 0.83 ],['2026', 0.79 ]
+                 ]);
+
+                 var options = {
+                     backgroundColor:'transparent',
+                     legend:{position:'none'},
+                     chartArea:{left:30,bottom:20,width:"80%",height:"80%"},
+                     colors:['#677DD6'],
+                     hAxis:{textStyle: {color: '#999'}, baselineColor: '#999'},
+                     vAxis:{textStyle: {color: '#999'}, format:'+#.##;-#.##;avg', negativeColor:'#800', baselineColor: '#666' /*,viewWindow:{max:5.5,min:0.5} */},
+                     pointSize:'3',
+                     lineWidth:1,
+                     tooltip: {textStyle: {fontSize:12} }
+                 };
+
+                  var formatter = new google.visualization.NumberFormat(
+                     {negativeColor: 'red', negativeParens: false});
+                 formatter.format(data, 1); // Apply formatter to second column
+
+                 var chart = new google.visualization.LineChart(document.getElementById('chart_div2'));
+                 chart.draw(data, options);
+               }
+            </script>
+      
+               </div>
+               <div id="catalog_list" class="catalog_list"><span class="navspan"><span class="navpage">Page </span><span class="navlinkcurrent">1</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/2');">2</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/902');">902</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/1805');">1805</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/2708');">2708</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/3610');">3610</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/4513');">4513</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/5416');">5416</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/6318');">6318</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/7221');">7221</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/8124');">8124</a> <span class="navdot">..</span> <a class="navlinknum" href = "javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/9027');">9027</a> <a class="navlinknext" href="javascript:RYMmediaPage.navCatalog('l', 45, true, 'ratings', '/2');">&gt;&gt;</a></span> <div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">14 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~hydradragon2014">hydradragon2014</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">14 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~LostCustidy">LostCustidy</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">14 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~Entz">Entz</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">14 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~lucas8294">lucas8294</a></span>
+                  <span class="catalog_ownership">Wishlist</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">14 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/bdf81130943f0ee6c8d9ceec2a1b9d8e/14344628" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~cyarbrough">cyarbrough</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/9m.png" width="90" height="16" style="border:0;" alt="4.50 stars" title="4.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">all-timer/favorite</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/63f8b2fe246ca7ffa011ac498a81dcfd/14461661" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~bentoec">bentoec</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">Honda Fit</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~Kyle_gt">Kyle_gt</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/7m.png" width="90" height="16" style="border:0;" alt="3.50 stars" title="3.50 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/d6b149b88193a06de94e33696653591a/14601348" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~leezzz">leezzz</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/cc0cc787ad57664c1f14b2d817b071bd/12888703" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~YrydDead">YrydDead</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small">Perfection, Amazing, Love</span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/55ffc7a04660e94f2c3493f970ea0322/14130482" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~onlyfelicity">onlyfelicity</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/85a0e9f737cd47985e548f0aaaee4a1b/11078225" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~tjcjrusa90">tjcjrusa90</a></span>
+                  <span class="catalog_ownership">Digital</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/6m.png" width="90" height="16" style="border:0;" alt="3.00 stars" title="3.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/da38587ecc8d077cdf499fcf3ec9d50c/14609228" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~Animeta51">Animeta51</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~gabrielzodan">gabrielzodan</a></span>
+                  <span class="catalog_ownership">Digital</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/8m.png" width="90" height="16" style="border:0;" alt="4.00 stars" title="4.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div class="lazyload" data-bkg="//cdn.sonemic.net/i/25/s/39bb5193928eb47045e4cc2aea2ccaf4/14606987" style="float:left;margin-right:7px;display:inline-block;border-radius:3px;width:25px;height:25px; center no-repeat;background-size:cover;background-color:var(--mono-0);"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~riicky">riicky</a></span>
+                  <span class="catalog_ownership">&nbsp;</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div><div class="catalog_line  "><div class="catalog_date"><div class="catalog_date_inner" id="catalog_date_inner_l_45">13 May 2026</div></div>
+               <div class="catalog_header "><div style="float:left;margin-right:7px;width:25px;height:25px;border-radius:3px;background:var(--mono-d8)"></div>
+                  <span class="catalog_user"> <a class="user" href = "/~sunny_april_day">sunny_april_day</a></span>
+                  <span class="catalog_ownership">Vinyl</span><span class="catalog_no_track_ratings"></span><span class="catalog_rating"><img src = "//e.snmc.io/2.5/img/images/10m.png" width="90" height="16" style="border:0;" alt="5.00 stars" title="5.00 stars" /></span>
+                  <span class="catalog_rating_system_comment hide-for-small"></span>
+               </div>
+         <div style="clear:both;"></div></div></div></div></div></div><div style="clear:both;"></div><div class="column_filler" id="column_filler_right"></div>
+        </div> <div id="column_container_left" class="large-4 pull-8 columns release_left_column column_container_left"><div class="page_release_art_frame"><div class="hide-for-small"><a  href="buy/">
+      <div class="coverart_45" style="position:relative;">
+      
+      <img srcset ="//cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg,
+                     //cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg 2x"
+           src="//cdn.sonemic.net/i/600/s/91f41d53d83f36ac3bb0cee7d6dffca3/11993756/radiohead-ok-computer-Cover-Art.jpg"
+           alt="Cover art for OK Computer by Radiohead"
+      />
+      <!-- <meta itemprop="image" content="//cdn.sonemic.net/i/300/s/0fa37201b199941562f3078dedf5caae/11993756" /> -->
+    </div></a>
+    
+            <div id="media_link_button_container_top" 
+                  
+                 data-medialink="true"
+                 data-support-open="true" 
+                 data-artists="Radiohead" 
+                 data-albums="OK Computer" 
+                 data-links="{&#34;spotify&#34;:{&#34;7dxKtc08dYeRVHt3p9CZJn&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;},&#34;6dVIqQ8qmQ5GBnJ9shOYGE&#34;:{&#34;for&#34;:[&#34;AU&#34;,&#34;DE&#34;,&#34;GB&#34;,&#34;MX&#34;],&#34;type&#34;:&#34;album&#34;},&#34;2fGCAYUMssLKiUAoNdxGLx&#34;:{&#34;for&#34;:[&#34;VE&#34;],&#34;type&#34;:&#34;album&#34;},&#34;4ENxWWkPImVwAle9cpJ12I&#34;:{&#34;for&#34;:[&#34;FI&#34;,&#34;FR&#34;,&#34;HU&#34;],&#34;type&#34;:&#34;album&#34;}},&#34;applemusic&#34;:{&#34;1097861387&#34;:{&#34;default&#34;:true,&#34;album&#34;:&#34;ok-computer&#34;,&#34;loc&#34;:&#34;us&#34;},&#34;1239489060&#34;:{&#34;for&#34;:[&#34;AU&#34;,&#34;FI&#34;,&#34;FR&#34;,&#34;HU&#34;],&#34;album&#34;:&#34;ok-computer-oknotok-1997-2017&#34;,&#34;loc&#34;:&#34;fr&#34;}},&#34;soundcloud&#34;:{&#34;242606955&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;playlists&#34;,&#34;url&#34;:&#34;soundcloud.com/radiohead/sets/ok-computer-3&#34;}},&#34;tidal&#34;:{&#34;58990510&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;deezer&#34;:{&#34;14879699&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}},&#34;qobuz&#34;:{&#34;0634904078164&#34;:{&#34;default&#34;:true,&#34;type&#34;:&#34;album&#34;}}}" 
+                 data-placement="top" 
+                 data-allow-ads="true" 
+                 class="media_link_container link_sonemic allow_ads support_open lazyload">
+            </div>
+       </div></div>
+<table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:4px;font-size:1px;padding:0;"><tr style="height:4px;padding:0;"><td style="background:#a8b7c0;height:4px;padding:0px;color:#a8b7c0">.</td><td style="background:#a9b8bc;height:4px;padding:0px;color:#a9b8bc">.</td><td style="background:#7694a2;height:4px;padding:0px;color:#7694a2">.</td><td style="background:#636468;height:4px;padding:0px;color:#636468">.</td><td style="background:#be855b;height:4px;padding:0px;color:#be855b">.</td><td style="background:#9e9ea6;height:4px;padding:0px;color:#9e9ea6">.</td><td style="background:#c8b497;height:4px;padding:0px;color:#c8b497">.</td><td style="background:#54bcec;height:4px;padding:0px;color:#54bcec">.</td></tr></table>
+<div style="padding:0px;padding-top:0;"><div class="hide-for-small"><div class="section_release_navigation"><div class="release_navigation"><div class="release_navigation_guidance">
+                    <div class="release_nav_guidance_artist">
+                     <div class="release_nav_guidance_left">
+                      <a href="/release/album/radiohead/the-bends/"><i class="fa fa-caret-left"></i>
+                      Previous</a>
+                     </div>                     
+                     <div class="release_nav_guidance_right">
+                     <a href="/release/album/radiohead/kid-a/">Next
+                      <i class="fa fa-caret-right"></i></a>
+                      
+                     </div></div>
+                     <div style="clear:both;"></div>
+                  </div>
+               
+                                 
+                  <div class="release_navigation_links">
+                    <div class="prev_image">
+                       <a href="/release/album/radiohead/the-bends/"><img alt="Previous in discography: The Bends" src="//cdn.sonemic.net/i/75/s/cc9173268ad1a610f71dbfb7d3a0ee04/14043991" /></a>
+                    </div>
+                    <div class="prev_link">
+                       <a  href="/release/album/radiohead/the-bends/" class="small">The Bends</a>
+                    </div>
+                    <div class="next_link">
+                       <a  href="/release/album/radiohead/kid-a/" class="small">Kid A</a>
+                    </div>
+                    <div class="next_image">
+                       <a href="/release/album/radiohead/kid-a/"><img alt="Next in discography: The Bends" src="//cdn.sonemic.net/i/75/s/84704ca8b24adf06888eb22aa82d69f0/12580450" /></a>
+                    </div>
+                    <div style="clear:both;"></div>
+                  </div>                
+               
+            </div></div></div><!-- /31961696/release.case-a.300-336.top-left -->
+            <div data-nosnippet class='page_creative_frame big-rectangle
+               lazyload-creative
+               
+               
+               
+               
+               ' id='frame-div-gpt-ad-1465817209349-19'  data-adcode='div-gpt-ad-1465817209349-19'  style='margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;min-height:300px;min-width:305px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-19'>
+            </div></div><div class="hide-for-small"><div class="section_tracklisting"><div class="release_page_header"><h2>Track listing</h2></div><meta content="12" itemprop="numTracks" /> 
+       <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+       <ul id="tracks" class="tracks tracklisting"><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     1
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/airbag/" itemprop="name">Airbag</a><a  href="/song/radiohead/airbag/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="284" itemprop="duration" content="PT4M44S">
+                     4:44
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     2
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/paranoid-android/" itemprop="name">Paranoid Android</a><a  href="/song/radiohead/paranoid-android/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="383" itemprop="duration" content="PT6M23S">
+                     6:23
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     3
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/subterranean-homesick-alien-1/" itemprop="name">Subterranean Homesick Alien</a><a  href="/song/radiohead/subterranean-homesick-alien-1/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="267" itemprop="duration" content="PT4M27S">
+                     4:27
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     4
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/exit-music-for-a-film/" itemprop="name">Exit Music (For a Film)</a><a  href="/song/radiohead/exit-music-for-a-film/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="264" itemprop="duration" content="PT4M24S">
+                     4:24
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     5
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/let-down/" itemprop="name">Let Down</a><a  href="/song/radiohead/let-down/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="299" itemprop="duration" content="PT4M59S">
+                     4:59
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     6
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/karma-police/" itemprop="name">Karma Police</a><a  href="/song/radiohead/karma-police/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="261" itemprop="duration" content="PT4M21S">
+                     4:21
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     7
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/radiohead/fitter-happier/" itemprop="name">Fitter Happier</a><a  href="/song/radiohead/fitter-happier/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="117" itemprop="duration" content="PT1M57S">
+                     1:57
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     8
+                  </span>
+                  <span class="tracklist_title"><span><a class="song " href="/song/radiohead/electioneering-1/" itemprop="name">Electioneering</a><a  href="/song/radiohead/electioneering-1/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="230" itemprop="duration" content="PT3M50S">
+                     3:50
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     9
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/climbing-up-the-walls/" itemprop="name">Climbing Up the Walls</a><a  href="/song/radiohead/climbing-up-the-walls/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="285" itemprop="duration" content="PT4M45S">
+                     4:45
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     10
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/no-surprises/" itemprop="name">No Surprises</a><a  href="/song/radiohead/no-surprises/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="228" itemprop="duration" content="PT3M48S">
+                     3:48
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     11
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/lucky/" itemprop="name">Lucky</a><a  href="/song/radiohead/lucky/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="259" itemprop="duration" content="PT4M19S">
+                     4:19
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track"><div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording" class="tracklist_line" style="width:100%;"><span class="tracklist_num">
+                     12
+                  </span>
+                  <span class="tracklist_title"><span><a class="song bolded" href="/song/radiohead/the-tourist/" itemprop="name">The Tourist</a><a  href="/song/radiohead/the-tourist/#lyrics" class="tracks_lyric_link">lyrics</a></span><span class="tracklist_duration" data-inseconds="324" itemprop="duration" content="PT5M24S">
+                     5:24
+                  </span>
+                  <meta content="https://rateyourmusic.com/release/album/radiohead/ok-computer/" itemprop="url" />
+                  </span><div style="clear:both;"></div></div>
+                           
+               </li><li class="track" style="text-align:right;padding-top:0.25em"><span style="line-height: 2.6em;color: var(--mono-6);margin-right:0.8em;" class="tracklist_total">Total length: 53:21</span></li></ul><div id="track_preview_tracks">
+            
+         </div> </div></div><div class="hide-for-small"><div class="section_credits"><div class="release_page_header hide-for-small"><h2>Credits</h2></div>
+          <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table>
+          <ul id="credits_" class="credits"><li><a title="[Artist42]"  href="/artist/radiohead" class="artist">Radiohead</a><br /> <span class="role_name "><span class="rendered_text">songwriting</span></span>,  <span class="role_name ">string arrangements</span>,  <span class="role_name ">producer</span></li>
+<li><a title="[Artist72630]"  href="/artist/thom-yorke" class="artist">Thom Yorke</a><br /> <span class="role_name ">vocals</span>,  <span class="role_name ">guitar</span>,  <span class="role_name ">piano</span>,  <span class="role_name ">programming</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist21860]"  href="/artist/jonny-greenwood" class="artist">Jonny Greenwood</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">keyboards</span>,  <span class="role_name ">piano</span>,  <span class="role_name ">Mellotron</span>,  <span class="role_name ">organ</span>,  <span class="role_name ">glockenspiel</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist521869]"  href="/artist/philip-selway" class="artist">Philip Selway</a><br /> <span class="role_name ">drums</span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist521870]"  href="/artist/ed-obrien" class="artist">Ed O&#39;Brien</a><br /> <span class="role_name ">guitar</span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">backing vocals</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist703643]"  href="/artist/colin-greenwood" class="artist">Colin Greenwood</a><br /> <span class="role_name ">bass guitar</span>,  <span class="role_name "><span class="rendered_text">bass synthesizer</span></span>,  <span class="role_name ">percussion</span>,  <span class="role_name ">songwriter</span></li>
+<li><a title="[Artist427029]"  href="/artist/nigel-godrich" class="artist">Nigel Godrich</a><br /> <span class="role_name ">producer</span>,  <span class="role_name ">mixing engineer</span></li>
+<li><a title="[Artist27082]"  href="/artist/nick-ingman" class="artist">Nick Ingman</a><br /> <span class="role_name ">conductor</span></li>
+<li><a title="[Artist954146]"  href="/artist/chris_blair" class="artist">Chris &#34;King Fader&#34; Blair</a><br /> <span class="role_name ">mastering engineer</span></li>
+<li><a title="[Artist954574]"  href="/artist/gerard_navarro" class="artist">Gerard Navarro</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist1062583]"  href="/artist/jon_bailey" class="artist">Jon Bailey</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist1062585]"  href="/artist/chris_scard" class="artist">Chris Scard</a><br /> <span class="role_name ">assistant engineer</span></li>
+<li><a title="[Artist995128]"  href="/artist/stanley-donwood" class="artist">Stanley Donwood</a><br /> <span class="role_name ">sleeve design</span>,  <span class="role_name "><span class="rendered_text">artwork</span></span>,  <span class="role_name "><span class="rendered_text">online editor</span></span></li>
+<li><a title="[Artist72630]"  href="/artist/thom-yorke" class="artist">The White Chocolate Farm</a><br /> <span class="role_name ">sleeve design</span>,  <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist1697068]"  href="/artist/matt-bale" class="artist">Matt Bale</a><br /> <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist1697072]"  href="/artist/mr-barry" class="artist">Mr. Barry</a><br /> <span class="role_name "><span class="rendered_text">artwork</span></span></li>
+<li><a title="[Artist2003472]"  href="/artist/adam-cummings" class="artist">Adam Cummings</a><br /> <span class="role_name ">guitar technician</span>,  <span class="role_name ">additional guitar</span></li>
+<li><span>Charlie Myatt</span><br /> <span class="role_name "><span class="rendered_text">booking</span></span></li>
+<li><a title="[Artist954139]"  href="/artist/jim_warren" class="artist">Jim Warren</a><br /> <span class="role_name ">engineer</span></li>
+<li><span>Andi Watson</span><br /> <span class="role_name "><span class="rendered_text">stage design</span></span></li>
+<li><span>Keith Wozencroft</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist1562967]"  href="/artist/peregrine-watts-russell" class="artist">Perry Watts-Russell</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Tony Wadsworth</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Big Al</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Carol Baxter</span><br /> <span class="role_name ">international marketing</span></li>
+<li><span>Julie Calland</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist1054980]"  href="/artist/brian_message" class="artist">Brian Message</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><a title="[Artist972381]"  href="/artist/chris_hufford" class="artist">Chris Hufford</a><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Bryce Edge</span><br /> <span class="role_name "><span class="rendered_text">management</span></span></li>
+<li><span>Caffy St Luce</span><br /> <span class="role_name "><span class="rendered_text">media management</span></span></li>
+<li><span>Duncan Swift</span><br /> <span class="role_name ">instrument maintenance</span></li>
+<li><a title="[Artist2029817]"  href="/artist/plank-6" class="artist">Plank</a><br /> <span class="role_name ">instrument technician</span>,  <span class="role_name "><span class="rendered_text">equipment</span></span></li>
+<li><a title="[Artist2003473]"  href="/artist/david-tordoff" class="artist">Tree</a><br /> <span class="role_name "><span class="rendered_text">sound technician</span></span></li>
+<li><a title="[Artist2064328]"  href="/artist/tim-greaves" class="artist">Tim Greaves</a><br /> <span class="role_name ">tour manager</span></li>
+<li><a title="[Artist817099]"  href="/artist/dilly-gent" class="artist">Dilly Gent</a><br /> <span class="role_name "><span class="rendered_text">video editor</span></span></li> </ul> </div>
+          </div>
+
+<div class="page_section_features_frame">
+   <h2>Features</h2>
+
+   <div class="page_section_features">
+      <a href="/feature/sonemic-selects-all-time-chart-toppers/" aria-label="Sonemic Selects: All-Time Chart-Toppers">
+         <div class="page_section_feature">
+            <img alt="Sonemic Selects: All-Time Chart-Toppers" class="page_section_feature_image lazyload" data-src="//cdn.sonemic.net/i/600/s/3f77f2a18d7ade30dc7563bce5ec0e10/10242101" />
+            <div class="page_section_feature_info">
+               <h3>Sonemic Selects: All-Time Chart-Toppers</h3>
+
+               <p>Sonemic Selects: All-Time #1 Chart-Toppers with Kendrick Lamar, Radiohead, Charles Mingus, John Coltrane, and more artists rated highly by the Rate Your Music / Sonemic community with member reviews.</p>
+            </div>
+         </div>
+      </a>
+   </div>
+</div>
+<div class="section_lists"><div class="release_page_header">
+         <h2 style="float:left;">
+            9,097 Lists
+         </h2>
+
+         </div><div class="clearfix"></div>
+       
+          <ul class="lists not_expanded">
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/c6fa0f8b9a94d8237d6e1002ef635787/8956646" data-bkg2x="//e.snmc.io/i/150/s/2ee15fbc39e6720649ca20c345419dc3/8956646" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/teh_TA/cloudy_rainy-albums/">cloudy/rainy albums</a></div>
+                        <div class="list_author"><a class="user" href="/~nerty_">nerty_</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/4dd9284a590cd4c62605661c6d8e643e/9782785" data-bkg2x="//e.snmc.io/i/150/s/d039b5a4a0744b383849931aa52e17b8/9782785" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/lookAghost/cante-waste-nape-ciyuzapo/">cante waste nape ciyuzapo</a></div>
+                        <div class="list_author"><a class="user" href="/~lookAghost">lookAghost</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/978838475c84675f0ce94e250f4fd25f/9745746" data-bkg2x="//e.snmc.io/i/150/s/838862f1a9fb9c19c46f3009d204eebf/9745746" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/FortCape/crazy-strange-funny-or-unique-releases/">Crazy, Strange, Funny, or Unique Releases</a></div>
+                        <div class="list_author"><a class="user" href="/~FortCape">FortCape</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/darth_tyrannus_rex/the-album-cover-design-style-wiki-wip/">The Album Cover Design Style Wiki (WIP)</a></div>
+                        <div class="list_author"><a class="user" href="/~darth_tyrannus_rex">darth_tyrannus_rex</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/mattymath/over-5000-great-songs-from-rock-and-closely-related-genres/">Over 5000 great songs from rock and closely related genres.</a></div>
+                        <div class="list_author"><a class="user" href="/~mattymath">mattymath</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/e8792e66b3e926b3a771e058664add23/4887413" data-bkg2x="//e.snmc.io/i/150/s/6186f9c0e7336265c94eefb972fbcb4b/4887413" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Kid_Charlemagne/kid-charlemagnes-ultimate-personal-listeners-diary/">Kid Charlemagne&#39;s Ultimate Personal Listener&#39;s Diary</a></div>
+                        <div class="list_author"><a class="user" href="/~Kid_Charlemagne">Kid_Charlemagne</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div class="list_image"></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Lustrum/post-prog-the-evolution-of-progressive_art_experimental-rock/">Post-Prog: The Evolution of Progressive/Art/Experimental Rock</a></div>
+                        <div class="list_author"><a class="user" href="/~Lustrum">Lustrum</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/3e18b0b678addeef12c20956d9647e2f/249361" data-bkg2x="//e.snmc.io/i/150/s/78d5d158d77e86e3c757447464ad7f2b/249361" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/SixStringMark/1001_albums_you_must_hear_before_you_die/">1001 Albums You Must Hear Before You Die</a></div>
+                        <div class="list_author"><a class="user" href="/~SixStringMark">SixStringMark</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/7790da79e75791e48de1c9347a51fb0c/8391676" data-bkg2x="//e.snmc.io/i/150/s/2e94a87742ece4afe4d1ba14f94ec10a/8391676" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Lordcrab/sounds-of-the-urban-jungle/">Sounds of the urban jungle</a></div>
+                        <div class="list_author"><a class="user" href="/~Lordcrab">Lordcrab</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/8f7aafbd22cbd89fd528bae051316222/13867378" data-bkg2x="//e.snmc.io/i/150/s/244e596e556cd7139f4975d3e359f532/13867378" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/olouichlf/history-of-music-summarised-by-rym-users/">History of music : Summarised by RYM users</a></div>
+                        <div class="list_author"><a class="user" href="/~olouichlf">olouichlf</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/23438b358cc1265cadedccdf69f457fe/9774326" data-bkg2x="//e.snmc.io/i/150/s/ba1cab3b365f6186c5a880eeb5eb4c1b/9774326" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/DaftPunkert/top-500-of-all-time-work-in-progress/">Top 500 Of All Time (Work in progress)</a></div>
+                        <div class="list_author"><a class="user" href="/~DaftPunkert">DaftPunkert</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/423369e514b65cbe5207581a00a62779/7001777" data-bkg2x="//e.snmc.io/i/150/s/21d23f96dbb824f2ebe1c2245fbebdfd/7001777" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/bvo/favorite-album-covers/">Favorite Album Covers</a></div>
+                        <div class="list_author"><a class="user" href="/~Zeja">Zeja</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/7f481072770d46e3af25429b71a7fe41/10732040" data-bkg2x="//e.snmc.io/i/150/s/9d48ab90ac7547dcae30eb886115ea3c/10732040" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/fruitsaladd/top-10-1965-2025/">Top 10, 1965-2025</a></div>
+                        <div class="list_author"><a class="user" href="/~fruitsaladd">fruitsaladd</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/a5c37943e3cded15429aa619f9e5ac42/8543787" data-bkg2x="//e.snmc.io/i/150/s/f7eba00b4beaefb2beb4816480cd6ce8/8543787" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/cuneyt81/my-top-1_000-songs-of-all-time/">My Top 1,000 Songs of All Time</a></div>
+                        <div class="list_author"><a class="user" href="/~cuneyt81">cuneyt81</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/4ba37abeb3929ad407f25f1f60dee327/13335641" data-bkg2x="//e.snmc.io/i/150/s/4b5172f48c9d2c3567938bb2e2ad3caf/13335641" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/mahamudra/ཨོཾ་ཨཱཿ་ཧཱུྂ/">ཨོཾ་ཨཱཿ་ཧཱུྂ</a></div>
+                        <div class="list_author"><a class="user" href="/~mahamudra">mahamudra</a></div>
+                     </div>
+                  </li>
+                  <li>
+                     <div data-bkg="//e.snmc.io/i/75/s/7327762033de5ad48787fe97fb45d5ed/5841542" data-bkg2x="//e.snmc.io/i/150/s/c78f7eef0a3ccdf04ca83851d3479aab/5841542" class="list_image lazyload" ></div>
+                     <div class="list_info">
+                        <div class="list_name"><a style="color:var(--gen-blue-dark)" href="/list/Jazzmaster11/guitar_effects_in_rock_history_/">Guitar Effects in Rock History.</a></div>
+                        <div class="list_author"><a class="user" href="/~Jazzmaster11">Jazzmaster11</a></div>
+                     </div>
+                  </li><li class="expand_button"><a href="lists/">See all 9097 lists</a></li></ul>       
+               </div><div class="section_videos"><div class="release_page_header"><h2>Video</h2></div>
+                <table class="color_bar" style="xborder:1px #333 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table><div class="youtube_container" id="youtube_container_e8ba0b499884f50c63e8922c1d9f7591" data-youtube-id="1uYWYWPc9HU"><a class="youtube_embed" id="youtube_video_e8ba0b499884f50c63e8922c1d9f7591" target="_blank" 
+               rel="nofollow noopener" data-youtube-id="1uYWYWPc9HU" 
+               href="//www.youtube.com/watch?v=1uYWYWPc9HU">
+
+               <div class="youtube_img lazyload" data-bkg="//img.youtube.com/vi/1uYWYWPc9HU/hqdefault.jpg"  data-bkg2x="//img.youtube.com/vi/1uYWYWPc9HU/hqdefault.jpg"></div>
+               <div class="youtube_playbutton"></div>
+               <div class="youtube_title">Radiohead - Karma Police</div>
+               </a></div></div><a name="suggestions" class="anchor"></a><div 
+            style="text-align:center;padding:0.5em;
+            margin-top:1em;display:block;font-size:1em;">
+             <a style="text-decoration:none;color:var(--gen-blue-darkest);" href="/subscribe/"><i class="fa fa-star"></i> Subscribe to see similar release suggestions</a> 
+            </div><!-- /31961696/Sonemic/main-300x600-mid-1 -->
+            <div data-nosnippet class='page_creative_frame large-desk-leaderboard-multisize
+               lazyload-creative
+               
+               
+               desktop-sticky-persist-ad
+               
+               ' id='frame-div-gpt-ad-1465817209349-222'  data-adcode='div-gpt-ad-1465817209349-222'  style='margin:0 auto;display: flex;flex-direction:column; align-items: center;margin-bottom:1em;min-height:360px;min-width:165px;'>
+
+                  <div data-nosnippet style="font-size:0.85em;
+                  color:var(--mono-6);text-align:center;
+                  margin:0 auto;
+               
+                  margin-bottom:0em;">
+               ADVERTISEMENT</div>
+               
+            <div id='div-gpt-ad-1465817209349-222'>
+            </div></div><div class="column_filler" id="column_filler_left"></div>
+    </div></div>
+      </div>
+      </div>
+
+<div style="border-top:1px solid var(--mono-d);padding:15px;padding-left:50px;padding-right:50px;padding-bottom:20px;"><div style=""><div class="release_page_header"><h2>Contributions</h2></div>
+       <table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:1px;font-size:1px;padding:0;"><tr style="height:1px;padding:0;"></tr></table><span class="contributor_header">Contributors to this release: </span><a class="user" href = "/~damon">damon</a>, <a class="user" href = "/~thought_house">thought_house</a>, <a class="user" href = "/~jonathan">jonathan</a>, <a class="user" href = "/~hornek">hornek</a>, <a class="user" href = "/~Cthulhu">Cthulhu</a>, <a class="user" href = "/~FJELCORP">FJELCORP</a>, <a class="user" href = "/~lulle">lulle</a>, <a class="user" href = "/~danny">danny</a>, <a class="user" href = "/~tomsteele">tomsteele</a>, <a class="user" href = "/~wehopethatyouchoke">wehopethatyouchoke</a>, <a class="user" href = "/~rachelc">rachelc</a>, <a class="user" href = "/~deadstation">deadstation</a>, <a class="user" href = "/~latadelixo">latadelixo</a>, <a class="user" href = "/~daveiscoolyeah">daveiscoolyeah</a>, <a class="user" href = "/~keir">keir</a>, <a class="user" href = "/~sodr1">sodr1</a>, <span class="userd" title="user doesn't exist or has been deleted">[deleted]</span>, <a class="user" href = "/~MoeHartman">MoeHartman</a>, <a class="user" href = "/~pivip">pivip</a>, <a class="user" href = "/~fourths">fourths</a>, <span class="userd" title="user doesn't exist or has been deleted">[deleted]</span>, <span class="userd" title="user doesn't exist or has been deleted">[deleted]</span>, <a class="user" href = "/~youtubecore">youtubecore</a>, <a class="user" href = "/~RoseLawrence">RoseLawrence</a>, <a class="user" href = "/~audiointerface">audiointerface</a>, <a class="user" href = "/~KalorXD">KalorXD</a>, <a class="user" href = "/~itskeit">itskeit</a>, <a class="user" href = "/~VoidKing">VoidKing</a>, <a class="user" href = "/~MunjaZevsova">MunjaZevsova</a>, <a class="user" href = "/~Joren">Joren</a>, <a class="user" href = "/~bakinakwa">bakinakwa</a>, <a class="user" href = "/~jizhart">jizhart</a>, <a class="user" href = "/~shockadelica">shockadelica</a>, <a class="user" href = "/~Hare">Hare</a>, <a class="user" href = "/~Nitestik">Nitestik</a><div style="margin-top:5px;margin-left:15px;margin-bottom:10px;"><a href="/login">Log in</a> to submit a correction or upload art for this release</a></div></div></div></div><div style="height:4px;width:100%;overflow:hidden;"><table class="color_bar" style="xborder:1px #2e3d46 solid; width:100%;height:4px;font-size:1px;padding:0;"><tr style="height:4px;padding:0;"><td style="background:#a8b7c0;height:4px;padding:0px;color:#a8b7c0">.</td><td style="background:#a9b8bc;height:4px;padding:0px;color:#a9b8bc">.</td><td style="background:#7694a2;height:4px;padding:0px;color:#7694a2">.</td><td style="background:#636468;height:4px;padding:0px;color:#636468">.</td><td style="background:#be855b;height:4px;padding:0px;color:#be855b">.</td><td style="background:#9e9ea6;height:4px;padding:0px;color:#9e9ea6">.</td><td style="background:#c8b497;height:4px;padding:0px;color:#c8b497">.</td><td style="background:#54bcec;height:4px;padding:0px;color:#54bcec">.</td></tr></table></div>
+         <div class="clearfix"></div>
+         <!-- end content and content_wrapper -->
+               </div>
+             </div>
+          </div>
+
+
+
+          <div class="overlay_invisible" id="overlay_invisible"></div>
+
+          <div class="ui_cropper_frame" id="ui_cropper_frame"></div>
+
+          <div class="modal_parent_frame" id="modal_parent_frame">
+             <div onClick="rym.closeModal();" id="modal_overlay" class="modal_overlay" style="">Close <i class="fa fa-times"></i></div>
+             <div onClick="rym.closeModal();" id="modal_overlay_invisible" class="modal_overlay_invisible" style=""></div>
+             <div id="modal_parent_frame_inner" class="modal_parent_frame_inner">
+                    <div id="modal_content" class="modal_content">
+                    </div>
+             </div>
+          </div>
+
+          <div class="modal_parent_frame_level_2" id="modal_parent_frame_level_2">
+             <div onClick="rym.closeModal2();" id="modal_overlay_level_2" class="modal_overlay" style="">Close <i class="fa fa-times"></i></div>
+             <div onClick="rym.closeModal2();" id="modal_overlay_invisible_level_2" class="modal_overlay_invisible" style=""></div>
+             <div id="modal_parent_frame_inner_level_2" class="modal_parent_frame_inner_level_2">
+                    <div id="modal_content_level_2" class="modal_content">
+                    </div>
+             </div>
+          </div>
+
+
+
+             <!-- ~~~~~~~~ end content ~~~~~~~~~~~~~~~ -->
+            <div class="ui_chooser_results_frame" id="ui_chooser_results_frame">
+                <div class="ui_chooser_results bg-fff alternate" id="ui_chooser_results">
+                </div>
+            </div>  
+
+
+
+             <div id="voting_ui_frame"></div>
+
+          <div style="clear:both;"></div>
+      
+         <!-- Playwire footer tag -->
+         <script data-cfasync="false" defer src="//cdn.intergient.com/1025628/76421/ramp.js"></script>         
+      
+               <script> 
+                   document.querySelectorAll('.mobile-sticky-ad').forEach( item => {
+                     console.log ('setting sticky timer for ' + item.id)
+                     setTimeout(function () {
+                        item.classList.add('seen')
+                     }, 2000);
+                   });
+               </script>
+         
+<footer>
+  <div class="footer_inner">
+
+     <div class="footer_main_section"><div class="minilogo_frame"><div class="minilogo"> <div class="logo_sonemic_bw_24"></div>
+                        <span class="minilogo_text">Rate Your Music</span>
+                        
+                    </div></div>
+
+
+        <div class="copyright">&copy; 2000-2026 Sonemic, Inc.</div>
+          
+
+
+        <div class="clearfix"></div>
+
+        <div class="clearfix"></div>
+
+        <div class="social_icons"> 
+           <a rel="noopener" title="Follow us on Facebook" href="https://facebook.com/sonemic.network/" target="_blank"><i class="fab fa-facebook-square"></i></a> 
+           <a rel="noopener" title="Follow us on Twitter" href="https://twitter.com/sonemic/" target="_blank"><i class="fab fa-twitter-square"></i></a> 
+           <a rel="noopener" title="Follow us on Instagram" href="https://instagram.com/sonemic/" target="_blank"><i class="fab fa-instagram-square"></i></a> 
+           <a rel="noopener" title="Follow us on Spotify" href="https://open.spotify.com/user/sonemic.com" target="_blank"><i class="fab fa-spotify"></i></a> 
+           <a rel="noopener" title="Subscribe to our weekly newsletter"  href="https://mailchi.mp/sonemic-selects/newsletter" target="_blank"><i class="fa fa-envelope"></i></a> 
+     
+        </div>
+
+
+     </div> 
+  
+  <div id="expand_full_footer" class="mobile_expandable_full mobile_expand_footer">
+
+        <div id="expand_full_header_footer" class="mobile_expandable_full_header" onclick="RYMmobile.mobileExpand.toggleFull('footer');">
+
+           <div class="mobile_expandable_full_icons">
+              <div class="mobile_expandable_full_expand_icon_expanded">
+                 <i class="fa fa-caret-down"></i>
+              </div>
+              <div class="mobile_expandable_full_expand_icon_hidden">
+                 <i class="fa fa-caret-right"></i>
+              </div>
+           </div>
+
+           <div id="expand_full_name_footer" class="mobile_expandable_full_name">
+              Site links
+           </div>
+
+        </div>
+
+        <div id="expand_full_content_footer" class="mobile_expandable_full_content">
+           
+     <div class="footer_sections">
+
+        <div class="footer_section" id="section_network">
+           <div class="footer_header">RYM Network</div>
+           <div class="footer_sub_links">
+              <a class="asonemic" href="https://rateyourmusic.com/">
+                  RYM
+                  
+                  <span class="sub">music</span></a>
+              <a class="asonemic" href="https://sonemic.com/">Sonemic <span class="sub">roadmap</span></a>
+              <a class="aglitchwave" href="https://glitchwave.com/">Glitchwave <span class="sub">video games (beta)</span></a>
+              <a class="aforum" href="https://rym.fm/">Discussion <span class="sub">rym.fm</span></a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Info</div>
+           <div class="footer_sub_links">
+              <a href="/wiki/RYM:FAQ">FAQ</a>
+              <a href="/development/">Development status</a>
+              <a href="/rymzilla/" class="has_tip" data-tiptip="Report bugs and request features">RYMzilla</a>
+              <a href="/submissions/">Submissions</a>
+              <a href="/data-access/register-interest/">Data access / API</a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Policy</div>
+           <div class="footer_sub_links">
+              
+              <a href="/wiki/">Database standards</a>
+              <a class="" href="/privacy">Privacy <span style="font-size:0.875em;"><br />(Updated: 29 Sep 2025)</span></a>
+              <a class="" href="/tos">Terms of service <span style="display:none;font-size:0.875em;">(Updated: 12 Aug 2024)</span></a>
+           </div>
+        </div>
+        <div class="footer_section">
+           <div class="footer_header">Contact us</div>
+           <div class="footer_sub_links">
+              <a href="/contact">Support / Feedback</a>
+              
+           </div>
+        </div>
+     </div>
+  
+        </div>
+     </div>
+  
+ 
+     <div style="clear:both;"></div>
+  </div>
+
+</footer><script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9fb5f467fd5e0cfb',t:'MTc3ODcyMDMwOA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body></html><script src="https://e.snmc.io/2.5/js/jquery.min.2.js"></script><script src="//e.snmc.io/dist/js/bundle.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script><script src="//e.snmc.io/dist/js/page/release.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script><script src="//e.snmc.io/dist/js/component/suggestions.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script><script src="//e.snmc.io/dist/js/component/play_history.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script><script src="//e.snmc.io/dist/js/ui/comments.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script><script src="//e.snmc.io/dist/js/component/content.js?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87"></script>
+            <script  type="module" id="module_dep_media_links">
+                import * as media_links from 'https://e.snmc.io/dist/js/ui/media_links.mjs?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87';
+                window.ui = window.ui || {};
+                window.ui.media_links = media_links;
+
+
+            if ( window.ui.media_links._initPage !== undefined ) {
+               rymQ(window.ui.media_links._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_contributions">
+                import * as contributions from 'https://e.snmc.io/dist/js/page/section/contributions.mjs?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87';
+                window.page = window.page || {};
+                window.page.section = window.page.section || {};
+                window.page.section.contributions = contributions;
+
+
+            if ( window.page.section.contributions._initPage !== undefined ) {
+               rymQ(window.page.section.contributions._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_release">
+                import * as release from 'https://e.snmc.io/dist/js/page/release.mjs?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87';
+                window.page = window.page || {};
+                window.page.release = release;
+
+
+            if ( window.page.release._initPage !== undefined ) {
+               rymQ(window.page.release._initPage);
+            }
+            </script>
+
+            <script  type="module" id="module_dep_community">
+                import * as community from 'https://e.snmc.io/dist/js/core/community.mjs?v=2cc494f3-2fa1-4b99-b59a-df5f51baca87';
+                window.core = window.core || {};
+                window.core.community = community;
+
+
+            if ( window.core.community._initPage !== undefined ) {
+               rymQ(window.core.community._initPage);
+            }
+            </script>
+
+         <script>
+
+           window.addEventListener('DOMContentLoaded', (event) => {
+
+               for ( var i in window.ryminit ) {
+                  var fn = window.ryminit[i];
+                  window.ryminit[i] = null;
+                  if ( fn ) {
+                     fn();
+                  }
+               }
+
+               window.ryminit = null;
+            });
+
+         </script>
+      
+
+
+      <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+      <script type="text/javascript">
+
+         rymQ(function () {
+             function drawChart() {
+               if (typeof(drawChart1) != 'undefined') {
+                  drawChart1();
+               }
+               if (typeof(drawChart2) != 'undefined') {
+                  drawChart2();
+               }
+            }
+           google.charts.load('42', {packages: ['corechart']});
+           google.charts.setOnLoadCallback(drawChart);
+         });
+      </script>
+
+    <script type="text/javascript">rymQ(function () {
+      
+      $(".has_tip").tipTip();
+
+
+
+      });
+
+     </script>

--- a/tests/catalog/test_music.py
+++ b/tests/catalog/test_music.py
@@ -303,3 +303,100 @@ class TestYouTubeMusic:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert str(site.resource.item.release_date) == "1983-01-01"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRateYourMusic:
+    def test_parse(self):
+        t_id_type = IdType.RateYourMusic_Release
+        t_id_value = "release/album/radiohead/ok-computer"
+        t_url = "https://rateyourmusic.com/release/album/radiohead/ok-computer/"
+        t_url_no_slash = "https://rateyourmusic.com/release/album/radiohead/ok-computer"
+        t_url_with_www = (
+            "https://www.rateyourmusic.com/release/album/radiohead/ok-computer/"
+        )
+        site = SiteManager.get_site_cls_by_id_type(t_id_type)
+        assert site is not None
+        assert site.validate_url(t_url)
+        assert site.validate_url(t_url_no_slash)
+        assert site.validate_url(t_url_with_www)
+        s = SiteManager.get_site_by_url(t_url)
+        assert s is not None
+        assert s.url == t_url
+        assert s.id_value == t_id_value
+        # www variant normalizes to canonical URL
+        s2 = SiteManager.get_site_by_url(t_url_with_www)
+        assert s2 is not None
+        assert s2.url == t_url
+        assert s2.id_value == t_id_value
+        # Non-album release types are accepted by URL pattern
+        ep_url = "https://rateyourmusic.com/release/ep/some-artist/some-ep/"
+        assert site.validate_url(ep_url)
+
+    @use_local_response
+    def test_scrape(self):
+        t_url = "https://rateyourmusic.com/release/album/radiohead/ok-computer/"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        assert not site.ready
+        site.get_resource_ready()
+        assert site.ready
+        assert site.resource is not None
+        meta = site.resource.metadata
+        assert meta["title"] == "OK Computer"
+        assert meta["artist"] == ["Radiohead"]
+        assert meta["album_type"] == "Album"
+        assert meta["release_date"] == "1997-06-16"
+        # Primary + secondary genres preserved in order
+        assert meta["genre"][:2] == ["Alternative Rock", "Art Rock"]
+        assert "Post-Britpop" in meta["genre"]
+        assert "Space Rock Revival" in meta["genre"]
+        # Tracks: 12 songs, ~53:21 total
+        track_lines = meta["track_list"].splitlines()
+        assert len(track_lines) == 12
+        assert track_lines[0] == "1. Airbag (4:44)"
+        assert track_lines[-1] == "12. The Tourist (5:24)"
+        assert meta["duration"] == 3201000
+        # Primary label parsed out of og:description
+        assert meta["company"] == ["Parlophone"]
+        assert meta["cover_image_url"].startswith("https://cdn.sonemic.net/")
+        # Brief excludes the "Featured performers:" credit dump
+        assert "Featured pe" not in meta["brief"]
+        assert meta["localized_title"][0]["text"] == "OK Computer"
+        # Streaming-platform IDs harvested from data-links blob
+        lookup = site.resource.other_lookup_ids or {}
+        assert lookup.get(IdType.Spotify_Album) == "7dxKtc08dYeRVHt3p9CZJn"
+        assert lookup.get(IdType.AppleMusic) == "1097861387"
+        # No bandcamp on this release (major-label, not self-published)
+        assert IdType.Bandcamp not in lookup
+        # Item creation
+        assert site.resource.item is not None
+        assert isinstance(site.resource.item, Album)
+        assert str(site.resource.item.release_date) == "1997-06-16"
+
+    @use_local_response
+    def test_scrape_bandcamp_release(self):
+        # King Gizzard self-publishes on Bandcamp; data-links has bandcamp
+        # (with a `url` field) and youtube, but no spotify.
+        t_url = (
+            "https://rateyourmusic.com/release/album/"
+            "king-gizzard-and-the-lizard-wizard/12-bar-bruise/"
+        )
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready
+        assert site.resource is not None
+        meta = site.resource.metadata
+        assert meta["title"] == "12 Bar Bruise"
+        assert meta["artist"] == ["King Gizzard & The Lizard Wizard"]
+        lookup = site.resource.other_lookup_ids or {}
+        # Bandcamp url field, not RYM's internal numeric id
+        assert (
+            lookup.get(IdType.Bandcamp)
+            == "kinggizzard.bandcamp.com/album/12-bar-bruise"
+        )
+        # Apple Music: RYM marks the de-locale entry as default
+        assert lookup.get(IdType.AppleMusic) == "1649045961"
+        # Spotify absent for this release in RYM's data-links
+        assert IdType.Spotify_Album not in lookup


### PR DESCRIPTION
## Summary

- New `catalog/sites/rateyourmusic.py` (ScrapDownloader-based) parses RYM release pages: title, artist, genres, tracks (with per-track + total duration), release date, cover, primary label, brief.
- Extracts Spotify / Apple Music / Bandcamp IDs from the embedded `data-links` JSON blob on `#media_link_button_container_top`, so a single RYM submission cross-links to existing items on those sites via NeoDB's `other_lookup_ids` matcher.
- Adds `SiteName.RateYourMusic` and `IdType.RateYourMusic_Release`; registers the site and updates `docs/sites.md`.
- Two real-page fixtures plus tests: Radiohead — OK Computer (major label, has Spotify + Apple Music, no Bandcamp) and King Gizzard — 12 Bar Bruise (self-published, has Bandcamp + Apple Music, no Spotify).

## Notes

- RYM is gated by Cloudflare, so runtime fetches go through `ScrapDownloader` (Scrapfly / Decodo / ScraperAPI / ScrapingBee / custom — already supported). Mock mode short-circuits to local fixtures, so tests don't need a provider.
- YouTube is present in RYM's `data-links` but as a video ID, not a YT Music playlist ID, so it doesn't map to `IdType.YouTubeMusic` and is intentionally skipped.
- `id_value` is the URL slug (e.g. `release/album/radiohead/ok-computer`) — RYM doesn't expose stable numeric release IDs publicly.
- `WIKI_PROPERTY_ID = "P8392"`.

## Test plan

- [x] `uv run pre-commit run -a` clean (ruff / format / ty / djLint)
- [x] `docker compose --profile dev run --rm dev-shell /neodb-venv/bin/pytest --reuse-db tests/catalog/test_music.py` — 21 passed
- [x] `TestRateYourMusic::test_parse` covers URL parsing (canonical / www / trailing-slash variants, non-album release types)
- [x] `TestRateYourMusic::test_scrape` covers OK Computer fixture (title, artist, genres ordered, tracks, duration, label, og:image, brief, Spotify + Apple Music lookup IDs)
- [x] `TestRateYourMusic::test_scrape_bandcamp_release` covers the King Gizzard fixture (Bandcamp URL slug, region-defaulted Apple Music ID, Spotify intentionally absent)