### PR TITLE
fix(social): add missing event templates for Article piece

### DIFF
--- a/social/templates/event/boosted_article.html
+++ b/social/templates/event/boosted_article.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans with piece_url=event.piece.url piece_title=event.piece.title %}
+boosted your article <a href="{{ piece_url }}">{{ piece_title }}</a>
+{% endblocktrans %}

--- a/social/templates/event/liked_article.html
+++ b/social/templates/event/liked_article.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans with piece_url=event.piece.url piece_title=event.piece.title %}
+liked your article <a href="{{ piece_url }}">{{ piece_title }}</a>
+{% endblocktrans %}

--- a/social/templates/event/mentioned_article.html
+++ b/social/templates/event/mentioned_article.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% blocktrans with piece_url=event.piece.url piece_title=event.piece.title %}
+replied to your article <a href="{{ piece_url }}">{{ piece_title }}</a>
+{% endblocktrans %}
+{% include "_event_post.html" with post=event.reply %}


### PR DESCRIPTION
## Summary
- Add `social/templates/event/{boosted,liked,mentioned}_article.html` to fix `TemplateDoesNotExist: event/boosted_article.html` (and the liked/mentioned siblings) raised when rendering a notification for a federation event whose subject piece is an `Article`.
- `social/views.py` constructs the template name as `event/<type>_<piece_class>.html` for liked/boosted/mentioned events. `Article` is a `Piece` subclass with `post_when_save = True`, but had no matching templates — these were the only missing ones (Collection / Comment / Note / Rating / Review / ShelfMember are all already covered).
- Templates mirror the Collection variants since `Article`, like `Collection`, has no related `Item`.

## Test plan
- [ ] Receive a boost / like / reply on an Article post and verify the notification renders instead of 500ing.