### PR TITLE
fix(ui): keep scroll position when closing image lightbox

### DIFF
--- a/catalog/templates/_item_notes.html
+++ b/catalog/templates/_item_notes.html
@@ -41,15 +41,15 @@
           <div class="attachments">
             {% for attachment in note.attachments %}
               {% if attachment.type == 'image' %}
-                <a href="#img_{{ note.uuid }}_{{ loop.index }}"
-                   _="on click halt the event then add .open to #img_{{ note.uuid }}_{{ loop.index }}">
+                <a href="#img_{{ note.uuid }}_{{ forloop.counter }}"
+                   _="on click halt the event then add .open to the next .lightbox">
                   <img src="{{ attachment.preview_url }}"
                        alt="image attachment"
                        class="preview">
                 </a>
                 <a href="#"
                    class="lightbox"
-                   id="img_{{ note.uuid }}_{{ loop.index }}"
+                   id="img_{{ note.uuid }}_{{ forloop.counter }}"
                    _="on click halt the event then remove .open from me">
                   <span style="background-image: url('{{ attachment.url }}')"></span>
                 </a>

--- a/catalog/templates/_item_notes.html
+++ b/catalog/templates/_item_notes.html
@@ -41,12 +41,16 @@
           <div class="attachments">
             {% for attachment in note.attachments %}
               {% if attachment.type == 'image' %}
-                <a href="#img_{{ note.uuid }}_{{ loop.index }}">
+                <a href="#img_{{ note.uuid }}_{{ loop.index }}"
+                   _="on click halt the event then add .open to #img_{{ note.uuid }}_{{ loop.index }}">
                   <img src="{{ attachment.preview_url }}"
                        alt="image attachment"
                        class="preview">
                 </a>
-                <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
+                <a href="#"
+                   class="lightbox"
+                   id="img_{{ note.uuid }}_{{ loop.index }}"
+                   _="on click halt the event then remove .open from me">
                   <span style="background-image: url('{{ attachment.url }}')"></span>
                 </a>
               {% endif %}

--- a/catalog/templates/_item_user_pieces.html
+++ b/catalog/templates/_item_user_pieces.html
@@ -101,15 +101,15 @@
         <div class="attachments">
           {% for attachment in note.attachments %}
             {% if attachment.type == 'image' %}
-              <a href="#img_{{ note.uuid }}_{{ loop.index }}"
-                 _="on click halt the event then add .open to #img_{{ note.uuid }}_{{ loop.index }}">
+              <a href="#img_{{ note.uuid }}_{{ forloop.counter }}"
+                 _="on click halt the event then add .open to the next .lightbox">
                 <img src="{{ attachment.preview_url }}"
                      alt="image attachment"
                      class="preview">
               </a>
               <a href="#"
                  class="lightbox"
-                 id="img_{{ note.uuid }}_{{ loop.index }}"
+                 id="img_{{ note.uuid }}_{{ forloop.counter }}"
                  _="on click halt the event then remove .open from me">
                 <span style="background-image: url('{{ attachment.url }}')"></span>
               </a>

--- a/catalog/templates/_item_user_pieces.html
+++ b/catalog/templates/_item_user_pieces.html
@@ -101,12 +101,16 @@
         <div class="attachments">
           {% for attachment in note.attachments %}
             {% if attachment.type == 'image' %}
-              <a href="#img_{{ note.uuid }}_{{ loop.index }}">
+              <a href="#img_{{ note.uuid }}_{{ loop.index }}"
+                 _="on click halt the event then add .open to #img_{{ note.uuid }}_{{ loop.index }}">
                 <img src="{{ attachment.preview_url }}"
                      alt="image attachment"
                      class="preview">
               </a>
-              <a href="#" class="lightbox" id="img_{{ note.uuid }}_{{ loop.index }}">
+              <a href="#"
+                 class="lightbox"
+                 id="img_{{ note.uuid }}_{{ loop.index }}"
+                 _="on click halt the event then remove .open from me">
                 <span style="background-image: url('{{ attachment.url }}')"></span>
               </a>
             {% endif %}

--- a/common/static/scss/_lightbox.scss
+++ b/common/static/scss/_lightbox.scss
@@ -11,7 +11,8 @@
   -webkit-backdrop-filter: var(--pico-modal-overlay-backdrop-filter);
 }
 
