### PR TITLE
feat(importer): RateYourMusic CSV import with interactive matching

### DIFF
--- a/catalog/sites/musicbrainz.py
+++ b/catalog/sites/musicbrainz.py
@@ -227,85 +227,6 @@ class MusicBrainzReleaseGroup(AbstractSite):
             return "0" + upc
         return upc
 
-    # @classmethod
-    # async def search_task(
-    #     cls, q: str, page: int, category: str, page_size: int
-    # ) -> list[ExternalSearchResultItem]:
-    #     """Search MusicBrainz for release-groups"""
-    #     if category not in ["music", "all"]:
-    #         return []
-
-    #     results = []
-    #     api_url = "https://musicbrainz.org/ws/2/release-group"
-    #     params = {
-    #         "query": q,
-    #         "fmt": "json",
-    #         "limit": page_size,
-    #         "offset": page * page_size,
-    #     }
-
-    #     headers = {
-    #         "User-Agent": getattr(settings, "NEODB_USER_AGENT", "NeoDBApp/1.0"),
-    #         "Accept": "application/json",
-    #     }
-
-    #     async with httpx.AsyncClient() as client:
-    #         try:
-    #             response = await client.get(
-    #                 api_url, params=params, headers=headers, timeout=10
-    #             )
-    #             response.raise_for_status()
-    #             data = response.json()
-
-    #             if "release-groups" in data:
-    #                 for rg in data["release-groups"]:
-    #                     title = rg.get("title", "")
-    #                     rg_id = rg.get("id", "")
-
-    #                     if not title or not rg_id:
-    #                         continue
-
-    #                     # Build subtitle with artist and date
-    #                     subtitle_parts = []
-    #                     if "artist-credit" in rg:
-    #                         artist_names = []
-    #                         for credit in rg["artist-credit"]:
-    #                             if isinstance(credit, dict) and "artist" in credit:
-    #                                 artist_names.append(credit["artist"]["name"])
-    #                             elif isinstance(credit, str):
-    #                                 artist_names.append(credit)
-    #                         if artist_names:
-    #                             subtitle_parts.append(" / ".join(artist_names))
-
-    #                     if "first-release-date" in rg and rg["first-release-date"]:
-    #                         subtitle_parts.append(
-    #                             rg["first-release-date"][:4]
-    #                         )  # Just year
-
-    #                     subtitle = " · ".join(subtitle_parts)
-    #                     url = cls.id_to_url(rg_id)
-
-    #                     results.append(
-    #                         ExternalSearchResultItem(
-    #                             ItemCategory.Music,
-    #                             SiteName.MusicBrainz,
-    #                             url,
-    #                             title,
-    #                             subtitle,
-    #                             "",
-    #                             "",  # No cover in search results
-    #                         )
-    #                     )
-
-    #         except httpx.TimeoutException:
-    #             logger.warning("MusicBrainz search timeout", extra={"query": q})
-    #         except Exception as e:
-    #             logger.error(
-    #                 "MusicBrainz search error", extra={"query": q, "exception": e}
-    #             )
-
-    #     return results
-
 
 @SiteManager.register
 class MusicBrainzRelease(AbstractSite):
@@ -575,4 +496,90 @@ class MusicBrainzRelease(AbstractSite):
                     extra={"query": q, "exception": e},
                 )
 
+        return results
+
+    @staticmethod
+    def _escape_lucene(s: str) -> str:
+        """Escape Lucene query-syntax special characters."""
+        for ch in r'\+-&|!(){}[]^"~*?:/':
+            s = s.replace(ch, "\\" + ch)
+        return s
+
+    @classmethod
+    def build_field_query(cls, album: str, artist: str, year: str | None = None) -> str:
+        """Build a Lucene field-scoped query for MusicBrainz release search."""
+        parts = []
+        if album:
+            parts.append(f'release:"{cls._escape_lucene(album)}"')
+        if artist:
+            parts.append(f'artist:"{cls._escape_lucene(artist)}"')
+        if year and str(year).isdigit():
+            parts.append(f"date:{year}")
+        return " AND ".join(parts)
+
+    @classmethod
+    async def search_by_fields(
+        cls,
+        album: str,
+        artist: str,
+        year: str | None = None,
+        limit: int = 5,
+    ) -> list[ExternalSearchResultItem]:
+        """Search MusicBrainz releases by separate (album, artist, year) fields."""
+        q = cls.build_field_query(album, artist, year)
+        if not q:
+            return []
+        results: list[ExternalSearchResultItem] = []
+        params = {"query": q, "fmt": "json", "limit": limit}
+        headers = {
+            "User-Agent": getattr(settings, "NEODB_USER_AGENT", "NeoDBApp/1.0"),
+            "Accept": "application/json",
+        }
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    "https://musicbrainz.org/ws/2/release",
+                    params=params,
+                    headers=headers,
+                    timeout=10,
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.TimeoutException:
+                logger.warning("MusicBrainz field search timeout", extra={"query": q})
+                return results
+            except Exception as e:
+                logger.error(
+                    "MusicBrainz field search error",
+                    extra={"query": q, "exception": e},
+                )
+                return results
+            for release in data.get("releases", []) or []:
+                title = release.get("title", "")
+                rid = release.get("id", "")
+                if not title or not rid:
+                    continue
+                subtitle_parts = []
+                names = []
+                for credit in release.get("artist-credit", []) or []:
+                    if isinstance(credit, dict) and "artist" in credit:
+                        names.append(credit["artist"].get("name", ""))
+                    elif isinstance(credit, str):
+                        names.append(credit)
+                names = [n for n in names if n]
+                if names:
+                    subtitle_parts.append(" / ".join(names))
+                if release.get("date"):
+                    subtitle_parts.append(release["date"][:4])
+                results.append(
+                    ExternalSearchResultItem(
+                        ItemCategory.Music,
+                        SiteName.MusicBrainz,
+                        cls.id_to_url(rid),
+                        title,
+                        " · ".join(subtitle_parts),
+                        "",
+                        "",
+                    )
+                )
         return results

--- a/catalog/sites/spotify.py
+++ b/catalog/sites/spotify.py
@@ -180,6 +180,78 @@ class Spotify(AbstractSite):
                 logger.error("Spotify search error", extra={"query": q, "exception": e})
         return results
 
+    @classmethod
+    def build_field_query(cls, album: str, artist: str, year: str | None = None) -> str:
+        """Build a Spotify field-scoped query string from separate fields.
+
+        Reference: https://developer.spotify.com/documentation/web-api/reference/search
+        """
+        parts = []
+        if album:
+            parts.append(f'album:"{album}"')
+        if artist:
+            parts.append(f'artist:"{artist}"')
+        if year and str(year).isdigit():
+            parts.append(f"year:{year}")
+        return " ".join(parts)
+
+    @classmethod
+    async def search_by_fields(
+        cls,
+        album: str,
+        artist: str,
+        year: str | None = None,
+        limit: int = 5,
+    ) -> list[ExternalSearchResultItem]:
+        """Search Spotify albums by separate (album, artist, year) fields.
+
+        Unlike :meth:`search_task` which interpolates ``q`` straight into the
+        URL, this method passes the query via httpx params so spaces and quotes
+        in the field-scoped syntax are URL-encoded correctly.
+        """
+        if not SiteConfig.system.spotify_api_key:
+            return []
+        q = cls.build_field_query(album, artist, year)
+        if not q:
+            return []
+        results: list[ExternalSearchResultItem] = []
+        params = {"q": q, "type": "album", "limit": limit}
+        async with httpx.AsyncClient() as client:
+            try:
+                headers = {"Authorization": f"Bearer {get_spotify_token()}"}
+                response = await client.get(
+                    "https://api.spotify.com/v1/search",
+                    params=params,
+                    headers=headers,
+                    timeout=5,
+                )
+                j = response.json()
+                for a in (j.get("albums") or {}).get("items", []):
+                    title = a["name"]
+                    subtitle = a.get("release_date", "")
+                    for ar in a.get("artists", []):
+                        subtitle += " " + ar.get("name", "")
+                    url = a["external_urls"]["spotify"]
+                    cover = a["images"][0]["url"] if a.get("images") else ""
+                    results.append(
+                        ExternalSearchResultItem(
+                            ItemCategory.Music,
+                            SiteName.Spotify,
+                            url,
+                            title,
+                            subtitle,
+                            "",
+                            cover,
+                        )
+                    )
+            except httpx.ReadTimeout:
+                logger.warning("Spotify field search timeout", extra={"query": q})
+            except Exception as e:
+                logger.error(
+                    "Spotify field search error", extra={"query": q, "exception": e}
+                )
+        return results
+
 
 @SiteManager.register
 class Spotify_Artist(AbstractSite):

--- a/journal/importers/__init__.py
+++ b/journal/importers/__init__.py
@@ -4,6 +4,7 @@ from .goodreads import GoodreadsImporter
 from .letterboxd import LetterboxdImporter
 from .ndjson import NdjsonImporter
 from .opml import OPMLImporter
+from .rym import RymImporter
 from .steam import SteamImporter
 from .storygraph import StoryGraphImporter
 from .trakt import TraktImporter
