### PR TITLE
RYM importer: cancel/htmx-only upload, progress counter fix, docs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -36,6 +36,7 @@ NeoDB has [various features](features.md), and you may image it as a mix of Mast
   - import list or archives from some 3rd party sites:
     - Goodreads reading list
     - Letterboxd watch list
+    - RateYourMusic album collection (CSV export)
     - Douban archive (via [Doufen](https://doufen.org/))
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,10 +33,12 @@ NeoDB has [various features](features.md), and you may image it as a mix of Mast
   - create and share list of items
   - tracking progress of a list (e.g. personal reading challenges)
   - Import and export full user data archive
-  - import list or archives from some 3rd party sites:
-    - Goodreads reading list
-    - Letterboxd watch list
+  - import list or archives from some 3rd party sites (see [supported sites](sites.md) for details):
+    - Goodreads reading list (CSV export)
+    - StoryGraph reading list (CSV export)
+    - Letterboxd watch list (ZIP export)
     - RateYourMusic album collection (CSV export)
+    - Podcast subscriptions (OPML)
     - Douban archive (via [Doufen](https://doufen.org/))
 
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -25,7 +25,7 @@ The following external sites are supported for importing catalog items.
 | MusicBrainz | Music (Album) | |
 | OpenLibrary | Book (Edition, Work) | |
 | Qidian 起点 | Book (Edition) | |
-| RateYourMusic | Music (Album) | |
+| RateYourMusic | Music (Album) | Yes — upload CSV export |
 | RSS feed | Podcast | Yes — upload OPML |
 | Spotify | Music (Album) | |
 | Steam | Game | |

--- a/journal/importers/rym.py
+++ b/journal/importers/rym.py
@@ -30,6 +30,18 @@ OWNERSHIP_TO_SHELF = {
 }
 MATCHED_EXTRA_COLUMNS = ["link", "match_source", "shelf", "collect_date", "notes"]
 
+
+class RymCancelled(Exception):
+    """Raised by the worker when the view has flipped phase to 'cancelled'.
+
+    Why: ``rym_cancel`` writes ``phase=cancelled`` directly to the DB. Without
+    re-reading, the worker's next ``self.save(update_fields=["metadata", ...])``
+    would clobber that flag with its in-memory copy of metadata. Worker code
+    calls ``_raise_if_cancelled`` immediately before every save so cancellation
+    takes effect and the loop exits cleanly.
+    """
+
+
 _BBCODE_PATTERNS = [
     (re.compile(r"\[b\](.*?)\[/b\]", re.DOTALL | re.IGNORECASE), r"**\1**"),
     (re.compile(r"\[i\](.*?)\[/i\]", re.DOTALL | re.IGNORECASE), r"*\1*"),
@@ -135,6 +147,17 @@ class RymImporter(Task):
 
     PROGRESS_SAVE_EVERY = 25  # flush task row at most every N processed rows
 
+    def _raise_if_cancelled(self) -> None:
+        """Honour user-initiated cancellation written by the view."""
+        fresh = (
+            type(self)
+            .objects.filter(pk=self.pk)
+            .values_list("metadata", flat=True)
+            .first()
+        )
+        if fresh and fresh.get("phase") == "cancelled":
+            raise RymCancelled()
+
     def progress(self, *, force: bool = False, **delta) -> None:
         for k, v in delta.items():
             self.metadata[k] = self.metadata.get(k, 0) + v
@@ -161,6 +184,7 @@ class RymImporter(Task):
             )
         # Avoid hammering the DB with one save per CSV row.
         if force or done % self.PROGRESS_SAVE_EVERY == 0 or done == total:
+            self._raise_if_cancelled()
             self.save(update_fields=["metadata", "message"])
 
     def run(self) -> None:
@@ -188,6 +212,7 @@ class RymImporter(Task):
                 rows.append({k.strip(): v for k, v in raw_row.items()})
         self.metadata["total"] = len(rows)
         self.metadata["matched_file"] = out_path
+        self._raise_if_cancelled()
         self.save(update_fields=["metadata"])
 
         # One asyncio loop reused for all external lookups in this phase —
@@ -212,6 +237,7 @@ class RymImporter(Task):
             ext=self.metadata.get("matched_external", 0),
             none=self.metadata.get("unmatched", 0),
         )
+        self._raise_if_cancelled()
         self.save(update_fields=["metadata", "message"])
 
     def _match_row(self, row: dict) -> None:
@@ -328,18 +354,22 @@ class RymImporter(Task):
             rows = [{k.strip(): v for k, v in r.items()} for r in reader]
         self.metadata["total"] = len(rows)
         self.metadata["processed"] = 0
+        self._raise_if_cancelled()
         self.save(update_fields=["metadata"])
         visibility = int(self.metadata.get("visibility", 0))
         owner = self.user.identity
         for row in rows:
             try:
                 self._import_row(row, owner, visibility)
+            except RymCancelled:
+                raise
             except Exception as e:
                 logger.exception(f"RYM row import failed: {e}")
                 self.progress(processed=1, failed=1)
                 url = (row.get("link") or "").strip()
                 if url:
                     self.metadata["failed_urls"].append(url)
+                    self._raise_if_cancelled()
                     self.save(update_fields=["metadata"])
 
         self.metadata["phase"] = "done"
@@ -350,6 +380,7 @@ class RymImporter(Task):
             skipped=self.metadata.get("skipped", 0),
             failed=self.metadata.get("failed", 0),
         )
+        self._raise_if_cancelled()
         self.save(update_fields=["metadata", "message"])
 
     def _import_row(self, row: dict, owner, visibility: int) -> None:
@@ -377,6 +408,7 @@ class RymImporter(Task):
         if not item:
             self.progress(processed=1, failed=1)
             self.metadata["failed_urls"].append(link)
+            self._raise_if_cancelled()
             self.save(update_fields=["metadata"])
             return
 

--- a/journal/importers/rym.py
+++ b/journal/importers/rym.py
@@ -200,7 +200,6 @@ class RymImporter(Task):
                 for row in rows:
                     self._match_row(row)
                     writer.writerow(row)
-                    self.progress(processed=1)
         finally:
             self._match_loop.close()
             self._match_loop = None
@@ -235,25 +234,26 @@ class RymImporter(Task):
         # already populated link (round-trip)
         if (row.get("link") or "").strip():
             row.setdefault("match_source", "preset")
+            self.progress(processed=1)
             return
 
         item = self._local_match(title, artist, year)
         if item:
             row["link"] = item.url
             row["match_source"] = "local"
-            self.progress(matched_local=1)
+            self.progress(processed=1, matched_local=1)
             return
 
         ext_url = self._external_match(title, artist, year)
         if ext_url:
             row["link"] = ext_url[0]
             row["match_source"] = ext_url[1]
-            self.progress(matched_external=1)
+            self.progress(processed=1, matched_external=1)
             return
 
         row["link"] = ""
         row["match_source"] = "none"
-        self.progress(unmatched=1)
+        self.progress(processed=1, unmatched=1)
 
     def _local_match(self, title: str, artist: str, year: str | None) -> Item | None:
         if not title:

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-16 15:48-0400\n"
+"POT-Creation-Date: 2026-05-16 16:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4345,7 +4345,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:411 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4355,26 +4355,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:146
+#: journal/importers/rym.py:168
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:156
+#: journal/importers/rym.py:178
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:210
+#: journal/importers/rym.py:233
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:323
+#: journal/importers/rym.py:348
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:347
+#: journal/importers/rym.py:376
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -6313,44 +6313,44 @@ msgid "(skip)"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:5
-#: users/templates/users/_rym_section.html:24
+#: users/templates/users/_rym_section.html:21
 msgid "Import from RateYourMusic"
 msgstr ""
 
-#: users/templates/users/_rym_section.html:11
+#: users/templates/users/_rym_section.html:9
 msgid "Review pending matches"
 msgstr ""
 
-#: users/templates/users/_rym_section.html:17
-msgid "Cancel the RateYourMusic import? Matching progress will be discarded."
+#: users/templates/users/_rym_section.html:15
+msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr ""
 
-#: users/templates/users/_rym_section.html:19
+#: users/templates/users/_rym_section.html:16
 msgid "Cancel import"
 msgstr ""
 
-#: users/templates/users/_rym_section.html:32
+#: users/templates/users/_rym_section.html:29
 msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/_rym_section.html:34
+#: users/templates/users/_rym_section.html:31
 #: users/templates/users/data.html:141
 msgid "Upload the downloaded CSV file below."
 msgstr ""
 
-#: users/templates/users/_rym_section.html:36
+#: users/templates/users/_rym_section.html:33
 msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
-#: users/templates/users/_rym_section.html:39
+#: users/templates/users/_rym_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
-#: users/templates/users/_rym_section.html:43
+#: users/templates/users/_rym_section.html:40
 msgid "Upload and match"
 msgstr ""
 
-#: users/templates/users/_rym_section.html:49
+#: users/templates/users/_rym_section.html:46
 msgid "Download previous matches"
 msgstr ""
 
@@ -7561,124 +7561,124 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:230 users/views/data.py:259
+#: users/views/data.py:221 users/views/data.py:250
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:253
+#: users/views/data.py:244
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:271
+#: users/views/data.py:262
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:286 users/views/data.py:306
+#: users/views/data.py:277 users/views/data.py:297
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:320
+#: users/views/data.py:311
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:334
+#: users/views/data.py:325
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:343 users/views/data.py:376 users/views/data.py:598
-#: users/views/data.py:622 users/views/data.py:647 users/views/data.py:671
-#: users/views/data.py:695
+#: users/views/data.py:334 users/views/data.py:367 users/views/data.py:583
+#: users/views/data.py:607 users/views/data.py:632 users/views/data.py:656
+#: users/views/data.py:680
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:412
+#: users/views/data.py:403
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:444
+#: users/views/data.py:428
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:463
+#: users/views/data.py:448
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:471 users/views/data.py:581
+#: users/views/data.py:456 users/views/data.py:566
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:567
+#: users/views/data.py:552
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:577
+#: users/views/data.py:562
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:815
+#: users/views/data.py:800
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:837
+#: users/views/data.py:822
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:853
+#: users/views/data.py:838
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:858
+#: users/views/data.py:843
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:868 users/views/data.py:919
+#: users/views/data.py:853 users/views/data.py:904
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:875
+#: users/views/data.py:860
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:880
+#: users/views/data.py:865
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:906
+#: users/views/data.py:891
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:911
+#: users/views/data.py:896
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:924
+#: users/views/data.py:909
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:935
+#: users/views/data.py:920
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:941
+#: users/views/data.py:926
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:999
+#: users/views/data.py:984
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1015
+#: users/views/data.py:1000
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1019
+#: users/views/data.py:1004
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1028
+#: users/views/data.py:1013
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-16 08:42-0400\n"
+"POT-Creation-Date: 2026-05-16 15:48-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4298,7 +4298,7 @@ msgstr ""
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
 #: users/templates/users/data.html:98 users/templates/users/data.html:151
 #: users/templates/users/data.html:204 users/templates/users/data.html:255
-#: users/templates/users/data.html:355 users/templates/users/data.html:414
+#: users/templates/users/data.html:318 users/templates/users/data.html:377
 #: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
@@ -4332,7 +4332,7 @@ msgstr ""
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:180 users/templates/users/data.html:569
+#: journal/forms.py:180 users/templates/users/data.html:532
 msgid "Status"
 msgstr ""
 
@@ -4405,8 +4405,8 @@ msgstr ""
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
 #: users/templates/users/data.html:160 users/templates/users/data.html:213
-#: users/templates/users/data.html:264 users/templates/users/data.html:363
-#: users/templates/users/data.html:423
+#: users/templates/users/data.html:264 users/templates/users/data.html:326
+#: users/templates/users/data.html:386
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -4419,7 +4419,7 @@ msgstr ""
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
 #: users/templates/users/data.html:115 users/templates/users/data.html:168
 #: users/templates/users/data.html:221 users/templates/users/data.html:272
-#: users/templates/users/data.html:371 users/templates/users/data.html:431
+#: users/templates/users/data.html:334 users/templates/users/data.html:394
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -4432,7 +4432,7 @@ msgstr ""
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
 #: users/templates/users/data.html:123 users/templates/users/data.html:176
 #: users/templates/users/data.html:229 users/templates/users/data.html:280
-#: users/templates/users/data.html:379 users/templates/users/data.html:439
+#: users/templates/users/data.html:342 users/templates/users/data.html:402
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -6312,6 +6312,48 @@ msgstr ""
 msgid "(skip)"
 msgstr ""
 
+#: users/templates/users/_rym_section.html:5
+#: users/templates/users/_rym_section.html:24
+msgid "Import from RateYourMusic"
+msgstr ""
+
+#: users/templates/users/_rym_section.html:11
+msgid "Review pending matches"
+msgstr ""
+
+#: users/templates/users/_rym_section.html:17
+msgid "Cancel the RateYourMusic import? Matching progress will be discarded."
+msgstr ""
+
+#: users/templates/users/_rym_section.html:19
+msgid "Cancel import"
+msgstr ""
+
+#: users/templates/users/_rym_section.html:32
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
+msgstr ""
+
+#: users/templates/users/_rym_section.html:34
+#: users/templates/users/data.html:141
+msgid "Upload the downloaded CSV file below."
+msgstr ""
+
+#: users/templates/users/_rym_section.html:36
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr ""
+
+#: users/templates/users/_rym_section.html:39
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr ""
+
+#: users/templates/users/_rym_section.html:43
+msgid "Upload and match"
+msgstr ""
+
+#: users/templates/users/_rym_section.html:49
+msgid "Download previous matches"
+msgstr ""
+
 #: users/templates/users/account.html:11
 msgid "Account Information"
 msgstr ""
@@ -6602,7 +6644,7 @@ msgstr ""
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
 #: users/templates/users/data.html:126 users/templates/users/data.html:179
 #: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:384 users/templates/users/data.html:444
+#: users/templates/users/data.html:347 users/templates/users/data.html:407
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -6718,7 +6760,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:342
+#: users/templates/users/data.html:34 users/templates/users/data.html:305
 msgid "Import Method"
 msgstr ""
 
@@ -6762,10 +6804,6 @@ msgstr ""
 msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:141 users/templates/users/data.html:299
-msgid "Upload the downloaded CSV file below."
-msgstr ""
-
 #: users/templates/users/data.html:146
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
@@ -6806,112 +6844,84 @@ msgstr ""
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:291
-msgid "Import from RateYourMusic"
-msgstr ""
-
-#: users/templates/users/data.html:297
-msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
-msgstr ""
-
-#: users/templates/users/data.html:301
-msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
-msgstr ""
-
-#: users/templates/users/data.html:304
-msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
-msgstr ""
-
-#: users/templates/users/data.html:308
-msgid "Upload and match"
-msgstr ""
-
-#: users/templates/users/data.html:313
-msgid "Review pending matches"
-msgstr ""
-
-#: users/templates/users/data.html:320
-msgid "Download previous matches"
-msgstr ""
-
-#: users/templates/users/data.html:329
+#: users/templates/users/data.html:292
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:332
+#: users/templates/users/data.html:295
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:338
+#: users/templates/users/data.html:301
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:349
+#: users/templates/users/data.html:312
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:353
+#: users/templates/users/data.html:316
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:382
+#: users/templates/users/data.html:345
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:392
+#: users/templates/users/data.html:355
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:398
+#: users/templates/users/data.html:361
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:400
+#: users/templates/users/data.html:363
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:410
+#: users/templates/users/data.html:373
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:434
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:497
+#: users/templates/users/data.html:460
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:522
+#: users/templates/users/data.html:485
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:546
+#: users/templates/users/data.html:509
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:550
+#: users/templates/users/data.html:513
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:557
+#: users/templates/users/data.html:520
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:565
+#: users/templates/users/data.html:528
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:568
+#: users/templates/users/data.html:531
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:573
+#: users/templates/users/data.html:536
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:582
+#: users/templates/users/data.html:545
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7551,120 +7561,124 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:224 users/views/data.py:253
+#: users/views/data.py:230 users/views/data.py:259
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:247
+#: users/views/data.py:253
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:265
+#: users/views/data.py:271
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:280 users/views/data.py:300
+#: users/views/data.py:286 users/views/data.py:306
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:314
+#: users/views/data.py:320
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:328
+#: users/views/data.py:334
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:568
-#: users/views/data.py:592 users/views/data.py:617 users/views/data.py:641
-#: users/views/data.py:665
+#: users/views/data.py:343 users/views/data.py:376 users/views/data.py:598
+#: users/views/data.py:622 users/views/data.py:647 users/views/data.py:671
+#: users/views/data.py:695
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:406
+#: users/views/data.py:412
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:433
+#: users/views/data.py:444
+msgid "Cancelled."
+msgstr ""
+
+#: users/views/data.py:463
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:441 users/views/data.py:551
+#: users/views/data.py:471 users/views/data.py:581
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:537
+#: users/views/data.py:567
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:547
+#: users/views/data.py:577
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:785
+#: users/views/data.py:815
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:807
+#: users/views/data.py:837
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:823
+#: users/views/data.py:853
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:828
+#: users/views/data.py:858
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:838 users/views/data.py:889
+#: users/views/data.py:868 users/views/data.py:919
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:845
+#: users/views/data.py:875
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:850
+#: users/views/data.py:880
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:876
+#: users/views/data.py:906
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:881
+#: users/views/data.py:911
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:894
+#: users/views/data.py:924
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:905
+#: users/views/data.py:935
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:911
+#: users/views/data.py:941
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:969
+#: users/views/data.py:999
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:985
+#: users/views/data.py:1015
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:989
+#: users/views/data.py:1019
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:998
+#: users/views/data.py:1028
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-16 08:42-0400\n"
+"POT-Creation-Date: 2026-05-16 15:48-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -4318,7 +4318,7 @@ msgstr "保存时将行首空格替换为全角"
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
 #: users/templates/users/data.html:98 users/templates/users/data.html:151
 #: users/templates/users/data.html:204 users/templates/users/data.html:255
-#: users/templates/users/data.html:355 users/templates/users/data.html:414
+#: users/templates/users/data.html:318 users/templates/users/data.html:377
 #: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 msgid "Visibility"
@@ -4352,7 +4352,7 @@ msgstr "创建者和他们的本地互关"
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:180 users/templates/users/data.html:569
+#: journal/forms.py:180 users/templates/users/data.html:532
 msgid "Status"
 msgstr "状态"
 
@@ -4425,8 +4425,8 @@ msgstr "创建了收藏单"
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
 #: users/templates/users/data.html:160 users/templates/users/data.html:213
-#: users/templates/users/data.html:264 users/templates/users/data.html:363
-#: users/templates/users/data.html:423
+#: users/templates/users/data.html:264 users/templates/users/data.html:326
+#: users/templates/users/data.html:386
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -4439,7 +4439,7 @@ msgstr "公开"
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
 #: users/templates/users/data.html:115 users/templates/users/data.html:168
 #: users/templates/users/data.html:221 users/templates/users/data.html:272
-#: users/templates/users/data.html:371 users/templates/users/data.html:431
+#: users/templates/users/data.html:334 users/templates/users/data.html:394
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
@@ -4452,7 +4452,7 @@ msgstr "仅关注者"
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
 #: users/templates/users/data.html:123 users/templates/users/data.html:176
 #: users/templates/users/data.html:229 users/templates/users/data.html:280
-#: users/templates/users/data.html:379 users/templates/users/data.html:439
+#: users/templates/users/data.html:342 users/templates/users/data.html:402
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
@@ -6430,6 +6430,48 @@ msgstr "然后将链接粘贴到上方；留空则跳过该行。"
 msgid "(skip)"
 msgstr "(跳过)"
 
+#: users/templates/users/_rym_section.html:5
+#: users/templates/users/_rym_section.html:24
+msgid "Import from RateYourMusic"
+msgstr "从RateYourMusic导入"
+
+#: users/templates/users/_rym_section.html:11
+msgid "Review pending matches"
+msgstr "审阅待处理的匹配"
+
+#: users/templates/users/_rym_section.html:17
+msgid "Cancel the RateYourMusic import? Matching progress will be discarded."
+msgstr "取消 RateYourMusic 导入？匹配进度将被丢弃。"
+
+#: users/templates/users/_rym_section.html:19
+msgid "Cancel import"
+msgstr "取消导入"
+
+#: users/templates/users/_rym_section.html:32
+msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
+msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
+
+#: users/templates/users/_rym_section.html:34
+#: users/templates/users/data.html:141
+msgid "Upload the downloaded CSV file below."
+msgstr "在下方上传下载到的 CSV 文件。"
+
+#: users/templates/users/_rym_section.html:36
+msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
+
+#: users/templates/users/_rym_section.html:39
+msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
+msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
+
+#: users/templates/users/_rym_section.html:43
+msgid "Upload and match"
+msgstr "上传并匹配"
+
+#: users/templates/users/_rym_section.html:49
+msgid "Download previous matches"
+msgstr "下载先前的匹配"
+
 #: users/templates/users/account.html:11
 msgid "Account Information"
 msgstr "账号信息"
@@ -6720,7 +6762,7 @@ msgstr "CSV 文件"
 #: users/templates/users/account.html:440 users/templates/users/data.html:74
 #: users/templates/users/data.html:126 users/templates/users/data.html:179
 #: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:384 users/templates/users/data.html:444
+#: users/templates/users/data.html:347 users/templates/users/data.html:407
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -6836,7 +6878,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:342
+#: users/templates/users/data.html:34 users/templates/users/data.html:305
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -6880,10 +6922,6 @@ msgstr "从StoryGraph导入"
 msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
-#: users/templates/users/data.html:141 users/templates/users/data.html:299
-msgid "Upload the downloaded CSV file below."
-msgstr "在下方上传下载到的 CSV 文件。"
-
 #: users/templates/users/data.html:146
 msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
 msgstr ""
@@ -6924,112 +6962,84 @@ msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
-#: users/templates/users/data.html:291
-msgid "Import from RateYourMusic"
-msgstr "从RateYourMusic导入"
-
-#: users/templates/users/data.html:297
-msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
-msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
-
-#: users/templates/users/data.html:301
-msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
-msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
-
-#: users/templates/users/data.html:304
-msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
-msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
-
-#: users/templates/users/data.html:308
-msgid "Upload and match"
-msgstr "上传并匹配"
-
-#: users/templates/users/data.html:313
-msgid "Review pending matches"
-msgstr "审阅待处理的匹配"
-
-#: users/templates/users/data.html:320
-msgid "Download previous matches"
-msgstr "下载先前的匹配"
-
-#: users/templates/users/data.html:329
+#: users/templates/users/data.html:292
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:332
+#: users/templates/users/data.html:295
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:338
+#: users/templates/users/data.html:301
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:349
+#: users/templates/users/data.html:312
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:353
+#: users/templates/users/data.html:316
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:382
+#: users/templates/users/data.html:345
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:392
+#: users/templates/users/data.html:355
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:398
+#: users/templates/users/data.html:361
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:400
+#: users/templates/users/data.html:363
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:410
+#: users/templates/users/data.html:373
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:434
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:497
+#: users/templates/users/data.html:460
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:522
+#: users/templates/users/data.html:485
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:546
+#: users/templates/users/data.html:509
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:550
+#: users/templates/users/data.html:513
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:557
+#: users/templates/users/data.html:520
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:565
+#: users/templates/users/data.html:528
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:568
+#: users/templates/users/data.html:531
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:573
+#: users/templates/users/data.html:536
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:582
+#: users/templates/users/data.html:545
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7672,120 +7682,124 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:224 users/views/data.py:253
+#: users/views/data.py:230 users/views/data.py:259
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:247
+#: users/views/data.py:253
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:265
+#: users/views/data.py:271
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:280 users/views/data.py:300
+#: users/views/data.py:286 users/views/data.py:306
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:314
+#: users/views/data.py:320
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:328
+#: users/views/data.py:334
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:337 users/views/data.py:370 users/views/data.py:568
-#: users/views/data.py:592 users/views/data.py:617 users/views/data.py:641
-#: users/views/data.py:665
+#: users/views/data.py:343 users/views/data.py:376 users/views/data.py:598
+#: users/views/data.py:622 users/views/data.py:647 users/views/data.py:671
+#: users/views/data.py:695
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:406
+#: users/views/data.py:412
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:433
+#: users/views/data.py:444
+msgid "Cancelled."
+msgstr "已取消。"
+
+#: users/views/data.py:463
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:441 users/views/data.py:551
+#: users/views/data.py:471 users/views/data.py:581
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:537
+#: users/views/data.py:567
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:547
+#: users/views/data.py:577
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:785
+#: users/views/data.py:815
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:807
+#: users/views/data.py:837
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:823
+#: users/views/data.py:853
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:828
+#: users/views/data.py:858
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:838 users/views/data.py:889
+#: users/views/data.py:868 users/views/data.py:919
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:845
+#: users/views/data.py:875
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:850
+#: users/views/data.py:880
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:876
+#: users/views/data.py:906
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:881
+#: users/views/data.py:911
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:894
+#: users/views/data.py:924
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:905
+#: users/views/data.py:935
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:911
+#: users/views/data.py:941
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:969
+#: users/views/data.py:999
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:985
+#: users/views/data.py:1015
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:989
+#: users/views/data.py:1019
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:998
+#: users/views/data.py:1028
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-16 15:48-0400\n"
+"POT-Creation-Date: 2026-05-16 16:34-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -4365,7 +4365,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:192 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:411 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4375,26 +4375,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:146
+#: journal/importers/rym.py:168
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:156
+#: journal/importers/rym.py:178
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:210
+#: journal/importers/rym.py:233
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:323
+#: journal/importers/rym.py:348
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:347
+#: journal/importers/rym.py:376
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -6431,44 +6431,44 @@ msgid "(skip)"
 msgstr "(跳过)"
 
 #: users/templates/users/_rym_section.html:5
-#: users/templates/users/_rym_section.html:24
+#: users/templates/users/_rym_section.html:21
 msgid "Import from RateYourMusic"
 msgstr "从RateYourMusic导入"
 
-#: users/templates/users/_rym_section.html:11
+#: users/templates/users/_rym_section.html:9
 msgid "Review pending matches"
 msgstr "审阅待处理的匹配"
 
-#: users/templates/users/_rym_section.html:17
-msgid "Cancel the RateYourMusic import? Matching progress will be discarded."
-msgstr "取消 RateYourMusic 导入？匹配进度将被丢弃。"
+#: users/templates/users/_rym_section.html:15
+msgid "Cancel the RateYourMusic import? Progress will be discarded."
+msgstr "取消 RateYourMusic 导入？进度将被丢弃。"
 
-#: users/templates/users/_rym_section.html:19
+#: users/templates/users/_rym_section.html:16
 msgid "Cancel import"
 msgstr "取消导入"
 
-#: users/templates/users/_rym_section.html:32
+#: users/templates/users/_rym_section.html:29
 msgid "On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file."
 msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
 
-#: users/templates/users/_rym_section.html:34
+#: users/templates/users/_rym_section.html:31
 #: users/templates/users/data.html:141
 msgid "Upload the downloaded CSV file below."
 msgstr "在下方上传下载到的 CSV 文件。"
 
-#: users/templates/users/_rym_section.html:36
+#: users/templates/users/_rym_section.html:33
 msgid "Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
-#: users/templates/users/_rym_section.html:39
+#: users/templates/users/_rym_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
 
-#: users/templates/users/_rym_section.html:43
+#: users/templates/users/_rym_section.html:40
 msgid "Upload and match"
 msgstr "上传并匹配"
 
-#: users/templates/users/_rym_section.html:49
+#: users/templates/users/_rym_section.html:46
 msgid "Download previous matches"
 msgstr "下载先前的匹配"
 
@@ -7682,124 +7682,124 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:230 users/views/data.py:259
+#: users/views/data.py:221 users/views/data.py:250
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:253
+#: users/views/data.py:244
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:271
+#: users/views/data.py:262
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:286 users/views/data.py:306
+#: users/views/data.py:277 users/views/data.py:297
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:320
+#: users/views/data.py:311
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:334
+#: users/views/data.py:325
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:343 users/views/data.py:376 users/views/data.py:598
-#: users/views/data.py:622 users/views/data.py:647 users/views/data.py:671
-#: users/views/data.py:695
+#: users/views/data.py:334 users/views/data.py:367 users/views/data.py:583
+#: users/views/data.py:607 users/views/data.py:632 users/views/data.py:656
+#: users/views/data.py:680
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:412
+#: users/views/data.py:403
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:444
+#: users/views/data.py:428
 msgid "Cancelled."
 msgstr "已取消。"
 
-#: users/views/data.py:463
+#: users/views/data.py:448
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:471 users/views/data.py:581
+#: users/views/data.py:456 users/views/data.py:566
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:567
+#: users/views/data.py:552
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:577
+#: users/views/data.py:562
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:815
+#: users/views/data.py:800
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:837
+#: users/views/data.py:822
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:853
+#: users/views/data.py:838
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:858
+#: users/views/data.py:843
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:868 users/views/data.py:919
+#: users/views/data.py:853 users/views/data.py:904
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:875
+#: users/views/data.py:860
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:880
+#: users/views/data.py:865
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:906
+#: users/views/data.py:891
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:911
+#: users/views/data.py:896
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:924
+#: users/views/data.py:909
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:935
+#: users/views/data.py:920
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:941
+#: users/views/data.py:926
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:999
+#: users/views/data.py:984
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:1015
+#: users/views/data.py:1000
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:1019
+#: users/views/data.py:1004
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:1028
+#: users/views/data.py:1013
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/tests/journal/test_rym.py
+++ b/tests/journal/test_rym.py
@@ -5,6 +5,7 @@ import pytest
 
 from catalog.models import Album
 from journal.importers.rym import (
+    RymCancelled,
     RymImporter,
     _bbcode_to_md,
     _row_artist,
@@ -241,6 +242,27 @@ class TestMatchedFileGeneration:
         assert task.metadata["phase"] == "preview"
         assert task.metadata["total"] == 4
         assert task.metadata["processed"] == 4
+
+    def test_cancellation_aborts_and_preserves_phase(self, monkeypatch):
+        """View flips phase=cancelled in DB mid-loop; worker must bail and not
+        clobber that flag with its in-memory metadata."""
+        task = self._make_task()
+
+        def cancel_then_match(self_, *a, **k):
+            # Simulate the rym_cancel view writing directly to the DB while
+            # the worker holds a stale in-memory copy of metadata.
+            RymImporter.objects.filter(pk=task.pk).update(
+                metadata={**task.metadata, "phase": "cancelled"}
+            )
+            return None  # no local match, proceeds to external lookup
+
+        monkeypatch.setattr(RymImporter, "_local_match", cancel_then_match)
+        monkeypatch.setattr(RymImporter, "_external_match", lambda *a, **k: None)
+        # The worker should see the cancellation on its next save and abort.
+        with pytest.raises(RymCancelled):
+            task._run_matching()
+        task.refresh_from_db()
+        assert task.metadata["phase"] == "cancelled"
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/users/templates/users/_rym_section.html
+++ b/users/templates/users/_rym_section.html
@@ -12,7 +12,7 @@
                 hx-post="{% url 'users:rym_cancel' %}"
                 hx-target="#rym"
                 hx-swap="innerHTML"
-                hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}"
+                hx-confirm="{% trans 'Cancel the RateYourMusic import? Progress will be discarded.' %}"
                 class="secondary outline">{% trans 'Cancel import' %}</button>
       </div>
     </details>

--- a/users/templates/users/_rym_section.html
+++ b/users/templates/users/_rym_section.html
@@ -1,0 +1,57 @@
+{% load i18n %}
+{% with phase=rym_task.metadata.phase %}
+  {% if rym_task and phase and phase != 'done' and phase != 'cancelled' %}
+    <details open>
+      <summary>{% trans 'Import from RateYourMusic' %}</summary>
+      {% include "users/user_task_status.html" with task=rym_task %}
+      {% if phase == 'preview' %}
+        <p>
+          <a href="{% url 'users:rym_preview' %}"
+             role="button"
+             class="secondary outline">{% trans 'Review pending matches' %}</a>
+        </p>
+      {% endif %}
+      <form hx-post="{% url 'users:rym_cancel' %}"
+            hx-target="#rym"
+            hx-swap="innerHTML"
+            hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}">
+        {% csrf_token %}
+        <button type="submit" class="secondary outline">{% trans 'Cancel import' %}</button>
+      </form>
+    </details>
+  {% else %}
+    <details {% if rym_task and phase == 'done' %}open{% endif %}>
+      <summary>{% trans 'Import from RateYourMusic' %}</summary>
+      <form hx-post="{% url 'users:import_rym_upload' %}"
+            hx-target="#rym"
+            hx-swap="innerHTML"
+            enctype="multipart/form-data">
+        {% csrf_token %}
+        <ul>
+          <li>
+            {% blocktrans %}On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file.{% endblocktrans %}
+          </li>
+          <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
+          <li>
+            {% blocktrans %}Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import.{% endblocktrans %}
+          </li>
+          <li>
+            {% blocktrans %}You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match.{% endblocktrans %}
+          </li>
+        </ul>
+        <input type="file" name="file" required accept=".csv">
+        <input type="submit" value="{% trans 'Upload and match' %}" />
+      </form>
+      {% if rym_task and phase == 'done' and rym_task.metadata.matched_file %}
+        <p>
+          <a href="{% url 'users:rym_download' %}"
+             role="button"
+             class="secondary outline">{% trans 'Download previous matches' %}</a>
+        </p>
+      {% endif %}
+      {% if rym_task and phase == 'done' %}
+        {% include "users/user_task_status.html" with task=rym_task %}
+      {% endif %}
+    </details>
+  {% endif %}
+{% endwith %}

--- a/users/templates/users/_rym_section.html
+++ b/users/templates/users/_rym_section.html
@@ -4,21 +4,16 @@
     <details open>
       <summary>{% trans 'Import from RateYourMusic' %}</summary>
       {% include "users/user_task_status.html" with task=rym_task %}
-      <div class="grid">
+      <div role="group">
         {% if phase == 'preview' %}
-          <a href="{% url 'users:rym_preview' %}"
-             role="button"
-             class="secondary"
-             style="text-align:center">{% trans 'Review pending matches' %}</a>
+          <a href="{% url 'users:rym_preview' %}" role="button" class="secondary">{% trans 'Review pending matches' %}</a>
         {% endif %}
-        <form hx-post="{% url 'users:rym_cancel' %}"
-              hx-target="#rym"
-              hx-swap="innerHTML"
-              hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}"
-              style="margin:0">
-          {% csrf_token %}
-          <button type="submit" class="secondary outline" style="width:100%">{% trans 'Cancel import' %}</button>
-        </form>
+        <button type="button"
+                hx-post="{% url 'users:rym_cancel' %}"
+                hx-target="#rym"
+                hx-swap="innerHTML"
+                hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}"
+                class="secondary outline">{% trans 'Cancel import' %}</button>
       </div>
     </details>
   {% else %}

