### PR TITLE
fix(journal): order latest_post by PiecePost.pk to handle aged pieces

### DIFF
--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -523,17 +523,9 @@ class Collection(List):
         data = self.get_ap_data()
         # if existing_post and existing_post.type_data == data:
         #     return existing_post
-        item_link = escape(self.absolute_url)
-        site_name = escape(settings.SITE_INFO["site_name"])
         title = escape(self.title)
-        prepend_content = (
-            f'<a href="{item_link}"><b>{title}</b> - {site_name} Collection</a><br>'
-        )
-        # ``content`` is sanitized through linebreaks_filter + FediverseHtmlParser
-        # (escapes raw HTML); we keep the short item-count summary in ``content``
-        # so prepend_content lands inside the first <p>. The collection brief is
-        # intentionally not included — the canonical page already shows it.
-        content = self._format_summary() or " "
+        prepend_content = f"<b>{title}</b><br><br>"
+        content = (self._format_summary() or "") + "\n\n" + self.absolute_url
         attachments = self._build_cover_attachments(existing_post)
         post = Takahe.post(
             self.owner.pk,

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -277,16 +277,20 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         pp = PiecePost.objects.filter(post_id=post_id).first()
         return pp.piece if pp else None
 
-    def link_post_id(self, post_id: int):
-        PiecePost.objects.get_or_create(piece=self, post_id=post_id)
+    def _invalidate_post_caches(self) -> None:
         # ``latest_post_id`` / ``latest_post`` / ``all_post_ids`` are
-        # ``cached_property``s over ``post_relations``; their stored values
-        # are now stale. Drop them so the next access re-queries.
+        # ``cached_property``s over ``post_relations``; call this after
+        # mutating PiecePost rows so the next access re-queries.
         for attr in ("latest_post_id", "latest_post", "all_post_ids"):
             self.__dict__.pop(attr, None)
 
+    def link_post_id(self, post_id: int):
+        PiecePost.objects.get_or_create(piece=self, post_id=post_id)
+        self._invalidate_post_caches()
+
     def clear_post_ids(self):
         PiecePost.objects.filter(piece=self).delete()
+        self._invalidate_post_caches()
 
     @cached_property
     def latest_post_id(self):

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -279,33 +279,25 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
 
     def link_post_id(self, post_id: int):
         PiecePost.objects.get_or_create(piece=self, post_id=post_id)
-        try:
-            del self.latest_post_id
-            del self.latest_post
-        except AttributeError:
-            pass
+        # ``latest_post_id`` / ``latest_post`` / ``all_post_ids`` are
+        # ``cached_property``s over ``post_relations``; their stored values
+        # are now stale. Drop them so the next access re-queries.
+        for attr in ("latest_post_id", "latest_post", "all_post_ids"):
+            self.__dict__.pop(attr, None)
 
     def clear_post_ids(self):
         PiecePost.objects.filter(piece=self).delete()
 
     @cached_property
     def latest_post_id(self):
-        # post id is ordered by their created time
         return (
-            self.post_relations.order_by("-post_id")
+            self.post_relations.order_by("-pk")
             .values_list("post_id", flat=True)
             .first()
         )
 
     @cached_property
     def latest_post(self) -> "Post | None":
-        # ``Takahe.get_posts`` filters out posts in ``deleted`` /
-        # ``deleted_fanned_out`` state — share that filter for the
-        # single-row case so a manually-deleted announcement doesn't
-        # leave behind a stale ``<link rel="alternate" type="ap+json">``
-        # in ``article.html`` / ``collection.html`` that Mastodon would
-        # 404 on with "Post unavailable". Matches the prefetch path in
-        # ``prefetch_latest_posts``.
         pk = self.latest_post_id
         return Takahe.get_posts([pk]).first() if pk else None
 
@@ -645,23 +637,25 @@ def prefetch_latest_posts(pieces: Sequence["Piece"]) -> None:
 
     Avoids N+1 queries when templates access piece.latest_post, which would
     otherwise trigger one PiecePost query and one Post query per piece.
+
+    Latest is picked by ``PiecePost.pk`` (monotonic per insertion),
+    matching ``Piece.latest_post_id``'s logic.
     """
     if not pieces:
         return
     piece_ids = [p.pk for p in pieces]
-    # Batch-fetch latest post ID per piece (highest post_id = most recent)
+    # For each piece pick the PiecePost row with the largest pk
+    # (=most-recently inserted link), then grab its post_id.
     piece_to_latest: dict[int, int] = dict(
         PiecePost.objects.filter(piece_id__in=piece_ids)
-        .values("piece_id")
-        .annotate(latest_id=models.Max("post_id"))
-        .values_list("piece_id", "latest_id")
+        .order_by("piece_id", "-pk")
+        .distinct("piece_id")
+        .values_list("piece_id", "post_id")
     )
-    # Batch-fetch Post objects with authors
     all_post_ids = list(piece_to_latest.values())
     posts_by_id = (
         {p.pk: p for p in Takahe.get_posts(all_post_ids)} if all_post_ids else {}
     )
-    # Inject into pieces to prevent lazy loading
     for piece in pieces:
         post_id = piece_to_latest.get(piece.pk)
         piece.__dict__["latest_post_id"] = post_id

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -32,6 +32,7 @@ Gaps (not covered here, called out for future work):
 
 import base64
 import time
+from datetime import timedelta
 from email.utils import formatdate
 from unittest.mock import MagicMock, patch
 
@@ -39,10 +40,12 @@ import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from django.test import RequestFactory
+from django.utils import timezone
 
 from catalog.models import Edition
 from catalog.views.search import resolve_url_query
 from journal.models import Collection
+from takahe.models import Post
 from users.models import User
 
 
@@ -840,3 +843,79 @@ class TestFetchRemoteListMembersJob:
         assert extract_items_url({}) is None
         # Bogus types: integer, list, etc. → None.
         assert extract_items_url({"first": 42}) is None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionVisibilityFlipPostSort:
+    """When a Collection's ``created_time`` is older than
+    ``fanout_limit_days`` (Takahe's silent-add threshold), every
+    regenerated post is stamped with a snowflake id derived from
+    ``created_time.timestamp()``. Repeated visibility flips therefore
+    produce post ids in the same millisecond bucket — only the 19
+    snowflake random bits differ. Ordering by ``-post_id`` could then
+    hand back a *deleted* prior post; ``Takahe.get_posts`` filters out
+    that state, and ``latest_post`` collapsed to None even though a
+    live post existed.
+
+    The fix orders by ``Post.created`` (auto_now_add, DB insert time —
+    genuinely monotonic regardless of how ``published`` is stamped) and
+    sweeps any historical lingering live posts on the next recreate."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="flipsort@test.com", username="flipsort_user")
+        self.identity = self.user.identity
+
+    def _alive_post_ids(self, collection: Collection) -> list[int]:
+        return sorted(
+            Post.objects.filter(pk__in=collection.all_post_ids)
+            .exclude(state__in=["deleted", "deleted_fanned_out"])
+            .values_list("pk", flat=True)
+        )
+
+    def test_visibility_flips_keep_latest_post_resolvable(self):
+        # Force ``created_time`` past Takahe's silent-add threshold so the
+        # snowflake-from-published path is exercised. Passing
+        # ``created_time`` directly to ``objects.create`` ensures the
+        # initial post is also created in the same old-time snowflake
+        # bucket (matching real-world collections that have aged past
+        # ``fanout_limit_days``).
+        old_time = timezone.now() - timedelta(days=400)
+        c = Collection.objects.create(
+            owner=self.identity,
+            title="Flip me",
+            visibility=0,
+            created_time=old_time,
+        )
+        c.refresh_from_db()
+        first_post_id = c.latest_post_id
+        assert first_post_id is not None
+        # created_time should NOT mutate across flips — that's the whole
+        # point of switching to Post.created for sort order.
+        original_created_time = c.created_time
+
+        # Flip visibility several times. Each flip deletes the existing
+        # post and creates a new one.
+        seen_post_ids: list[int] = [first_post_id]
+        for new_visibility in (1, 0, 2, 0, 1):
+            c.visibility = new_visibility
+            c.save()
+            c.refresh_from_db()
+            # ``latest_post`` must always resolve to a live post.
+            assert c.latest_post is not None, (
+                f"latest_post collapsed to None after flipping to {new_visibility}; "
+                f"all_post_ids={c.all_post_ids}"
+            )
+            assert c.latest_post.state not in ("deleted", "deleted_fanned_out")
+            seen_post_ids.append(c.latest_post_id)
+
+        # Only one post should be alive at the end; prior ones must be
+        # marked deleted.
+        alive = self._alive_post_ids(c)
+        assert alive == [c.latest_post_id], (
+            f"expected exactly one live post, got {alive}"
+        )
+
+        # ``created_time`` is preserved (this is the simpler-fix
+        # contract; we used to bump it).
+        assert c.created_time == original_created_time

--- a/tests/journal/test_collection_federation.py
+++ b/tests/journal/test_collection_federation.py
@@ -857,9 +857,9 @@ class TestCollectionVisibilityFlipPostSort:
     that state, and ``latest_post`` collapsed to None even though a
     live post existed.
 
-    The fix orders by ``Post.created`` (auto_now_add, DB insert time —
-    genuinely monotonic regardless of how ``published`` is stamped) and
-    sweeps any historical lingering live posts on the next recreate."""
+    The fix orders by ``PiecePost.pk`` (BigAutoField in the neodb DB,
+    monotonic per insertion — independent of how ``published`` is
+    stamped on the Takahe Post)."""
 
     @pytest.fixture(autouse=True)
     def setup_data(self):


### PR DESCRIPTION
## Summary

- `Piece.latest_post_id` switched from ordering `post_relations` by `-post_id` (Takahe's snowflake-derived Post.pk) to `-pk` (PiecePost's own BigAutoField). For pieces older than `fanout_limit_days`, Takahe stamps every regenerated post with a snowflake at `published.timestamp() == created_time.timestamp()` so repost ids cluster in the same millisecond bucket and only the 19 random bits differ — the prior ordering could hand back a deleted earlier post and `latest_post` collapsed to None, masking the live one in the collection view.
- `prefetch_latest_posts` updated to match via `distinct("piece_id")` after `order_by("piece_id", "-pk")`.
- `link_post_id` now also drops `all_post_ids` from the `cached_property` cache (latent stale-cache bug exposed while testing the sort fix).
- Tidied the Collection federation post header: title in bold + canonical URL appended, dropping the `"<title> - <site_name> Collection"` prefix link.

The legitimate "wishlist → progress → complete posts all kept on the timeline" flow is unaffected — those posts live under separate `ShelfLogEntry` pieces, so per-piece alive count is 1 and the sort change is a no-op there. Verified by the existing `test_mark_book_progression_with_posts` (still passing).

## Test plan
- [x] `tests/journal/test_collection_federation.py::TestCollectionVisibilityFlipPostSort::test_visibility_flips_keep_latest_post_resolvable` — 5 visibility flips on a Collection with old `created_time`, `latest_post` always resolves to a live post.
- [x] Full `tests/journal/` suite (516 passed).
- [x] `pre-commit run -a` (ruff / ruff-format / djLint / ty).
- [ ] Manual smoke: flip visibility on an aged collection; verify `collection.latest_post` resolves and the canonical post appears in the collection view.