### PR TITLE
fix(catalog): handle blank ArrayField submissions on edit

### DIFF
--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -1,5 +1,6 @@
 # pyright: reportIncompatibleMethodOverride=false
 import copy
+import json
 from base64 import b64encode
 from datetime import date, datetime
 from functools import partialmethod
@@ -11,6 +12,7 @@ from django.core.exceptions import FieldError
 from django.db.models import DEFERRED, fields
 from django.utils import dateparse, timezone
 from django.utils.encoding import force_bytes
+from django_jsonform.forms.fields import ArrayFormField as DJANGO_ArrayFormField
 from django_jsonform.forms.fields import JSONFormField as DJANGO_JSONFormField
 
 # from django.db.models import JSONField as DJANGO_JSONField
@@ -309,10 +311,28 @@ class URLField(JSONFieldMixin, fields.URLField):
     pass
 
 
+class TolerantArrayFormField(DJANGO_ArrayFormField):
+    # Empty / non-JSON submissions arrive when the JS widget didn't serialize
+    # a value. Upstream calls json.loads() unconditionally and raises
+    # JSONDecodeError, surfacing as a 500 on the edit endpoint.
+
+    def to_python(self, value):
+        if isinstance(value, str):
+            try:
+                value = json.loads(value.strip() or "[]")
+            except json.JSONDecodeError:
+                return []
+        return super().to_python(value)
+
+
 class ArrayField(JSONFieldMixin, DJANGO_ArrayField):
     # def __init__(self, *args, **kwargs):
     #     kwargs["help_text"] = _("comma separated list of values")
     #     super().__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        kwargs.setdefault("form_class", TolerantArrayFormField)
+        return super().formfield(**kwargs)
 
     def from_json(self: "fields.Field", value):
         if value:

--- a/common/models/jsondata.py
+++ b/common/models/jsondata.py
@@ -317,12 +317,12 @@ class TolerantArrayFormField(DJANGO_ArrayFormField):
     # JSONDecodeError, surfacing as a 500 on the edit endpoint.
 
     def to_python(self, value):
-        if isinstance(value, str):
-            try:
-                value = json.loads(value.strip() or "[]")
-            except json.JSONDecodeError:
-                return []
-        return super().to_python(value)
+        if isinstance(value, str) and not value.strip():
+            return []
+        try:
+            return super().to_python(value)
+        except (json.JSONDecodeError, TypeError):
+            return []
 
 
 class ArrayField(JSONFieldMixin, DJANGO_ArrayField):

--- a/tests/catalog/test_common.py
+++ b/tests/catalog/test_common.py
@@ -29,6 +29,7 @@ class TestArrayField:
         assert f.to_python("") == []
         assert f.to_python("   ") == []
         assert f.to_python("not json") == []
+        assert f.to_python(None) == []
         assert f.to_python("[]") == []
         assert f.to_python('["drama"]') == ["drama"]
 

--- a/tests/catalog/test_common.py
+++ b/tests/catalog/test_common.py
@@ -2,7 +2,7 @@ import pytest
 
 from catalog.common.downloaders import use_local_response
 from catalog.common.sites import SiteManager
-from catalog.models import Edition
+from catalog.models import Edition, Movie
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -16,6 +16,47 @@ class TestArrayField:
         assert o.other_title == ["a", "b"]
         o.other_title = None
         assert o.other_title == []
+
+    def test_tolerant_array_form_field_empty_string(self):
+        """Regression for EGGPLANT-1CM: empty/blank string POSTed for an
+        ArrayField widget must not raise JSONDecodeError."""
+        from common.models.jsondata import ArrayField, TolerantArrayFormField
+
+        field = Movie._meta.get_field("genre")
+        assert isinstance(field, ArrayField)
+        f = field.formfield()
+        assert isinstance(f, TolerantArrayFormField)
+        assert f.to_python("") == []
+        assert f.to_python("   ") == []
+        assert f.to_python("not json") == []
+        assert f.to_python("[]") == []
+        assert f.to_python('["drama"]') == ["drama"]
+
+    def test_edit_form_accepts_blank_array_fields(self):
+        """Regression for EGGPLANT-1CM: posting an edit with blank array
+        fields must not crash form validation."""
+        from catalog.forms import CatalogForms
+
+        movie = Movie.objects.create(title="Test Movie")
+        form_cls = CatalogForms["Movie"]
+        post_data = {
+            "id": movie.pk,
+            "localized_title": '[{"lang":"en","text":"Test Movie"}]',
+            "localized_description": '[{"lang":"en","text":""}]',
+            "genre": "",
+            "language": "",
+            "area": "",
+            "director": "",
+            "playwright": "",
+            "actor": "",
+            "producer": "",
+            "primary_lookup_id_type": "",
+            "primary_lookup_id_value": "",
+        }
+        form = form_cls(post_data, instance=movie)
+        # Must not raise JSONDecodeError; validity itself is not the point.
+        form.is_valid()
+        assert form.cleaned_data.get("genre", None) in ([], None)
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Summary

- Catalog edit forms crashed with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` when the browser posted an empty string for an `ArrayField` widget (genre, language, area, director, etc.). Upstream `django_jsonform.forms.fields.ArrayFormField.to_python` calls `json.loads(value)` unconditionally, so a missing/blank widget value 500'd the whole edit POST.
- Added `TolerantArrayFormField` in `common/models/jsondata.py` that resolves blank or unparseable strings to `[]`, then wired our local `ArrayField.formfield()` to use it. Covers every `jsondata.ArrayField` (including `GenreListField` / `LanguageListField`).

Fixes EGGPLANT-1CM

## Test plan

- [x] `uv run pre-commit run --files common/models/jsondata.py tests/catalog/test_common.py`
- [x] `pytest tests/catalog/test_common.py::TestArrayField` (3 passed, including 2 new regression cases)
- [x] `pytest tests/catalog/test_people.py -k "form or jsondata"` (5 passed, unchanged)
- [ ] Manual: POST the TVSeason edit page with an empty `genre` and confirm no 500 (server-side regression test already covers this).