--- a/users/templates/users/_rym_section.html
+++ b/users/templates/users/_rym_section.html
@@ -5,11 +5,11 @@
       <summary>{% trans 'Import from RateYourMusic' %}</summary>
       {% include "users/user_task_status.html" with task=rym_task %}
       {% if phase == 'preview' %}
-        <p>
-          <a href="{% url 'users:rym_preview' %}"
-             role="button"
-             class="secondary outline">{% trans 'Review pending matches' %}</a>
-        </p>
+        <a href="{% url 'users:rym_preview' %}"
+           role="button"
+           class="secondary"
+           style="display:block;
+                  width:100%">{% trans 'Review pending matches' %}</a>
       {% endif %}
       <form hx-post="{% url 'users:rym_cancel' %}"
             hx-target="#rym"

--- a/users/templates/users/_rym_section.html
+++ b/users/templates/users/_rym_section.html
@@ -4,20 +4,22 @@
     <details open>
       <summary>{% trans 'Import from RateYourMusic' %}</summary>
       {% include "users/user_task_status.html" with task=rym_task %}
-      {% if phase == 'preview' %}
-        <a href="{% url 'users:rym_preview' %}"
-           role="button"
-           class="secondary"
-           style="display:block;
-                  width:100%">{% trans 'Review pending matches' %}</a>
-      {% endif %}
-      <form hx-post="{% url 'users:rym_cancel' %}"
-            hx-target="#rym"
-            hx-swap="innerHTML"
-            hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}">
-        {% csrf_token %}
-        <button type="submit" class="secondary outline">{% trans 'Cancel import' %}</button>
-      </form>
+      <div class="grid">
+        {% if phase == 'preview' %}
+          <a href="{% url 'users:rym_preview' %}"
+             role="button"
+             class="secondary"
+             style="text-align:center">{% trans 'Review pending matches' %}</a>
+        {% endif %}
+        <form hx-post="{% url 'users:rym_cancel' %}"
+              hx-target="#rym"
+              hx-swap="innerHTML"
+              hx-confirm="{% trans 'Cancel the RateYourMusic import? Matching progress will be discarded.' %}"
+              style="margin:0">
+          {% csrf_token %}
+          <button type="submit" class="secondary outline" style="width:100%">{% trans 'Cancel import' %}</button>
+        </form>
+      </div>
     </details>
   {% else %}
     <details {% if rym_task and phase == 'done' %}open{% endif %}>