@@ -15,6 +16,7 @@ __all__ = [
     "OPMLImporter",
     "DoubanImporter",
     "GoodreadsImporter",
+    "RymImporter",
     "SteamImporter",
     "StoryGraphImporter",
     "TraktImporter",

--- a/journal/importers/rym.py
+++ b/journal/importers/rym.py
@@ -1,0 +1,464 @@
+import asyncio
+import csv
+import datetime
+import os
+import re
+import tempfile
+import time
+
+from django.conf import settings
+from django.utils import timezone
+from django.utils.timezone import make_aware
+from django.utils.translation import gettext as _
+from loguru import logger
+
+from catalog.common import SiteManager
+from catalog.models import Album, Item
+from catalog.search.index import CatalogIndex, CatalogQueryParser
+from catalog.sites.musicbrainz import MusicBrainzRelease
+from catalog.sites.spotify import Spotify
+from common.models import SiteConfig
+from journal.models import Mark, Review, ShelfType
+from users.models import Task
+
+RYM_HEADER_PREFIX = "RYM Album,"
+OWNERSHIP_TO_SHELF = {
+    "o": ShelfType.COMPLETE,
+    "w": ShelfType.WISHLIST,
+}
+MATCHED_EXTRA_COLUMNS = ["link", "match_source", "shelf", "collect_date", "notes"]
+
+_BBCODE_PATTERNS = [
+    (re.compile(r"\[b\](.*?)\[/b\]", re.DOTALL | re.IGNORECASE), r"**\1**"),
+    (re.compile(r"\[i\](.*?)\[/i\]", re.DOTALL | re.IGNORECASE), r"*\1*"),
+    (re.compile(r"\[s\](.*?)\[/s\]", re.DOTALL | re.IGNORECASE), r"~~\1~~"),
+    (re.compile(r"\[u\](.*?)\[/u\]", re.DOTALL | re.IGNORECASE), r"\1"),
+    (
+        re.compile(r"\[url=([^\]]+)\](.*?)\[/url\]", re.DOTALL | re.IGNORECASE),
+        r"[\2](\1)",
+    ),
+    (re.compile(r"\[url\](.*?)\[/url\]", re.DOTALL | re.IGNORECASE), r"\1"),
+    (re.compile(r"\[/?(?:Artist|Album|Release)\d+\]", re.IGNORECASE), r""),
+]
+
+
+def _bbcode_to_md(text: str) -> str:
+    """Convert the subset of BBCode that RateYourMusic emits to Markdown."""
+    if not text:
+        return ""
+    out = text
+    for pat, repl in _BBCODE_PATTERNS:
+        out = pat.sub(repl, out)
+    return out.strip()
+
+
+def _row_artist(row: dict) -> str:
+    """Concatenate First/Last (preferring localized variants when present)."""
+    first_loc = (row.get("First Name localized") or "").strip()
+    last_loc = (row.get("Last Name localized") or "").strip()
+    if first_loc or last_loc:
+        return f"{first_loc} {last_loc}".strip()
+    return f"{(row.get('First Name') or '').strip()} {(row.get('Last Name') or '').strip()}".strip()
+
+
+def _run_async(coro):
+    """Run an async coroutine from sync code, isolated from any running loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _parse_collect_date(raw: str | None) -> datetime.datetime | None:
+    if not raw:
+        return None
+    raw = raw.strip()
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%m/%d/%Y", "%d/%m/%Y"):
+        try:
+            return make_aware(datetime.datetime.strptime(raw, fmt).replace(hour=22))
+        except ValueError:
+            continue
+    return None
+
+
+def _default_collect_date(purchase_date_raw: str | None) -> datetime.datetime:
+    dt = _parse_collect_date(purchase_date_raw)
+    if dt:
+        return dt
+    return timezone.now() - datetime.timedelta(days=7)
+
+
+def _site_url_prefix() -> str:
+    return settings.SITE_INFO["site_url"].rstrip("/")
+
+
+class RymImporter(Task):
+    class Meta:
+        app_label = "journal"
+
+    TaskQueue = "import"
+    DefaultMetadata = {
+        "phase": "matching",
+        "visibility": 0,
+        "file": None,
+        "matched_file": None,
+        "filename_hint": None,
+        "total": 0,
+        "processed": 0,
+        "matched_local": 0,
+        "matched_external": 0,
+        "unmatched": 0,
+        "imported": 0,
+        "skipped": 0,
+        "failed": 0,
+        "failed_urls": [],
+        "had_link_column": False,
+    }
+
+    @classmethod
+    def validate_file(cls, uploaded_file) -> bool:
+        try:
+            first_line = uploaded_file.read(200).decode("utf-8", errors="ignore")
+            uploaded_file.seek(0)
+            return first_line.lstrip("﻿").startswith(RYM_HEADER_PREFIX)
+        except Exception:
+            return False
+
+    def progress(self, **delta) -> None:
+        for k, v in delta.items():
+            self.metadata[k] = self.metadata.get(k, 0) + v
+        phase = self.metadata.get("phase", "")
+        total = self.metadata.get("total", 0)
+        done = self.metadata.get("processed", 0)
+        if phase == "matching":
+            self.message = _(
+                "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+            ).format(
+                done=done,
+                total=total,
+                local=self.metadata.get("matched_local", 0),
+                ext=self.metadata.get("matched_external", 0),
+                none=self.metadata.get("unmatched", 0),
+            )
+        else:
+            self.message = _(
+                "Importing: {imported} imported, {skipped} skipped, {failed} failed"
+            ).format(
+                imported=self.metadata.get("imported", 0),
+                skipped=self.metadata.get("skipped", 0),
+                failed=self.metadata.get("failed", 0),
+            )
+        self.save(update_fields=["metadata", "message"])
+
+    def run(self) -> None:
+        phase = self.metadata.get("phase", "matching")
+        if phase == "matching":
+            self._run_matching()
+        elif phase == "importing":
+            self._run_import()
+        else:
+            logger.warning(f"RymImporter run() called in unexpected phase: {phase}")
+
+    # ---- Phase 1: matching ----
+
+    def _run_matching(self) -> None:
+        in_path = self.metadata["file"]
+        out_path = self._derive_matched_path(in_path)
+        with open(in_path, encoding="utf-8-sig", newline="") as fin:
+            reader = csv.DictReader(fin)
+            raw_fieldnames = list(reader.fieldnames or [])
+            fieldnames = [h.strip() for h in raw_fieldnames]
+            extra = [c for c in MATCHED_EXTRA_COLUMNS if c not in fieldnames]
+            rows = []
+            for raw_row in reader:
+                # normalize header whitespace (RYM exports have inconsistent spaces)
+                rows.append({k.strip(): v for k, v in raw_row.items()})
+        self.metadata["total"] = len(rows)
+        self.metadata["matched_file"] = out_path
+        self.save(update_fields=["metadata"])
+
+        with open(out_path, "w", encoding="utf-8", newline="") as fout:
+            writer = csv.DictWriter(fout, fieldnames=fieldnames + extra)
+            writer.writeheader()
+            for row in rows:
+                self._match_row(row)
+                writer.writerow(row)
+                self.progress(processed=1)
+
+        self.metadata["phase"] = "preview"
+        self.message = _(
+            "Matching complete: {local} local, {ext} external, {none} unmatched"
+        ).format(
+            local=self.metadata.get("matched_local", 0),
+            ext=self.metadata.get("matched_external", 0),
+            none=self.metadata.get("unmatched", 0),
+        )
+        self.save(update_fields=["metadata", "message"])
+
+    def _match_row(self, row: dict) -> None:
+        title = (row.get("Title") or "").strip()
+        artist = _row_artist(row)
+        year = (row.get("Release_Date") or "").strip() or None
+
+        # default shelf from RYM Ownership
+        ownership = (row.get("Ownership") or "").strip().lower()
+        shelf = OWNERSHIP_TO_SHELF.get(ownership)
+        if shelf is None:
+            if (int_or_zero(row.get("Rating")) > 0) or (
+                row.get("Review") or ""
+            ).strip():
+                shelf = ShelfType.COMPLETE
+        row.setdefault("shelf", shelf.value if shelf else "")
+
+        # default collect date
+        if not row.get("collect_date"):
+            cd = _default_collect_date(row.get("Purchase Date"))
+            row["collect_date"] = cd.strftime("%Y-%m-%d")
+
+        # already populated link (round-trip)
+        if (row.get("link") or "").strip():
+            row.setdefault("match_source", "preset")
+            return
+
+        item = self._local_match(title, artist, year)
+        if item:
+            row["link"] = item.url
+            row["match_source"] = "local"
+            self.progress(matched_local=1)
+            return
+
+        ext_url = self._external_match(title, artist, year)
+        if ext_url:
+            row["link"] = ext_url[0]
+            row["match_source"] = ext_url[1]
+            self.progress(matched_external=1)
+            return
+
+        row["link"] = ""
+        row["match_source"] = "none"
+        self.progress(unmatched=1)
+
+    def _local_match(self, title: str, artist: str, year: str | None) -> Item | None:
+        if not title:
+            return None
+        q = f'"{_escape_quotes(title)}"'
+        if artist:
+            q += f' people:"{_escape_quotes(artist)}"'
+        if year:
+            q += f" year:{year}"
+        q += " category:music"
+        try:
+            parser = CatalogQueryParser(q, page=1, page_size=5)
+            hits = list(CatalogIndex.instance().search(parser).items)
+        except Exception as e:
+            logger.warning(f"RYM local index search failed: {e}")
+            hits = []
+        title_lc = title.lower()
+        artist_lc = artist.lower()
+        for it in hits:
+            if not isinstance(it, Album):
+                continue
+            titles = [(t.get("text") or "").lower() for t in it.localized_title or []]
+            titles.append((it.title or "").lower())
+            title_ok = any(
+                title_lc == t or title_lc in t or t in title_lc for t in titles if t
+            )
+            artist_ok = (not artist) or any(
+                artist_lc in (a or "").lower() or (a or "").lower() in artist_lc
+                for a in (it.artist or [])
+            )
+            if title_ok and artist_ok:
+                return it
+        return None
+
+    def _external_match(
+        self, title: str, artist: str, year: str | None
+    ) -> tuple[str, str] | None:
+        if not title:
+            return None
+        # MusicBrainz guideline: max 1 request/sec per IP
+        time.sleep(1.05)
+        try:
+            mb = _run_async(MusicBrainzRelease.search_by_fields(title, artist, year))
+        except Exception as e:
+            logger.warning(f"RYM MusicBrainz search failed: {e}")
+            mb = []
+        if mb:
+            return mb[0].source_url, "musicbrainz"
+        if SiteConfig.system.spotify_api_key:
+            try:
+                sp = _run_async(Spotify.search_by_fields(title, artist, year))
+            except Exception as e:
+                logger.warning(f"RYM Spotify search failed: {e}")
+                sp = []
+            if sp:
+                return sp[0].source_url, "spotify"
+        return None
+
+    # ---- Phase 2: import ----
+
+    def _run_import(self) -> None:
+        path = self.metadata.get("matched_file")
+        if not path or not os.path.exists(path):
+            self.message = _("Matched file missing; cannot import.")
+            self.save(update_fields=["message"])
+            return
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            reader = csv.DictReader(f)
+            rows = [{k.strip(): v for k, v in r.items()} for r in reader]
+        self.metadata["total"] = len(rows)
+        self.metadata["processed"] = 0
+        self.save(update_fields=["metadata"])
+        visibility = int(self.metadata.get("visibility", 0))
+        owner = self.user.identity
+        for row in rows:
+            try:
+                self._import_row(row, owner, visibility)
+            except Exception as e:
+                logger.exception(f"RYM row import failed: {e}")
+                self.progress(processed=1, failed=1)
+                url = (row.get("link") or "").strip()
+                if url:
+                    self.metadata["failed_urls"].append(url)
+                    self.save(update_fields=["metadata"])
+
+        self.metadata["phase"] = "done"
+        self.message = _(
+            "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+        ).format(
+            imported=self.metadata.get("imported", 0),
+            skipped=self.metadata.get("skipped", 0),
+            failed=self.metadata.get("failed", 0),
+        )
+        self.save(update_fields=["metadata", "message"])
+
+    def _import_row(self, row: dict, owner, visibility: int) -> None:
+        link = (row.get("link") or "").strip()
+        shelf_raw = (row.get("shelf") or "").strip()
+        rating_raw = int_or_zero(row.get("Rating"))
+        review_raw = (row.get("Review") or "").strip()
+        title = (row.get("Title") or "").strip()
+
+        if not link:
+            # nothing to do — user didn't pick a match
+            self.progress(processed=1, skipped=1)
+            return
+        if not shelf_raw:
+            # rating/review but explicit "skip" from user
+            self.progress(processed=1, skipped=1)
+            return
+        try:
+            shelf_type = ShelfType(shelf_raw)
+        except ValueError:
+            self.progress(processed=1, skipped=1)
+            return
+
+        item = self._resolve_link(link)
+        if not item:
+            self.progress(processed=1, failed=1)
+            self.metadata["failed_urls"].append(link)
+            self.save(update_fields=["metadata"])
+            return
+
+        review_md = _bbcode_to_md(review_raw)
+        comment: str | None = None
+        long_review: str | None = None
+        if review_md:
+            if "\n" not in review_md and len(review_md) < 360:
+                comment = review_md
+            else:
+                long_review = review_md
+
+        rating = rating_raw if rating_raw > 0 else None
+        collect_dt = _parse_collect_date(row.get("collect_date")) or (
+            timezone.now() - datetime.timedelta(days=7)
+        )
+
+        mark = Mark(owner, item)
+        mark.update(
+            shelf_type,
+            comment,
+            rating,
+            visibility=visibility,
+            created_time=collect_dt,
+        )
+        if long_review:
+            item_title = item.display_title or title
+            Review.update_item_review(
+                item,
+                owner,
+                (row.get("Review Title") or "").strip()
+                or _("a review of {item_title}").format(item_title=item_title),
+                long_review,
+                visibility,
+                collect_dt,
+            )
+        self.progress(processed=1, imported=1)
+
+    def _resolve_link(self, url: str) -> Item | None:
+        site_url = _site_url_prefix() + "/"
+        if url.startswith("/") or url.startswith(site_url):
+            item = Item.get_by_url(url, resolve_merge=True)
+            if item and not item.is_deleted:
+                return item
+            return None
+        site = SiteManager.get_site_by_url(url, detect_redirection=False)
+        if not site:
+            return None
+        item = site.get_item()
+        if item:
+            return item
+        try:
+            site.get_resource_ready()
+        except Exception as e:
+            logger.warning(f"RYM remote fetch failed for {url}: {e}")
+            return None
+        return site.get_item()
+
+    # ---- helpers ----
+
+    @staticmethod
+    def _derive_matched_path(in_path: str) -> str:
+        base = os.path.basename(in_path)
+        stem, _ext = os.path.splitext(base)
+        out_dir = os.path.dirname(in_path)
+        return os.path.join(out_dir, f"{stem}-matched.csv")
+
+
+def _escape_quotes(s: str) -> str:
+    return s.replace('"', '\\"')
+
+
+def int_or_zero(v) -> int:
+    try:
+        return int(v or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def update_row_in_matched_file(path: str, index: int, updates: dict) -> dict | None:
+    """Apply ``updates`` to the ``index``-th data row of ``path`` (atomic rewrite).
+
+    Returns the updated row, or None if the index is out of range.
+    """
+    with open(path, encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    if index < 0 or index >= len(rows):
+        return None
+    rows[index].update({k: v for k, v in updates.items() if k in fieldnames})
+    fd, tmp = tempfile.mkstemp(
+        suffix=".csv", dir=os.path.dirname(path) or None, text=True
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fout:
+            writer = csv.DictWriter(fout, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        os.replace(tmp, path)
+    except Exception:
+        os.unlink(tmp)
+        raise
+    return rows[index]

--- a/journal/importers/rym.py
+++ b/journal/importers/rym.py
@@ -25,6 +25,7 @@ RYM_HEADER_PREFIX = "RYM Album,"
 OWNERSHIP_TO_SHELF = {
     "o": ShelfType.COMPLETE,
     "w": ShelfType.WISHLIST,
+    "u": ShelfType.DROPPED,  # RYM "used to own"
 }
 MATCHED_EXTRA_COLUMNS = ["link", "match_source", "shelf", "collect_date", "notes"]
 
@@ -201,15 +202,12 @@ class RymImporter(Task):
         artist = _row_artist(row)
         year = (row.get("Release_Date") or "").strip() or None
 
-        # default shelf from RYM Ownership
+        # default shelf from RYM Ownership; anything not in OWNERSHIP_TO_SHELF
+        # (e.g. RYM 'n' = never owned) falls back to COMPLETE so no row defaults
+        # to skip — the user can still flip individual rows in the preview UI.
         ownership = (row.get("Ownership") or "").strip().lower()
-        shelf = OWNERSHIP_TO_SHELF.get(ownership)
-        if shelf is None:
-            if (int_or_zero(row.get("Rating")) > 0) or (
-                row.get("Review") or ""
-            ).strip():
-                shelf = ShelfType.COMPLETE
-        row.setdefault("shelf", shelf.value if shelf else "")
+        shelf = OWNERSHIP_TO_SHELF.get(ownership, ShelfType.COMPLETE)
+        row.setdefault("shelf", shelf.value)
 
         # default collect date
         if not row.get("collect_date"):

--- a/journal/importers/rym.py
+++ b/journal/importers/rym.py
@@ -1,6 +1,7 @@
 import asyncio
 import csv
 import datetime
+import fcntl
 import os
 import re
 import tempfile
@@ -62,8 +63,14 @@ def _row_artist(row: dict) -> str:
     return f"{(row.get('First Name') or '').strip()} {(row.get('Last Name') or '').strip()}".strip()
 
 
-def _run_async(coro):
-    """Run an async coroutine from sync code, isolated from any running loop."""
+def _run_async(coro, loop: asyncio.AbstractEventLoop | None = None):
+    """Run an async coroutine synchronously.
+
+    When *loop* is provided it's reused (cheaper for tight match loops);
+    otherwise a one-shot loop is created and closed for the call.
+    """
+    if loop is not None:
+        return loop.run_until_complete(coro)
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(coro)
@@ -126,7 +133,9 @@ class RymImporter(Task):
         except Exception:
             return False
 
-    def progress(self, **delta) -> None:
+    PROGRESS_SAVE_EVERY = 25  # flush task row at most every N processed rows
+
+    def progress(self, *, force: bool = False, **delta) -> None:
         for k, v in delta.items():
             self.metadata[k] = self.metadata.get(k, 0) + v
         phase = self.metadata.get("phase", "")
@@ -150,7 +159,9 @@ class RymImporter(Task):
                 skipped=self.metadata.get("skipped", 0),
                 failed=self.metadata.get("failed", 0),
             )
-        self.save(update_fields=["metadata", "message"])
+        # Avoid hammering the DB with one save per CSV row.
+        if force or done % self.PROGRESS_SAVE_EVERY == 0 or done == total:
+            self.save(update_fields=["metadata", "message"])
 
     def run(self) -> None:
         phase = self.metadata.get("phase", "matching")
@@ -179,13 +190,20 @@ class RymImporter(Task):
         self.metadata["matched_file"] = out_path
         self.save(update_fields=["metadata"])
 
-        with open(out_path, "w", encoding="utf-8", newline="") as fout:
-            writer = csv.DictWriter(fout, fieldnames=fieldnames + extra)
-            writer.writeheader()
-            for row in rows:
-                self._match_row(row)
-                writer.writerow(row)
-                self.progress(processed=1)
+        # One asyncio loop reused for all external lookups in this phase —
+        # avoids the cost of creating/closing a loop per row.
+        self._match_loop = asyncio.new_event_loop()
+        try:
+            with open(out_path, "w", encoding="utf-8", newline="") as fout:
+                writer = csv.DictWriter(fout, fieldnames=fieldnames + extra)
+                writer.writeheader()
+                for row in rows:
+                    self._match_row(row)
+                    writer.writerow(row)
+                    self.progress(processed=1)
+        finally:
+            self._match_loop.close()
+            self._match_loop = None
 
         self.metadata["phase"] = "preview"
         self.message = _(
@@ -275,10 +293,13 @@ class RymImporter(Task):
     ) -> tuple[str, str] | None:
         if not title:
             return None
+        loop = getattr(self, "_match_loop", None)
         # MusicBrainz guideline: max 1 request/sec per IP
         time.sleep(1.05)
         try:
-            mb = _run_async(MusicBrainzRelease.search_by_fields(title, artist, year))
+            mb = _run_async(
+                MusicBrainzRelease.search_by_fields(title, artist, year), loop
+            )
         except Exception as e:
             logger.warning(f"RYM MusicBrainz search failed: {e}")
             mb = []
@@ -286,7 +307,7 @@ class RymImporter(Task):
             return mb[0].source_url, "musicbrainz"
         if SiteConfig.system.spotify_api_key:
             try:
-                sp = _run_async(Spotify.search_by_fields(title, artist, year))
+                sp = _run_async(Spotify.search_by_fields(title, artist, year), loop)
             except Exception as e:
                 logger.warning(f"RYM Spotify search failed: {e}")
                 sp = []
@@ -438,8 +459,19 @@ def int_or_zero(v) -> int:
 def update_row_in_matched_file(path: str, index: int, updates: dict) -> dict | None:
     """Apply ``updates`` to the ``index``-th data row of ``path`` (atomic rewrite).
 
+    Wraps the read-modify-write in an exclusive ``fcntl.flock`` on a sibling
+    ``<path>.lock`` so concurrent HTMX saves from the same user can't clobber
+    each other.
+
     Returns the updated row, or None if the index is out of range.
     """
+    lock_path = path + ".lock"
+    with open(lock_path, "a+") as lock_fp:
+        fcntl.flock(lock_fp.fileno(), fcntl.LOCK_EX)
+        return _update_row_locked(path, index, updates)
+
+
+def _update_row_locked(path: str, index: int, updates: dict) -> dict | None:
     with open(path, encoding="utf-8-sig", newline="") as f:
         reader = csv.DictReader(f)
         fieldnames = list(reader.fieldnames or [])

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-13 21:14-0400\n"
+"POT-Creation-Date: 2026-05-15 21:53-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -515,7 +515,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:147 catalog/models/common.py:164
-#: journal/templates/collection.html:23 journal/templates/collection.html:29
+#: journal/templates/collection.html:23 journal/templates/collection.html:34
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -606,7 +606,7 @@ msgstr ""
 msgid "year of publication"
 msgstr ""
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:194
+#: catalog/models/game.py:135 catalog/models/podcast.py:200
 msgid "date of publication"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "show time"
 msgstr ""
 
-#: catalog/models/tv.py:220
+#: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
 msgid "Date"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 #: catalog/templates/_item_comments.html:58
 #: catalog/templates/item_mark_list.html:46
 #: journal/templates/action_translate_post.html:3
-#: journal/templates/review.html:49
+#: journal/templates/review.html:54
 msgid "translate"
 msgstr ""
 
@@ -1154,10 +1154,10 @@ msgid "my notes"
 msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:86
-#: catalog/templates/catalog_edit.html:12 journal/templates/article.html:111
-#: journal/templates/collection.html:138
+#: catalog/templates/catalog_edit.html:12 journal/templates/article.html:116
+#: journal/templates/collection.html:143
 #: journal/templates/collection_edit.html:10
-#: journal/templates/collection_edit.html:26 journal/templates/review.html:99
+#: journal/templates/collection_edit.html:26 journal/templates/review.html:104
 #: journal/templates/tag_edit.html:16
 msgid "Edit"
 msgstr ""
@@ -1329,10 +1329,10 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:224
 #: catalog/templates/_sidebar_edit.html:228
-#: catalog/templates/catalog_delete.html:12 journal/templates/article.html:114
-#: journal/templates/collection.html:146 journal/templates/mark.html:157
+#: catalog/templates/catalog_delete.html:12 journal/templates/article.html:119
+#: journal/templates/collection.html:151 journal/templates/mark.html:157
 #: journal/templates/note.html:45 journal/templates/piece_delete.html:10
-#: journal/templates/piece_delete.html:34 journal/templates/review.html:102
+#: journal/templates/piece_delete.html:34 journal/templates/review.html:107
 #: users/templates/users/account.html:258
 msgid "Delete"
 msgstr ""
@@ -1950,31 +1950,31 @@ msgstr ""
 
 #: catalog/views/edit.py:214 catalog/views/edit.py:268
 #: catalog/views/edit.py:386 catalog/views/edit.py:475
-#: catalog/views/edit.py:507 journal/views/article.py:41
-#: journal/views/article.py:116 journal/views/collection.py:218
-#: journal/views/collection.py:278 journal/views/collection.py:297
-#: journal/views/collection.py:321 journal/views/collection.py:394
-#: journal/views/collection.py:430 journal/views/collection.py:468
-#: journal/views/collection.py:480 journal/views/collection.py:505
-#: journal/views/collection.py:508 journal/views/collection.py:545
-#: journal/views/common.py:200 journal/views/mark.py:241
-#: journal/views/post.py:54 journal/views/post.py:75 journal/views/post.py:98
-#: journal/views/post.py:117 journal/views/post.py:179
-#: journal/views/post.py:258 journal/views/post.py:273
-#: journal/views/post.py:427 journal/views/review.py:40
-#: journal/views/review.py:53 journal/views/review.py:78
+#: catalog/views/edit.py:507 journal/views/article.py:42
+#: journal/views/article.py:138 journal/views/collection.py:250
+#: journal/views/collection.py:310 journal/views/collection.py:329
+#: journal/views/collection.py:353 journal/views/collection.py:426
+#: journal/views/collection.py:462 journal/views/collection.py:500
+#: journal/views/collection.py:512 journal/views/collection.py:537
+#: journal/views/collection.py:540 journal/views/collection.py:581
+#: journal/views/common.py:246 journal/views/mark.py:241
+#: journal/views/post.py:55 journal/views/post.py:76 journal/views/post.py:99
+#: journal/views/post.py:119 journal/views/post.py:181
+#: journal/views/post.py:260 journal/views/post.py:275
+#: journal/views/post.py:459 journal/views/review.py:51
+#: journal/views/review.py:64 journal/views/review.py:89
 msgid "Insufficient permission"
 msgstr ""
 
 #: catalog/views/edit.py:271 catalog/views/edit.py:274
-#: journal/views/collection.py:68 journal/views/collection.py:93
-#: journal/views/collection.py:485 journal/views/collection.py:575
-#: journal/views/common.py:129 journal/views/mark.py:167
-#: journal/views/post.py:129 journal/views/post.py:131
-#: journal/views/post.py:175 journal/views/post.py:197
-#: journal/views/post.py:199 journal/views/post.py:217
-#: journal/views/post.py:230 journal/views/review.py:126
-#: journal/views/review.py:129 users/views/actions.py:171
+#: journal/views/collection.py:73 journal/views/collection.py:98
+#: journal/views/collection.py:517 journal/views/collection.py:611
+#: journal/views/common.py:175 journal/views/mark.py:167
+#: journal/views/post.py:131 journal/views/post.py:133
+#: journal/views/post.py:177 journal/views/post.py:199
+#: journal/views/post.py:201 journal/views/post.py:219
+#: journal/views/post.py:232 journal/views/review.py:137
+#: journal/views/review.py:140 users/views/actions.py:171
 msgid "Invalid parameter"
 msgstr ""
 
@@ -3395,7 +3395,7 @@ msgstr ""
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:173
+#: common/templates/_header.html:173 users/templates/users/_rym_row.html:23
 msgid "Open"
 msgstr ""
 
@@ -3664,7 +3664,7 @@ msgid "Access denied"
 msgstr ""
 
 #: common/utils.py:103 common/utils.py:105 journal/views/profile.py:428
-#: journal/views/review.py:169
+#: journal/views/review.py:180
 msgid "Login required"
 msgstr ""
 
@@ -4296,9 +4296,10 @@ msgstr ""
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:188 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:204 users/templates/users/data.html:255
-#: users/templates/users/data.html:317 users/templates/users/data.html:376
+#: users/templates/users/data.html:98 users/templates/users/data.html:180
+#: users/templates/users/data.html:233 users/templates/users/data.html:284
+#: users/templates/users/data.html:346 users/templates/users/data.html:405
+#: users/templates/users/rym_import.html:79
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
 msgstr ""
@@ -4327,11 +4328,11 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:156 journal/templates/collection.html:149
+#: journal/forms.py:156 journal/templates/collection.html:154
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:180 users/templates/users/data.html:531
+#: journal/forms.py:180 users/templates/users/data.html:560
 msgid "Status"
 msgstr ""
 
@@ -4344,7 +4345,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/storygraph.py:203
+#: journal/importers/rym.py:390 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4352,6 +4353,30 @@ msgstr ""
 #: journal/importers/opml.py:45
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
+msgstr ""
+
+#: journal/importers/rym.py:138
+#, python-brace-format
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgstr ""
+
+#: journal/importers/rym.py:148
+#, python-brace-format
+msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
+msgstr ""
+
+#: journal/importers/rym.py:193
+#, python-brace-format
+msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
+msgstr ""
+
+#: journal/importers/rym.py:302
+msgid "Matched file missing; cannot import."
+msgstr ""
+
+#: journal/importers/rym.py:326
+#, python-brace-format
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
 #: journal/models/article.py:139
@@ -4379,10 +4404,11 @@ msgstr ""
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:55
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:213
-#: users/templates/users/data.html:264 users/templates/users/data.html:325
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:189 users/templates/users/data.html:242
+#: users/templates/users/data.html:293 users/templates/users/data.html:354
+#: users/templates/users/data.html:414
 #: users/templates/users/preferences.html:56
+#: users/templates/users/rym_import.html:82
 #: users/templates/users/steam_import.html:128
 msgid "Public"
 msgstr ""
@@ -4391,10 +4417,11 @@ msgstr ""
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:62
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:221 users/templates/users/data.html:272
-#: users/templates/users/data.html:333 users/templates/users/data.html:393
+#: users/templates/users/data.html:115 users/templates/users/data.html:197
+#: users/templates/users/data.html:250 users/templates/users/data.html:301
+#: users/templates/users/data.html:362 users/templates/users/data.html:422
 #: users/templates/users/preferences.html:63
+#: users/templates/users/rym_import.html:86
 #: users/templates/users/steam_import.html:132
 msgid "Followers Only"
 msgstr ""
@@ -4403,10 +4430,11 @@ msgstr ""
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:69
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:229 users/templates/users/data.html:280
-#: users/templates/users/data.html:341 users/templates/users/data.html:401
+#: users/templates/users/data.html:123 users/templates/users/data.html:205
+#: users/templates/users/data.html:258 users/templates/users/data.html:309
+#: users/templates/users/data.html:370 users/templates/users/data.html:430
 #: users/templates/users/preferences.html:70
+#: users/templates/users/rym_import.html:90
 #: users/templates/users/steam_import.html:136
 msgid "Mentioned Only"
 msgstr ""
@@ -4427,7 +4455,7 @@ msgstr ""
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
-#: journal/models/note.py:34
+#: journal/models/note.py:34 users/templates/users/rym_import.html:71
 msgid "Page"
 msgstr ""
 
@@ -4968,7 +4996,7 @@ msgid "Update note"
 msgstr ""
 
 #: journal/templates/_list_item.html:100 journal/templates/review.html:22
-#: journal/templates/review.html:28 journal/templates/review.html:71
+#: journal/templates/review.html:33 journal/templates/review.html:76
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5113,20 +5141,20 @@ msgstr ""
 msgid "Article"
 msgstr ""
 
-#: journal/templates/article.html:63
+#: journal/templates/article.html:68
 msgid "View on origin"
 msgstr ""
 
-#: journal/templates/article.html:77
+#: journal/templates/article.html:82
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:88 journal/templates/review.html:81
+#: journal/templates/article.html:93 journal/templates/review.html:86
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
-#: journal/templates/article.html:106 journal/templates/collection.html:133
-#: journal/templates/review.html:94
+#: journal/templates/article.html:111 journal/templates/collection.html:138
+#: journal/templates/review.html:99
 msgid "Reply"
 msgstr ""
 
@@ -5186,18 +5214,18 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:53
+#: journal/templates/collection.html:58
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:142
+#: journal/templates/collection.html:147
 msgid "Query"
 msgstr ""
 
-#: journal/templates/collection.html:157
+#: journal/templates/collection.html:162
 msgid "Created date"
 msgstr ""
 
@@ -5375,7 +5403,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:153 journal/views/collection.py:364
+#: journal/templates/profile.html:153 journal/views/collection.py:396
 #: journal/views/profile.py:327
 msgid "collection"
 msgstr ""
@@ -5532,46 +5560,46 @@ msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/views/collection.py:50 journal/views/collection.py:87
+#: journal/views/collection.py:55 journal/views/collection.py:92
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:369
+#: journal/views/collection.py:401
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:372
+#: journal/views/collection.py:404
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:432 journal/views/collection.py:470
-#: journal/views/collection.py:482 journal/views/collection.py:510
+#: journal/views/collection.py:464 journal/views/collection.py:502
+#: journal/views/collection.py:514 journal/views/collection.py:542
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:447
+#: journal/views/collection.py:479
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:449
+#: journal/views/collection.py:481
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:495
+#: journal/views/collection.py:527
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:82 journal/views/mark.py:131
+#: journal/views/common.py:128 journal/views/mark.py:131
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
-#: journal/views/common.py:84
+#: journal/views/common.py:130
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr ""
 
-#: journal/views/common.py:91
+#: journal/views/common.py:137
 msgid "List not found."
 msgstr ""
 
@@ -5584,8 +5612,8 @@ msgid "Invalid input"
 msgstr ""
 
 #: journal/views/mark.py:189 journal/views/mark.py:239
-#: journal/views/note.py:100 journal/views/review.py:38
-#: journal/views/review.py:51
+#: journal/views/note.py:100 journal/views/review.py:49
+#: journal/views/review.py:62
 msgid "Content not found"
 msgstr ""
 
@@ -5609,45 +5637,45 @@ msgstr ""
 msgid "Invalid form data"
 msgstr ""
 
-#: journal/views/post.py:115
+#: journal/views/post.py:117
 msgid "Post not found"
 msgstr ""
 
-#: journal/views/post.py:201
+#: journal/views/post.py:203
 msgid "Visibility too high for quoting this post"
 msgstr ""
 
-#: journal/views/post.py:323
+#: journal/views/post.py:325
 msgid "Content cannot be empty."
 msgstr ""
 
-#: journal/views/post.py:419
+#: journal/views/post.py:451
 msgid "Invalid choices"
 msgstr ""
 
-#: journal/views/post.py:422
+#: journal/views/post.py:454
 msgid "Invalid post"
 msgstr ""
 
-#: journal/views/review.py:151
+#: journal/views/review.py:162
 msgid "User not local"
 msgstr ""
 
-#: journal/views/review.py:157 journal/views/review.py:171
+#: journal/views/review.py:168 journal/views/review.py:182
 #, python-brace-format
 msgid "Reviews by {0}"
 msgstr ""
 
-#: journal/views/review.py:159 journal/views/review.py:167
+#: journal/views/review.py:170 journal/views/review.py:178
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/review.py:180
+#: journal/views/review.py:191
 #, python-brace-format
 msgid "{review_title} - a review of {item_title}"
 msgstr ""
 
-#: journal/views/review.py:184
+#: journal/views/review.py:195
 msgid "may contain spoiler or triggering content"
 msgstr ""
 
@@ -5931,7 +5959,11 @@ msgstr ""
 msgid "wrote a note"
 msgstr ""
 
-#: social/templates/_event_post.html:85 social/templates/_event_post.html:87
+#: social/templates/_event_post.html:85
+msgid "wrote a review"
+msgstr ""
+
+#: social/templates/_event_post.html:87
 msgid "wrote an article"
 msgstr ""
 
@@ -6268,6 +6300,18 @@ msgstr ""
 msgid "Settings for current device saved"
 msgstr ""
 
+#: users/templates/users/_rym_row.html:27
+msgid "Create new album"
+msgstr ""
+
+#: users/templates/users/_rym_row.html:28
+msgid "then paste the link above; leave blank to skip this row."
+msgstr ""
+
+#: users/templates/users/_rym_row.html:39
+msgid "(skip)"
+msgstr ""
+
 #: users/templates/users/account.html:11
 msgid "Account Information"
 msgstr ""
@@ -6556,9 +6600,9 @@ msgid "CSV file"
 msgstr ""
 
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:346 users/templates/users/data.html:406
+#: users/templates/users/data.html:126 users/templates/users/data.html:208
+#: users/templates/users/data.html:261 users/templates/users/data.html:312
+#: users/templates/users/data.html:375 users/templates/users/data.html:435
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -6674,7 +6718,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:304
+#: users/templates/users/data.html:34 users/templates/users/data.html:333
 msgid "Import Method"
 msgstr ""
 
@@ -6706,140 +6750,164 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93 users/templates/users/data.html:172
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:133
-msgid "Import from StoryGraph"
+msgid "Import from RateYourMusic"
 msgstr ""
 
 #: users/templates/users/data.html:139
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgid "On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:141
+#: users/templates/users/data.html:141 users/templates/users/data.html:170
 msgid "Upload the downloaded CSV file below."
 msgstr ""
 
+#: users/templates/users/data.html:143
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr ""
+
 #: users/templates/users/data.html:146
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr ""
+
+#: users/templates/users/data.html:150
+msgid "Upload and match"
+msgstr ""
+
+#: users/templates/users/data.html:153
+msgid "Review pending RateYourMusic matches"
+msgstr ""
+
+#: users/templates/users/data.html:162
+msgid "Import from StoryGraph"
+msgstr ""
+
+#: users/templates/users/data.html:168
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr ""
+
+#: users/templates/users/data.html:175
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
 
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:215
 msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:221
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:224
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:227
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:233 users/templates/users/data.html:284
+#: users/templates/users/data.html:262 users/templates/users/data.html:313
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:240
+#: users/templates/users/data.html:269
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:275
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:278
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:251
+#: users/templates/users/data.html:280
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:291
+#: users/templates/users/data.html:320
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:294
+#: users/templates/users/data.html:323
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:300
+#: users/templates/users/data.html:329
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:311
+#: users/templates/users/data.html:340
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:344
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:344
+#: users/templates/users/data.html:373
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:354
+#: users/templates/users/data.html:383
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:360
+#: users/templates/users/data.html:389
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:362
+#: users/templates/users/data.html:391
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:372
+#: users/templates/users/data.html:401
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:433
+#: users/templates/users/data.html:462
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:459
+#: users/templates/users/data.html:488
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:484
+#: users/templates/users/data.html:513
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:508
+#: users/templates/users/data.html:537
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:541
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:519
+#: users/templates/users/data.html:548
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:527
+#: users/templates/users/data.html:556
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:530
+#: users/templates/users/data.html:559
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:535
+#: users/templates/users/data.html:564
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:544
+#: users/templates/users/data.html:573
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7233,6 +7301,51 @@ msgstr ""
 msgid "You may download the list here."
 msgstr ""
 
+#: users/templates/users/rym_import.html:9
+#: users/templates/users/rym_import.html:37
+msgid "Review RateYourMusic Matches"
+msgstr ""
+
+#: users/templates/users/rym_import.html:39
+#, python-format
+msgid ""
+"\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
+"            "
+msgstr ""
+
+#: users/templates/users/rym_import.html:45
+msgid "Download matched CSV"
+msgstr ""
+
+#: users/templates/users/rym_import.html:57
+msgid "Title / Artist"
+msgstr ""
+
+#: users/templates/users/rym_import.html:58
+msgid "Matched Link"
+msgstr ""
+
+#: users/templates/users/rym_import.html:59
+msgid "Shelf"
+msgstr ""
+
+#: users/templates/users/rym_import.html:69
+msgid "Prev"
+msgstr ""
+
+#: users/templates/users/rym_import.html:73
+msgid "Next"
+msgstr ""
+
+#: users/templates/users/rym_import.html:93
+msgid "Confirm Import"
+msgstr ""
+
+#: users/templates/users/rym_import.html:94
+msgid "Back"
+msgstr ""
+
 #: users/templates/users/steam_import.html:10
 msgid "Import from Steam"
 msgstr ""
@@ -7434,99 +7547,120 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:207 users/views/data.py:236
+#: users/views/data.py:224 users/views/data.py:253
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:230
+#: users/views/data.py:247
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:248
+#: users/views/data.py:265
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:263 users/views/data.py:283
+#: users/views/data.py:280 users/views/data.py:300
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:297
+#: users/views/data.py:314
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:311
+#: users/views/data.py:328
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:320 users/views/data.py:344 users/views/data.py:368
-#: users/views/data.py:393 users/views/data.py:417 users/views/data.py:441
+#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:553
+#: users/views/data.py:577 users/views/data.py:602 users/views/data.py:626
+#: users/views/data.py:650
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:561
+#: users/views/data.py:406
+msgid "Loaded from uploaded matched file."
+msgstr ""
+
+#: users/views/data.py:424
+msgid "No RateYourMusic import to preview."
+msgstr ""
+
+#: users/views/data.py:429 users/views/data.py:536
+msgid "Matched file missing."
+msgstr ""
+
+#: users/views/data.py:522
+msgid "Starting import..."
+msgstr ""
+
+#: users/views/data.py:532
+msgid "No matched file available."
+msgstr ""
+
+#: users/views/data.py:770
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:583
+#: users/views/data.py:792
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:599
+#: users/views/data.py:808
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:604
+#: users/views/data.py:813
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:614 users/views/data.py:665
+#: users/views/data.py:823 users/views/data.py:874
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:621
+#: users/views/data.py:830
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:626
+#: users/views/data.py:835
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:652
+#: users/views/data.py:861
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:657
+#: users/views/data.py:866
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:670
+#: users/views/data.py:879
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:681
+#: users/views/data.py:890
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:687
+#: users/views/data.py:896
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:745
+#: users/views/data.py:954
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:761
+#: users/views/data.py:970
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:765
+#: users/views/data.py:974
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:774
+#: users/views/data.py:983
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-13 21:14-0400\n"
+"POT-Creation-Date: 2026-05-15 21:53-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -514,7 +514,7 @@ msgid "Exhibition"
 msgstr "展览"
 
 #: catalog/models/common.py:147 catalog/models/common.py:164
-#: journal/templates/collection.html:23 journal/templates/collection.html:29
+#: journal/templates/collection.html:23 journal/templates/collection.html:34
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -605,7 +605,7 @@ msgstr "开发者"
 msgid "year of publication"
 msgstr "发行年份"
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:194
+#: catalog/models/game.py:135 catalog/models/podcast.py:200
 msgid "date of publication"
 msgstr "发行日期"
 
@@ -987,7 +987,7 @@ msgstr "集数"
 msgid "show time"
 msgstr "上映时间"
 
-#: catalog/models/tv.py:220
+#: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
 msgid "Date"
 msgstr "日期"
 
@@ -1052,7 +1052,7 @@ msgstr "不再提示"
 #: catalog/templates/_item_comments.html:58
 #: catalog/templates/item_mark_list.html:46
 #: journal/templates/action_translate_post.html:3
-#: journal/templates/review.html:49
+#: journal/templates/review.html:54
 msgid "translate"
 msgstr "翻译"
 
@@ -1153,10 +1153,10 @@ msgid "my notes"
 msgstr "我的笔记"
 
 #: catalog/templates/_item_user_pieces.html:86
-#: catalog/templates/catalog_edit.html:12 journal/templates/article.html:111
-#: journal/templates/collection.html:138
+#: catalog/templates/catalog_edit.html:12 journal/templates/article.html:116
+#: journal/templates/collection.html:143
 #: journal/templates/collection_edit.html:10
-#: journal/templates/collection_edit.html:26 journal/templates/review.html:99
+#: journal/templates/collection_edit.html:26 journal/templates/review.html:104
 #: journal/templates/tag_edit.html:16
 msgid "Edit"
 msgstr "编辑"
@@ -1328,10 +1328,10 @@ msgstr "合并到另一条目"
 
 #: catalog/templates/_sidebar_edit.html:224
 #: catalog/templates/_sidebar_edit.html:228
-#: catalog/templates/catalog_delete.html:12 journal/templates/article.html:114
-#: journal/templates/collection.html:146 journal/templates/mark.html:157
+#: catalog/templates/catalog_delete.html:12 journal/templates/article.html:119
+#: journal/templates/collection.html:151 journal/templates/mark.html:157
 #: journal/templates/note.html:45 journal/templates/piece_delete.html:10
-#: journal/templates/piece_delete.html:34 journal/templates/review.html:102
+#: journal/templates/piece_delete.html:34 journal/templates/review.html:107
 #: users/templates/users/account.html:258
 msgid "Delete"
 msgstr "删除"
@@ -1949,31 +1949,31 @@ msgstr "条目不可被删除。"
 
 #: catalog/views/edit.py:214 catalog/views/edit.py:268
 #: catalog/views/edit.py:386 catalog/views/edit.py:475
-#: catalog/views/edit.py:507 journal/views/article.py:41
-#: journal/views/article.py:116 journal/views/collection.py:218
-#: journal/views/collection.py:278 journal/views/collection.py:297
-#: journal/views/collection.py:321 journal/views/collection.py:394
-#: journal/views/collection.py:430 journal/views/collection.py:468
-#: journal/views/collection.py:480 journal/views/collection.py:505
-#: journal/views/collection.py:508 journal/views/collection.py:545
-#: journal/views/common.py:200 journal/views/mark.py:241
-#: journal/views/post.py:54 journal/views/post.py:75 journal/views/post.py:98
-#: journal/views/post.py:117 journal/views/post.py:179
-#: journal/views/post.py:258 journal/views/post.py:273
-#: journal/views/post.py:427 journal/views/review.py:40
-#: journal/views/review.py:53 journal/views/review.py:78
+#: catalog/views/edit.py:507 journal/views/article.py:42
+#: journal/views/article.py:138 journal/views/collection.py:250
+#: journal/views/collection.py:310 journal/views/collection.py:329
+#: journal/views/collection.py:353 journal/views/collection.py:426
+#: journal/views/collection.py:462 journal/views/collection.py:500
+#: journal/views/collection.py:512 journal/views/collection.py:537
+#: journal/views/collection.py:540 journal/views/collection.py:581
+#: journal/views/common.py:246 journal/views/mark.py:241
+#: journal/views/post.py:55 journal/views/post.py:76 journal/views/post.py:99
+#: journal/views/post.py:119 journal/views/post.py:181
+#: journal/views/post.py:260 journal/views/post.py:275
+#: journal/views/post.py:459 journal/views/review.py:51
+#: journal/views/review.py:64 journal/views/review.py:89
 msgid "Insufficient permission"
 msgstr "权限不足"
 
 #: catalog/views/edit.py:271 catalog/views/edit.py:274
-#: journal/views/collection.py:68 journal/views/collection.py:93
-#: journal/views/collection.py:485 journal/views/collection.py:575
-#: journal/views/common.py:129 journal/views/mark.py:167
-#: journal/views/post.py:129 journal/views/post.py:131
-#: journal/views/post.py:175 journal/views/post.py:197
-#: journal/views/post.py:199 journal/views/post.py:217
-#: journal/views/post.py:230 journal/views/review.py:126
-#: journal/views/review.py:129 users/views/actions.py:171
+#: journal/views/collection.py:73 journal/views/collection.py:98
+#: journal/views/collection.py:517 journal/views/collection.py:611
+#: journal/views/common.py:175 journal/views/mark.py:167
+#: journal/views/post.py:131 journal/views/post.py:133
+#: journal/views/post.py:177 journal/views/post.py:199
+#: journal/views/post.py:201 journal/views/post.py:219
+#: journal/views/post.py:232 journal/views/review.py:137
+#: journal/views/review.py:140 users/views/actions.py:171
 msgid "Invalid parameter"
 msgstr "无效参数"
 
@@ -3394,7 +3394,7 @@ msgstr "搜索你的评论或条目，可加过滤条件如 category:tv status:c
 msgid "name of a person or company"
 msgstr "人物或公司名称"
 
-#: common/templates/_header.html:173
+#: common/templates/_header.html:173 users/templates/users/_rym_row.html:23
 msgid "Open"
 msgstr "打开"
 
@@ -3684,7 +3684,7 @@ msgid "Access denied"
 msgstr "访问被拒绝"
 
 #: common/utils.py:103 common/utils.py:105 journal/views/profile.py:428
-#: journal/views/review.py:169
+#: journal/views/review.py:180
 msgid "Login required"
 msgstr "登录后访问"
 
@@ -4316,9 +4316,10 @@ msgstr "保存时将行首空格替换为全角"
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:188 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:204 users/templates/users/data.html:255
-#: users/templates/users/data.html:317 users/templates/users/data.html:376
+#: users/templates/users/data.html:98 users/templates/users/data.html:180
+#: users/templates/users/data.html:233 users/templates/users/data.html:284
+#: users/templates/users/data.html:346 users/templates/users/data.html:405
+#: users/templates/users/rym_import.html:79
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
 msgstr "可见性"
@@ -4347,11 +4348,11 @@ msgstr "仅创建者"
 msgid "owner and their local mutuals"
 msgstr "创建者和他们的本地互关"
 
-#: journal/forms.py:156 journal/templates/collection.html:149
+#: journal/forms.py:156 journal/templates/collection.html:154
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:180 users/templates/users/data.html:531
+#: journal/forms.py:180 users/templates/users/data.html:560
 msgid "Status"
 msgstr "状态"
 
@@ -4364,7 +4365,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/storygraph.py:203
+#: journal/importers/rym.py:390 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4373,6 +4374,30 @@ msgstr "关于 {item_title} 的评论"
 #, python-brace-format
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
+
+#: journal/importers/rym.py:138
+#, python-brace-format
+msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
+
+#: journal/importers/rym.py:148
+#, python-brace-format
+msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
+msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
+
+#: journal/importers/rym.py:193
+#, python-brace-format
+msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
+msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
+
+#: journal/importers/rym.py:302
+msgid "Matched file missing; cannot import."
+msgstr "匹配文件丢失，无法导入。"
+
+#: journal/importers/rym.py:326
+#, python-brace-format
+msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
 #: journal/models/article.py:139
 msgid "(may contain sensitive content)"
@@ -4399,10 +4424,11 @@ msgstr "创建了收藏单"
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:55
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:213
-#: users/templates/users/data.html:264 users/templates/users/data.html:325
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:189 users/templates/users/data.html:242
+#: users/templates/users/data.html:293 users/templates/users/data.html:354
+#: users/templates/users/data.html:414
 #: users/templates/users/preferences.html:56
+#: users/templates/users/rym_import.html:82
 #: users/templates/users/steam_import.html:128
 msgid "Public"
 msgstr "公开"
@@ -4411,10 +4437,11 @@ msgstr "公开"
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:62
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:221 users/templates/users/data.html:272
-#: users/templates/users/data.html:333 users/templates/users/data.html:393
+#: users/templates/users/data.html:115 users/templates/users/data.html:197
+#: users/templates/users/data.html:250 users/templates/users/data.html:301
+#: users/templates/users/data.html:362 users/templates/users/data.html:422
 #: users/templates/users/preferences.html:63
+#: users/templates/users/rym_import.html:86
 #: users/templates/users/steam_import.html:132
 msgid "Followers Only"
 msgstr "仅关注者"
@@ -4423,10 +4450,11 @@ msgstr "仅关注者"
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:69
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:229 users/templates/users/data.html:280
-#: users/templates/users/data.html:341 users/templates/users/data.html:401
+#: users/templates/users/data.html:123 users/templates/users/data.html:205
+#: users/templates/users/data.html:258 users/templates/users/data.html:309
+#: users/templates/users/data.html:370 users/templates/users/data.html:430
 #: users/templates/users/preferences.html:70
+#: users/templates/users/rym_import.html:90
 #: users/templates/users/steam_import.html:136
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
@@ -4447,7 +4475,7 @@ msgstr "帖文未能发布到联邦实例，请重新验证登录。"
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能发布到联邦实例。"
 
-#: journal/models/note.py:34
+#: journal/models/note.py:34 users/templates/users/rym_import.html:71
 msgid "Page"
 msgstr "页码"
 
@@ -4988,7 +5016,7 @@ msgid "Update note"
 msgstr "修改备注"
 
 #: journal/templates/_list_item.html:100 journal/templates/review.html:22
-#: journal/templates/review.html:28 journal/templates/review.html:71
+#: journal/templates/review.html:33 journal/templates/review.html:76
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5133,20 +5161,20 @@ msgstr "创建新收藏单"
 msgid "Article"
 msgstr "文章"
 
-#: journal/templates/article.html:63
+#: journal/templates/article.html:68
 msgid "View on origin"
 msgstr "查看原始内容"
 
-#: journal/templates/article.html:77
+#: journal/templates/article.html:82
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr "文章可能包含敏感内容，点击显示全文。"
 
-#: journal/templates/article.html:88 journal/templates/review.html:81
+#: journal/templates/article.html:93 journal/templates/review.html:86
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "作者已设置仅限已登录用户查看。"
 
-#: journal/templates/article.html:106 journal/templates/collection.html:133
-#: journal/templates/review.html:94
+#: journal/templates/article.html:111 journal/templates/collection.html:138
+#: journal/templates/review.html:99
 msgid "Reply"
 msgstr "回应"
 
@@ -5206,18 +5234,18 @@ msgstr "十一月"
 msgid "DEC"
 msgstr "十二月"
 
-#: journal/templates/collection.html:53
+#: journal/templates/collection.html:58
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "分享"
 
-#: journal/templates/collection.html:142
+#: journal/templates/collection.html:147
 msgid "Query"
 msgstr ""
 
-#: journal/templates/collection.html:157
+#: journal/templates/collection.html:162
 msgid "Created date"
 msgstr "创建日期"
 
@@ -5440,7 +5468,7 @@ msgstr "年度小结"
 msgid "Articles"
 msgstr "文章"
 
-#: journal/templates/profile.html:153 journal/views/collection.py:364
+#: journal/templates/profile.html:153 journal/views/collection.py:396
 #: journal/views/profile.py:327
 msgid "collection"
 msgstr "收藏单"
@@ -5597,46 +5625,46 @@ msgid_plural "%(count)d items"
 msgstr[0] "%(count)d 个条目"
 msgstr[1] "%(count)d 个条目"
 
-#: journal/views/collection.py:50 journal/views/collection.py:87
+#: journal/views/collection.py:55 journal/views/collection.py:92
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "{0} 的收藏单"
 
-#: journal/views/collection.py:369
+#: journal/views/collection.py:401
 msgid "shared my collection"
 msgstr "分享我的收藏单"
 
-#: journal/views/collection.py:372
+#: journal/views/collection.py:404
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
-#: journal/views/collection.py:432 journal/views/collection.py:470
-#: journal/views/collection.py:482 journal/views/collection.py:510
+#: journal/views/collection.py:464 journal/views/collection.py:502
+#: journal/views/collection.py:514 journal/views/collection.py:542
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
-#: journal/views/collection.py:447
+#: journal/views/collection.py:479
 msgid "The item is already in the collection."
 msgstr "条目已在收藏单中。"
 
-#: journal/views/collection.py:449
+#: journal/views/collection.py:481
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到条目，请使用本站条目网址。"
 
-#: journal/views/collection.py:495
+#: journal/views/collection.py:527
 msgid "Saved."
 msgstr "已保存"
 
-#: journal/views/common.py:82 journal/views/mark.py:131
+#: journal/views/common.py:128 journal/views/mark.py:131
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "数据已保存但未能转发到联邦实例。"
 
-#: journal/views/common.py:84
+#: journal/views/common.py:130
 msgid "Redirecting to your Fediverse instance now to re-authenticate."
 msgstr "正在重定向到你的联邦实例以重新认证。"
 
-#: journal/views/common.py:91
+#: journal/views/common.py:137
 msgid "List not found."
 msgstr "列表未找到。"
 
@@ -5649,8 +5677,8 @@ msgid "Invalid input"
 msgstr "无效输入"
 
 #: journal/views/mark.py:189 journal/views/mark.py:239
-#: journal/views/note.py:100 journal/views/review.py:38
-#: journal/views/review.py:51
+#: journal/views/note.py:100 journal/views/review.py:49
+#: journal/views/review.py:62
 msgid "Content not found"
 msgstr "内容未找到"
 
@@ -5674,45 +5702,45 @@ msgstr "进度类型（选填）"
 msgid "Invalid form data"
 msgstr "无效表单信息。"
 
-#: journal/views/post.py:115
+#: journal/views/post.py:117
 msgid "Post not found"
 msgstr "帖文未找到"
 
-#: journal/views/post.py:201
+#: journal/views/post.py:203
 msgid "Visibility too high for quoting this post"
 msgstr "引用这则帖文时使用的可见性无效"
 
-#: journal/views/post.py:323
+#: journal/views/post.py:325
 msgid "Content cannot be empty."
 msgstr "内容不可为空。"
 
-#: journal/views/post.py:419
+#: journal/views/post.py:451
 msgid "Invalid choices"
 msgstr "无效选择"
 
-#: journal/views/post.py:422
+#: journal/views/post.py:454
 msgid "Invalid post"
 msgstr "无效帖文"
 
-#: journal/views/review.py:151
+#: journal/views/review.py:162
 msgid "User not local"
 msgstr "用户不在本站"
 
-#: journal/views/review.py:157 journal/views/review.py:171
+#: journal/views/review.py:168 journal/views/review.py:182
 #, python-brace-format
 msgid "Reviews by {0}"
 msgstr "{0} 的评论"
 
-#: journal/views/review.py:159 journal/views/review.py:167
+#: journal/views/review.py:170 journal/views/review.py:178
 msgid "Link invalid"
 msgstr "链接无效"
 
-#: journal/views/review.py:180
+#: journal/views/review.py:191
 #, python-brace-format
 msgid "{review_title} - a review of {item_title}"
 msgstr "{review_title} - 关于 {item_title} 的评论"
 
-#: journal/views/review.py:184
+#: journal/views/review.py:195
 msgid "may contain spoiler or triggering content"
 msgstr "可能包含剧透或敏感内容"
 
@@ -6013,7 +6041,11 @@ msgstr "标记"
 msgid "wrote a note"
 msgstr "写了笔记"
 
-#: social/templates/_event_post.html:85 social/templates/_event_post.html:87
+#: social/templates/_event_post.html:85
+msgid "wrote a review"
+msgstr "写了评论"
+
+#: social/templates/_event_post.html:87
 msgid "wrote an article"
 msgstr "写了文章"
 
@@ -6386,6 +6418,18 @@ msgstr "自定义样式代码"
 msgid "Settings for current device saved"
 msgstr "当前设备设置已保存"
 
+#: users/templates/users/_rym_row.html:27
+msgid "Create new album"
+msgstr "新建专辑"
+
+#: users/templates/users/_rym_row.html:28
+msgid "then paste the link above; leave blank to skip this row."
+msgstr "然后将链接粘贴到上方；留空则跳过该行。"
+
+#: users/templates/users/_rym_row.html:39
+msgid "(skip)"
+msgstr "(跳过)"
+
 #: users/templates/users/account.html:11
 msgid "Account Information"
 msgstr "账号信息"
@@ -6674,9 +6718,9 @@ msgid "CSV file"
 msgstr "CSV 文件"
 
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:346 users/templates/users/data.html:406
+#: users/templates/users/data.html:126 users/templates/users/data.html:208
+#: users/templates/users/data.html:261 users/templates/users/data.html:312
+#: users/templates/users/data.html:375 users/templates/users/data.html:435
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -6792,7 +6836,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:304
+#: users/templates/users/data.html:34 users/templates/users/data.html:333
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -6824,140 +6868,164 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93 users/templates/users/data.html:172
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr "将导入想读、在读、已读和放弃的书籍及其评论。"
 
 #: users/templates/users/data.html:133
+msgid "Import from RateYourMusic"
+msgstr "从RateYourMusic导入"
+
+#: users/templates/users/data.html:139
+msgid "On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file."
+msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your data</b> 选项将你的收藏导出为 CSV 文件。"
+
+#: users/templates/users/data.html:141 users/templates/users/data.html:170
+msgid "Upload the downloaded CSV file below."
+msgstr "在下方上传下载到的 CSV 文件。"
+
+#: users/templates/users/data.html:143
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
+
+#: users/templates/users/data.html:146
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
+
+#: users/templates/users/data.html:150
+msgid "Upload and match"
+msgstr "上传并匹配"
+
+#: users/templates/users/data.html:153
+msgid "Review pending RateYourMusic matches"
+msgstr "审阅待处理的 RateYourMusic 匹配"
+
+#: users/templates/users/data.html:162
 msgid "Import from StoryGraph"
 msgstr "从StoryGraph导入"
 
-#: users/templates/users/data.html:139
+#: users/templates/users/data.html:168
 msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:141
-msgid "Upload the downloaded CSV file below."
-msgstr ""
-
-#: users/templates/users/data.html:146
+#: users/templates/users/data.html:175
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
 
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:215
 msgid "Import from Letterboxd"
 msgstr "导入Letterboxd标记"
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:221
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:224
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:227
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:233 users/templates/users/data.html:284
+#: users/templates/users/data.html:262 users/templates/users/data.html:313
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "导入时仅更新正向变化(未标->想看->已看)标记；不足360字符的评论会作为短评添加。"
 
-#: users/templates/users/data.html:240
+#: users/templates/users/data.html:269
 msgid "Import from Trakt"
 msgstr "导入Trakt标记"
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:275
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr "在<a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt设置 - 数据</a>页面，点击<b>Export now</b>，等待下载链接出现。"
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:278
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 
-#: users/templates/users/data.html:251
+#: users/templates/users/data.html:280
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
-#: users/templates/users/data.html:291
+#: users/templates/users/data.html:320
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:294
+#: users/templates/users/data.html:323
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:300
+#: users/templates/users/data.html:329
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:311
+#: users/templates/users/data.html:340
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:344
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:344
+#: users/templates/users/data.html:373
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:354
+#: users/templates/users/data.html:383
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:360
+#: users/templates/users/data.html:389
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:362
+#: users/templates/users/data.html:391
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:372
+#: users/templates/users/data.html:401
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:433
+#: users/templates/users/data.html:462
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:459
+#: users/templates/users/data.html:488
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:484
+#: users/templates/users/data.html:513
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:508
+#: users/templates/users/data.html:537
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:541
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:519
+#: users/templates/users/data.html:548
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:527
+#: users/templates/users/data.html:556
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:530
+#: users/templates/users/data.html:559
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:535
+#: users/templates/users/data.html:564
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:544
+#: users/templates/users/data.html:573
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7351,6 +7419,51 @@ msgstr "导出"
 msgid "You may download the list here."
 msgstr "此处可导出你在本站的关系列表。"
 
+#: users/templates/users/rym_import.html:9
+#: users/templates/users/rym_import.html:37
+msgid "Review RateYourMusic Matches"
+msgstr "审阅 RateYourMusic 匹配结果"
+
+#: users/templates/users/rym_import.html:39
+#, python-format
+msgid ""
+"\n"
+"              Matched %(local)s locally, %(external)s externally, %(unmatched)s unmatched out of %(total)s rows.\n"
+"            "
+msgstr ""
+
+#: users/templates/users/rym_import.html:45
+msgid "Download matched CSV"
+msgstr "下载已匹配的 CSV"
+
+#: users/templates/users/rym_import.html:57
+msgid "Title / Artist"
+msgstr "标题 / 艺术家"
+
+#: users/templates/users/rym_import.html:58
+msgid "Matched Link"
+msgstr "匹配链接"
+
+#: users/templates/users/rym_import.html:59
+msgid "Shelf"
+msgstr "标记"
+
+#: users/templates/users/rym_import.html:69
+msgid "Prev"
+msgstr "上一页"
+
+#: users/templates/users/rym_import.html:73
+msgid "Next"
+msgstr "下一页"
+
+#: users/templates/users/rym_import.html:93
+msgid "Confirm Import"
+msgstr "确认导入"
+
+#: users/templates/users/rym_import.html:94
+msgid "Back"
+msgstr "返回"
+
 #: users/templates/users/steam_import.html:10
 msgid "Import from Steam"
 msgstr "从Steam导入"
@@ -7555,99 +7668,120 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:207 users/views/data.py:236
+#: users/views/data.py:224 users/views/data.py:253
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:230
+#: users/views/data.py:247
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:248
+#: users/views/data.py:265
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:263 users/views/data.py:283
+#: users/views/data.py:280 users/views/data.py:300
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:297
+#: users/views/data.py:314
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:311
+#: users/views/data.py:328
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:320 users/views/data.py:344 users/views/data.py:368
-#: users/views/data.py:393 users/views/data.py:417 users/views/data.py:441
+#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:553
+#: users/views/data.py:577 users/views/data.py:602 users/views/data.py:626
+#: users/views/data.py:650
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:561
+#: users/views/data.py:406
+msgid "Loaded from uploaded matched file."
+msgstr "已从上传的匹配文件中加载。"
+
+#: users/views/data.py:424
+msgid "No RateYourMusic import to preview."
+msgstr "暂无可预览的 RateYourMusic 导入任务。"
+
+#: users/views/data.py:429 users/views/data.py:536
+msgid "Matched file missing."
+msgstr "匹配文件丢失。"
+
+#: users/views/data.py:522
+msgid "Starting import..."
+msgstr "开始导入..."
+
+#: users/views/data.py:532
+msgid "No matched file available."
+msgstr "没有可用的匹配文件。"
+
+#: users/views/data.py:770
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:583
+#: users/views/data.py:792
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:599
+#: users/views/data.py:808
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:604
+#: users/views/data.py:813
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:614 users/views/data.py:665
+#: users/views/data.py:823 users/views/data.py:874
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:621
+#: users/views/data.py:830
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:626
+#: users/views/data.py:835
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:652
+#: users/views/data.py:861
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:657
+#: users/views/data.py:866
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:670
+#: users/views/data.py:879
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:681
+#: users/views/data.py:890
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:687
+#: users/views/data.py:896
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:745
+#: users/views/data.py:954
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:761
+#: users/views/data.py:970
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:765
+#: users/views/data.py:974
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:774
+#: users/views/data.py:983
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/test_data/rym_export.csv
+++ b/test_data/rym_export.csv
@@ -1,0 +1,6 @@
+RYM Album, First Name,Last Name,First Name localized, Last Name localized,Title,Release_Date,Rating,Ownership,Purchase Date,Media Type, Review, Review Title
+"10","The Jimi","Hendrix Experience","","","Are You Experienced?","1967","10","o","","CD","[b]bold[/b] review",""
+"20","","Radiohead","","","OK Computer","1997","9","n","","","",""
+"30","Action","Bronson","","","Planet Frog","2026","0","w","2026-04-01","MP3","",""
+"40","","Panopticon","","","Det hjemsøkte hjertet","2026","9","n","","","[b]BB[/b]\n\n[i]III[/I]\n\n[Artist577519]","My Review"
+"50","The","Vehicle Birth","","","Tragedy","","0","u","","","",""

--- a/tests/journal/test_rym.py
+++ b/tests/journal/test_rym.py
@@ -207,9 +207,8 @@ class TestMatchedFileGeneration:
         assert rows[1]["shelf"] == ShelfType.COMPLETE.value
         # Ownership=w -> WISHLIST
         assert rows[2]["shelf"] == ShelfType.WISHLIST.value
-        # Ownership=u with rating 0 and no review -> shelf left empty (skip);
-        # user can override per-row in the preview UI.
-        assert rows[3]["shelf"] == ""
+        # Ownership=u -> DROPPED (RYM "used to own")
+        assert rows[3]["shelf"] == ShelfType.DROPPED.value
 
     def test_collect_date_default_one_week_ago(self, monkeypatch):
         self._stub_matchers(monkeypatch)

--- a/tests/journal/test_rym.py
+++ b/tests/journal/test_rym.py
@@ -1,0 +1,463 @@
+import csv
+import io
+
+import pytest
+
+from catalog.models import Album
+from journal.importers.rym import (
+    RymImporter,
+    _bbcode_to_md,
+    _row_artist,
+    update_row_in_matched_file,
+)
+from journal.models import Mark, ShelfType
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestBBCodeConversion:
+    def test_bold_italic_strike(self):
+        assert _bbcode_to_md("[b]hi[/b]") == "**hi**"
+        assert _bbcode_to_md("[i]oh[/i]") == "*oh*"
+        assert _bbcode_to_md("[s]gone[/s]") == "~~gone~~"
+
+    def test_underline_dropped(self):
+        assert _bbcode_to_md("[u]link[/u]") == "link"
+
+    def test_url(self):
+        assert _bbcode_to_md("[url=https://x.com]X[/url]") == "[X](https://x.com)"
+        assert _bbcode_to_md("[url]https://y.com[/url]") == "https://y.com"
+
+    def test_ref_tag_stripped(self):
+        assert _bbcode_to_md("see [Artist123]") == "see"
+        assert _bbcode_to_md("[Album999]done[/Album999]") == "done"
+
+    def test_newlines_preserved(self):
+        out = _bbcode_to_md("[b]a[/b]\n\n[i]b[/i]")
+        assert out == "**a**\n\n*b*"
+
+    def test_combined(self):
+        src = "[b]BB[/b]\n\n[i]III[/i]\n\n[Artist577519]"
+        assert _bbcode_to_md(src) == "**BB**\n\n*III*"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRowArtist:
+    def test_localized_takes_precedence(self):
+        assert (
+            _row_artist(
+                {
+                    "First Name": "John",
+                    "Last Name": "Doe",
+                    "First Name localized": "山田",
+                    "Last Name localized": "太郎",
+                }
+            )
+            == "山田 太郎"
+        )
+
+    def test_fallback_to_ascii(self):
+        assert (
+            _row_artist({"First Name": "Action", "Last Name": "Bronson"})
+            == "Action Bronson"
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestValidateFile:
+    def test_accepts_rym_header(self):
+        assert RymImporter.validate_file(
+            io.BytesIO(b"RYM Album, First Name,Last Name,Title\n1,2,3,4\n")
+        )
+
+    def test_rejects_other_csv(self):
+        assert not RymImporter.validate_file(
+            io.BytesIO(b"Book Id,Title,Author\n1,2,3\n")
+        )
+
+    def test_accepts_bom(self):
+        assert RymImporter.validate_file(
+            io.BytesIO("﻿RYM Album, First Name\n".encode("utf-8"))
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMatchedFileGeneration:
+    """Phase 1: drive _run_matching() with patched matchers and inspect the CSV it writes."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self, tmp_path):
+        self.user = User.register(email="rymtest@example.com", username="rymtestuser")
+        self.identity = self.user.identity
+        self.in_path = str(tmp_path / "rym_input.csv")
+        with open(self.in_path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(
+                [
+                    "RYM Album",
+                    " First Name",
+                    "Last Name",
+                    "First Name localized",
+                    " Last Name localized",
+                    "Title",
+                    "Release_Date",
+                    "Rating",
+                    "Ownership",
+                    "Purchase Date",
+                    "Media Type",
+                    " Review",
+                    " Review Title",
+                ]
+            )
+            w.writerow(
+                [
+                    "10",
+                    "The Jimi",
+                    "Hendrix Experience",
+                    "",
+                    "",
+                    "Are You Experienced?",
+                    "1967",
+                    "10",
+                    "o",
+                    "2026-04-01",
+                    "CD",
+                    "[b]bold[/b] review",
+                    "",
+                ]
+            )
+            w.writerow(
+                [
+                    "20",
+                    "",
+                    "Radiohead",
+                    "",
+                    "",
+                    "OK Computer",
+                    "1997",
+                    "9",
+                    "n",
+                    "",
+                    "",
+                    "",
+                    "",
+                ]
+            )
+            w.writerow(
+                [
+                    "30",
+                    "Action",
+                    "Bronson",
+                    "",
+                    "",
+                    "Planet Frog",
+                    "2026",
+                    "0",
+                    "w",
+                    "",
+                    "MP3",
+                    "",
+                    "",
+                ]
+            )
+            w.writerow(
+                [
+                    "50",
+                    "The",
+                    "Vehicle Birth",
+                    "",
+                    "",
+                    "Tragedy",
+                    "",
+                    "0",
+                    "u",
+                    "",
+                    "",
+                    "",
+                    "",
+                ]
+            )
+
+    def _make_task(self, **extra):
+        return RymImporter.create(
+            self.user,
+            phase="matching",
+            visibility=0,
+            file=self.in_path,
+            **extra,
+        )
+
+    def _stub_matchers(self, monkeypatch, ext_url=None):
+        monkeypatch.setattr(RymImporter, "_local_match", lambda self, *a, **k: None)
+        monkeypatch.setattr(
+            RymImporter, "_external_match", lambda self, *a, **k: ext_url
+        )
+
+    def test_default_shelf_and_collect_date(self, monkeypatch):
+        self._stub_matchers(monkeypatch)
+        task = self._make_task()
+        task.run()
+        path = task.metadata["matched_file"]
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.DictReader(f))
+        # Ownership=o -> COMPLETE; collect_date copied from Purchase Date
+        assert rows[0]["shelf"] == ShelfType.COMPLETE.value
+        assert rows[0]["collect_date"] == "2026-04-01"
+        # Ownership=n with rating 9 -> COMPLETE (rating implies you heard it)
+        assert rows[1]["shelf"] == ShelfType.COMPLETE.value
+        # Ownership=w -> WISHLIST
+        assert rows[2]["shelf"] == ShelfType.WISHLIST.value
+        # Ownership=u with rating 0 and no review -> shelf left empty (skip);
+        # user can override per-row in the preview UI.
+        assert rows[3]["shelf"] == ""
+
+    def test_collect_date_default_one_week_ago(self, monkeypatch):
+        self._stub_matchers(monkeypatch)
+        task = self._make_task()
+        task.run()
+        path = task.metadata["matched_file"]
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.DictReader(f))
+        # Radiohead row had no Purchase Date -> collect_date defaults to ~today-7d
+        assert rows[1]["collect_date"]  # populated
+        assert rows[2]["collect_date"]  # populated
+
+    def test_external_match_recorded(self, monkeypatch):
+        self._stub_matchers(
+            monkeypatch,
+            ext_url=("https://musicbrainz.org/release-group/abc-123", "musicbrainz"),
+        )
+        task = self._make_task()
+        task.run()
+        path = task.metadata["matched_file"]
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.DictReader(f))
+        assert all(r["match_source"] == "musicbrainz" for r in rows)
+        assert all(r["link"].startswith("https://musicbrainz.org/") for r in rows)
+
+    def test_phase_transitions_to_preview(self, monkeypatch):
+        self._stub_matchers(monkeypatch)
+        task = self._make_task()
+        task.run()
+        assert task.metadata["phase"] == "preview"
+        assert task.metadata["total"] == 4
+        assert task.metadata["processed"] == 4
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestImportPhase:
+    @pytest.fixture(autouse=True)
+    def setup_data(self, tmp_path):
+        self.user = User.register(email="rymimp@example.com", username="rymimpuser")
+        self.identity = self.user.identity
+        # seed a local Album for direct link resolution
+        self.album_hendrix = Album.objects.create(
+            title="Are You Experienced?",
+            localized_title=[{"lang": "en", "text": "Are You Experienced?"}],
+            primary_lookup_id_type="dummy",
+            primary_lookup_id_value="rymtest-hendrix",
+        )
+        self.album_hendrix.artist = ["The Jimi Hendrix Experience"]
+        self.album_hendrix.save()
+        self.album_bronson = Album.objects.create(
+            title="Planet Frog",
+            localized_title=[{"lang": "en", "text": "Planet Frog"}],
+            primary_lookup_id_type="dummy",
+            primary_lookup_id_value="rymtest-bronson",
+        )
+        self.album_bronson.artist = ["Action Bronson"]
+        self.album_bronson.save()
+        self.matched_path = str(tmp_path / "matched.csv")
+        with open(self.matched_path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            headers = [
+                "RYM Album",
+                "First Name",
+                "Last Name",
+                "First Name localized",
+                "Last Name localized",
+                "Title",
+                "Release_Date",
+                "Rating",
+                "Ownership",
+                "Purchase Date",
+                "Media Type",
+                "Review",
+                "Review Title",
+                "link",
+                "match_source",
+                "shelf",
+                "collect_date",
+                "notes",
+            ]
+            w.writerow(headers)
+            w.writerow(
+                [
+                    "10",
+                    "The Jimi",
+                    "Hendrix Experience",
+                    "",
+                    "",
+                    "Are You Experienced?",
+                    "1967",
+                    "10",
+                    "o",
+                    "",
+                    "CD",
+                    "[b]bold[/b] short review",
+                    "",
+                    self.album_hendrix.url,
+                    "local",
+                    ShelfType.COMPLETE.value,
+                    "2026-04-01",
+                    "",
+                ]
+            )
+            w.writerow(
+                [
+                    "30",
+                    "Action",
+                    "Bronson",
+                    "",
+                    "",
+                    "Planet Frog",
+                    "2026",
+                    "0",
+                    "w",
+                    "",
+                    "MP3",
+                    "",
+                    "",
+                    self.album_bronson.url,
+                    "local",
+                    ShelfType.WISHLIST.value,
+                    "2026-05-01",
+                    "",
+                ]
+            )
+            # row 3: unmatched (no link) -> skipped
+            w.writerow(
+                [
+                    "50",
+                    "The",
+                    "Vehicle Birth",
+                    "",
+                    "",
+                    "Tragedy",
+                    "",
+                    "0",
+                    "u",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "none",
+                    "",
+                    "",
+                    "",
+                ]
+            )
+
+    def _run_import_task(self):
+        task = RymImporter.create(
+            self.user,
+            phase="importing",
+            visibility=0,
+            file="dummy",
+            matched_file=self.matched_path,
+        )
+        task.run()
+        return task
+
+    def test_import_creates_complete_mark_with_short_comment(self):
+        task = self._run_import_task()
+        assert task.metadata["imported"] == 2
+        assert task.metadata["skipped"] == 1
+        assert task.metadata["failed"] == 0
+        mark = Mark(self.identity, self.album_hendrix)
+        assert mark.shelf_type == ShelfType.COMPLETE
+        assert mark.rating_grade == 10
+        # short BBCode -> markdown in comment_text
+        assert mark.comment_text and "**bold**" in mark.comment_text
+
+    def test_import_creates_wishlist_no_rating(self):
+        self._run_import_task()
+        mark = Mark(self.identity, self.album_bronson)
+        assert mark.shelf_type == ShelfType.WISHLIST
+        assert mark.rating_grade is None
+
+    def test_import_phase_completes(self):
+        task = self._run_import_task()
+        assert task.metadata["phase"] == "done"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestUpdateRowInMatchedFile:
+    def test_atomic_rewrite(self, tmp_path):
+        path = str(tmp_path / "matched.csv")
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["Title", "link", "shelf", "collect_date"])
+            w.writerow(["Album A", "", "", ""])
+            w.writerow(["Album B", "https://x", "complete", "2026-05-01"])
+        row = update_row_in_matched_file(
+            path,
+            0,
+            {"link": "/album/abc", "shelf": "wishlist", "collect_date": "2026-05-10"},
+        )
+        assert row is not None
+        assert row["link"] == "/album/abc"
+        assert row["shelf"] == "wishlist"
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.DictReader(f))
+        assert rows[0]["link"] == "/album/abc"
+        assert rows[1]["link"] == "https://x"
+
+    def test_out_of_range_returns_none(self, tmp_path):
+        path = str(tmp_path / "matched.csv")
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["Title", "link", "shelf", "collect_date"])
+            w.writerow(["Album A", "", "", ""])
+        assert update_row_in_matched_file(path, 5, {"link": "x"}) is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestExternalSearchFieldQueries:
+    def test_musicbrainz_lucene_query(self):
+        from catalog.sites.musicbrainz import MusicBrainzRelease
+
+        q = MusicBrainzRelease.build_field_query("OK Computer", "Radiohead", "1997")
+        assert 'release:"OK Computer"' in q
+        assert 'artist:"Radiohead"' in q
+        assert "date:1997" in q
+        assert " AND " in q
+
+    def test_musicbrainz_escapes_special_chars(self):
+        from catalog.sites.musicbrainz import MusicBrainzRelease
+
+        q = MusicBrainzRelease.build_field_query('A:B"', "X", None)
+        # special chars escaped with backslash
+        assert "\\:" in q
+        assert '\\"' in q
+
+    def test_spotify_field_query(self):
+        from catalog.sites.spotify import Spotify
+
+        q = Spotify.build_field_query("OK Computer", "Radiohead", "1997")
+        assert 'album:"OK Computer"' in q
+        assert 'artist:"Radiohead"' in q
+        assert "year:1997" in q
+
+    def test_spotify_field_query_no_year(self):
+        from catalog.sites.spotify import Spotify
+
+        q = Spotify.build_field_query("X", "Y", None)
+        assert "year:" not in q
+
+    def test_spotify_field_query_invalid_year(self):
+        from catalog.sites.spotify import Spotify
+
+        q = Spotify.build_field_query("X", "Y", "abcd")
+        assert "year:" not in q

