### PR TITLE
feat(rym): style preview/download buttons; clarify export hint

### DIFF
--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 21:53-0400\n"
+"POT-Creation-Date: 2026-05-16 08:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3395,7 +3395,7 @@ msgstr ""
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:173 users/templates/users/_rym_row.html:23
+#: common/templates/_header.html:173
 msgid "Open"
 msgstr ""
 
@@ -4296,10 +4296,10 @@ msgstr ""
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:188 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:180
-#: users/templates/users/data.html:233 users/templates/users/data.html:284
-#: users/templates/users/data.html:346 users/templates/users/data.html:405
-#: users/templates/users/rym_import.html:79
+#: users/templates/users/data.html:98 users/templates/users/data.html:151
+#: users/templates/users/data.html:204 users/templates/users/data.html:255
+#: users/templates/users/data.html:355 users/templates/users/data.html:414
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
 msgstr ""
@@ -4332,7 +4332,7 @@ msgstr ""
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:180 users/templates/users/data.html:560
+#: journal/forms.py:180 users/templates/users/data.html:569
 msgid "Status"
 msgstr ""
 
@@ -4345,7 +4345,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:390 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:411 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4355,26 +4355,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:138
+#: journal/importers/rym.py:146
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:148
+#: journal/importers/rym.py:156
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:193
+#: journal/importers/rym.py:210
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:302
+#: journal/importers/rym.py:323
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:326
+#: journal/importers/rym.py:347
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -4404,11 +4404,11 @@ msgstr ""
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:55
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:189 users/templates/users/data.html:242
-#: users/templates/users/data.html:293 users/templates/users/data.html:354
-#: users/templates/users/data.html:414
+#: users/templates/users/data.html:160 users/templates/users/data.html:213
+#: users/templates/users/data.html:264 users/templates/users/data.html:363
+#: users/templates/users/data.html:423
 #: users/templates/users/preferences.html:56
-#: users/templates/users/rym_import.html:82
+#: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
 msgid "Public"
 msgstr ""
@@ -4417,11 +4417,11 @@ msgstr ""
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:62
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:197
-#: users/templates/users/data.html:250 users/templates/users/data.html:301
-#: users/templates/users/data.html:362 users/templates/users/data.html:422
+#: users/templates/users/data.html:115 users/templates/users/data.html:168
+#: users/templates/users/data.html:221 users/templates/users/data.html:272
+#: users/templates/users/data.html:371 users/templates/users/data.html:431
 #: users/templates/users/preferences.html:63
-#: users/templates/users/rym_import.html:86
+#: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
 msgid "Followers Only"
 msgstr ""
@@ -4430,11 +4430,11 @@ msgstr ""
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:69
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:205
-#: users/templates/users/data.html:258 users/templates/users/data.html:309
-#: users/templates/users/data.html:370 users/templates/users/data.html:430
+#: users/templates/users/data.html:123 users/templates/users/data.html:176
+#: users/templates/users/data.html:229 users/templates/users/data.html:280
+#: users/templates/users/data.html:379 users/templates/users/data.html:439
 #: users/templates/users/preferences.html:70
-#: users/templates/users/rym_import.html:90
+#: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
 msgid "Mentioned Only"
 msgstr ""
@@ -4455,7 +4455,7 @@ msgstr ""
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:71
+#: journal/models/note.py:34 users/templates/users/rym_import.html:73
 msgid "Page"
 msgstr ""
 
@@ -6600,9 +6600,9 @@ msgid "CSV file"
 msgstr ""
 
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:208
-#: users/templates/users/data.html:261 users/templates/users/data.html:312
-#: users/templates/users/data.html:375 users/templates/users/data.html:435
+#: users/templates/users/data.html:126 users/templates/users/data.html:179
+#: users/templates/users/data.html:232 users/templates/users/data.html:283
+#: users/templates/users/data.html:384 users/templates/users/data.html:444
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -6718,7 +6718,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:333
+#: users/templates/users/data.html:34 users/templates/users/data.html:342
 msgid "Import Method"
 msgstr ""
 
@@ -6750,164 +6750,168 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:172
+#: users/templates/users/data.html:93 users/templates/users/data.html:143
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
 #: users/templates/users/data.html:133