--- a/users/templates/users/data.html
+++ b/users/templates/users/data.html
@@ -286,44 +286,7 @@
             </form>
           </details>
         </article>
-        <article id="rym">
-          <details {% if rym_task and rym_task.metadata.phase and rym_task.metadata.phase != 'done' %}open{% endif %}>
-            <summary>{% trans 'Import from RateYourMusic' %}</summary>
-            <form hx-post="{% url 'users:import_rym_upload' %}"
-                  enctype="multipart/form-data">
-              {% csrf_token %}
-              <ul>
-                <li>
-                  {% blocktrans %}On RateYourMusic, go to your profile and use the <b>Export your music catalog</b> option to download your library as a CSV file.{% endblocktrans %}
-                </li>
-                <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
-                <li>
-                  {% blocktrans %}Albums are matched by title + artist (and year if present) — first against the local catalog, then MusicBrainz, then Spotify. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import.{% endblocktrans %}
-                </li>
-                <li>
-                  {% blocktrans %}You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match.{% endblocktrans %}
-                </li>
-              </ul>
-              <input type="file" name="file" required accept=".csv">
-              <input type="submit" value="{% trans 'Upload and match' %}" />
-              {% if rym_task and rym_task.metadata.phase == 'preview' %}
-                <p>
-                  <a href="{% url 'users:rym_preview' %}"
-                     role="button"
-                     class="secondary outline">{% trans 'Review pending matches' %}</a>
-                </p>
-              {% endif %}
-              {% if rym_task and rym_task.metadata.phase == 'done' and rym_task.metadata.matched_file %}
-                <p>
-                  <a href="{% url 'users:rym_download' %}"
-                     role="button"
-                     class="secondary outline">{% trans 'Download previous matches' %}</a>
-                </p>
-              {% endif %}
-              {% include "users/user_task_status.html" with task=rym_task %}
-            </form>
-          </details>
-        </article>
+        <article id="rym">{% include "users/_rym_section.html" %}</article>
         <article>
           <details>
             <summary>{% trans 'Import from Steam Wishlist / Library' %}</summary>

