### PR TITLE
fix(journal): align Article/Review/Collection AP discovery with inline-only consumption

### DIFF
--- a/boofilsic/settings.py
+++ b/boofilsic/settings.py
@@ -151,10 +151,6 @@ env = environ.FileAwareEnv(
     SKIP_MIGRATIONS=(list, []),
     TAKAHE_REMOTE_PRUNE_HORIZON=(int, 92),
     NEODB_HIDDEN_CATEGORIES=(list, []),
-    # Federate Review as ActivityPub Article (with title/HTML/markdown source)
-    # rather than Note. Set to False to roll back to legacy Note federation if
-    # interoperability issues arise with peer servers.
-    NEODB_REVIEW_AS_ARTICLE=(bool, True),
 )
 
 # ====== End of user configuration variables ======
@@ -236,8 +232,6 @@ THREADS_APP_SECRET = env("THREADS_APP_SECRET")
 
 ENABLE_LOGIN_BLUESKY = env("NEODB_ENABLE_LOGIN_BLUESKY")
 ENABLE_LOGIN_THREADS = env("NEODB_ENABLE_LOGIN_THREADS")
-
-REVIEW_AS_ARTICLE: bool = env("NEODB_REVIEW_AS_ARTICLE")
 
 SITE_DOMAIN: str = env("NEODB_SITE_DOMAIN").lower()
 SITE_INFO = {

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -122,16 +122,25 @@ def _maybe_remote_piece(url: str, user):
                 # inline-only refactor, so the job can't re-dereference
                 # ``remote_id`` for these fields.
                 items_url, inline_items = _list_sync_args_from_post(piece)
-                try:
-                    django_rq.get_queue("fetch").enqueue(
-                        "journal.jobs.list_sync.fetch_remote_list_members",
-                        f"{type(piece).__module__}.{type(piece).__name__}",
-                        piece.pk,
-                        items_url,
-                        inline_items,
-                    )
-                except Exception:
-                    pass
+                # When the cache yields nothing (announcement Post
+                # deleted, or malformed ``type_data``), skip the
+                # enqueue rather than scheduling a no-op job: the job
+                # has no path to recover the items URL without
+                # re-dereferencing ``remote_id``, which is HTML for
+                # peers on the new code. The user still receives the
+                # existing mirror; a refresh will arrive with the next
+                # pushed Update activity from the origin.
+                if items_url or inline_items is not None:
+                    try:
+                        django_rq.get_queue("fetch").enqueue(
+                            "journal.jobs.list_sync.fetch_remote_list_members",
+                            f"{type(piece).__module__}.{type(piece).__name__}",
+                            piece.pk,
+                            items_url,
+                            inline_items,
+                        )
+                    except Exception:
+                        pass
             return piece
     return None
 

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -20,6 +20,7 @@ from common.utils import (
     get_page_size_from_request,
     user_identity_required,
 )
+from journal.jobs.list_sync import extract_items_url
 from journal.models import Collection, Note, Review, Shelf, Tag
 from journal.models.mark import Mark
 from journal.models.rating import Rating
@@ -158,7 +159,7 @@ def _list_sync_args_from_post(piece):
     if not related or not isinstance(related[0], dict):
         return None, None
     envelope = related[0]
-    items_url = envelope.get("first") or envelope.get("items")
+    items_url = extract_items_url(envelope)
     inline_items_raw = envelope.get("orderedItems")
     inline_items = inline_items_raw if isinstance(inline_items_raw, list) else None
     return items_url, inline_items

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -116,16 +116,43 @@ def _maybe_remote_piece(url: str, user):
         piece = cls.objects.filter(remote_id=url, local=False).first()
         if piece and piece.is_visible_to(user):
             if isinstance(piece, (Collection, Shelf)):
+                # Recover the items endpoint URL (and any inline
+                # ``orderedItems``) from the cached announcement Post's
+                # envelope — Collection's AP id is HTML-only post the
+                # inline-only refactor, so the job can't re-dereference
+                # ``remote_id`` for these fields.
+                items_url, inline_items = _list_sync_args_from_post(piece)
                 try:
                     django_rq.get_queue("fetch").enqueue(
                         "journal.jobs.list_sync.fetch_remote_list_members",
                         f"{type(piece).__module__}.{type(piece).__name__}",
                         piece.pk,
+                        items_url,
+                        inline_items,
                     )
                 except Exception:
                     pass
             return piece
     return None
+
+
+def _list_sync_args_from_post(piece):
+    """Pull ``items_url`` and ``inline_items`` out of the cached
+    announcement Post's stored envelope so URL-paste refreshes can
+    re-enqueue ``fetch_remote_list_members`` without re-fetching the
+    Shelf envelope. Returns ``(None, None)`` if no Post is linked or
+    the structure isn't what we wrote on inbound."""
+    post = piece.latest_post
+    if not post or not isinstance(post.type_data, dict):
+        return None, None
+    related = (post.type_data.get("object") or {}).get("relatedWith") or []
+    if not related or not isinstance(related[0], dict):
+        return None, None
+    envelope = related[0]
+    items_url = envelope.get("first") or envelope.get("items")
+    inline_items_raw = envelope.get("orderedItems")
+    inline_items = inline_items_raw if isinstance(inline_items_raw, list) else None
+    return items_url, inline_items
 
 
 def resolve_url_query(request, keywords):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,7 +326,6 @@ The following settings can still be set in `.env` for backward compatibility, bu
  - `NEODB_FANOUT_LIMIT_DAYS`
  - `TAKAHE_REMOTE_PRUNE_HORIZON`
  - `NEODB_HIDDEN_CATEGORIES`
- - `NEODB_REVIEW_AS_ARTICLE` (default `True`; set `False` to federate Reviews as `Note` for backward compatibility)
 
 ### External item sources
  - `SPOTIFY_API_KEY`

--- a/docs/internals/federation.md
+++ b/docs/internals/federation.md
@@ -34,15 +34,33 @@ NeoDB's ActivityPub implementation is based on [Takahē](https://jointakahe.org)
 
 ### Activity
 
-NeoDB add additional fields to `Note` activity:
+NeoDB adds additional fields to `Note` activity (and to `Article` for reviews — see below):
 
-  - `relatedWith` is a list of NeoDB specific activities which are associated with this `Note`. For each activity, `id` and `href` are both unique links to that activity, `withRegardTo` links to the catalog item, `attributedTo` links to the user, `type` is one of:
+  - `relatedWith` is a list of NeoDB-specific activities associated with this Post. For each entry, `id` and `href` are both unique links to that activity, `withRegardTo` links to the catalog item, `attributedTo` links to the user, `type` is one of:
     - `Status`, its `status` can be one of: `complete`, `progress`, `wishlist` and `dropped`
     - `Rating`, its `value` is rating grade (int, 1-10), `worst` is always 1, `best` is always 10
     - `Comment`, its `content` is comment text
-    - `Review`, its `name` is review title, `content` is its body, `mediaType` is always `text/markdown` for now
+    - `Review`, its `name` is review title, `content` is its body, `mediaType` is always `text/markdown` for now (see [Review](#review))
     - `Note`, its `content` is note text
+    - `Shelf`, the lightweight envelope of a NeoDB Collection or Shelf — items are paginated behind `first`/`last` (see [Collection / Shelf](#collection--shelf))
   - `tag` is used to store list of NeoDB catalog items, which are related with this activity. `type` of NeoDB catalog item can be one of `Edition`, `Movie`, `TVShow`, `TVSeason`, `TVEpisode`, `Album`, `Game`, `Podcast`, `PodcastEpisode`, `Performance`, `PerformanceProduction`; href will be the link to that item.
+
+#### Review
+
+A Review rides in a Post of `type: Article`. The outer object carries `name`, `content` (HTML), `source` (`{content, mediaType: text/markdown}`), and `summary` for general AP clients; the full `Review` activity sits in `relatedWith[0]` with raw markdown body and `withRegardTo` for NeoDB peers.
+
+#### Collection / Shelf
+
+NeoDB Collections (user-curated lists) and Shelves (per-status item lists: Wishlist / Progress / Complete / Dropped) federate as a `Shelf` envelope in `relatedWith[0]` of an announcement Note. The envelope omits `orderedItems`; instead it carries:
+
+- `totalItems`, plus `first` / `last` URLs to the paginated items endpoint (e.g. `…/collection/<uuid>/items?page=1`)
+- `content` (Collection only): description in markdown
+- `shelfType` (Shelf only): `wishlist` / `progress` / `complete` / `dropped`
+- `query` (dynamic Collection only): the NeoDB search query
+
+Peers parse the envelope inline and walk `first` → `next` at the items endpoint with signed GETs. Each `OrderedCollectionPage` returns `orderedItems` of `type: ShelfItem` with `withRegardTo`, optional `commentText` (Collection), and optional `post` URL (Shelf — lets peers chain one signed GET to ingest the associated Mark/Rating/Comment/Review).
+
+The envelope `id` is the human-facing NeoDB URL (HTML for Collection, AP for Shelf) — peers should not assume it dereferences as AP. Only the items endpoint must remain AP-dereferenceable.
 
 Example:
 ```json

--- a/journal/jobs/list_sync.py
+++ b/journal/jobs/list_sync.py
@@ -48,6 +48,22 @@ def _resolve_class(class_path: str):
     return getattr(module, class_name)
 
 
+def extract_items_url(envelope: dict[str, Any]) -> str | None:
+    """Normalize an envelope's ``first`` / ``items`` to a URL string or
+    ``None``. ActivityStreams 2.0 permits these fields to be either a
+    URL string *or* an embedded ``OrderedCollection(Page)`` object;
+    fall back to the embedded object's ``id`` when we hit the latter so
+    downstream callers always work with a hashable URL. Anything we
+    can't reduce to a string yields ``None``."""
+    val = envelope.get("first") or envelope.get("items")
+    if isinstance(val, str):
+        return val
+    if isinstance(val, dict):
+        inner = val.get("id")
+        return inner if isinstance(inner, str) else None
+    return None
+
+
 def _signed_get_json(url: str) -> dict[str, Any] | None:
     """SSRF-gated signed GET that returns the parsed JSON body or None.
 

--- a/journal/jobs/list_sync.py
+++ b/journal/jobs/list_sync.py
@@ -77,7 +77,7 @@ def _signed_get_json(url: str) -> dict[str, Any] | None:
 def fetch_remote_list_members(
     class_path: str,
     pk: int,
-    items_url: str | None = None,
+    items_url: str | int | None = None,
     inline_items: list[dict[str, Any]] | None = None,
     attempts: int = 0,
 ) -> None:
@@ -100,6 +100,13 @@ def fetch_remote_list_members(
     backward compatibility with jobs queued under the previous
     signature.
     """
+    # Backward compat: the previous signature was
+    # ``(class_path, pk, attempts)``. A job queued before deployment
+    # arrives with ``attempts`` (int) bound to ``items_url``; recover
+    # the retry counter and clear the spurious URL before proceeding.
+    if isinstance(items_url, int):
+        attempts = items_url
+        items_url = None
     cls = _resolve_class(class_path)
     inst = cls.objects.filter(pk=pk, local=False).first()
     if not inst:
@@ -142,8 +149,12 @@ def fetch_remote_list_members(
         # exhaust ``MAX_FETCH_ATTEMPTS`` and bail.
         _maybe_retry(class_path, pk, items_url, inline_items, attempts)
         return
-    if not flat_items and not items_url:
-        # Nothing to do — neither inline items nor a paginated URL.
+    if inline_items is None and not items_url:
+        # No data at all — caller passed neither a paginated URL nor an
+        # inline ``orderedItems`` array. Distinct from
+        # ``orderedItems: []`` (explicit empty membership), which must
+        # still flow through ``_sync_members_from_ap`` so the local
+        # mirror gets cleared.
         return
     pending = cls._sync_members_from_ap(inst, flat_items)
     if pending:

--- a/journal/jobs/list_sync.py
+++ b/journal/jobs/list_sync.py
@@ -1,12 +1,19 @@
 """Page-walking inbound sync for federated NeoDB List objects.
 
 Used for both NeoDB ``Collection`` and NeoDB ``Shelf`` mirrors. Given a
-local ``List`` mirror with ``remote_id`` set, this job:
+local ``List`` mirror plus the ``items_url`` captured from the inbound
+envelope (``first`` or ``items``), this job:
 
-1. Issues a signed GET to ``remote_id`` to fetch the Shelf envelope.
-2. Walks the ``first``→``next`` chain of ``OrderedCollectionPage`` URLs,
-   accumulating ``orderedItems`` entries.
-3. Hands the flattened list to ``cls._sync_members_from_ap`` to persist.
+1. Walks the ``items_url``→``next`` chain of ``OrderedCollectionPage``
+   URLs, accumulating ``orderedItems`` entries.
+2. Hands the flattened list to ``cls._sync_members_from_ap`` to persist.
+
+The envelope is parsed *inline* from the announcement Post by
+``update_by_ap_envelope``; we don't re-dereference the envelope ``id``
+here. This mirrors how Review consumes its inline ``relatedWith`` and
+removes the requirement that the envelope ``id`` self-resolve to AP —
+peers only need the items endpoint (``/collection/<uuid>/items``) to
+remain AP-dereferenceable, which it is.
 
 Each page-fetch passes through the ``is_valid_url`` SSRF gate; the page
 walker bounds total pages to ``MAX_PAGES`` (defense in depth — unbounded
@@ -67,56 +74,65 @@ def _signed_get_json(url: str) -> dict[str, Any] | None:
         return None
 
 
-def fetch_remote_list_members(class_path: str, pk: int, attempts: int = 0) -> None:
+def fetch_remote_list_members(
+    class_path: str,
+    pk: int,
+    items_url: str | None = None,
+    inline_items: list[dict[str, Any]] | None = None,
+    attempts: int = 0,
+) -> None:
     """Resync members for one local ``List`` mirror.
 
     ``class_path`` is the dotted import path of the model class (e.g.
     ``journal.models.collection.Collection`` or
     ``journal.models.shelf.Shelf``) so the same job module serves all
     federated list types.
+
+    ``items_url`` is the starting page URL — the ``first`` (or
+    ``items``) field captured from the inbound envelope. ``None`` if
+    the envelope had no paginated items endpoint (e.g. a server that
+    inlines ``orderedItems`` instead).
+
+    ``inline_items`` is the envelope's own ``orderedItems`` list (if
+    any) — the original payload may carry the first slice inline AND
+    a ``first`` URL to the rest, so both inputs flow through the same
+    ``_sync_members_from_ap`` call. Both default to ``None`` for
+    backward compatibility with jobs queued under the previous
+    signature.
     """
     cls = _resolve_class(class_path)
     inst = cls.objects.filter(pk=pk, local=False).first()
-    if not inst or not inst.remote_id:
-        logger.debug(f"list_sync: {class_path}#{pk} gone or no remote_id")
+    if not inst:
+        logger.debug(f"list_sync: {class_path}#{pk} gone")
         return
-    envelope = _signed_get_json(inst.remote_id)
-    if envelope is None:
-        _maybe_retry(class_path, pk, attempts)
-        return
-    items_url = envelope.get("first") or envelope.get("items")
-    # Some servers may inline the items list under `orderedItems` even
-    # when paginated; prefer it as a fast-path.
-    pages_to_walk: list[str] = []
-    flat_items: list[dict[str, Any]] = []
-    inline = envelope.get("orderedItems")
-    if isinstance(inline, list):
-        flat_items.extend(e for e in inline if isinstance(e, dict))
-    if items_url:
-        pages_to_walk.append(items_url)
-    visited: set[str] = set()
-    pages_walked = 0
+    flat_items: list[dict[str, Any]] = [
+        e for e in (inline_items or []) if isinstance(e, dict)
+    ]
     failed_page = False
-    while pages_to_walk and pages_walked < MAX_PAGES:
-        next_url = pages_to_walk.pop(0)
-        if next_url in visited:
-            break
-        visited.add(next_url)
-        page = _signed_get_json(next_url)
-        if page is None:
-            failed_page = True
-            break
-        page_items = page.get("orderedItems")
-        if isinstance(page_items, list):
-            flat_items.extend(e for e in page_items if isinstance(e, dict))
-        nxt = page.get("next")
-        if isinstance(nxt, str) and nxt:
-            pages_to_walk.append(nxt)
-        pages_walked += 1
-    if pages_walked >= MAX_PAGES:
-        logger.warning(
-            f"list_sync: hit MAX_PAGES walking {inst.remote_id}; partial sync"
-        )
+    pages_walked = 0
+    if items_url:
+        pages_to_walk: list[str] = [items_url]
+        visited: set[str] = set()
+        while pages_to_walk and pages_walked < MAX_PAGES:
+            next_url = pages_to_walk.pop(0)
+            if next_url in visited:
+                break
+            visited.add(next_url)
+            page = _signed_get_json(next_url)
+            if page is None:
+                failed_page = True
+                break
+            page_items = page.get("orderedItems")
+            if isinstance(page_items, list):
+                flat_items.extend(e for e in page_items if isinstance(e, dict))
+            nxt = page.get("next")
+            if isinstance(nxt, str) and nxt:
+                pages_to_walk.append(nxt)
+            pages_walked += 1
+        if pages_walked >= MAX_PAGES:
+            logger.warning(
+                f"list_sync: hit MAX_PAGES walking {items_url}; partial sync"
+            )
     if failed_page:
         # A page in the chain failed to fetch. ``_sync_members_from_ap``
         # treats omitted entries as stale and would *delete* them, so a
@@ -124,16 +140,25 @@ def fetch_remote_list_members(class_path: str, pk: int, attempts: int = 0) -> No
         # later-page failure would drop subsequent members. Retry without
         # mutating local state; the next attempt either succeeds or we
         # exhaust ``MAX_FETCH_ATTEMPTS`` and bail.
-        _maybe_retry(class_path, pk, attempts)
+        _maybe_retry(class_path, pk, items_url, inline_items, attempts)
+        return
+    if not flat_items and not items_url:
+        # Nothing to do — neither inline items nor a paginated URL.
         return
     pending = cls._sync_members_from_ap(inst, flat_items)
     if pending:
         # Items pending catalog fetch — retry so the next pass picks them
         # up after the catalog cache primes.
-        _maybe_retry(class_path, pk, attempts)
+        _maybe_retry(class_path, pk, items_url, inline_items, attempts)
 
 
-def _maybe_retry(class_path: str, pk: int, attempts: int) -> None:
+def _maybe_retry(
+    class_path: str,
+    pk: int,
+    items_url: str | None,
+    inline_items: list[dict[str, Any]] | None,
+    attempts: int,
+) -> None:
     if attempts + 1 >= MAX_FETCH_ATTEMPTS:
         return
     try:
@@ -142,6 +167,8 @@ def _maybe_retry(class_path: str, pk: int, attempts: int) -> None:
             "journal.jobs.list_sync.fetch_remote_list_members",
             class_path,
             pk,
+            items_url,
+            inline_items,
             attempts + 1,
         )
     except Exception as e:

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -12,6 +12,7 @@ from loguru import logger
 from catalog.models import Item, ItemCategory
 from catalog.models.item import item_content_types
 from common.validators import is_valid_url
+from journal.jobs.list_sync import extract_items_url
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -410,8 +411,10 @@ class List(Piece):
         # URL is HTML-only, mirroring Review's "inline only" consumption
         # pattern. Peers that inline the items list (no ``first``/
         # ``items`` URL) still federate correctly because the job
-        # consumes ``inline_items`` directly.
-        items_url = obj.get("first") or obj.get("items")
+        # consumes ``inline_items`` directly. ``extract_items_url``
+        # tolerates AS2 peers that send an embedded
+        # ``OrderedCollection(Page)`` object instead of a URL string.
+        items_url = extract_items_url(obj)
         inline_items_raw = obj.get("orderedItems")
         inline_items = inline_items_raw if isinstance(inline_items_raw, list) else None
         try:

--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -404,11 +404,23 @@ class List(Piece):
         # so future staleness checks compare against the remote's `updated`.
         cls.objects.filter(pk=inst.pk).update(edited_time=edited)
         inst.edited_time = edited
+        # Forward both the items endpoint URL and any inline
+        # ``orderedItems`` from the inbound envelope so the job doesn't
+        # need to re-dereference ``remote_id`` — Collection's canonical
+        # URL is HTML-only, mirroring Review's "inline only" consumption
+        # pattern. Peers that inline the items list (no ``first``/
+        # ``items`` URL) still federate correctly because the job
+        # consumes ``inline_items`` directly.
+        items_url = obj.get("first") or obj.get("items")
+        inline_items_raw = obj.get("orderedItems")
+        inline_items = inline_items_raw if isinstance(inline_items_raw, list) else None
         try:
             django_rq.get_queue("fetch").enqueue(
                 cls.fetch_remote_member_url(),
                 cls.__module__ + "." + cls.__name__,
                 inst.pk,
+                items_url,
+                inline_items,
             )
         except Exception as e:
             logger.warning(

--- a/journal/models/review.py
+++ b/journal/models/review.py
@@ -86,20 +86,19 @@ class Review(Content):
 
     def get_ap_data(self):
         data = super().get_ap_data()
-        if settings.REVIEW_AS_ARTICLE:
-            data["object"].update(
-                {
-                    "name": self.title,
-                    "content": self.html_content,
-                    "source": {"content": self.body, "mediaType": "text/markdown"},
-                    # Mastodon strips converted-type bodies down to
-                    # ``<h2>{name}</h2> {summary} {url}``; expose the
-                    # auto-summary so federation peers (and our own
-                    # timeline teaser) see "a review of <item>"
-                    # instead of just the title + URL.
-                    "summary": self.display_summary,
-                }
-            )
+        data["object"].update(
+            {
+                "name": self.title,
+                "content": self.html_content,
+                "source": {"content": self.body, "mediaType": "text/markdown"},
+                # Mastodon strips converted-type bodies down to
+                # ``<h2>{name}</h2> {summary} {url}``; expose the
+                # auto-summary so federation peers (and our own
+                # timeline teaser) see "a review of <item>"
+                # instead of just the title + URL.
+                "summary": self.display_summary,
+            }
+        )
         return data
 
     @classmethod
@@ -158,9 +157,8 @@ class Review(Content):
         params: dict[str, Any] = {
             "prepend_content": prepend_content,
             "content": content,
+            "post_type": "Article",
         }
-        if settings.REVIEW_AS_ARTICLE:
-            params["post_type"] = "Article"
         return params
 
     @property

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -639,7 +639,11 @@ class Shelf(List):
         latest_post = member.latest_post
         if latest_post is not None:
             try:
-                entry["post"] = latest_post.absolute_object_uri()
+                # ``object_uri`` (long ``@user@domain`` form) is the
+                # canonical AP id. Peers chasing this link land on the
+                # right resource in one fetch instead of double-backing
+                # on a short→long handle mismatch.
+                entry["post"] = latest_post.object_uri
             except Exception:
                 pass
         return entry

--- a/journal/templates/article.html
+++ b/journal/templates/article.html
@@ -32,7 +32,7 @@
     {% if article.latest_post %}
       <link rel="alternate"
             type="application/activity+json"
-            href="{{ article.latest_post.absolute_object_uri }}">
+            href="{{ article.latest_post.object_uri }}">
     {% endif %}
     {% if not article.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
     <title>{{ site_name }} | {{ article.title }}</title>

--- a/journal/templates/collection.html
+++ b/journal/templates/collection.html
@@ -28,7 +28,7 @@
     {% if collection.latest_post %}
       <link rel="alternate"
             type="application/activity+json"
-            href="{{ collection.latest_post.absolute_object_uri }}">
+            href="{{ collection.latest_post.object_uri }}">
     {% endif %}
     {% if not collection.owner.anonymous_viewable %}<meta name="robots" content="noindex">{% endif %}
     <title>{{ site_name }} {% trans 'Collection' %} | {{ collection.title }}</title>

--- a/journal/views/article.py
+++ b/journal/views/article.py
@@ -15,16 +15,6 @@ from ..models.common import prefetch_latest_posts, q_owned_piece_visible_to_user
 from ..models.renderers import convert_leading_space_in_md, sanitize_md_images
 from .common import conditional_get_for_anonymous
 
-_AP_ACCEPT_TYPES = (
-    "application/activity+json",
-    "application/ld+json",
-)
-
-
-def _wants_activitypub(request) -> bool:
-    accept = request.headers.get("Accept", "")
-    return any(t in accept for t in _AP_ACCEPT_TYPES)
-
 
 def _parse_tags(raw: str) -> list[str]:
     if not raw:
@@ -100,11 +90,6 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
 
 
 def _article_last_modified(request, article_uuid: str):
-    # AP requests redirect to a different URI (the canonical Takahē post);
-    # a 304 here would let a stale HTML-cached client bypass that redirect.
-    # The view body handles the AP branch.
-    if _wants_activitypub(request):
-        return None
     # Owner-level toggles (``anonymous_viewable``, ``restricted``) don't
     # bump piece ``edited_time``, so the visibility check must run here —
     # otherwise a privacy flip would leave anonymous clients with a
@@ -123,19 +108,15 @@ def _article_last_modified(request, article_uuid: str):
 @conditional_get_for_anonymous(_article_last_modified)
 def article_retrieve(request, article_uuid: str):
     article = get_object_or_404(Article, uid=get_uuid_or_404(article_uuid))
-    if request.method == "HEAD":
-        return HttpResponse()
-    if _wants_activitypub(request):
-        # The Takahe Post is the canonical AP wire object — it owns
-        # signing, caching, and visibility gating. Defer to it instead of
-        # serving a duplicate AP envelope here. (For remote articles the
-        # Takahe view in turn redirects to the origin's `object_uri`.)
-        post = article.latest_post
-        if not post:
-            raise Http404("No post for article")
-        return redirect(post.absolute_object_uri())
     if not article.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
+    if request.method == "HEAD":
+        return HttpResponse()
+    # AP clients reach the canonical Takahe Post via the
+    # ``<link rel="alternate" type="application/activity+json">`` in
+    # the rendered HTML head (see ``article.html``). The href there
+    # points at ``latest_post.object_uri`` (the AP ``id``), so
+    # Mastodon's HTML-fallback resolver lands on the right resource.
     return render(request, "article.html", {"article": article})
 
 

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -108,17 +108,6 @@ def collection_retrieve_redirect(request: AuthedHttpRequest, collection_uuid):
     return redirect(f"/collection/{b62_encode(uid.int).zfill(22)}", permanent=True)
 
 
-_AP_ACCEPT_TYPES = (
-    "application/activity+json",
-    "application/ld+json",
-)
-
-
-def _wants_activitypub(request) -> bool:
-    accept = request.headers.get("Accept", "")
-    return any(t in accept for t in _AP_ACCEPT_TYPES)
-
-
 def _resolve_signed_viewer(request):
     """Return ``(viewer | None, error_response | None)``.
 
@@ -215,11 +204,6 @@ def collection_ap_items(request, collection_uuid):
 
 
 def _collection_last_modified(request, collection_uuid):
-    # AP responses go through their own caching/signing path; skip the
-    # conditional-GET short-circuit here so AP fetchers always run the
-    # canonical envelope code.
-    if _wants_activitypub(request):
-        return None
     try:
         uid = get_uuid_or_404(collection_uuid)
     except Http404:
@@ -242,9 +226,11 @@ def _collection_last_modified(request, collection_uuid):
 
 @conditional_get_for_anonymous(_collection_last_modified)
 def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
-    if _wants_activitypub(request):
-        collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
-        return _list_ap_object_view(request, collection)
+    # AP clients consume the Shelf envelope inline from the announcement
+    # Post's ``relatedWith[0]`` (which carries the items endpoint URL in
+    # its ``first``/``last`` fields); the canonical ``/collection/<uuid>/``
+    # only needs to render HTML for humans. Mirrors ``article_retrieve``
+    # / ``review_retrieve``.
     collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
     if not collection.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))

--- a/tests/journal/test_ap_object.py
+++ b/tests/journal/test_ap_object.py
@@ -10,7 +10,6 @@ Verifies that:
 from unittest.mock import MagicMock
 
 import pytest
-from django.test import override_settings
 
 from catalog.models import Edition
 from journal.models import (
@@ -292,19 +291,6 @@ class TestGetApData:
         assert "summary" in obj_data
         assert "a review of" in obj_data["summary"]
 
-    @override_settings(REVIEW_AS_ARTICLE=False)
-    def test_review_get_ap_data_legacy_note(self):
-        review = Review.update_item_review(
-            self.book, self.identity, "My Title", "Body text", visibility=0
-        )
-        assert review is not None
-        obj_data = review.get_ap_data()["object"]
-        # relatedWith still carries Review for NeoDB-to-NeoDB compat
-        assert obj_data["relatedWith"][0]["type"] == "Review"
-        # Article fields must NOT be injected when the flag is off
-        assert "name" not in obj_data
-        assert "source" not in obj_data
-
     def test_note_get_ap_data(self):
         note = Note.objects.create(
             item=self.book,
@@ -409,23 +395,6 @@ class TestPostTypeData:
         # corresponding ``test_review_get_ap_data`` for rationale.
         assert "summary" in post.type_data["object"]
         assert "a review of" in post.type_data["object"]["summary"]
-
-    @override_settings(REVIEW_AS_ARTICLE=False)
-    def test_review_post_type_data_legacy_note(self):
-        review = Review.update_item_review(
-            self.book, self.identity, "Legacy Review", "Legacy body", visibility=0
-        )
-        assert review is not None
-        post_id = review.latest_post_id
-        assert post_id is not None
-        post = Takahe.get_post(post_id)
-        assert post is not None
-        # Flag off: post type stays Note, no Article fields injected
-        assert post.type == "Note"
-        assert "name" not in post.type_data["object"]
-        assert "source" not in post.type_data["object"]
-        # relatedWith still present for NeoDB-to-NeoDB compat
-        assert post.type_data["object"]["relatedWith"][0]["type"] == "Review"
 
     def test_note_post_type_data_without_progress(self):
         note = Note.objects.create(

--- a/tests/journal/test_article.py
+++ b/tests/journal/test_article.py
@@ -435,8 +435,9 @@ class TestArticleInboundParsing:
 
 @pytest.mark.django_db(databases="__all__")
 class TestArticleRetrieveView:
-    """``/article/<uuid>`` serves HTML; AP requests redirect to the Takahe
-    Post URL (which is the canonical AP wire object)."""
+    """``/article/<uuid>`` serves HTML to every Accept header; AP clients
+    reach the canonical Takahe Post via the ``<link rel="alternate">`` in
+    the rendered HTML head, mirroring ``review_retrieve``."""
 
     @pytest.fixture(autouse=True)
     def setup_data(self):
@@ -456,19 +457,26 @@ class TestArticleRetrieveView:
         assert b"Hello View" in resp.content
         assert b"<strong>bold</strong>" in resp.content
 
-    def test_ap_request_redirects_to_post(self):
+    def test_ap_request_serves_html_with_alternate_link(self):
         article = Article.update_local_article(
             owner=self.identity,
-            title="AP Redirect",
+            title="AP Alt",
             body="Body",
             visibility=0,
         )
         resp = self.client.get(article.url, HTTP_ACCEPT="application/activity+json")
-        assert resp.status_code in (301, 302)
+        assert resp.status_code == 200
         post = article.latest_post
         assert post is not None
-        # The redirect target is the Takahe Post's canonical AP URL.
-        assert resp["Location"] == post.absolute_object_uri()
+        body = resp.content.decode()
+        # The HTML head's ``<link rel="alternate" type="application/activity+json">``
+        # points at the Takahe Post's AP ``id`` (long ``@user@domain`` form)
+        # so AP clients dereference the canonical wire object on the second
+        # fetch — Mastodon's ``FetchResourceService.process_html`` follows
+        # this link when content negotiation returns HTML.
+        assert 'rel="alternate"' in body
+        assert 'type="application/activity+json"' in body
+        assert post.object_uri in body
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -19,8 +19,10 @@ Covers the two-step model after the AP wire-type rename to ``Shelf``:
   it follows ``first``→``next``).
 - URL paste resolution maps a remote Collection URL to the local mirror
   while respecting visibility, and now also handles remote Shelf URLs.
-- AP content-negotiation in ``collection_retrieve`` routes signed AP
-  fetches to the dereferenceable endpoint.
+- ``collection_retrieve`` is HTML-only: AP peers consume the Shelf
+  envelope inline from the announcement Post's ``relatedWith[0]`` (the
+  pattern Review uses); the ``_list_ap_object_view`` helper is still
+  exercised here because ``shelf_ap_retrieve`` calls it.
 
 Gaps (not covered here, called out for future work):
 - ``takahe.auth.sign_get`` outbound signing (needs httpx + key fixtures).
@@ -369,7 +371,14 @@ class TestRemoteCollectionUrlPaste:
 
 
 @pytest.mark.django_db(databases="__all__")
-class TestApContentNegotiation:
+class TestApEndpointHelpers:
+    """``collection_retrieve`` is HTML-only; peers consume the Shelf
+    envelope inline from the announcement Post's ``relatedWith[0]``. The
+    ``_list_ap_object_view`` / ``_list_items_view`` helpers are still
+    exercised by ``shelf_ap`` routes and by the items-page sub-URL, so
+    their behaviour is asserted directly with a ``RequestFactory``-built
+    request."""
+
     @pytest.fixture(autouse=True)
     def setup_data(self):
         self.user = User.register(email="cn@test.com", username="cn_user")
@@ -377,20 +386,6 @@ class TestApContentNegotiation:
         self.collection = Collection.objects.create(
             owner=self.identity, title="Public", visibility=0
         )
-
-    def test_html_view_when_no_ap_accept(self):
-        from journal.views.collection import _wants_activitypub
-
-        rf = RequestFactory().get(self.collection.url)
-        assert _wants_activitypub(rf) is False
-
-    def test_ap_view_when_ap_accept(self):
-        from journal.views.collection import _wants_activitypub
-
-        rf = RequestFactory().get(
-            self.collection.url, HTTP_ACCEPT="application/activity+json"
-        )
-        assert _wants_activitypub(rf) is True
 
     def test_ap_view_unsigned_public_returns_200(self):
         # Public collections are returned to anonymous callers — same as

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -223,6 +223,11 @@ class TestCollectionUpdateByApObject:
             # both Collection and Shelf models from one entry point.
             assert args[1] == "journal.models.collection.Collection"
             assert args[2] == result.pk
+            # ``items_url`` is forwarded from the envelope so the job
+            # doesn't have to re-dereference ``remote_id``.
+            assert args[3] == ap_obj["first"]
+            # No inline ``orderedItems`` in this envelope.
+            assert args[4] is None
         assert result.members.count() == 0
 
     def test_stale_payload_is_ignored(self):
@@ -703,3 +708,74 @@ class TestItemGetByApObject:
         from catalog.models import Item
 
         assert Item.get_by_ap_object({"type": "Edition"}) is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestFetchRemoteListMembersJob:
+    """Exercise the two backward-compat / edge-case branches in
+    ``journal.jobs.list_sync.fetch_remote_list_members`` directly:
+
+    - Jobs queued under the previous signature
+      ``(class_path, pk, attempts)`` must not crash — the integer in
+      slot 3 is the retry counter, not an items URL.
+    - An envelope that explicitly inlines an empty ``orderedItems``
+      list (``[]``, no pagination) must still flow through
+      ``_sync_members_from_ap`` so a peer can clear the mirror.
+    - When the caller passes neither inline items nor a URL, the job
+      is a no-op (avoids accidental member purges).
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="jobedge@test.com", username="jobedge_user")
+        self.identity = self.user.identity
+        self.collection = Collection.objects.create(
+            owner=self.identity,
+            title="JobEdge",
+            visibility=0,
+            local=False,
+            remote_id="https://remote.example/collection/jobedge",
+        )
+
+    def test_legacy_int_in_items_url_slot_recovers_attempts(self):
+        from journal.jobs.list_sync import fetch_remote_list_members
+
+        with patch.object(Collection, "_sync_members_from_ap") as sync:
+            # Old enqueue shape: (class_path, pk, attempts). The ``1``
+            # in the items_url slot is a retry counter; it must not be
+            # parsed as a URL or fed to the SSRF gate.
+            fetch_remote_list_members(
+                "journal.models.collection.Collection",
+                self.collection.pk,
+                1,
+            )
+            sync.assert_not_called()
+
+    def test_empty_inline_items_clears_mirror(self):
+        from journal.jobs.list_sync import fetch_remote_list_members
+
+        with patch.object(Collection, "_sync_members_from_ap") as sync:
+            sync.return_value = []
+            fetch_remote_list_members(
+                "journal.models.collection.Collection",
+                self.collection.pk,
+                None,
+                [],
+            )
+            sync.assert_called_once()
+            # The envelope explicitly carries an empty list — the job
+            # must hand that through, not short-circuit on "no data".
+            args, _ = sync.call_args
+            assert args[1] == []
+
+    def test_no_data_is_noop(self):
+        from journal.jobs.list_sync import fetch_remote_list_members
+
+        with patch.object(Collection, "_sync_members_from_ap") as sync:
+            fetch_remote_list_members(
+                "journal.models.collection.Collection",
+                self.collection.pk,
+                None,
+                None,
+            )
+            sync.assert_not_called()

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -820,3 +820,23 @@ class TestFetchRemoteListMembersJob:
                 None,
             )
             sync.assert_not_called()
+
+    def test_extract_items_url_handles_embedded_object(self):
+        # AS2 lets ``first`` / ``items`` be either a URL string or an
+        # embedded ``OrderedCollection(Page)`` object. The job's page
+        # walker calls ``next_url in visited`` (set membership) and
+        # would blow up on a dict; ``extract_items_url`` normalizes to
+        # the embedded object's ``id`` when present.
+        from journal.jobs.list_sync import extract_items_url
+
+        assert extract_items_url({"first": "https://x/page?1"}) == "https://x/page?1"
+        assert extract_items_url({"items": "https://x/items"}) == "https://x/items"
+        embedded = {
+            "first": {"type": "OrderedCollectionPage", "id": "https://x/page?1"}
+        }
+        assert extract_items_url(embedded) == "https://x/page?1"
+        # No ``id`` on the embedded object → give up rather than crash.
+        assert extract_items_url({"first": {"type": "OrderedCollectionPage"}}) is None
+        assert extract_items_url({}) is None
+        # Bogus types: integer, list, etc. → None.
+        assert extract_items_url({"first": 42}) is None

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -342,12 +342,53 @@ class TestRemoteCollectionUrlPaste:
         col = Collection.objects.get(remote_id=remote_url)
         rf = RequestFactory().get("/search?q=" + remote_url)
         rf.user = self.user
-        with patch("django_rq.get_queue") as gq:
+        # ``_list_sync_args_from_post`` reads from a real Takahē Post's
+        # cached ``type_data``; the test fixture's ``MagicMock`` post
+        # isn't persisted, so stub the helper to return the envelope
+        # the announcement Post would actually carry.
+        items_url = ap_obj["first"]
+        with (
+            patch("django_rq.get_queue") as gq,
+            patch(
+                "catalog.views.search._list_sync_args_from_post",
+                return_value=(items_url, None),
+            ),
+        ):
             response = resolve_url_query(rf, remote_url)
         assert response is not None
         assert response.status_code in (302, 301)
         assert col.url in response["Location"]
         gq.return_value.enqueue.assert_called()
+        args = gq.return_value.enqueue.call_args.args
+        assert args[3] == items_url
+        assert args[4] is None
+
+    def test_resolve_url_skips_enqueue_when_cache_empty(self):
+        # ``_list_sync_args_from_post`` returns ``(None, None)`` when
+        # the announcement Post is missing or malformed. Skip the
+        # enqueue rather than scheduling a no-op job — the user still
+        # gets the existing mirror, and a refresh arrives with the
+        # next pushed Update activity from the origin.
+        remote_url = "https://remote.example/collection/cccccccccccccccccccccc"
+        ap_obj = _shelf_envelope(remote_url, self.identity, name="NoCache")
+        post = _make_remote_post(self.identity.pk, post_id=92003)
+        with patch("journal.models.itemlist.django_rq.get_queue"):
+            Collection.update_by_ap_object(self.identity, None, ap_obj, post)
+        col = Collection.objects.get(remote_id=remote_url)
+        rf = RequestFactory().get("/search?q=" + remote_url)
+        rf.user = self.user
+        with (
+            patch("django_rq.get_queue") as gq,
+            patch(
+                "catalog.views.search._list_sync_args_from_post",
+                return_value=(None, None),
+            ),
+        ):
+            response = resolve_url_query(rf, remote_url)
+        assert response is not None
+        assert response.status_code in (302, 301)
+        assert col.url in response["Location"]
+        assert not gq.return_value.enqueue.called
 
     def test_resolve_url_hides_invisible_remote_mirror(self):
         remote_url = "https://remote.example/collection/bbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/journal/test_conditional_get.py
+++ b/tests/journal/test_conditional_get.py
@@ -111,14 +111,6 @@ class TestCollectionConditionalGet:
         )
         assert resp.status_code == 304
 
-    def test_ap_request_skips_conditional_path(self):
-        # AP requests should always run the canonical envelope code, never 304.
-        first = self.client.get(
-            self.collection.url, HTTP_ACCEPT="application/activity+json"
-        )
-        # AP path doesn't set Last-Modified.
-        assert "Last-Modified" not in first
-
 
 @pytest.mark.django_db(databases="__all__")
 class TestPostConditionalGet:
@@ -345,26 +337,6 @@ class TestConditionalGetGating:
         resp = self.client.get(bad_url, HTTP_IF_MODIFIED_SINCE=last_mod)
         assert resp.status_code != 304
 
-    def test_article_ap_accept_skips_conditional_path(self):
-        # AP requests on the article URL should redirect to the canonical
-        # Post object_uri, not 304-bypass via the article's mtime.
-        article = Article.update_local_article(
-            owner=self.user.identity,
-            title="Alt",
-            body="b",
-            visibility=0,
-        )
-        first = self.client.get(article.url)
-        assert first.status_code == 200
-        last_mod = first["Last-Modified"]
-        resp = self.client.get(
-            article.url,
-            HTTP_ACCEPT="application/activity+json",
-            HTTP_IF_MODIFIED_SINCE=last_mod,
-        )
-        # Must NOT be 304; the AP-Accept path runs the view and redirects.
-        assert resp.status_code != 304
-
     def test_post_view_rejects_json_accept(self):
         # Regression for the ``HTTP_ACCEPT`` vs ``Accept`` header-name bug —
         # ``request.headers`` keys are normalized; ``HTTP_ACCEPT`` always
@@ -432,7 +404,7 @@ class TestAlternateLinkInHead:
         resp = self.client.get(article.url)
         post = article.latest_post
         assert post is not None
-        ap = post.absolute_object_uri()
+        ap = post.object_uri
         body = resp.content.decode()
         assert 'rel="alternate"' in body
         assert 'type="application/activity+json"' in body

--- a/tests/journal/test_shelf_federation.py
+++ b/tests/journal/test_shelf_federation.py
@@ -122,11 +122,14 @@ class TestShelfApEnvelope:
             position=1,
         )
         # Stub ``latest_post`` so the entry serializer surfaces ``post``.
+        # ``entry["post"]`` must be the AP ``id`` (long ``@user@domain``
+        # form), not the short ``url`` form, so peers chasing the link
+        # resolve in a single fetch.
         fake_post = MagicMock()
-        fake_post.absolute_object_uri.return_value = "https://site/@x/123"
+        fake_post.object_uri = "https://site/@x@site/posts/123/"
         with patch.object(type(m), "latest_post", fake_post):
             entry = wishlist.ap_member_entry(m)
-        assert entry["post"] == "https://site/@x/123"
+        assert entry["post"] == "https://site/@x@site/posts/123/"
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Summary

- Article / Review / Collection canonical URLs (`/article/<uuid>/`, `/review/<uuid>/`, `/collection/<uuid>/`) are now HTML-only. AP peers consume the activity inline from the announcement Post's outer object or `relatedWith[0]` instead of dereferencing the envelope `id` — mirroring how Review already worked.
- `fetch_remote_list_members` accepts `items_url` and `inline_items` from the inbound envelope at enqueue time, so the job no longer re-GETs the envelope `id`. Both args default to `None` for backward compatibility with queued jobs from the previous signature, and peers that inline `orderedItems` (no `first`/`items` URL) still sync correctly.
- `_maybe_remote_piece` (URL-paste refresh path in `catalog/views/search.py`) recovers the same args from the cached announcement Post's stored envelope, so URL-paste refreshes don't TypeError under the new signature.
- Alternate-link `href` in `article.html` / `collection.html` and shelf federation's `entry["post"]` switch to `Post.object_uri` (long `@user@domain` form, the canonical AP id) — Mastodon's HTML-fallback resolver lands on the right resource in one fetch instead of double-backing on the short→long handle mismatch.
- `NEODB_REVIEW_AS_ARTICLE` setting is removed — Review now unconditionally federates as an Article post with `name`/`content`/`source`/`summary` on the outer object plus the Review envelope in `relatedWith[0]`.
- `docs/internals/federation.md` documents the `Shelf` envelope shape (`first`/`last` paginated items) and the inline-consume contract for Review / Collection.

## Background

Reported as: Mastodon search of a NeoDB article URL doesn't resolve. Investigation found Mastodon's `FetchResourceService` does follow the redirect/alternate-link path correctly, but Takahē's short-form profile URL (`/@user/`) doesn't match the AP `id` (long-form `/@user@domain/`), forcing a second fetch. Aligning the redirect target / alternate-link `href` to the AP `id` eliminates that round trip. The broader cleanup (Collection / Shelf no longer needing self-dereferenceable envelope ids) follows from the same observation that NeoDB peers can consume the full envelope inline from the announcement Post.

## Test plan

- [x] `uv run pre-commit run -a` — clean
- [x] `pytest tests/journal/ tests/catalog/` — 1006 passed
- [ ] Manual: paste a remote NeoDB Collection URL on a peer instance — verify the mirror refreshes members via `fetch_remote_list_members` using the cached envelope's `first` URL (no envelope GET)
- [ ] Manual: search a NeoDB article URL from a Mastodon instance — verify it resolves to the post in one effective fetch