### PR TITLE
fix: don't fail _delete_crossposts when remote delete errors

### DIFF
--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -404,10 +404,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         user = User.objects.get(pk=user_pk)
         toot_id = metadata.get("mastodon_id")
         if toot_id and user.mastodon:
-            try:
-                user.mastodon.delete_post(toot_id)
-            except Exception as e:
-                logger.warning(f"Delete {user.mastodon} post {toot_id} error {e}")
+            user.mastodon.delete_post(toot_id)
         post_id = metadata.get("bluesky_id")
         if post_id and user.bluesky:
             try:

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -404,10 +404,16 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         user = User.objects.get(pk=user_pk)
         toot_id = metadata.get("mastodon_id")
         if toot_id and user.mastodon:
-            user.mastodon.delete_post(toot_id)
+            try:
+                user.mastodon.delete_post(toot_id)
+            except Exception as e:
+                logger.warning(f"Delete {user.mastodon} post {toot_id} error {e}")
         post_id = metadata.get("bluesky_id")
         if post_id and user.bluesky:
-            user.bluesky.delete_post(post_id)
+            try:
+                user.bluesky.delete_post(post_id)
+            except Exception as e:
+                logger.warning(f"Delete {user.bluesky} post {post_id} error {e}")
 
     def delete_crossposts(self):
         if hasattr(self, "metadata") and self.metadata:


### PR DESCRIPTION
## Summary

The RQ background job `_delete_crossposts` (`journal/models/common.py:402`) crashed when the remote delete call raised — most recently observed as `BadRequestError(ExpiredToken, 'Token has been revoked')` from atproto when a user's Bluesky session had been revoked. The unhandled exception kills the job and surfaces in Sentry without actually cleaning up anything the user can do about it.

Mirror the pre-existing try/except pattern in `sync_to_bluesky` (same file, ~line 472) so a stale token or transient remote error just logs a warning, and the rest of the cleanup proceeds.

Fixes EGGPLANT-1CJ

## Test plan

- [x] `uv run pre-commit run --files journal/models/common.py` passes (ruff, ruff-format, ty)
- [ ] Manual: revoke a Bluesky token, delete a piece with a recorded `bluesky_id`, confirm the RQ job logs a warning instead of erroring