### PR TITLE
feat(discover): group recommendations by category

### DIFF
--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -629,6 +629,12 @@ def discover(request):
             Item.prefetch_parent_items(reco_items)
             Item.prefetch_edition_works(reco_items)
             prefetch_related_objects(reco_items, "external_resources")
+            cat_order: dict[str, int] = {}
+            for it in reco_items:
+                cat = str(it.category)
+                if cat not in cat_order:
+                    cat_order[cat] = len(cat_order)
+            reco_items.sort(key=lambda i: cat_order[str(i.category)])
 
     updated = cache.get("trends_updated", timezone.now())
     return render(

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -629,11 +629,12 @@ def discover(request):
             Item.prefetch_parent_items(reco_items)
             Item.prefetch_edition_works(reco_items)
             prefetch_related_objects(reco_items, "external_resources")
-            cat_order: dict[str, int] = {}
-            for it in reco_items:
-                cat = str(it.category)
-                if cat not in cat_order:
-                    cat_order[cat] = len(cat_order)
+            cat_order = {
+                cat: i
+                for i, cat in enumerate(
+                    dict.fromkeys(str(it.category) for it in reco_items)
+                )
+            }
             reco_items.sort(key=lambda i: cat_order[str(i.category)])
 
     updated = cache.get("trends_updated", timezone.now())


### PR DESCRIPTION
## Summary
- Group the Discover page's "Recommended for you" row by item category so books cluster with books, movies with movies, etc.
- Preserve the blended relevance ordering within each category and use the order of first appearance to decide category order (most-recommended category leads).

## Test plan
- [ ] Visit `/discover/` as a logged-in user whose recommendations span multiple categories; confirm the recommendation row groups items by category instead of interleaving them.
- [ ] Confirm a user with recommendations from only one category sees no behavioral change.
- [ ] Anonymous user / user with fewer than 3 recommendations: section is hidden as before.