--- a/users/urls.py
+++ b/users/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path("data/import/rym/preview", rym_preview, name="rym_preview"),
     path("data/import/rym/row/<int:i>", rym_save_row, name="rym_save_row"),
     path("data/import/rym/confirm", rym_confirm, name="rym_confirm"),
+    path("data/import/rym/cancel", rym_cancel, name="rym_cancel"),
     path("data/import/rym/download", rym_download, name="rym_download"),
     path("data/import/storygraph", import_storygraph, name="import_storygraph"),
     path("data/import/douban", import_douban, name="import_douban"),

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -195,24 +195,20 @@ def user_task_status(request, task_type: str):
         case _:
             return redirect(reverse("users:data"))
     task = task_cls.latest_task(request.user)
-    if task_cls is RymImporter and task and task.state == Task.States.complete:
-        phase = task.metadata.get("phase")
-        if phase == "preview":
-            target = reverse("users:rym_preview")
-            if request.headers.get("HX-Request"):
-                resp = HttpResponse(status=204)
-                resp["HX-Redirect"] = target
-                return resp
-            return redirect(target)
-        if phase == "done":
-            # Importing just finished — swap the whole RYM section so the
-            # cancel button is replaced by the upload form + download link.
-            if request.headers.get("HX-Request"):
-                resp = render(request, "users/_rym_section.html", {"rym_task": task})
-                resp["HX-Retarget"] = "#rym"
-                resp["HX-Reswap"] = "innerHTML"
-                return resp
-            return redirect(reverse("users:data") + "#rym")
+    if (
+        task_cls is RymImporter
+        and task
+        and task.state == Task.States.complete
+        and task.metadata.get("phase") in ("preview", "done")
+    ):
+        # Matching or importing just finished — swap the whole RYM section
+        # so the cancel button is replaced by the Review/Download/upload UI.
+        if request.headers.get("HX-Request"):
+            resp = render(request, "users/_rym_section.html", {"rym_task": task})
+            resp["HX-Retarget"] = "#rym"
+            resp["HX-Reswap"] = "innerHTML"
+            return resp
+        return redirect(reverse("users:data") + "#rym")
     return render(request, "users/user_task_status.html", {"task": task})
 
 