-.lightbox:target {
+.lightbox:target,
+.lightbox.open {
   display: block;
 }
 

--- a/journal/templates/replies.html
+++ b/journal/templates/replies.html
@@ -38,12 +38,16 @@
         <div class="attachments">
           {% for attachment in post.attachments.all %}
             {% if attachment.is_image %}
-              <a href="#img_{{ post.pk }}_{{ loop.index }}">
+              <a href="#img_{{ post.pk }}_{{ loop.index }}"
+                 _="on click halt the event then add .open to #img_{{ post.pk }}_{{ loop.index }}">
                 <img src="{{ attachment.thumbnail_url.relative }}"
                      alt="image attachment"
                      class="preview">
               </a>
-              <a href="#" class="lightbox" id="img_{{ post.pk }}_{{ loop.index }}">
+              <a href="#"
+                 class="lightbox"
+                 id="img_{{ post.pk }}_{{ loop.index }}"
+                 _="on click halt the event then remove .open from me">
                 <span style="background-image: url('{{ attachment.full_url.relative }}')"></span>
               </a>
             {% endif %}

--- a/journal/templates/replies.html
+++ b/journal/templates/replies.html
@@ -38,15 +38,15 @@
         <div class="attachments">
           {% for attachment in post.attachments.all %}
             {% if attachment.is_image %}
-              <a href="#img_{{ post.pk }}_{{ loop.index }}"
-                 _="on click halt the event then add .open to #img_{{ post.pk }}_{{ loop.index }}">
+              <a href="#img_{{ post.pk }}_{{ forloop.counter }}"
+                 _="on click halt the event then add .open to the next .lightbox">
                 <img src="{{ attachment.thumbnail_url.relative }}"
                      alt="image attachment"
                      class="preview">
               </a>
               <a href="#"
                  class="lightbox"
-                 id="img_{{ post.pk }}_{{ loop.index }}"
+                 id="img_{{ post.pk }}_{{ forloop.counter }}"
                  _="on click halt the event then remove .open from me">
                 <span style="background-image: url('{{ attachment.full_url.relative }}')"></span>
               </a>

--- a/social/templates/_event_post.html
+++ b/social/templates/_event_post.html
@@ -109,12 +109,16 @@
             <div class="attachments">
               {% for attachment in post.attachments.all %}
                 {% if attachment.is_image %}
-                  <a href="#img_{{ post.pk }}_{{ loop.index }}">
+                  <a href="#img_{{ post.pk }}_{{ loop.index }}"
+                     _="on click halt the event then add .open to #img_{{ post.pk }}_{{ loop.index }}">
                     <img src="{{ attachment.thumbnail_url.relative }}"
                          alt="image attachment"
                          class="preview">
                   </a>
-                  <a href="#" class="lightbox" id="img_{{ post.pk }}_{{ loop.index }}">
+                  <a href="#"
+                     class="lightbox"
+                     id="img_{{ post.pk }}_{{ loop.index }}"
+                     _="on click halt the event then remove .open from me">
                     <span style="background-image: url('{{ attachment.full_url.relative }}')"></span>
                   </a>
                 {% elif attachment.is_video %}

--- a/social/templates/_event_post.html
+++ b/social/templates/_event_post.html
@@ -109,15 +109,15 @@
             <div class="attachments">
               {% for attachment in post.attachments.all %}
                 {% if attachment.is_image %}
-                  <a href="#img_{{ post.pk }}_{{ loop.index }}"
-                     _="on click halt the event then add .open to #img_{{ post.pk }}_{{ loop.index }}">
+                  <a href="#img_{{ post.pk }}_{{ forloop.counter }}"
+                     _="on click halt the event then add .open to the next .lightbox">
                     <img src="{{ attachment.thumbnail_url.relative }}"
                          alt="image attachment"
                          class="preview">
                   </a>
                   <a href="#"
                      class="lightbox"
-                     id="img_{{ post.pk }}_{{ loop.index }}"
+                     id="img_{{ post.pk }}_{{ forloop.counter }}"
                      _="on click halt the event then remove .open from me">
                     <span style="background-image: url('{{ attachment.full_url.relative }}')"></span>
                   </a>


### PR DESCRIPTION
## Summary
- Clicking an image attachment in the timeline (or other lightbox sites) and then clicking outside to close it caused the page to scroll back to the top.
- Root cause: the lightbox used CSS `:target` for show/hide and `<a href=\"#\">` to close. An empty URL fragment scrolls to top per the HTML spec.
- Fix: toggle a `.open` class via hyperscript and halt the click. `:target` is kept as a no-JS fallback.
- Applied to all four templates using the lightbox pattern: `social/templates/_event_post.html`, `journal/templates/replies.html`, `catalog/templates/_item_notes.html`, `catalog/templates/_item_user_pieces.html`.

## Test plan
- [ ] Open the timeline, scroll down, click a post image — lightbox opens without losing scroll position.
- [ ] Click outside the image — lightbox closes and the page stays at the same scroll position.
- [ ] Repeat on an item notes page and a user pieces page.
- [ ] Verify with JS disabled the lightbox still opens via `:target` (and the existing scroll-to-top on close remains as before, since no-JS users had this anyway).