--- a/users/jobs/cleanup.py
+++ b/users/jobs/cleanup.py
@@ -8,15 +8,10 @@ from loguru import logger
 from common.models import BaseJob, JobManager, SiteConfig
 from users.models import Task
 
+_TASK_FILE_KEYS = ("file", "matched_file")
 
-def delete_task_file(task: Task) -> bool:
-    """Delete the file associated with a task, if it exists.
 
-    Returns True if a file was deleted, False otherwise.
-    """
-    file_path = task.metadata.get("file") if task.metadata else None
-    if not file_path:
-        return False
+def _delete_path(file_path: str) -> bool:
     try:
         if os.path.isfile(file_path):
             os.remove(file_path)
@@ -38,6 +33,24 @@ def delete_task_file(task: Task) -> bool:
     except OSError as e:
         logger.warning(f"Failed to delete {file_path}: {e}")
     return False
+
+
+def delete_task_file(task: Task) -> bool:
+    """Delete the file(s) associated with a task, if any exist.
+
+    Some importers (e.g. RYM) keep a derived ``matched_file`` alongside the
+    original upload — both belong to the task and must be pruned together.
+
+    Returns True if at least one file was deleted, False otherwise.
+    """
+    if not task.metadata:
+        return False
+    deleted = False
+    for key in _TASK_FILE_KEYS:
+        path = task.metadata.get(key)
+        if path and _delete_path(path):
+            deleted = True
+    return deleted
 
 
 def prune_tasks(days: int = 28) -> tuple[int, int]:

--- a/users/migrations/0012_task_rym_type.py
+++ b/users/migrations/0012_task_rym_type.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0011_preference_disable_recommendations"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="task",
+            name="type",
+            field=models.CharField(
+                choices=[
+                    ("journal.baseimporter", "base importer"),
+                    ("journal.csvexporter", "csv exporter"),
+                    ("journal.csvimporter", "csv importer"),
+                    ("journal.doubanimporter", "douban importer"),
+                    ("journal.doufenexporter", "doufen exporter"),
+                    ("journal.goodreadsimporter", "goodreads importer"),
+                    ("journal.letterboxdimporter", "letterboxd importer"),
+                    ("journal.ndjsonexporter", "ndjson exporter"),
+                    ("journal.ndjsonimporter", "ndjson importer"),
+                    ("journal.opmlimporter", "opml importer"),
+                    ("journal.rymimporter", "rym importer"),
+                    ("journal.steamimporter", "steam importer"),
+                    ("journal.storygraphimporter", "story graph importer"),
+                    ("journal.traktimporter", "trakt importer"),
+                ],
+                db_index=True,
+                max_length=255,
+            ),
+        ),
+    ]

--- a/users/templates/users/_rym_row.html
+++ b/users/templates/users/_rym_row.html
@@ -15,7 +15,6 @@
            name="link"
            value="{{ row.link }}"
            placeholder="https://… or /album/…"
