### PR TITLE
feat(catalog/search): emit Sentry metric for external search failures

### DIFF
--- a/catalog/search/__init__.py
+++ b/catalog/search/__init__.py
@@ -1,7 +1,7 @@
 from .external import ExternalSearchResultItem, ExternalSources
 from .index import CatalogIndex, CatalogQueryParser, CatalogSearchResult
 from .people_index import PeopleIndex, PeopleQueryParser, PeopleSearchResult
-from .utils import enqueue_fetch, get_fetch_lock, query_index
+from .utils import enqueue_fetch, get_fetch_lock, query_index, record_search_failure
 
 __all__ = [
     "CatalogIndex",
@@ -13,6 +13,7 @@ __all__ = [
     "query_index",
     "get_fetch_lock",
     "enqueue_fetch",
+    "record_search_failure",
     "ExternalSources",
     "ExternalSearchResultItem",
 ]

--- a/catalog/search/utils.py
+++ b/catalog/search/utils.py
@@ -161,6 +161,13 @@ def _record_fetch_failure(url: str) -> None:
     )
 
 
+def record_search_failure(site: str, reason: str) -> None:
+    sentry_count(
+        "catalog.search.failure",
+        attributes={"site": site, "reason": reason},
+    )
+
+
 def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
     user = User.objects.get(pk=user_pk) if user_pk else None
     with set_actor(user):

--- a/catalog/sites/apple_podcast.py
+++ b/catalog/sites/apple_podcast.py
@@ -68,8 +68,10 @@ class ApplePodcast(AbstractSite):
                         )
             except httpx.ReadTimeout:
                 logger.warning("ApplePodcast search timeout", extra={"query": q})
+                record_search_failure(cls.SITE_NAME.value, "timeout")
             except Exception as e:
                 logger.error(
                     "ApplePodcast search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(cls.SITE_NAME.value, "error")
         return results

--- a/catalog/sites/bandcamp.py
+++ b/catalog/sites/bandcamp.py
@@ -160,8 +160,10 @@ class Bandcamp(AbstractSite):
                     )
             except httpx.ReadTimeout:
                 logger.warning("Bandcamp search timeout", extra={"query": q})
+                record_search_failure(SiteName.Bandcamp.value, "timeout")
             except Exception as e:
                 logger.error(
                     "Bandcamp search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(SiteName.Bandcamp.value, "error")
         return results[offset : offset + page_size]

--- a/catalog/sites/bangumi.py
+++ b/catalog/sites/bangumi.py
@@ -20,7 +20,7 @@ from catalog.models import (
 )
 from catalog.models.game import GameReleaseType
 from catalog.models.utils import detect_isbn_asin
-from catalog.search import ExternalSearchResultItem
+from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models.lang import detect_language
 
 _logger = logging.getLogger(__name__)
@@ -177,8 +177,10 @@ class Bangumi(AbstractSite):
                         )
             except httpx.ReadTimeout:
                 logger.warning("Bangumi search timeout", extra={"query": q})
+                record_search_failure(cls.SITE_NAME.value, "timeout")
             except Exception as e:
                 logger.error("Bangumi search error", extra={"query": q, "exception": e})
+                record_search_failure(cls.SITE_NAME.value, "error")
         return results
 
     def scrape(self):

--- a/catalog/sites/fedi.py
+++ b/catalog/sites/fedi.py
@@ -206,7 +206,7 @@ class FediverseInstance(AbstractSite):
                     extra={"url": api_url, "query": q, "exception": e},
                 )
                 reason = "timeout" if isinstance(e, httpx.TimeoutException) else "error"
-                record_search_failure(f"fediverse:{host}", reason)
+                record_search_failure("fediverse", reason)
                 return []
             if "data" in r:
                 for item in r["data"]:

--- a/catalog/sites/fedi.py
+++ b/catalog/sites/fedi.py
@@ -31,7 +31,7 @@ from catalog.models import (
     TVSeason,
     TVShow,
 )
-from catalog.search import ExternalSearchResultItem
+from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import SiteConfig
 
 
@@ -205,6 +205,8 @@ class FediverseInstance(AbstractSite):
                     f"Fediverse search {host} error",
                     extra={"url": api_url, "query": q, "exception": e},
                 )
+                reason = "timeout" if isinstance(e, httpx.TimeoutException) else "error"
+                record_search_failure(f"fediverse:{host}", reason)
                 return []
             if "data" in r:
                 for item in r["data"]:

--- a/catalog/sites/goodreads.py
+++ b/catalog/sites/goodreads.py
@@ -20,7 +20,7 @@ from catalog.models import (
     Work,
 )
 from catalog.models.utils import binding_to_format, detect_isbn_asin
-from catalog.search import ExternalSearchResultItem
+from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import detect_language
 from journal.models.renderers import html_to_text
 
@@ -227,10 +227,12 @@ class Goodreads(AbstractSite):
                         )
             except httpx.ReadTimeout:
                 logger.warning("Goodreads search timeout", extra={"query": q})
+                record_search_failure(SiteName.Goodreads.value, "timeout")
             except Exception as e:
                 logger.error(
                     "Goodreads search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(SiteName.Goodreads.value, "error")
         return results[offset : offset + page_size]
 
 

--- a/catalog/sites/google_books.py
+++ b/catalog/sites/google_books.py
@@ -171,8 +171,10 @@ class GoogleBooks(AbstractSite):
                         )
             except httpx.ReadTimeout:
                 logger.warning("GoogleBooks search timeout", extra={"query": q})