-msgid "Import from RateYourMusic"
-msgstr ""
-
-#: users/templates/users/data.html:139
-msgid "On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file."
-msgstr ""
-
-#: users/templates/users/data.html:141 users/templates/users/data.html:170
-msgid "Upload the downloaded CSV file below."
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
-msgstr ""
-
-#: users/templates/users/data.html:150
-msgid "Upload and match"
-msgstr ""
-
-#: users/templates/users/data.html:153
-msgid "Review pending RateYourMusic matches"
-msgstr ""
-
-#: users/templates/users/data.html:162
 msgid "Import from StoryGraph"
 msgstr ""
 
-#: users/templates/users/data.html:168
+#: users/templates/users/data.html:139
 msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:175
+#: users/templates/users/data.html:141 users/templates/users/data.html:299
+msgid "Upload the downloaded CSV file below."
+msgstr ""
+
+#: users/templates/users/data.html:146
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
 
-#: users/templates/users/data.html:215
+#: users/templates/users/data.html:186
 msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:221
+#: users/templates/users/data.html:192
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:224
+#: users/templates/users/data.html:195
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:227
+#: users/templates/users/data.html:198
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:262 users/templates/users/data.html:313
+#: users/templates/users/data.html:233 users/templates/users/data.html:284
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:269
+#: users/templates/users/data.html:240
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:275
+#: users/templates/users/data.html:246
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:278
+#: users/templates/users/data.html:249
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:280
+#: users/templates/users/data.html:251
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
+#: users/templates/users/data.html:291
+msgid "Import from RateYourMusic"
+msgstr ""
+
+#: users/templates/users/data.html:297
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
+msgstr ""
+
+#: users/templates/users/data.html:301
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr ""
+
+#: users/templates/users/data.html:304
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr ""
+
+#: users/templates/users/data.html:308
+msgid "Upload and match"
+msgstr ""
+
+#: users/templates/users/data.html:313
+msgid "Review pending matches"
+msgstr ""
+
 #: users/templates/users/data.html:320
+msgid "Download previous matches"
+msgstr ""
+
+#: users/templates/users/data.html:329
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:323
+#: users/templates/users/data.html:332
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:329
+#: users/templates/users/data.html:338
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:340
+#: users/templates/users/data.html:349
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:344
+#: users/templates/users/data.html:353
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:373
+#: users/templates/users/data.html:382
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:383
+#: users/templates/users/data.html:392
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:398
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:391
+#: users/templates/users/data.html:400
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:401
+#: users/templates/users/data.html:410
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:462
+#: users/templates/users/data.html:471
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:497
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:513
+#: users/templates/users/data.html:522
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:537
+#: users/templates/users/data.html:546
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:541
+#: users/templates/users/data.html:550
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:557
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:556
+#: users/templates/users/data.html:565
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:559
+#: users/templates/users/data.html:568
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:564
+#: users/templates/users/data.html:573
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:573
+#: users/templates/users/data.html:582
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7330,19 +7334,19 @@ msgstr ""
 msgid "Shelf"
 msgstr ""
 
-#: users/templates/users/rym_import.html:69
+#: users/templates/users/rym_import.html:71
 msgid "Prev"
 msgstr ""
 
-#: users/templates/users/rym_import.html:73
+#: users/templates/users/rym_import.html:75
 msgid "Next"
 msgstr ""
 
-#: users/templates/users/rym_import.html:93
+#: users/templates/users/rym_import.html:95
 msgid "Confirm Import"
 msgstr ""
 
-#: users/templates/users/rym_import.html:94
+#: users/templates/users/rym_import.html:96
 msgid "Back"
 msgstr ""
 
@@ -7571,9 +7575,9 @@ msgstr ""
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:553
-#: users/views/data.py:577 users/views/data.py:602 users/views/data.py:626
-#: users/views/data.py:650
+#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:568
+#: users/views/data.py:592 users/views/data.py:617 users/views/data.py:641
+#: users/views/data.py:665
 msgid "Invalid file."
 msgstr ""
 