-           style="width:100%"
            hx-post="{{ save_url }}"
            hx-trigger="change"
            hx-include="closest tr"

--- a/users/templates/users/_rym_row.html
+++ b/users/templates/users/_rym_row.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+{% url 'users:rym_save_row' row.index as save_url %}
+<tr id="rym-row-{{ row.index }}">
+  <td>
+    <div>
+      <strong>{{ row.title }}</strong>
+    </div>
+    <small>
+      {{ row.artist_display }}
+      {% if row.year %}({{ row.year }}){% endif %}
+    </small>
+  </td>
+  <td>
+    <input type="text"
+           name="link"
+           value="{{ row.link }}"
+           placeholder="https://… or /album/…"
+           style="width:100%"
+           hx-post="{{ save_url }}"
+           hx-trigger="change"
+           hx-include="closest tr"
+           hx-target="closest tr"
+           hx-swap="outerHTML">
+    {% if not row.link %}
+      <div>
+        <a href="/catalog/create/Album?title={{ row.title|urlencode }}"
+           target="_blank"
+           rel="noopener">{% trans 'Create new album' %}</a>
+        <small>{% trans 'then paste the link above; leave blank to skip this row.' %}</small>
+      </div>
+    {% endif %}
+  </td>
+  <td>
+    <select name="shelf"
+            hx-post="{{ save_url }}"
+            hx-trigger="change"
+            hx-include="closest tr"
+            hx-target="closest tr"
+            hx-swap="outerHTML">
+      <option value="" {% if not row.shelf %}selected{% endif %}>{% trans '(skip)' %}</option>
+      {% for value, label in shelf_choices %}
+        <option value="{{ value }}" {% if row.shelf == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </td>
+  <td>
+    <input type="date"
+           name="collect_date"
+           value="{{ row.collect_date }}"
+           hx-post="{{ save_url }}"
+           hx-trigger="change"
+           hx-include="closest tr"
+           hx-target="closest tr"
+           hx-swap="outerHTML">
+  </td>
+</tr>

--- a/users/templates/users/data.html
+++ b/users/templates/users/data.html
@@ -286,6 +286,35 @@
             </form>
           </details>
         </article>
+        <article id="rym">
+          <details {% if rym_task and rym_task.metadata.phase and rym_task.metadata.phase != 'done' %}open{% endif %}>
+            <summary>{% trans 'Import from RateYourMusic' %}</summary>
+            <form hx-post="{% url 'users:import_rym_upload' %}"
+                  enctype="multipart/form-data">
+              {% csrf_token %}
+              <ul>
+                <li>
+                  {% blocktrans %}On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file.{% endblocktrans %}
+                </li>
+                <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
+                <li>
+                  {% blocktrans %}Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import.{% endblocktrans %}
+                </li>
+                <li>
+                  {% blocktrans %}You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match.{% endblocktrans %}
+                </li>
+              </ul>
+              <input type="file" name="file" required accept=".csv">
+              <input type="submit" value="{% trans 'Upload and match' %}" />
+              {% if rym_task and rym_task.metadata.phase == 'preview' %}
+                <p>
+                  <a href="{% url 'users:rym_preview' %}">{% trans 'Review pending RateYourMusic matches' %}</a>
+                </p>
+              {% endif %}
+              {% include "users/user_task_status.html" with task=rym_task %}
+            </form>
+          </details>
+        </article>
         <article>
           <details>
             <summary>{% trans 'Import from Steam Wishlist / Library' %}</summary>

--- a/users/templates/users/rym_import.html
+++ b/users/templates/users/rym_import.html
@@ -1,0 +1,101 @@
+{% load static %}
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans 'Review RateYourMusic Matches' %}</title>
+    {% include "common_libs.html" %}
+    <style>
+    main.rym-preview {
+      max-width: none;
+      width: 100%;
+      padding: calc(2 * var(--pico-spacing));
+      margin: 0;
+    }
+    main.rym-preview table { width: 100%; table-layout: fixed; }
+    main.rym-preview table th, main.rym-preview table td { word-break: break-word; vertical-align: top; }
+    main.rym-preview table td input[type="text"] { width: 100%; box-sizing: border-box; }
+    </style>
+    <script>
+    document.addEventListener('htmx:responseError', (event) => {
+      let response = event.detail.xhr.response;
+      let body = response ? response : `Request error: ${event.detail.xhr.statusText}`;
+      alert(body);
+    });
+    document.addEventListener('htmx:configRequest', (event) => {
+      event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+    });
+    </script>
+  </head>
+  <body>
+    {% include "_header.html" %}
+    <main class="rym-preview">
+      <article>
+        <h3>{% trans 'Review RateYourMusic Matches' %}</h3>
+        <p>
+          {% blocktrans with total=total local=task.metadata.matched_local external=task.metadata.matched_external unmatched=task.metadata.unmatched %}
+              Matched {{ local }} locally, {{ external }} externally, {{ unmatched }} unmatched out of {{ total }} rows.
+            {% endblocktrans %}
+        </p>
+        <p>
+          <a href="{% url 'users:rym_download' %}">
+            <i class="fa fa-download"></i> {% trans 'Download matched CSV' %}
+          </a>
+        </p>
+        <table>
+          <colgroup>
+            <col style="width:20%">
+            <col style="width:50%">
+            <col style="width:15%">
+            <col style="width:15%">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>{% trans 'Title / Artist' %}</th>
+              <th>{% trans 'Matched Link' %}</th>
+              <th>{% trans 'Shelf' %}</th>
+              <th>{% trans 'Date' %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+              {% include "users/_rym_row.html" %}
+            {% endfor %}
+          </tbody>
+        </table>
+        <p>
+          {% if has_prev %}
+            <a href="?page={{ page|add:'-1' }}">&laquo; {% trans 'Prev' %}</a>
+          {% endif %}
+          {% trans 'Page' %} {{ page }}
+          {% if has_next %}
+            <a href="?page={{ page|add:'1' }}">{% trans 'Next' %} &raquo;</a>
+          {% endif %}
+        </p>
+        <form method="post" action="{% url 'users:rym_confirm' %}">
+          {% csrf_token %}
+          <fieldset>
+            <legend>{% trans 'Visibility' %}</legend>
+            <label>
+              <input type="radio" name="visibility" value="0" checked>
+              {% trans 'Public' %}
+            </label>
+            <label>
+              <input type="radio" name="visibility" value="1">
+              {% trans 'Followers Only' %}
+            </label>
+            <label>
+              <input type="radio" name="visibility" value="2">
+              {% trans 'Mentioned Only' %}
+            </label>
+          </fieldset>
+          <button type="submit">{% trans 'Confirm Import' %}</button>
+          <a href="{% url 'users:data' %}">{% trans 'Back' %}</a>
+        </form>
+      </article>
+    </main>
+  </body>
+</html>

--- a/users/urls.py
+++ b/users/urls.py
@@ -16,6 +16,11 @@ urlpatterns = [
         "task/<str:task_type>/download", user_task_download, name="user_task_download"
     ),
     path("data/import/goodreads", import_goodreads, name="import_goodreads"),
+    path("data/import/rym", import_rym_upload, name="import_rym_upload"),
+    path("data/import/rym/preview", rym_preview, name="rym_preview"),
+    path("data/import/rym/row/<int:i>", rym_save_row, name="rym_save_row"),
+    path("data/import/rym/confirm", rym_confirm, name="rym_confirm"),
+    path("data/import/rym/download", rym_download, name="rym_download"),
     path("data/import/storygraph", import_storygraph, name="import_storygraph"),
     path("data/import/douban", import_douban, name="import_douban"),
     path("data/import/letterboxd", import_letterboxd, name="import_letterboxd"),

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -30,10 +30,12 @@ from journal.importers import (
     LetterboxdImporter,
     NdjsonImporter,
     OPMLImporter,
+    RymImporter,
     SteamImporter,
     StoryGraphImporter,
     TraktImporter,
 )
+from journal.importers.rym import update_row_in_matched_file
 from journal.models import ShelfType
 from journal.models.common import VisibilityType
 from takahe.models import InboxMessage
@@ -153,6 +155,7 @@ def data(request):
             "ndjson_export_task": NdjsonExporter.latest_task(request.user),
             "letterboxd_task": LetterboxdImporter.latest_task(request.user),
             "goodreads_task": GoodreadsImporter.latest_task(request.user),
+            "rym_task": RymImporter.latest_task(request.user),
             "storygraph_task": StoryGraphImporter.latest_task(request.user),
             "steam_task": SteamImporter.latest_task(request.user),
             "trakt_task": TraktImporter.latest_task(request.user),
@@ -187,9 +190,23 @@ def user_task_status(request, task_type: str):
             task_cls = SteamImporter
         case "journal.traktimporter":
             task_cls = TraktImporter
+        case "journal.rymimporter":
+            task_cls = RymImporter
         case _:
             return redirect(reverse("users:data"))
     task = task_cls.latest_task(request.user)
+    if (
+        task_cls is RymImporter
+        and task
+        and task.state == Task.States.complete
+        and task.metadata.get("phase") == "preview"
+    ):
+        target = reverse("users:rym_preview")
+        if request.headers.get("HX-Request"):
+            resp = HttpResponse(status=204)
+            resp["HX-Redirect"] = target
+            return resp
+        return redirect(target)
     return render(request, "users/user_task_status.html", {"task": task})
 
 
@@ -334,6 +351,207 @@ def import_goodreads(request):
     )
     task.enqueue()
     return redirect(reverse("users:user_task_status", args=(task.type,)))
