### PR TITLE
feat(journal): richer fediverse post for collections

### DIFF
--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -1,3 +1,4 @@
+import mimetypes
 import re
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -7,6 +8,7 @@ from django.core.paginator import Paginator
 from django.db import models, transaction
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 from loguru import logger
 
 from catalog.models import CatalogCollection, Item
@@ -405,6 +407,95 @@ class Collection(List):
             }
         }
 
+    def _format_summary(self) -> str:
+        summary = self.get_summary() or {}
+        parts: list[str] = []
+        for category, count in summary.items():
+            if not count:
+                continue
+            match category:
+                case "book":
+                    parts.append(
+                        ngettext("%(count)d book", "%(count)d books", count)
+                        % {"count": count}
+                    )
+                case "movie":
+                    parts.append(
+                        ngettext("%(count)d movie", "%(count)d movies", count)
+                        % {"count": count}
+                    )
+                case "tv":
+                    parts.append(
+                        ngettext("%(count)d tv show", "%(count)d tv shows", count)
+                        % {"count": count}
+                    )
+                case "music":
+                    parts.append(
+                        ngettext("%(count)d album", "%(count)d albums", count)
+                        % {"count": count}
+                    )
+                case "game":
+                    parts.append(
+                        ngettext("%(count)d game", "%(count)d games", count)
+                        % {"count": count}
+                    )
+                case "podcast":
+                    parts.append(
+                        ngettext("%(count)d podcast", "%(count)d podcasts", count)
+                        % {"count": count}
+                    )
+                case "performance":
+                    parts.append(
+                        ngettext(
+                            "%(count)d performance",
+                            "%(count)d performances",
+                            count,
+                        )
+                        % {"count": count}
+                    )
+                case _:
+                    parts.append(
+                        ngettext("%(count)d item", "%(count)d items", count)
+                        % {"count": count}
+                    )
+        return ", ".join(parts)
+
+    def _build_cover_attachments(self, existing_post) -> list | None:
+        has_cover = bool(self.cover) and str(self.cover) != settings.DEFAULT_ITEM_COVER
+        existing = list(existing_post.attachments.all()) if existing_post else []
+        if not has_cover:
+            # clear stale attachments on existing posts; leave new posts as-is
+            return [] if existing else None
+        try:
+            cover_size = self.cover.size
+        except Exception:
+            cover_size = None
+        if existing and cover_size is not None:
+            current = existing[0]
+            try:
+                if current.file and current.file.size == cover_size:
+                    return existing
+            except Exception:
+                pass
+        try:
+            with self.cover.open("rb") as f:
+                content = f.read()
+        except Exception as e:
+            logger.error(f"error reading collection cover {self.cover}: {e}")
+            return existing or None
+        filename = (self.cover.name or "").rsplit("/", 1)[-1] or "cover"
+        mimetype, _enc = mimetypes.guess_type(filename)
+        if not mimetype:
+            mimetype = "image/jpeg"
+        try:
+            attachment = Takahe.upload_image(
+                self.owner.pk, filename, content, mimetype, self.title
+            )
+        except Exception as e:
+            logger.error(f"error uploading collection cover {self.cover}: {e}")
+            return existing or None
+        return [attachment]
+
     def sync_to_timeline(self, update_mode: int = 0):
         existing_post = self.latest_post
         owner: APIdentity = self.owner
@@ -416,23 +507,33 @@ class Collection(List):
         data = self.get_ap_data()
         # if existing_post and existing_post.type_data == data:
         #     return existing_post
-        action = _("created a collection")
         item_link = self.absolute_url
-        prepend_content = f'{action} <a href="{item_link}">{self.title}</a><br>'
-        content = self.plain_content
-        if len(content) > 360:
-            content = content[:357] + "..."
+        site_name = settings.SITE_INFO["site_name"]
+        prepend_content = f'<a href="{item_link}"><b>{self.title}</b> - {site_name} Collection</a><br>'
+        # ``content`` is sanitized through linebreaks_filter + FediverseHtmlParser
+        # (escapes raw HTML); ``append_content`` is inserted verbatim. We keep the
+        # short summary in ``content`` so prepend_content lands inside the first
+        # <p>, and ship the rendered-markdown description via ``append_content``.
+        brief = self.brief or ""
+        if len(brief) > 360:
+            brief = brief[:357] + "..."
+        content = self._format_summary()
+        append_content = f"\n{render_md(brief)}" if brief else ""
+        if not content:
+            content = " "
+        attachments = self._build_cover_attachments(existing_post)
         post = Takahe.post(
             self.owner.pk,
             content,
             v,
             prepend_content,
-            "",
+            append_content,
             None,
             False,
             data,
             existing_post.pk if existing_post else None,
             self.created_time,
+            attachments=attachments,
             language=owner.user.macrolanguage,
             application_id=self.application_id_when_save,
         )

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.db import models, transaction
 from django.dispatch import receiver