@@ -7581,86 +7585,86 @@ msgstr ""
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:424
+#: users/views/data.py:433
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:429 users/views/data.py:536
+#: users/views/data.py:441 users/views/data.py:551
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:522
+#: users/views/data.py:537
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:532
+#: users/views/data.py:547
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:770
+#: users/views/data.py:785
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:792
+#: users/views/data.py:807
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:808
+#: users/views/data.py:823
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:813
+#: users/views/data.py:828
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:823 users/views/data.py:874
+#: users/views/data.py:838 users/views/data.py:889
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:830
+#: users/views/data.py:845
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:835
+#: users/views/data.py:850
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:861
+#: users/views/data.py:876
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:866
+#: users/views/data.py:881
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:879
+#: users/views/data.py:894
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:890
+#: users/views/data.py:905
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:896
+#: users/views/data.py:911
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:954
+#: users/views/data.py:969
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:970
+#: users/views/data.py:985
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:974
+#: users/views/data.py:989
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:983
+#: users/views/data.py:998
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 21:53-0400\n"
+"POT-Creation-Date: 2026-05-16 08:42-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -3394,7 +3394,7 @@ msgstr "搜索你的评论或条目，可加过滤条件如 category:tv status:c
 msgid "name of a person or company"
 msgstr "人物或公司名称"
 
-#: common/templates/_header.html:173 users/templates/users/_rym_row.html:23
+#: common/templates/_header.html:173
 msgid "Open"
 msgstr "打开"
 
@@ -4316,10 +4316,10 @@ msgstr "保存时将行首空格替换为全角"
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:188 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:180
-#: users/templates/users/data.html:233 users/templates/users/data.html:284
-#: users/templates/users/data.html:346 users/templates/users/data.html:405
-#: users/templates/users/rym_import.html:79
+#: users/templates/users/data.html:98 users/templates/users/data.html:151
+#: users/templates/users/data.html:204 users/templates/users/data.html:255
+#: users/templates/users/data.html:355 users/templates/users/data.html:414
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
 msgstr "可见性"
@@ -4352,7 +4352,7 @@ msgstr "创建者和他们的本地互关"
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:180 users/templates/users/data.html:560
+#: journal/forms.py:180 users/templates/users/data.html:569
 msgid "Status"
 msgstr "状态"
 
@@ -4365,7 +4365,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:390 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:411 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4375,26 +4375,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:138
+#: journal/importers/rym.py:146
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:148
+#: journal/importers/rym.py:156
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:193
+#: journal/importers/rym.py:210
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:302
+#: journal/importers/rym.py:323
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:326
+#: journal/importers/rym.py:347
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -4424,11 +4424,11 @@ msgstr "创建了收藏单"
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:55
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:189 users/templates/users/data.html:242
-#: users/templates/users/data.html:293 users/templates/users/data.html:354
-#: users/templates/users/data.html:414
+#: users/templates/users/data.html:160 users/templates/users/data.html:213
+#: users/templates/users/data.html:264 users/templates/users/data.html:363
+#: users/templates/users/data.html:423
 #: users/templates/users/preferences.html:56
-#: users/templates/users/rym_import.html:82
+#: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
 msgid "Public"
 msgstr "公开"
@@ -4437,11 +4437,11 @@ msgstr "公开"
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:62
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:197
-#: users/templates/users/data.html:250 users/templates/users/data.html:301
-#: users/templates/users/data.html:362 users/templates/users/data.html:422
+#: users/templates/users/data.html:115 users/templates/users/data.html:168
+#: users/templates/users/data.html:221 users/templates/users/data.html:272
+#: users/templates/users/data.html:371 users/templates/users/data.html:431
 #: users/templates/users/preferences.html:63
-#: users/templates/users/rym_import.html:86
+#: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
 msgid "Followers Only"
 msgstr "仅关注者"
@@ -4450,11 +4450,11 @@ msgstr "仅关注者"
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:69
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:205
-#: users/templates/users/data.html:258 users/templates/users/data.html:309
-#: users/templates/users/data.html:370 users/templates/users/data.html:430
+#: users/templates/users/data.html:123 users/templates/users/data.html:176
+#: users/templates/users/data.html:229 users/templates/users/data.html:280
+#: users/templates/users/data.html:379 users/templates/users/data.html:439
 #: users/templates/users/preferences.html:70
-#: users/templates/users/rym_import.html:90
+#: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
@@ -4475,7 +4475,7 @@ msgstr "帖文未能发布到联邦实例，请重新验证登录。"
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能发布到联邦实例。"
 
-#: journal/models/note.py:34 users/templates/users/rym_import.html:71
+#: journal/models/note.py:34 users/templates/users/rym_import.html:73
 msgid "Page"
 msgstr "页码"
 