@@ -411,7 +407,9 @@ def import_rym_upload(request):
         task.state = Task.States.complete
         task.message = _("Loaded from uploaded matched file.")
         task.save(update_fields=["state", "message"])
-        return _hx_or_full_redirect(request, reverse("users:rym_preview"))
+        if request.headers.get("HX-Request"):
+            return render(request, "users/_rym_section.html", {"rym_task": task})
+        return redirect(reverse("users:data") + "#rym")
     task = RymImporter.create(
         request.user,
         phase="matching",
@@ -423,15 +421,6 @@ def import_rym_upload(request):
         # Replace the section in place so the page doesn't reload during upload.
         return render(request, "users/_rym_section.html", {"rym_task": task})
     return redirect(reverse("users:data") + "#rym")
-
-
-def _hx_or_full_redirect(request, target: str) -> HttpResponse:
-    """Redirect properly whether the request was sent by HTMX or normal browser."""
-    if request.headers.get("HX-Request"):
-        resp = HttpResponse(status=204)
-        resp["HX-Redirect"] = target
-        return resp
-    return redirect(target)
 
 
 @login_required

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -195,18 +195,24 @@ def user_task_status(request, task_type: str):
         case _:
             return redirect(reverse("users:data"))
     task = task_cls.latest_task(request.user)
-    if (
-        task_cls is RymImporter
-        and task
-        and task.state == Task.States.complete
-        and task.metadata.get("phase") == "preview"
-    ):
-        target = reverse("users:rym_preview")
-        if request.headers.get("HX-Request"):
-            resp = HttpResponse(status=204)
-            resp["HX-Redirect"] = target
-            return resp
-        return redirect(target)
+    if task_cls is RymImporter and task and task.state == Task.States.complete:
+        phase = task.metadata.get("phase")
+        if phase == "preview":
+            target = reverse("users:rym_preview")
+            if request.headers.get("HX-Request"):
+                resp = HttpResponse(status=204)
+                resp["HX-Redirect"] = target
+                return resp
+            return redirect(target)
+        if phase == "done":
+            # Importing just finished — swap the whole RYM section so the
+            # cancel button is replaced by the upload form + download link.
+            if request.headers.get("HX-Request"):
+                resp = render(request, "users/_rym_section.html", {"rym_task": task})
+                resp["HX-Retarget"] = "#rym"
+                resp["HX-Reswap"] = "innerHTML"
+                return resp
+            return redirect(reverse("users:data") + "#rym")
     return render(request, "users/user_task_status.html", {"task": task})
 
 
@@ -413,7 +419,10 @@ def import_rym_upload(request):
         filename_hint=uploaded_name,
     )
     task.enqueue()