+                record_search_failure(SiteName.GoogleBooks.value, "timeout")
             except Exception as e:
                 logger.error(
                     "GoogleBooks search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(SiteName.GoogleBooks.value, "error")
         return results

--- a/catalog/sites/igdb.py
+++ b/catalog/sites/igdb.py
@@ -17,7 +17,7 @@ from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
-from catalog.search import ExternalSearchResultItem
+from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import SiteConfig
 
 _cache_key = "igdb_access_token"
@@ -209,6 +209,8 @@ class IGDB(AbstractSite):
                     rs = json.loads(response.content)
             except httpx.HTTPError as e:
                 logger.error(f"IGDB API: {e}", extra={"exception": e})
+                reason = "timeout" if isinstance(e, httpx.TimeoutException) else "error"
+                record_search_failure(SiteName.IGDB.value, reason)
         result = []
         for r in rs:
             subtitle = ""

--- a/catalog/sites/musicbrainz.py
+++ b/catalog/sites/musicbrainz.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
-from catalog.search import ExternalSearchResultItem
+from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models.lang import detect_language
 
 _logger = logging.getLogger(__name__)
@@ -490,11 +490,13 @@ class MusicBrainzRelease(AbstractSite):
 
             except httpx.TimeoutException:
                 logger.warning("MusicBrainz release search timeout", extra={"query": q})
+                record_search_failure(SiteName.MusicBrainz.value, "timeout")
             except Exception as e:
                 logger.error(
                     "MusicBrainz release search error",
                     extra={"query": q, "exception": e},
                 )
+                record_search_failure(SiteName.MusicBrainz.value, "error")
 
         return results
 
@@ -547,12 +549,14 @@ class MusicBrainzRelease(AbstractSite):
                 data = response.json()
             except httpx.TimeoutException:
                 logger.warning("MusicBrainz field search timeout", extra={"query": q})
+                record_search_failure(SiteName.MusicBrainz.value, "timeout")
                 return results
             except Exception as e:
                 logger.error(
                     "MusicBrainz field search error",
                     extra={"query": q, "exception": e},
                 )
+                record_search_failure(SiteName.MusicBrainz.value, "error")
                 return results
             for release in data.get("releases", []) or []:
                 title = release.get("title", "")

--- a/catalog/sites/openlibrary.py
+++ b/catalog/sites/openlibrary.py
@@ -230,10 +230,12 @@ class OpenLibrary(AbstractSite):
 
             except httpx.ReadTimeout:
                 logger.warning("OpenLibrary search timeout", extra={"query": q})
+                record_search_failure(cls.SITE_NAME.value, "timeout")
             except Exception as e:
                 logger.error(
                     "OpenLibrary search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(cls.SITE_NAME.value, "error")
 
         return results
 

--- a/catalog/sites/spotify.py
+++ b/catalog/sites/spotify.py
@@ -14,6 +14,7 @@ from loguru import logger
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import upc_to_gtin_13
+from catalog.search import record_search_failure
 from common.models import SiteConfig
 from common.models.lang import detect_language
 
@@ -176,8 +177,10 @@ class Spotify(AbstractSite):
                     logger.warning(f"Spotify search '{q}' no results found.")
             except httpx.ReadTimeout:
                 logger.warning("Spotify search timeout", extra={"query": q})
+                record_search_failure(SiteName.Spotify.value, "timeout")
             except Exception as e:
                 logger.error("Spotify search error", extra={"query": q, "exception": e})
+                record_search_failure(SiteName.Spotify.value, "error")
         return results
 
     @classmethod
@@ -246,10 +249,12 @@ class Spotify(AbstractSite):
                     )
             except httpx.ReadTimeout:
                 logger.warning("Spotify field search timeout", extra={"query": q})
+                record_search_failure(SiteName.Spotify.value, "timeout")
             except Exception as e:
                 logger.error(
                     "Spotify field search error", extra={"query": q, "exception": e}
                 )
+                record_search_failure(SiteName.Spotify.value, "error")
         return results
 
 

--- a/catalog/sites/tmdb.py
+++ b/catalog/sites/tmdb.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
+from catalog.search import record_search_failure
 from common.models import SiteConfig
 from common.models.lang import SITE_PREFERRED_LANGUAGES
 
@@ -290,8 +291,10 @@ class TMDB_Movie(AbstractSite):
                     logger.warning(f"TMDB search '{q}' no results found.")
             except httpx.ReadTimeout:
                 logger.warning("TMDb search timeout", extra={"query": q})
+                record_search_failure(SiteName.TMDB.value, "timeout")
             except Exception as e:
                 logger.error("TMDb search error", extra={"query": q, "exception": e})
+                record_search_failure(SiteName.TMDB.value, "error")
         return results[offset : offset + page_size]
 
 


### PR DESCRIPTION
## Summary
- Adds `catalog.search.failure` Sentry counter with `{site, reason}` attributes, emitted from the except blocks of every external `search_task` (goodreads, bandcamp, bangumi, apple_podcast, openlibrary, google_books, musicbrainz [release + field], tmdb, spotify [search_task + search_by_fields], igdb, and fedi `peer_search_task`).
- Shared helper `record_search_failure(site, reason)` lives in `catalog/search/utils.py` and is re-exported from `catalog/search/__init__.py`, mirroring the existing `catalog.fetch.failure` / `_record_fetch_failure` pattern.
- `reason` is `"timeout"` for `httpx.ReadTimeout`/`TimeoutException`, otherwise `"error"`. For IGDB and fedi (which use broader except clauses) the kind is determined via `isinstance(..., httpx.TimeoutException)`. Fedi reports site as `fediverse:<host>` so per-peer reliability is visible.

## Test plan
- [x] `uv run pre-commit run -a` passes
- [ ] Verify in Sentry that `catalog.search.failure` counter shows up with `site`/`reason` attributes when an external search times out or errors