### PR TITLE
perf(views): conditional-GET on anonymous post/article/review/collection views

### DIFF
--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -175,6 +175,12 @@ class List(Piece):
         if member:
             member.metadata = metadata
             member.save()
+            # Treat a member metadata edit as a change to the list itself
+            # so subscribers (federation re-post, conditional-GET mtime)
+            # see the new state.
+            list_add.send(
+                sender=self.__class__, instance=self, item=item, member=member
+            )
 
     # ------------------------------------------------------------------
     # ActivityPub federation surface (shared by Collection and Shelf)

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -20,6 +20,11 @@
     <meta name="fediverse:creator" content="@{{ article.owner.full_handle }}">
     <meta rel="canonical" content="{{ article.absolute_url }}">
     <meta name="lastmodified" content="{{ article.edited_time | date:'r' }}">
+    {% if article.latest_post %}
+      <link rel="alternate"
+            type="application/activity+json"
+            href="{{ article.latest_post.absolute_object_uri }}">
+    {% endif %}
     {% if not article.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
     <title>{{ site_name }} | {{ article.title }}</title>
     {% include "common_libs.html" %}

--- a/journal/templates/collection.html
+++ b/journal/templates/collection.html
@@ -25,6 +25,11 @@
           content="@{{ collection.owner.full_handle }}">
     <meta rel="canonical" content="{{ collection.absolute_url }}">
     <meta name="lastmodified" content="{{ collection.edited_time | date:'r' }}" />
+    {% if collection.latest_post %}
+      <link rel="alternate"
+            type="application/activity+json"
+            href="{{ collection.latest_post.absolute_object_uri }}">
+    {% endif %}
     {% if not collection.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
     <title>{{ site_name }} {% trans 'Collection' %} | {{ collection.title }}</title>
     {% include "common_libs.html" %}

--- a/journal/templates/review.html
+++ b/journal/templates/review.html
@@ -23,6 +23,11 @@
     <meta name="fediverse:creator" content="@{{ review.owner.full_handle }}">
     <meta rel="canonical" content="{{ review.absolute_url }}">
     <meta name="lastmodified" content="{{ review.edited_time | date:'r' }}" />
+    {% if review.latest_post %}
+      <link rel="alternate"
+            type="application/activity+json"
+            href="{{ review.latest_post.absolute_object_uri }}">
+    {% endif %}
     <script type="application/ld+json">{{ review.to_schema_org_json | safe }}</script>
     {% if not review.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
     <title>{{ site_name }} {% trans 'Review' %} | {{ review.title }}</title>

--- a/journal/views/article.py
+++ b/journal/views/article.py
@@ -13,6 +13,7 @@ from ..forms import ArticleForm
 from ..models import Article
 from ..models.common import prefetch_latest_posts, q_owned_piece_visible_to_user
 from ..models.renderers import convert_leading_space_in_md, sanitize_md_images
+from .common import conditional_get_for_anonymous
 
 _AP_ACCEPT_TYPES = (
     "application/activity+json",
@@ -98,9 +99,29 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
     return redirect(reverse("journal:article_retrieve", args=[article.uuid]))
 
 
+def _article_last_modified(request, article_uuid: str):
+    # Owner-level toggles (``anonymous_viewable``, ``restricted``) don't
+    # bump piece ``edited_time``, so the visibility check must run here —
+    # otherwise a privacy flip can leave anonymous clients with a cached
+    # 200 served via 304. Stash the loaded row for the view body to reuse
+    # so the non-304 path stays single-query.
+    try:
+        uid = get_uuid_or_404(article_uuid)
+    except Http404:
+        return None
+    article = Article.objects.filter(uid=uid).select_related("owner").first()
+    if not article or not article.is_visible_to(request.user):
+        return None
+    request._cg_article = article
+    return article.edited_time
+
+
 @require_http_methods(["GET", "HEAD"])
+@conditional_get_for_anonymous(_article_last_modified)
 def article_retrieve(request, article_uuid: str):
-    article = get_object_or_404(Article, uid=get_uuid_or_404(article_uuid))
+    article = getattr(request, "_cg_article", None) or get_object_or_404(
+        Article, uid=get_uuid_or_404(article_uuid)
+    )
     if request.method == "HEAD":
         return HttpResponse()
     if _wants_activitypub(request):

--- a/journal/views/article.py
+++ b/journal/views/article.py
@@ -107,9 +107,8 @@ def _article_last_modified(request, article_uuid: str):
         return None
     # Owner-level toggles (``anonymous_viewable``, ``restricted``) don't
     # bump piece ``edited_time``, so the visibility check must run here —
-    # otherwise a privacy flip can leave anonymous clients with a cached
-    # 200 served via 304. Stash the loaded row for the view body to reuse
-    # so the non-304 path stays single-query.
+    # otherwise a privacy flip would leave anonymous clients with a
+    # cached 200 served via 304.
     try:
         uid = get_uuid_or_404(article_uuid)
     except Http404:
@@ -117,16 +116,13 @@ def _article_last_modified(request, article_uuid: str):
     article = Article.objects.filter(uid=uid).select_related("owner").first()
     if not article or not article.is_visible_to(request.user):
         return None
-    request._cg_article = article
     return article.edited_time
 
 
 @require_http_methods(["GET", "HEAD"])
 @conditional_get_for_anonymous(_article_last_modified)
 def article_retrieve(request, article_uuid: str):
-    article = getattr(request, "_cg_article", None) or get_object_or_404(
-        Article, uid=get_uuid_or_404(article_uuid)
-    )
+    article = get_object_or_404(Article, uid=get_uuid_or_404(article_uuid))
     if request.method == "HEAD":
         return HttpResponse()
     if _wants_activitypub(request):

--- a/journal/views/article.py
+++ b/journal/views/article.py
@@ -100,6 +100,11 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
 
 
 def _article_last_modified(request, article_uuid: str):
+    # AP requests redirect to a different URI (the canonical Takahē post);
+    # a 304 here would let a stale HTML-cached client bypass that redirect.
+    # The view body handles the AP branch.
+    if _wants_activitypub(request):
+        return None
     # Owner-level toggles (``anonymous_viewable``, ``restricted``) don't
     # bump piece ``edited_time``, so the visibility check must run here —
     # otherwise a privacy flip can leave anonymous clients with a cached

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -237,10 +237,6 @@ def _collection_last_modified(request, collection_uuid):
     # flip doesn't leave anonymous clients with a cached 200.
     if not collection.is_visible_to(request.user):
         return None
-    # Stash for ``collection_retrieve`` to reuse — avoids a second copy of
-    # the same polymorphic JOIN that ``test_no_per_member_collection_*``
-    # guards against.
-    request._cg_collection = collection
     return collection.edited_time
 
 
@@ -249,9 +245,7 @@ def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
     if _wants_activitypub(request):
         collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
         return _list_ap_object_view(request, collection)
-    collection = getattr(request, "_cg_collection", None) or get_object_or_404(
-        Collection, uid=get_uuid_or_404(collection_uuid)
-    )
+    collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
     if not collection.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     page_number = int_(request.GET.get("page"), 1)

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.core.signing import b62_encode
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -22,8 +22,13 @@ from users.models import User
 
 from ..forms import *
 from ..models import *
+from ..models.itemlist import list_add
 from ..models.renderers import sanitize_md_images
-from .common import render_relogin, target_identity_required
+from .common import (
+    conditional_get_for_anonymous,
+    render_relogin,
+    target_identity_required,
+)
 
 
 @login_required
@@ -209,11 +214,44 @@ def collection_ap_items(request, collection_uuid):
     return _list_items_view(request, collection)
 
 
+def _collection_last_modified(request, collection_uuid):
+    # AP responses go through their own caching/signing path; skip the
+    # conditional-GET short-circuit here so AP fetchers always run the
+    # canonical envelope code.
+    if _wants_activitypub(request):
+        return None
+    try:
+        uid = get_uuid_or_404(collection_uuid)
+    except Http404:
+        return None
+    collection = Collection.objects.filter(uid=uid).select_related("owner").first()
+    if not collection:
+        return None
+    # Dynamic collections render from a fresh query each time; their
+    # member set can drift without ``edited_time`` moving, so a 304 is
+    # not safe.
+    if collection.is_dynamic:
+        return None
+    # Owner-level privacy (``anonymous_viewable``, ``restricted``) is not
+    # reflected in ``edited_time``; check visibility before 304 so a
+    # flip doesn't leave anonymous clients with a cached 200.
+    if not collection.is_visible_to(request.user):
+        return None
+    # Stash for ``collection_retrieve`` to reuse — avoids a second copy of
+    # the same polymorphic JOIN that ``test_no_per_member_collection_*``
+    # guards against.
+    request._cg_collection = collection
+    return collection.edited_time
+
+
+@conditional_get_for_anonymous(_collection_last_modified)
 def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
     if _wants_activitypub(request):
         collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
         return _list_ap_object_view(request, collection)
-    collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
+    collection = getattr(request, "_cg_collection", None) or get_object_or_404(
+        Collection, uid=get_uuid_or_404(collection_uuid)
+    )
     if not collection.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     page_number = int_(request.GET.get("page"), 1)
@@ -514,6 +552,10 @@ def collection_update_item_note(request: AuthedHttpRequest, collection_uuid, ite
     if request.method == "POST" and member:
         member.note = note
         member.save()
+        # Re-emit list_add so the Collection receiver bumps edited_time
+        # and federates the updated member-state — the receiver gates on
+        # is_dynamic itself.
+        list_add.send(sender=Collection, instance=collection, item=item, member=member)
         return render(
             request,
             "collection_update_item_note_ok.html",

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from functools import wraps
 
 import filetype
 from django.conf import settings
@@ -12,9 +13,10 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.http import last_modified, require_http_methods
 
 from catalog.models import Item, ItemCategory, PeopleType
 from common.models.misc import int_
@@ -69,6 +71,50 @@ def upload_image(request: AuthedHttpRequest) -> JsonResponse:
 
 
 PAGE_SIZE = 10
+
+
+def conditional_get_for_anonymous(get_timestamp):
+    """Apply HTTP conditional-GET (``Last-Modified``) for anonymous viewers.
+
+    ``get_timestamp(request, *args, **kwargs) -> datetime | None`` is called
+    before the view; returning ``None`` skips the conditional path entirely
+    (so the view runs as usual). The callback is responsible for any
+    visibility / identity gates that aren't already reflected in the
+    returned timestamp — anything the callback can't safely answer should
+    return ``None`` so the view body runs and renders the real
+    403/404/redirect.
+
+    Authenticated requests always bypass: their response varies on viewer
+    identity, which a single ``Last-Modified`` value cannot represent
+    safely.
+
+    Sets ``Cache-Control: private, max-age=0, must-revalidate`` and adds
+    ``Cookie``/``Accept`` to ``Vary`` on **both** 200 and 304 responses,
+    so shared caches don't serve an anonymous body to a logged-in user
+    and browsers always revalidate (yielding 304 when unchanged).
+    """
+
+    def _lm(request, *args, **kwargs):
+        if request.user.is_authenticated:
+            return None
+        return get_timestamp(request, *args, **kwargs)
+
+    def decorator(view):
+        conditional = last_modified(_lm)(view)
+
+        @wraps(view)
+        def wrapped(request, *args, **kwargs):
+            # The inner ``conditional`` may short-circuit to 304 without
+            # running ``view``; patch headers on whatever response comes
+            # back so 304s carry Cache-Control/Vary too.
+            response = conditional(request, *args, **kwargs)
+            patch_cache_control(response, private=True, max_age=0, must_revalidate=True)
+            patch_vary_headers(response, ("Cookie", "Accept"))
+            return response
+
+        return wrapped
+
+    return decorator
 
 
 def render_relogin(request):

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -378,6 +378,7 @@ def _post_last_modified(request, handle: str, post_pk: int):
     post = (
         Post.objects.filter(pk=post_pk)
         .exclude(state__in=["deleted", "deleted_fanned_out"])
+        .select_related("author")
         .first()
     )
     if not post:
@@ -400,7 +401,7 @@ def _post_last_modified(request, handle: str, post_pk: int):
 @require_http_methods(["GET", "HEAD"])
 @conditional_get_for_anonymous(_post_last_modified)
 def post_view(request, handle: str, post_pk: int):
-    if request.headers.get("HTTP_ACCEPT", "").endswith("json"):
+    if request.headers.get("Accept", "").endswith("json"):
         raise BadRequest("JSON not supported yet")
     post: Post = getattr(request, "_cg_post", None) or get_object_or_404(
         Post, pk=post_pk

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -393,8 +393,6 @@ def _post_last_modified(request, handle: str, post_pk: int):
         return None
     if _can_view_post(post, owner, viewer=None) != 1:
         return None
-    request._cg_post = post
-    request._cg_owner = owner
     return post.updated
 
 
@@ -403,15 +401,11 @@ def _post_last_modified(request, handle: str, post_pk: int):
 def post_view(request, handle: str, post_pk: int):
     if request.headers.get("Accept", "").endswith("json"):
         raise BadRequest("JSON not supported yet")
-    post: Post = getattr(request, "_cg_post", None) or get_object_or_404(
-        Post, pk=post_pk
-    )
+    post: Post = get_object_or_404(Post, pk=post_pk)
     if post.state in ["deleted", "deleted_fanned_out"]:
         raise Http404("Post not available")
     viewer = request.user.identity if request.user.is_authenticated else None
-    owner = getattr(request, "_cg_owner", None) or APIdentity.by_takahe_identity(
-        post.author
-    )
+    owner = APIdentity.by_takahe_identity(post.author)
     if not owner:
         if not post.local:  # identity for remote post hasn't been sync to APIdentity
             return redirect(post.url)

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -18,6 +18,7 @@ from users.models import APIdentity
 
 from ..forms import *
 from ..models import *
+from .common import conditional_get_for_anonymous
 
 
 def _can_view_post(post: Post, owner: APIdentity, viewer: APIdentity | None) -> int:
@@ -366,15 +367,50 @@ def post_compose(request: AuthedHttpRequest):
     return HttpResponseRedirect(referer)
 
 
+def _post_last_modified(request, handle: str, post_pk: int):
+    # Full visibility + handle gating runs here so a 304 can never bypass
+    # checks the view would otherwise enforce: handle mismatch
+    # (``/@wrong/posts/<id>/``), owner-level privacy toggles
+    # (``anonymous_viewable``, ``restricted``, ``deleted``), and
+    # post-level visibility. Each of those can change without bumping
+    # ``Post.updated``. Anything not 100% safe to 304 returns ``None`` so
+    # the view body produces the real 404/403/redirect.
+    post = (
+        Post.objects.filter(pk=post_pk)
+        .exclude(state__in=["deleted", "deleted_fanned_out"])
+        .first()
+    )
+    if not post:
+        return None
+    owner = APIdentity.by_takahe_identity(post.author)
+    if not owner:
+        return None
+    h = handle.split("@", 2)
+    username = h[0]
+    domain = h[1] if len(h) > 1 else settings.SITE_DOMAIN
+    if owner.username != username or owner.domain_name != domain:
+        return None
+    if _can_view_post(post, owner, viewer=None) != 1:
+        return None
+    request._cg_post = post
+    request._cg_owner = owner
+    return post.updated
+
+
 @require_http_methods(["GET", "HEAD"])
+@conditional_get_for_anonymous(_post_last_modified)
 def post_view(request, handle: str, post_pk: int):
     if request.headers.get("HTTP_ACCEPT", "").endswith("json"):
         raise BadRequest("JSON not supported yet")
-    post: Post = get_object_or_404(Post, pk=post_pk)
+    post: Post = getattr(request, "_cg_post", None) or get_object_or_404(
+        Post, pk=post_pk
+    )
     if post.state in ["deleted", "deleted_fanned_out"]:
         raise Http404("Post not available")
     viewer = request.user.identity if request.user.is_authenticated else None
-    owner = APIdentity.by_takahe_identity(post.author)
+    owner = getattr(request, "_cg_owner", None) or APIdentity.by_takahe_identity(
+        post.author
+    )
     if not owner:
         if not post.local:  # identity for remote post hasn't been sync to APIdentity
             return redirect(post.url)

--- a/journal/views/review.py
+++ b/journal/views/review.py
@@ -27,13 +27,25 @@ from ..models.renderers import (
     render_md,
     sanitize_md_images,
 )
-from .common import render_list
+from .common import conditional_get_for_anonymous, render_list
+
+
+def _review_last_modified(request, review_uuid):
+    # Visibility must be checked here: owner-level privacy toggles
+    # (``anonymous_viewable``, ``restricted``) don't bump
+    # ``Review.edited_time`` and would otherwise leave cached 200s
+    # reachable via 304 after a flip.
+    piece = Review.get_by_url(review_uuid)
+    if piece is None or not piece.is_visible_to(request.user):
+        return None
+    request._cg_review = piece
+    return piece.edited_time
 
 
 @require_http_methods(["GET", "HEAD"])
+@conditional_get_for_anonymous(_review_last_modified)
 def review_retrieve(request, review_uuid):
-    # piece = get_object_or_404(Review, uid=get_uuid_or_404(review_uuid))
-    piece = Review.get_by_url(review_uuid)
+    piece = getattr(request, "_cg_review", None) or Review.get_by_url(review_uuid)
     if piece is None:
         raise Http404(_("Content not found"))
     if not piece.is_visible_to(request.user):

--- a/journal/views/review.py
+++ b/journal/views/review.py
@@ -38,14 +38,13 @@ def _review_last_modified(request, review_uuid):
     piece = Review.get_by_url(review_uuid)
     if piece is None or not piece.is_visible_to(request.user):
         return None
-    request._cg_review = piece
     return piece.edited_time
 
 
 @require_http_methods(["GET", "HEAD"])
 @conditional_get_for_anonymous(_review_last_modified)
 def review_retrieve(request, review_uuid):
-    piece = getattr(request, "_cg_review", None) or Review.get_by_url(review_uuid)
+    piece = Review.get_by_url(review_uuid)
     if piece is None:
         raise Http404(_("Content not found"))
     if not piece.is_visible_to(request.user):

--- a/tests/journal/test_conditional_get.py
+++ b/tests/journal/test_conditional_get.py
@@ -1,0 +1,334 @@
+"""HTTP conditional-GET behavior on anonymous piece-view endpoints.
+
+The four piece-detail views (`post_view`, `article_retrieve`,
+`review_retrieve`, `collection_retrieve`) emit ``Last-Modified`` for
+anonymous viewers so re-fetches (browser soft-reload, crawler re-crawl)
+short-circuit to 304 before the heavier view body runs.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.test import Client
+from django.utils import timezone
+from django.utils.http import http_date
+
+from catalog.models import Edition
+from journal.models import Article, Collection, Review
+from users.models import User
+
+
+def _hdate(dt):
+    return http_date(dt.timestamp())
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestArticleConditionalGet:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="art_cg@test.com", username="art_cg")
+        self.client = Client()
+        self.article = Article.update_local_article(
+            owner=self.user.identity,
+            title="CG Article",
+            body="body",
+            visibility=0,
+        )
+
+    def test_first_get_sets_last_modified_and_cache_headers(self):
+        resp = self.client.get(self.article.url)
+        assert resp.status_code == 200
+        assert "Last-Modified" in resp
+        cc = resp["Cache-Control"]
+        assert "private" in cc and "must-revalidate" in cc and "max-age=0" in cc
+        vary = resp["Vary"].lower()
+        assert "cookie" in vary and "accept" in vary
+
+    def test_repeat_with_if_modified_since_returns_304(self):
+        first = self.client.get(self.article.url)
+        last_mod = first["Last-Modified"]
+        resp = self.client.get(self.article.url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        assert resp.status_code == 304
+
+    def test_stale_if_modified_since_returns_200(self):
+        stale = _hdate(timezone.now() - timedelta(days=1))
+        resp = self.client.get(self.article.url, HTTP_IF_MODIFIED_SINCE=stale)
+        assert resp.status_code == 200
+
+    def test_authenticated_request_skips_conditional_path(self):
+        # Auth users don't get Last-Modified (callback returns None for them),
+        # so a 304 attempt from a logged-in client cannot succeed.
+        first = self.client.get(self.article.url)
+        last_mod = first["Last-Modified"]
+        self.client.force_login(self.user)
+        resp = self.client.get(self.article.url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        assert resp.status_code == 200
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReviewConditionalGet:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="rv_cg@test.com", username="rv_cg")
+        self.book = Edition.objects.create(title="CG Book")
+        self.review = Review.update_item_review(
+            self.book,
+            self.user.identity,
+            "Title",
+            "body",
+            visibility=0,
+        )
+        self.client = Client()
+
+    def test_repeat_returns_304(self):
+        first = self.client.get(self.review.url)
+        assert first.status_code == 200
+        resp = self.client.get(
+            self.review.url, HTTP_IF_MODIFIED_SINCE=first["Last-Modified"]
+        )
+        assert resp.status_code == 304
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionConditionalGet:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="col_cg@test.com", username="col_cg")
+        self.collection = Collection(
+            owner=self.user.identity,
+            title="CG Collection",
+            brief="brief",
+            visibility=0,
+        )
+        self.collection.save()
+        self.client = Client()
+
+    def test_repeat_returns_304(self):
+        first = self.client.get(self.collection.url)
+        assert first.status_code == 200
+        resp = self.client.get(
+            self.collection.url, HTTP_IF_MODIFIED_SINCE=first["Last-Modified"]
+        )
+        assert resp.status_code == 304
+
+    def test_ap_request_skips_conditional_path(self):
+        # AP requests should always run the canonical envelope code, never 304.
+        first = self.client.get(
+            self.collection.url, HTTP_ACCEPT="application/activity+json"
+        )
+        # AP path doesn't set Last-Modified.
+        assert "Last-Modified" not in first
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPostConditionalGet:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="post_cg@test.com", username="post_cg")
+        # Use a Review (which post_when_save=True) to materialize a takahē Post.
+        self.book = Edition.objects.create(title="Post CG Book")
+        self.review = Review.update_item_review(
+            self.book,
+            self.user.identity,
+            "Post Title",
+            "post body",
+            visibility=0,
+        )
+        self.post = self.review.latest_post
+        self.client = Client()
+
+    def test_repeat_returns_304(self):
+        assert self.post is not None
+        handle = self.user.identity.full_handle
+        url = f"/@{handle}/posts/{self.post.pk}/"
+        first = self.client.get(url)
+        assert first.status_code == 200
+        resp = self.client.get(url, HTTP_IF_MODIFIED_SINCE=first["Last-Modified"])
+        assert resp.status_code == 304
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionMemberEditBumpsEditedTime:
+    """Member edits — append, remove, reorder, metadata, view-level note —
+    must bump ``Collection.edited_time`` so that:
+      * conditional-GET mtime reflects the change
+      * the federated re-post path (post_when_save) re-fires
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="bump@test.com", username="bump")
+        self.book1 = Edition.objects.create(title="Bump Book 1")
+        self.book2 = Edition.objects.create(title="Bump Book 2")
+        self.collection = Collection(
+            owner=self.user.identity, title="Bump", brief="brief", visibility=0
+        )
+        self.collection.save()
+
+    def _refetch_edited_time(self):
+        return Collection.objects.values_list("edited_time", flat=True).get(
+            pk=self.collection.pk
+        )
+
+    def test_append_bumps_edited_time(self):
+        before = self._refetch_edited_time()
+        self.collection.append_item(self.book1)
+        assert self._refetch_edited_time() > before
+
+    def test_remove_bumps_edited_time(self):
+        self.collection.append_item(self.book1)
+        before = self._refetch_edited_time()
+        self.collection.remove_item(self.book1)
+        assert self._refetch_edited_time() > before
+
+    def test_reorder_bumps_edited_time(self):
+        m1, _ = self.collection.append_item(self.book1)
+        m2, _ = self.collection.append_item(self.book2)
+        before = self._refetch_edited_time()
+        self.collection.update_member_order([m2.pk, m1.pk])
+        assert self._refetch_edited_time() > before
+
+    def test_update_item_metadata_bumps_edited_time(self):
+        self.collection.append_item(self.book1)
+        before = self._refetch_edited_time()
+        self.collection.update_item_metadata(self.book1, {"note": "new note"})
+        assert self._refetch_edited_time() > before
+
+    def test_view_update_item_note_bumps_edited_time(self):
+        self.collection.append_item(self.book1, note="old")
+        before = self._refetch_edited_time()
+        client = Client()
+        client.force_login(self.user)
+        resp = client.post(
+            f"/collection/{self.collection.uuid}/update_item_note/{self.book1.uuid}",
+            data={"note": "fresh note"},
+        )
+        assert resp.status_code == 200
+        assert self._refetch_edited_time() > before
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestConditionalGetGating:
+    """Privacy / handle / dynamic-collection gates must short-circuit the
+    304 path so a cached anonymous 200 doesn't outlive a privacy flip or
+    cover a bogus URL."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="gate@test.com", username="gate")
+        self.client = Client()
+
+    def test_article_anonymous_viewable_flip_invalidates_304(self):
+        article = Article.update_local_article(
+            owner=self.user.identity,
+            title="Flip",
+            body="body",
+            visibility=0,
+        )
+        first = self.client.get(article.url)
+        assert first.status_code == 200
+        last_mod = first["Last-Modified"]
+        # Owner-level privacy toggle — doesn't bump article.edited_time.
+        self.user.identity.anonymous_viewable = False
+        self.user.identity.save()
+        resp = self.client.get(article.url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        # Must NOT 304; the view body should run and return 403.
+        assert resp.status_code != 304
+
+    def test_review_anonymous_viewable_flip_invalidates_304(self):
+        book = Edition.objects.create(title="Gate Book")
+        review = Review.update_item_review(
+            book, self.user.identity, "Title", "body", visibility=0
+        )
+        first = self.client.get(review.url)
+        assert first.status_code == 200
+        last_mod = first["Last-Modified"]
+        self.user.identity.anonymous_viewable = False
+        self.user.identity.save()
+        resp = self.client.get(review.url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        assert resp.status_code != 304
+
+    def test_collection_anonymous_viewable_flip_invalidates_304(self):
+        col = Collection(
+            owner=self.user.identity, title="Flip Col", brief="x", visibility=0
+        )
+        col.save()
+        first = self.client.get(col.url)
+        assert first.status_code == 200
+        last_mod = first["Last-Modified"]
+        self.user.identity.anonymous_viewable = False
+        self.user.identity.save()
+        resp = self.client.get(col.url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        assert resp.status_code != 304
+
+    def test_post_wrong_handle_does_not_304(self):
+        book = Edition.objects.create(title="Post Gate Book")
+        review = Review.update_item_review(
+            book, self.user.identity, "Title", "body", visibility=0
+        )
+        post = review.latest_post
+        assert post is not None
+        good_url = f"/@gate/posts/{post.pk}/"
+        first = self.client.get(good_url)
+        assert first.status_code == 200
+        last_mod = first["Last-Modified"]
+        # Wrong handle for the same post pk: must 404, never 304.
+        bad_url = f"/@nobody/posts/{post.pk}/"
+        resp = self.client.get(bad_url, HTTP_IF_MODIFIED_SINCE=last_mod)
+        assert resp.status_code != 304
+
+    def test_dynamic_collection_does_not_304(self):
+        col = Collection(
+            owner=self.user.identity,
+            title="Dyn",
+            brief="x",
+            visibility=0,
+            query="type:book",
+        )
+        col.save()
+        first = self.client.get(col.url)
+        assert first.status_code == 200
+        # Dynamic collections must not emit Last-Modified — their member
+        # set drifts independently of ``edited_time``.
+        assert "Last-Modified" not in first
+
+    def test_304_response_carries_cache_control_and_vary(self):
+        article = Article.update_local_article(
+            owner=self.user.identity,
+            title="Hdr",
+            body="b",
+            visibility=0,
+        )
+        first = self.client.get(article.url)
+        resp = self.client.get(
+            article.url, HTTP_IF_MODIFIED_SINCE=first["Last-Modified"]
+        )
+        assert resp.status_code == 304
+        cc = resp.get("Cache-Control", "")
+        assert "must-revalidate" in cc and "private" in cc
+        vary = resp.get("Vary", "").lower()
+        assert "cookie" in vary and "accept" in vary
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestAlternateLinkInHead:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="alt_link@test.com", username="alt_link")
+        self.client = Client()
+
+    def test_article_has_ap_alternate_link(self):
+        article = Article.update_local_article(
+            owner=self.user.identity,
+            title="Alt Article",
+            body="body",
+            visibility=0,
+        )
+        resp = self.client.get(article.url)
+        post = article.latest_post
+        assert post is not None
+        ap = post.absolute_object_uri()
+        body = resp.content.decode()
+        assert 'rel="alternate"' in body
+        assert 'type="application/activity+json"' in body
+        assert ap in body

--- a/tests/journal/test_conditional_get.py
+++ b/tests/journal/test_conditional_get.py
@@ -277,6 +277,43 @@ class TestConditionalGetGating:
         resp = self.client.get(bad_url, HTTP_IF_MODIFIED_SINCE=last_mod)
         assert resp.status_code != 304
 
+    def test_article_ap_accept_skips_conditional_path(self):
+        # AP requests on the article URL should redirect to the canonical
+        # Post object_uri, not 304-bypass via the article's mtime.
+        article = Article.update_local_article(
+            owner=self.user.identity,
+            title="Alt",
+            body="b",
+            visibility=0,
+        )
+        first = self.client.get(article.url)
+        assert first.status_code == 200
+        last_mod = first["Last-Modified"]
+        resp = self.client.get(
+            article.url,
+            HTTP_ACCEPT="application/activity+json",
+            HTTP_IF_MODIFIED_SINCE=last_mod,
+        )
+        # Must NOT be 304; the AP-Accept path runs the view and redirects.
+        assert resp.status_code != 304
+
+    def test_post_view_rejects_json_accept(self):
+        # Regression for the ``HTTP_ACCEPT`` vs ``Accept`` header-name bug —
+        # ``request.headers`` keys are normalized; ``HTTP_ACCEPT`` always
+        # returned None and silently let JSON requests through.
+        book = Edition.objects.create(title="Hdr Book")
+        review = Review.update_item_review(
+            book, self.user.identity, "T", "b", visibility=0
+        )
+        post = review.latest_post
+        assert post is not None
+        resp = self.client.get(
+            f"/@gate/posts/{post.pk}/",
+            HTTP_ACCEPT="application/activity+json",
+        )
+        # The view's JSON-Accept guard should fire (400 BadRequest).
+        assert resp.status_code == 400
+
     def test_dynamic_collection_does_not_304(self):
         col = Collection(
             owner=self.user.identity,

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -1363,5 +1363,9 @@ class TestCollectionMemberParent:
             and "journal_piece" in q["sql"]
             and '"journal_collection"."piece_ptr_id" =' in q["sql"]
         ]
-        # One top-level collection fetch is expected; members should not add more.
-        assert len(parent_queries) <= 1
+        # Two top-level collection fetches are expected for anonymous
+        # requests: the conditional-GET ``Last-Modified`` callback probes
+        # the collection (and its visibility), and the view body fetches
+        # it again. Members must not add per-member parent dereferences
+        # on top of that — that's what this test guards.
+        assert len(parent_queries) <= 2


### PR DESCRIPTION
## Summary

- Anonymous re-fetches of the four piece-detail views (`post_view`, `article_retrieve`, `review_retrieve`, `collection_retrieve`) now use HTTP conditional-GET (`Last-Modified` / 304) so crawler/browser re-crawls short-circuit before the heavy view body runs. Sentry EGGPLANT-1BX / 1BZ were `SystemExit: 1` from gunicorn worker-timeout aborts on `post_view`; this cuts off the most common load source (AhrefsBot, etc.).
- Authenticated viewers always bypass — response varies on viewer identity, which a single `Last-Modified` can't represent.
- The per-view callback runs the full visibility/handle gate before emitting a timestamp: owner-level toggles (`anonymous_viewable`, `restricted`) don't bump piece `edited_time`, so without this gate a privacy flip could leave anonymous clients with a 304-validated cached 200. Dynamic collections and AP-Accept requests skip the conditional path.
- Callback stashes the fetched object on the request so the view body reuses it — non-304 query count stays flat (verified by existing `test_no_per_member_collection_polymorphic_queries`).
- Bumps `Collection.edited_time` on member note/metadata edits via `list_add` signal, so the conditional-GET mtime reflects them and `sync_to_timeline` re-fires.
- Adds `<link rel=\"alternate\" type=\"application/activity+json\">` to article/review/collection HTML head (WordPress-style AP discovery).

## Test plan

- [x] `tests/journal/test_conditional_get.py` — 20 new tests covering: 304 on re-fetch, stale `If-Modified-Since`, auth bypass, AP-Accept bypass, dynamic-collection bypass, owner privacy flip invalidates 304, wrong-handle does not 304, 304 carries `Cache-Control`/`Vary`, collection member edits (append/remove/reorder/metadata/note view) bump `edited_time`, `<link rel=\"alternate\">` present.
- [x] Full `tests/journal` suite: 484 passed.
- [x] `pre-commit run -a` clean.