-    return _hx_or_full_redirect(request, reverse("users:data") + "#rym")
+    if request.headers.get("HX-Request"):
+        # Replace the section in place so the page doesn't reload during upload.
+        return render(request, "users/_rym_section.html", {"rym_task": task})
+    return redirect(reverse("users:data") + "#rym")
 
 
 def _hx_or_full_redirect(request, target: str) -> HttpResponse:
@@ -423,6 +432,27 @@ def _hx_or_full_redirect(request, target: str) -> HttpResponse:
         resp["HX-Redirect"] = target
         return resp
     return redirect(target)
+
+
+@login_required
+@require_http_methods(["POST"])
+def rym_cancel(request):
+    task = RymImporter.latest_task(request.user)
+    if task and task.metadata.get("phase") in ("matching", "preview", "importing"):
+        task.metadata["phase"] = "cancelled"
+        task.state = Task.States.failed
+        task.message = _("Cancelled.")
+        task.save(update_fields=["metadata", "state", "message"])
+        # Best-effort: drop the job if still queued. A job already running
+        # in the worker will finish on its own; the cancelled phase keeps
+        # the UI from surfacing it either way.
+        try:
+            django_rq.get_queue(task.TaskQueue).remove(task.job_id)
+        except Exception as e:
+            logger.warning(f"RYM cancel: failed to remove job: {e}")
+    if request.headers.get("HX-Request"):
+        return render(request, "users/_rym_section.html", {"rym_task": None})
+    return redirect(reverse("users:data") + "#rym")
 
 
 @login_required

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -203,12 +203,7 @@ def user_task_status(request, task_type: str):
     ):
         # Matching or importing just finished — swap the whole RYM section
         # so the cancel button is replaced by the Review/Download/upload UI.