+
+
+def _rym_active_task(user):
+    task = RymImporter.latest_task(user)
+    if not task:
+        return None
+    if task.metadata.get("phase") not in ("matching", "preview", "importing", "done"):
+        return None
+    return task
+
+
+@login_required
+def import_rym_upload(request):
+    if request.method != "POST":
+        return redirect(reverse("users:data"))
+    if not RymImporter.validate_file(request.FILES.get("file")):
+        raise BadRequest(_("Invalid file."))
+    f = (
+        settings.MEDIA_ROOT
+        + "/"
+        + GenerateDateUUIDMediaFilePath("x.csv", settings.SYNC_FILE_PATH_ROOT)
+    )
+    os.makedirs(os.path.dirname(f), exist_ok=True)
+    with open(f, "wb+") as destination:
+        for chunk in request.FILES["file"].chunks():
+            destination.write(chunk)
+    # detect 'link' column for round-trip
+    had_link = False
+    with open(f, encoding="utf-8-sig", newline="") as fp:
+        reader = csv.reader(fp)
+        try:
+            headers = next(reader)
+            had_link = "link" in [h.strip() for h in headers]
+        except StopIteration:
+            pass
+    uploaded_name = getattr(request.FILES["file"], "name", "rym_export.csv")
+    if had_link:
+        # already matched; copy to matched_file and skip phase 1
+        import shutil
+
+        stem, _ext = os.path.splitext(os.path.basename(f))
+        matched = os.path.join(os.path.dirname(f), f"{stem}-matched.csv")
+        shutil.copyfile(f, matched)
+        task = RymImporter.create(
+            request.user,
+            phase="preview",
+            file=f,
+            matched_file=matched,
+            filename_hint=uploaded_name,
+            had_link_column=True,
+        )
+        task.state = Task.States.complete
+        task.message = _("Loaded from uploaded matched file.")
+        task.save(update_fields=["state", "message"])
+        return _hx_or_full_redirect(request, reverse("users:rym_preview"))
+    task = RymImporter.create(
+        request.user,
+        phase="matching",
+        file=f,
+        filename_hint=uploaded_name,
+    )
+    task.enqueue()
+    return _hx_or_full_redirect(request, reverse("users:data") + "#rym")
+
+
+def _hx_or_full_redirect(request, target: str) -> HttpResponse:
+    """Redirect properly whether the request was sent by HTMX or normal browser."""
+    if request.headers.get("HX-Request"):
+        resp = HttpResponse(status=204)
+        resp["HX-Redirect"] = target
+        return resp
+    return redirect(target)
+
+
+@login_required
+def rym_preview(request):
+    task = _rym_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        messages.add_message(
+            request, messages.ERROR, _("No RateYourMusic import to preview.")
+        )
+        return redirect(reverse("users:data"))
+    path = task.metadata["matched_file"]
+    if not os.path.exists(path):
+        messages.add_message(request, messages.ERROR, _("Matched file missing."))
+        return redirect(reverse("users:data"))
+    page = max(1, int(request.GET.get("page", 1)))
+    page_size = 100
+    with open(path, encoding="utf-8-sig", newline="") as fp:
+        reader = csv.DictReader(fp)
+        all_rows = list(reader)
+    total = len(all_rows)
+    start = (page - 1) * page_size
+    end = start + page_size
+    rows = [
+        _rym_row_for_template(start + i, raw)
+        for i, raw in enumerate(all_rows[start:end])
+    ]
+    return render(
+        request,
+        "users/rym_import.html",
+        {
+            "task": task,
+            "rows": rows,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "has_prev": page > 1,
+            "has_next": end < total,
+            "shelf_choices": ShelfType.choices,
+        },
+    )
+
+
+def _rym_row_for_template(index: int, raw: dict) -> dict:
+    first = (raw.get("First Name localized") or raw.get("First Name") or "").strip()
+    last = (raw.get("Last Name localized") or raw.get("Last Name") or "").strip()
+    artist_display = f"{first} {last}".strip()
+    review_title = (raw.get("Review Title") or "").strip()
+    review_body = (raw.get("Review") or "").strip()
+    source = review_title or review_body
+    excerpt = (source[:14] + "…") if len(source) > 15 else source
+    return {
+        "index": index,
+        "title": raw.get("Title", ""),
+        "year": raw.get("Release_Date", ""),
+        "artist_display": artist_display,
+        "link": raw.get("link", ""),
+        "match_source": raw.get("match_source", ""),
+        "shelf": raw.get("shelf", ""),
+        "collect_date": raw.get("collect_date", ""),
+        "rating": raw.get("Rating", ""),
+        "review_excerpt": excerpt,
+    }
+
+
+@login_required
+@require_http_methods(["POST"])
+def rym_save_row(request, i: int):
+    task = _rym_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        raise BadRequest("no matched file")
+    if task.metadata.get("phase") not in ("preview",):
+        raise BadRequest("cannot edit in current phase")
+    updates = {
+        "link": (request.POST.get("link") or "").strip(),
+        "shelf": (request.POST.get("shelf") or "").strip(),
+        "collect_date": (request.POST.get("collect_date") or "").strip(),
+    }
+    row = update_row_in_matched_file(task.metadata["matched_file"], i, updates)
+    if row is None:
+        raise BadRequest("row index out of range")
+    return render(
+        request,
+        "users/_rym_row.html",
+        {
+            "row": _rym_row_for_template(i, row),
+            "shelf_choices": ShelfType.choices,
+            "task": task,
+        },
+    )
+
+
+@login_required
+@require_http_methods(["POST"])
+def rym_confirm(request):
+    task = _rym_active_task(request.user)
+    if not task or task.metadata.get("phase") != "preview":
+        return redirect(reverse("users:data"))
+    task.metadata["visibility"] = int(request.POST.get("visibility", 0))
+    task.metadata["phase"] = "importing"
+    task.metadata["processed"] = 0
+    task.metadata["imported"] = 0
+    task.metadata["skipped"] = 0
+    task.metadata["failed"] = 0
+    task.metadata["failed_urls"] = []
+    task.state = Task.States.pending
+    task.message = _("Starting import...")
+    task.save(update_fields=["metadata", "state", "message"])
+    task.enqueue()
+    return redirect(reverse("users:data") + "#rym")
+
+
+@login_required
+def rym_download(request):
+    task = _rym_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        messages.add_message(request, messages.ERROR, _("No matched file available."))
+        return redirect(reverse("users:data"))
+    path = task.metadata["matched_file"]
+    if not os.path.exists(path):
+        messages.add_message(request, messages.ERROR, _("Matched file missing."))
+        return redirect(reverse("users:data"))
+    response = HttpResponse()
+    response["X-Accel-Redirect"] = settings.MEDIA_URL + path[len(settings.MEDIA_ROOT) :]
+    response["Content-Type"] = "text/csv"
+    hint = task.metadata.get("filename_hint") or "rym_export.csv"
+    stem, _ext = os.path.splitext(hint)
+    filename = f"{stem}-matched.csv"
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
 
 
 @login_required

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -433,6 +433,9 @@ def rym_preview(request):
             request, messages.ERROR, _("No RateYourMusic import to preview.")
         )
         return redirect(reverse("users:data"))
