### PR TITLE
feat(journal): add compose icon to user article list header

### DIFF
--- a/journal/templates/user_article_list.html
+++ b/journal/templates/user_article_list.html
@@ -18,15 +18,19 @@
     {% include "_header.html" %}
     <main>
       <div class="grid__main">
-        <h5>{{ identity.display_name }} - {% trans "Articles" %}</h5>
-        {% if identity == request.user.identity %}
-          <p>
-            <a href="{% url 'journal:article_compose' %}">
-              <i class="fa-solid fa-pen-to-square"></i>
-              {% trans "Compose new article" %}
-            </a>
-          </p>
-        {% endif %}
+        <h5>
+          {% if identity == request.user.identity %}
+            <span class="action">
+              <span>
+                <a href="{% url 'journal:article_compose' %}"
+                   title="{% trans 'Compose new article' %}">
+                  <i class="fa-regular fa-pen-to-square"></i>
+                </a>
+              </span>
+            </span>
+          {% endif %}
+          {{ identity.display_name }} - {% trans "Articles" %}
+        </h5>
         {% for article in articles %}
           <p>
             <div class="action">


### PR DESCRIPTION
## Summary
- Adds a compose icon (pen-to-square) to the `/users/<handle>/articles/` page header for the owner, matching the icon-button style used in the timeline/feed header.
- Replaces the previous plain text "Compose new article" link with a smaller, header-level action icon.

## Test plan
- [ ] Visit your own `/users/<handle>/articles/` and confirm the pen icon appears in the heading action area and links to `journal:article_compose`.
- [ ] Visit another user's articles page and confirm the icon does not appear.