-        if request.headers.get("HX-Request"):
-            resp = render(request, "users/_rym_section.html", {"rym_task": task})
-            resp["HX-Retarget"] = "#rym"
-            resp["HX-Reswap"] = "innerHTML"
-            return resp
-        return redirect(reverse("users:data") + "#rym")
+        return render(request, "users/_rym_section.html", {"rym_task": task})
     return render(request, "users/user_task_status.html", {"task": task})
 
 
@@ -432,13 +427,14 @@ def rym_cancel(request):
         task.state = Task.States.failed
         task.message = _("Cancelled.")
         task.save(update_fields=["metadata", "state", "message"])
-        # Best-effort: drop the job if still queued. A job already running
-        # in the worker will finish on its own; the cancelled phase keeps
-        # the UI from surfacing it either way.
-        try:
-            django_rq.get_queue(task.TaskQueue).remove(task.job_id)
-        except Exception as e:
-            logger.warning(f"RYM cancel: failed to remove job: {e}")
+        # Best-effort: drop the job if still queued. A running worker
+        # picks up phase=cancelled on its next progress save and bails;
+        # the not-yet-enqueued case (had_link round-trip) is skipped.
+        if task.pk:
+            try:
+                django_rq.get_queue(task.TaskQueue).remove(task.job_id)
+            except Exception as e:
+                logger.warning(f"RYM cancel: failed to remove job: {e}")
     if request.headers.get("HX-Request"):
         return render(request, "users/_rym_section.html", {"rym_task": None})
     return redirect(reverse("users:data") + "#rym")