@@ -6718,9 +6718,9 @@ msgid "CSV file"
 msgstr "CSV 文件"
 
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:208
-#: users/templates/users/data.html:261 users/templates/users/data.html:312
-#: users/templates/users/data.html:375 users/templates/users/data.html:435
+#: users/templates/users/data.html:126 users/templates/users/data.html:179
+#: users/templates/users/data.html:232 users/templates/users/data.html:283
+#: users/templates/users/data.html:384 users/templates/users/data.html:444
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -6836,7 +6836,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:333
+#: users/templates/users/data.html:34 users/templates/users/data.html:342
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -6868,164 +6868,168 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:172
+#: users/templates/users/data.html:93 users/templates/users/data.html:143
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr "将导入想读、在读、已读和放弃的书籍及其评论。"
 
 #: users/templates/users/data.html:133
-msgid "Import from RateYourMusic"
-msgstr "从RateYourMusic导入"
-
-#: users/templates/users/data.html:139
-msgid "On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file."
-msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your data</b> 选项将你的收藏导出为 CSV 文件。"
-
-#: users/templates/users/data.html:141 users/templates/users/data.html:170
-msgid "Upload the downloaded CSV file below."
-msgstr "在下方上传下载到的 CSV 文件。"
-
-#: users/templates/users/data.html:143
-msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
-msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
-
-#: users/templates/users/data.html:146
-msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
-msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
-
-#: users/templates/users/data.html:150
-msgid "Upload and match"
-msgstr "上传并匹配"
-
-#: users/templates/users/data.html:153
-msgid "Review pending RateYourMusic matches"
-msgstr "审阅待处理的 RateYourMusic 匹配"
-
-#: users/templates/users/data.html:162
 msgid "Import from StoryGraph"
 msgstr "从StoryGraph导入"
 
-#: users/templates/users/data.html:168
+#: users/templates/users/data.html:139
 msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:175
+#: users/templates/users/data.html:141 users/templates/users/data.html:299
+msgid "Upload the downloaded CSV file below."
+msgstr "在下方上传下载到的 CSV 文件。"
+
+#: users/templates/users/data.html:146
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
 
-#: users/templates/users/data.html:215
+#: users/templates/users/data.html:186
 msgid "Import from Letterboxd"
 msgstr "导入Letterboxd标记"
 
-#: users/templates/users/data.html:221
+#: users/templates/users/data.html:192
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:224
+#: users/templates/users/data.html:195
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:227
+#: users/templates/users/data.html:198
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:262 users/templates/users/data.html:313
+#: users/templates/users/data.html:233 users/templates/users/data.html:284
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "导入时仅更新正向变化(未标->想看->已看)标记；不足360字符的评论会作为短评添加。"
 
-#: users/templates/users/data.html:269
+#: users/templates/users/data.html:240
 msgid "Import from Trakt"
 msgstr "导入Trakt标记"
 
-#: users/templates/users/data.html:275
+#: users/templates/users/data.html:246
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr "在<a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt设置 - 数据</a>页面，点击<b>Export now</b>，等待下载链接出现。"
 
-#: users/templates/users/data.html:278
+#: users/templates/users/data.html:249
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 
-#: users/templates/users/data.html:280
+#: users/templates/users/data.html:251
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
+#: users/templates/users/data.html:291
+msgid "Import from RateYourMusic"
+msgstr "从RateYourMusic导入"
+
+#: users/templates/users/data.html:297
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
+msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
+
+#: users/templates/users/data.html:301
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
+
+#: users/templates/users/data.html:304
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
+
+#: users/templates/users/data.html:308
+msgid "Upload and match"
+msgstr "上传并匹配"
+
+#: users/templates/users/data.html:313
+msgid "Review pending matches"
+msgstr "审阅待处理的匹配"
+
 #: users/templates/users/data.html:320
+msgid "Download previous matches"
+msgstr "下载先前的匹配"
+
+#: users/templates/users/data.html:329
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:323
+#: users/templates/users/data.html:332
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:329
+#: users/templates/users/data.html:338
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:340
+#: users/templates/users/data.html:349
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:344
+#: users/templates/users/data.html:353
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:373
+#: users/templates/users/data.html:382
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:383
+#: users/templates/users/data.html:392
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:398
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:391
+#: users/templates/users/data.html:400
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:401
+#: users/templates/users/data.html:410
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:462
+#: users/templates/users/data.html:471
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:497
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:513
+#: users/templates/users/data.html:522
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:537
+#: users/templates/users/data.html:546
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:541
+#: users/templates/users/data.html:550
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:557
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:556
+#: users/templates/users/data.html:565
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:559
+#: users/templates/users/data.html:568
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:564
+#: users/templates/users/data.html:573
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:573
+#: users/templates/users/data.html:582
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7448,19 +7452,19 @@ msgstr "匹配链接"
 msgid "Shelf"
 msgstr "标记"
 