+    if task.metadata.get("phase") == "done":
+        # import already applied; preview/matched-CSV are no longer relevant
+        return redirect(reverse("users:data") + "#rym")
     path = task.metadata["matched_file"]
     if not os.path.exists(path):
         messages.add_message(request, messages.ERROR, _("Matched file missing."))

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -437,7 +437,10 @@ def rym_preview(request):
     if not os.path.exists(path):
         messages.add_message(request, messages.ERROR, _("Matched file missing."))
         return redirect(reverse("users:data"))
-    page = max(1, int(request.GET.get("page", 1)))
+    try:
+        page = max(1, int(request.GET.get("page", 1)))
+    except (TypeError, ValueError):
+        page = 1
     page_size = 100
     with open(path, encoding="utf-8-sig", newline="") as fp:
         reader = csv.DictReader(fp)


### PR DESCRIPTION
## Summary

Adds a new **RateYourMusic** CSV importer that drops users into an interactive preview/edit step before applying any changes to their journal.

Two-phase background task (`matching → preview → importing → done`):

1. **Matching** — every row is matched by *(artist, title, year)* as separate fields against:
   - the local catalog index (uses `people:` / `year:` filters via `CatalogQueryParser`, no free-text concat — `Item.title` is no longer queried);
   - then MusicBrainz' release search (`release:\"…\" AND artist:\"…\" AND date:…`, ~1 req/sec to respect MB guidelines);
   - then Spotify (`album:\"…\" artist:\"…\" year:…`, only when `SiteConfig.system.spotify_api_key` is set).

   The output is a `<upload>-matched.csv` containing the original RYM columns plus `link`, `match_source`, `shelf`, `collect_date`, and `notes`.