### PR DESCRIPTION
## Summary

Follow-up to the RateYourMusic CSV importer landed in #f7223b10.

- **UX**: while an RYM import is in flight (matching / awaiting preview / importing), the data page now hides the upload form and shows a **Cancel import** button (and **Review pending matches** when the preview is ready). The two actions live in a Pico `role=\"group\"`. Cancel marks the task `phase=cancelled` and best-effort drops the queued RQ job.
- **htmx**: the upload form submits via htmx and swaps the RYM section in place, so the page no longer reloads on submit. When the importing task finishes, the polling status response re-renders the whole section (via `HX-Retarget: #rym`) so the form and Download link reappear without a manual refresh.
- **Progress fix**: the matching loop was bumping `matched_local/external/unmatched` inside `_match_row` and then `processed` afterwards. Because `progress()` flushes on `processed % 25 == 0` (including 0), the in-flight status line could show \"0/6 — 0 local, 1 external, 0 unmatched\". `processed` now increments together with the per-row outcome, mirroring what the import phase already does.
- **Docs**: `docs/features.md` import list now covers Goodreads, StoryGraph, Letterboxd, RateYourMusic, podcast OPML, and Douban, and links to `docs/sites.md`; `docs/sites.md` marks RateYourMusic as importable via CSV.

## Test plan

- [x] `pytest tests/journal/test_rym.py` (25 passed)
- [x] `uv run pre-commit run -a`
- [ ] Manual: upload a CSV on the data page — section swaps in place, no reload; Cancel returns to the upload form; Review pending matches navigates to the preview page; Done state shows upload form + Download previous matches.