### PR TITLE
fix(bgg): send Authorization: Bearer when BGG_API_TOKEN is set

### DIFF
--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -128,6 +128,8 @@ env = environ.FileAwareEnv(
     # IGDB - https://api-docs.igdb.com/
     IGDB_API_CLIENT_ID=(str, "TESTONLY"),
     IGDB_API_CLIENT_SECRET=(str, ""),
+    # BoardGameGeek - bearer token from https://boardgamegeek.com/using_the_xml_api#toc9
+    BGG_API_TOKEN=(str, ""),
     # DeepL
     DEEPL_API_KEY=(str, ""),
     # LibreTranslate
@@ -308,6 +310,7 @@ STEAM_API_KEY = env("STEAM_API_KEY")
 DISCOGS_API_KEY = env("DISCOGS_API_KEY")
 IGDB_CLIENT_ID = env("IGDB_API_CLIENT_ID")
 IGDB_CLIENT_SECRET = env("IGDB_API_CLIENT_SECRET")
+BGG_API_TOKEN = env("BGG_API_TOKEN")
 DEEPL_API_KEY = env("DEEPL_API_KEY")
 LT_API_URL = env("LT_API_URL").rstrip("/")
 LT_API_KEY = env("LT_API_KEY")

--- a/catalog/sites/bgg.py
+++ b/catalog/sites/bgg.py
@@ -9,6 +9,7 @@ import html
 from catalog.common import *
 from catalog.models import *
 from catalog.models.game import GameReleaseType
+from common.models import SiteConfig
 from common.models.lang import detect_language
 
 
@@ -29,7 +30,13 @@ class BoardGameGeek(AbstractSite):
 
     def scrape(self):
         api_url = f"https://boardgamegeek.com/xmlapi2/thing?stats=1&type=boardgame,boardgameexpansion&id={self.id_value}"
-        content = BasicDownloader(api_url).download().xml()
+        token = SiteConfig.system.bgg_api_token
+        headers = (
+            {**BasicDownloader.headers, "Authorization": f"Bearer {token}"}
+            if token
+            else None
+        )
+        content = BasicDownloader(api_url, headers=headers).download().xml()
         items = list(content.xpath("/items/item"))
         if not len(items):
             raise ParseError(scraper=self, field="id")

--- a/catalog/sites/bgg.py
+++ b/catalog/sites/bgg.py
@@ -30,12 +30,9 @@ class BoardGameGeek(AbstractSite):
 
     def scrape(self):
         api_url = f"https://boardgamegeek.com/xmlapi2/thing?stats=1&type=boardgame,boardgameexpansion&id={self.id_value}"
-        token = SiteConfig.system.bgg_api_token
-        headers = (
-            {**BasicDownloader.headers, "Authorization": f"Bearer {token}"}
-            if token
-            else None
-        )
+        headers = None
+        if token := SiteConfig.system.bgg_api_token:
+            headers = {**BasicDownloader.headers, "Authorization": f"Bearer {token}"}
         content = BasicDownloader(api_url, headers=headers).download().xml()
         items = list(content.xpath("/items/item"))
         if not len(items):

--- a/common/models/site_config.py
+++ b/common/models/site_config.py
@@ -85,6 +85,7 @@ class SiteConfig(models.Model):
         discogs_api_key: str = "TESTONLY"
         igdb_client_id: str = "TESTONLY"
         igdb_client_secret: str = ""
+        bgg_api_token: str = ""
 
         # API Keys - Services
         steam_api_key: str = ""
@@ -192,6 +193,7 @@ class SiteConfig(models.Model):
             "discogs_api_key": getattr(settings, "DISCOGS_API_KEY", "TESTONLY"),
             "igdb_client_id": getattr(settings, "IGDB_CLIENT_ID", "TESTONLY"),
             "igdb_client_secret": getattr(settings, "IGDB_CLIENT_SECRET", ""),
+            "bgg_api_token": getattr(settings, "BGG_API_TOKEN", ""),
             # API Keys - Services
             "steam_api_key": getattr(settings, "STEAM_API_KEY", ""),
             "deepl_api_key": getattr(settings, "DEEPL_API_KEY", ""),

--- a/common/views_manage.py
+++ b/common/views_manage.py
@@ -602,6 +602,13 @@ class APIKeysSettings(SiteConfigSettingsPage):
         "igdb_client_secret": {
             "title": _("IGDB Client Secret"),
         },
+        "bgg_api_token": {
+            "title": _("BoardGameGeek API Token"),
+            "help_text": _(
+                "Bearer token from https://boardgamegeek.com/applications "
+                "(see https://boardgamegeek.com/using_the_xml_api#toc9)."
+            ),
+        },
         "steam_api_key": {
             "title": _("Steam API Key"),
             "help_text": _(
@@ -663,6 +670,7 @@ class APIKeysSettings(SiteConfigSettingsPage):
             "discogs_api_key",
             "igdb_client_id",
             "igdb_client_secret",
+            "bgg_api_token",
             "steam_api_key",
         ],
         _("Translation"): [


### PR DESCRIPTION
## Summary

- Adds a `BGG_API_TOKEN` env/config and exposes it via `SiteConfig.system.bgg_api_token`.
- When set, the BoardGameGeek XML API call (`xmlapi2/thing`) now sends `Authorization: Bearer <token>` so requests work against BGG's new auth requirement (per https://boardgamegeek.com/using_the_xml_api#toc9).
- Fixes #1523.

## Notes

- Default is empty string, matching other optional API key settings; unauthenticated requests continue to work as before for instances that haven't registered a token.
- Tokens can be obtained at https://boardgamegeek.com/applications.

## Test plan

- [ ] Set `BGG_API_TOKEN` in `.env`, fetch a BGG item (e.g. `https://boardgamegeek.com/boardgame/357873/the-old-kings-crown`), confirm catalog item is created.
- [ ] With `BGG_API_TOKEN` unset, confirm existing behaviour is preserved (request still goes out without an Authorization header).