2. **Preview** — full-width review page renders the matched CSV as an editable table. Every input HTMX-auto-saves on `change` (link, shelf, date). Unmatched rows surface a "Create new album" button pre-filled with the RYM title via `/catalog/create/Album?title=…`. The matched CSV is downloadable; re-uploading a CSV that already has a `link` column skips matching and jumps straight to this screen.

3. **Importing** — after the user picks visibility and clicks Confirm, the worker resolves each row's link (`Item.get_by_url` for local URLs, `SiteManager.get_site_by_url(...).get_resource_ready()` for remote), then writes Mark + Rating + (BBCode→markdown) comment-or-Review.

### Defaults

- **Ownership → shelf**: `o → COMPLETE`, `w → WISHLIST`, `u (used to own) → DROPPED`, everything else → `COMPLETE` (no row auto-skips; the user can still flip to skip per-row).
- **Collect date** = RYM `Purchase Date` if present, else `today - 7 days`.

### Other changes

- Added field-based `search_by_fields(album, artist, year)` to `MusicBrainzRelease` and `Spotify` — same JSON parsing as `search_task` but Lucene / Spotify field syntax built from separate args.
- `users.0012_task_rym_type` migration registers the `journal.rymimporter` TypedModel choice.
- `users.jobs.cleanup.delete_task_file` now prunes the derived `matched_file` alongside the original upload so old RYM tasks don't leave orphan CSVs in MEDIA storage.
- Translations updated (zh_Hans).

## Test plan

- [x] `pytest tests/journal/test_rym.py` — 25 unit tests covering BBCode conversion, row-artist resolution, file validation, matched-CSV generation (defaults, external match, link-column round-trip, atomic row updates), shelf rules, collect_date defaults, MusicBrainz/Spotify field-query construction.
- [x] `uv run pre-commit run -a` — ruff, ruff-format, djLint, ty all green.
- [x] End-to-end smoke against the dev stack (`docker compose --profile dev`): upload RYM CSV → preview opens → edit a row → confirm import → Mark + comment land on the seeded Album.
- [x] Re-upload the downloaded `*-matched.csv` → matching phase is skipped, preview opens with prior `link` values honoured.
- [ ] Manual UI run for visibility selection at confirm time.
- [ ] Manual UI run for the auto-navigation after matching completes (`HX-Redirect` from polled status widget).