### PR TITLE
fix(takahe): handle nodeinfo metadata being None (EGGPLANT-1C7)

### DIFF
--- a/takahe/utils.py
+++ b/takahe/utils.py
@@ -49,7 +49,7 @@ class Takahe:
         name = ""
         domain = Domain.objects.filter(domain=d).first()
         if domain and domain.nodeinfo:
-            name = domain.nodeinfo.get("metadata", {}).get("nodeName") or ""
+            name = (domain.nodeinfo.get("metadata") or {}).get("nodeName") or ""
         cache.set(cache_key, name, 600)
         if name:
             return name


### PR DESCRIPTION
## Summary
- A federated peer can return `nodeinfo` with an explicit `"metadata": null`. In that case `domain.nodeinfo.get("metadata", {})` returns `None` (the `{}` default only fires when the key is absent), and the chained `.get("nodeName")` raises `AttributeError: 'NoneType' object has no attribute 'get'` while rendering item pages — observed in production from `velhaestante.com.br`.
- Replace the chained `.get` with `(domain.nodeinfo.get("metadata") or {}).get("nodeName") or ""` so a null `metadata` value is treated like a missing one.

## Test plan
- [x] Verified the new expression against all edge cases: missing `metadata`, `metadata: None`, `metadata: {}`, `nodeName: None`, and a valid value — all return either `""` or the expected name without raising.
- [x] `uv run pre-commit run --files takahe/utils.py` passes (ruff, ruff format, ty).

Fixes EGGPLANT-1C7