-#: users/templates/users/rym_import.html:69
+#: users/templates/users/rym_import.html:71
 msgid "Prev"
 msgstr "上一页"
 
-#: users/templates/users/rym_import.html:73
+#: users/templates/users/rym_import.html:75
 msgid "Next"
 msgstr "下一页"
 
-#: users/templates/users/rym_import.html:93
+#: users/templates/users/rym_import.html:95
 msgid "Confirm Import"
 msgstr "确认导入"
 
-#: users/templates/users/rym_import.html:94
+#: users/templates/users/rym_import.html:96
 msgid "Back"
 msgstr "返回"
 
@@ -7692,9 +7696,9 @@ msgstr "正在同步。"
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:553
-#: users/views/data.py:577 users/views/data.py:602 users/views/data.py:626
-#: users/views/data.py:650
+#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:568
+#: users/views/data.py:592 users/views/data.py:617 users/views/data.py:641
+#: users/views/data.py:665
 msgid "Invalid file."
 msgstr "无效文件。"
 
@@ -7702,86 +7706,86 @@ msgstr "无效文件。"
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:424
+#: users/views/data.py:433
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:429 users/views/data.py:536
+#: users/views/data.py:441 users/views/data.py:551
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:522
+#: users/views/data.py:537
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:532
+#: users/views/data.py:547
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:770
+#: users/views/data.py:785
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:792
+#: users/views/data.py:807
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:808
+#: users/views/data.py:823
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:813
+#: users/views/data.py:828
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:823 users/views/data.py:874
+#: users/views/data.py:838 users/views/data.py:889
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:830
+#: users/views/data.py:845
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:835
+#: users/views/data.py:850
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:861
+#: users/views/data.py:876
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:866
+#: users/views/data.py:881
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:879
+#: users/views/data.py:894
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:890
+#: users/views/data.py:905
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:896
+#: users/views/data.py:911
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:954
+#: users/views/data.py:969
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:970
+#: users/views/data.py:985
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:974
+#: users/views/data.py:989
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:983
+#: users/views/data.py:998
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/users/templates/users/data.html
+++ b/users/templates/users/data.html
@@ -294,7 +294,7 @@
               {% csrf_token %}
               <ul>
                 <li>
-                  {% blocktrans %}On RateYourMusic, go to your profile and use the <b>Export your data</b> option to download your library as a CSV file.{% endblocktrans %}
+                  {% blocktrans %}On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file.{% endblocktrans %}
                 </li>
                 <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
                 <li>
@@ -308,7 +308,16 @@
               <input type="submit" value="{% trans 'Upload and match' %}" />
               {% if rym_task and rym_task.metadata.phase == 'preview' %}
                 <p>
-                  <a href="{% url 'users:rym_preview' %}">{% trans 'Review pending RateYourMusic matches' %}</a>
+                  <a href="{% url 'users:rym_preview' %}"
+                     role="button"
+                     class="secondary outline">{% trans 'Review pending matches' %}</a>
+                </p>
+              {% endif %}
+              {% if rym_task and rym_task.metadata.phase == 'done' and rym_task.metadata.matched_file %}
+                <p>
+                  <a href="{% url 'users:rym_download' %}"
+                     role="button"
+                     class="secondary outline">{% trans 'Download previous matches' %}</a>
                 </p>
               {% endif %}
               {% include "users/user_task_status.html" with task=rym_task %}


### PR DESCRIPTION
## Summary
- Convert "Review pending RateYourMusic matches" link into a styled secondary outline button labeled "Review pending matches".
- Add a "Download previous matches" button on the data page when the RYM importer phase is `done` and a matched file exists.
- Update the RateYourMusic instructions to reference the actual menu label, "Export your music catalog".
- Refresh zh_Hans translations.

## Test plan
- [ ] Upload a RYM CSV; verify the "Review pending matches" appears as a button while `phase == preview`.
- [ ] Complete an import; verify "Download previous matches" appears and downloads the matched CSV.
- [ ] Verify zh_Hans copy reads naturally.