+from django.utils.html import escape
+from django.utils.text import Truncator
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from loguru import logger
@@ -25,6 +27,7 @@ from .itemlist import AP_PAGE_SIZE, List, ListMember, list_add, list_remove
 from .renderers import render_md, render_text
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
+_COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
 
 
 class CollectionMember(ListMember):
@@ -477,6 +480,11 @@ class Collection(List):
                     return existing
             except Exception:
                 pass
+        if cover_size is not None and cover_size > _COVER_MAX_BYTES:
+            logger.warning(
+                f"collection cover too large to attach ({cover_size} bytes): {self.cover}"
+            )
+            return existing or None
         try:
             with self.cover.open("rb") as f:
                 content = f.read()
@@ -507,18 +515,24 @@ class Collection(List):
         data = self.get_ap_data()
         # if existing_post and existing_post.type_data == data:
         #     return existing_post
-        item_link = self.absolute_url
-        site_name = settings.SITE_INFO["site_name"]
-        prepend_content = f'<a href="{item_link}"><b>{self.title}</b> - {site_name} Collection</a><br>'
+        item_link = escape(self.absolute_url)
+        site_name = escape(settings.SITE_INFO["site_name"])
+        title = escape(self.title)
+        prepend_content = (
+            f'<a href="{item_link}"><b>{title}</b> - {site_name} Collection</a><br>'
+        )
         # ``content`` is sanitized through linebreaks_filter + FediverseHtmlParser
         # (escapes raw HTML); ``append_content`` is inserted verbatim. We keep the
         # short summary in ``content`` so prepend_content lands inside the first
         # <p>, and ship the rendered-markdown description via ``append_content``.
-        brief = self.brief or ""
-        if len(brief) > 360:
-            brief = brief[:357] + "..."
         content = self._format_summary()
-        append_content = f"\n{render_md(brief)}" if brief else ""
+        if self.brief:
+            # Render markdown first, then truncate the HTML so we don't slice a
+            # link/bold marker mid-syntax.
+            brief_html = Truncator(render_md(self.brief)).chars(360, html=True)
+            append_content = f"\n{brief_html}"
+        else:
+            append_content = ""
         if not content:
             content = " "
         attachments = self._build_cover_attachments(existing_post)


### PR DESCRIPTION
## Summary

Reworks `Collection.sync_to_timeline` so a collection's fediverse post carries useful information instead of just `created collection <title>`.

The post now looks like:

```
<b>{title}</b> - {site} Collection
{N books, N movies, ...}

{markdown-rendered description}
```

Plus the collection cover is attached to the post when present.

## Changes

- **Title link**: `<a href><b>title</b> - SITE Collection</a>` (drops the `_("created collection")` action prefix; that key is no longer used).
- **Summary line**: `_format_summary()` walks `get_summary()` and produces the same pluralized text the collection card uses (e.g. `2 books, 2 movies`). Placed in `content` so it lands inside the first `<p>` alongside the title link.
- **Description**: rendered as markdown via `render_md(brief)` (truncated at 360 raw chars) and shipped via `append_content` so Takahe's `linebreaks_filter` + `FediverseHtmlParser` insert it verbatim instead of escaping the HTML.
- **Cover attachment** (`_build_cover_attachments`):
  - skipped when the cover is the `DEFAULT_ITEM_COVER` placeholder;
  - existing post attachments are reused when their file size matches the current cover (avoids re-uploading on every save);
  - otherwise re-uploaded via `Takahe.upload_image` so a swapped cover propagates.
- Returning `[]` vs `None` from `_build_cover_attachments` lets us clear stale attachments on edits while leaving fresh posts unaffected.

## Test plan

- [x] `uv run pre-commit run -a` (ruff, ruff-format, ty, djlint) — clean
- [x] Manual e2e against a local dev cluster: created two collections (one with a cover, one without) via the demo user; verified the rendered post HTML matches the spec, the cover image appears as a media attachment on the post with a cover, and re-syncing without changing the cover reuses the existing attachment.
- [ ] (Not run here) full pytest sweep — no existing tests reference `sync_to_timeline` for Collection, but maintainers may want to add coverage.

## Notes

- `locale/*/django.po` files still contain the obsolete `created collection` msgid. They'll be cleaned up the next time `django-admin makemessages --no-obsolete` runs; not done in this PR because it requires the dev env.
- The file-size heuristic for cover-change detection can collide (two images with identical byte size). For NeoDB's use that seemed acceptable; happy to swap to storing a fingerprint on the attachment if reviewers prefer.