### PR TITLE
fix(journal): prefetch item credits in user list views

### DIFF
--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -224,6 +224,7 @@ def render_list(
     items = [m.item for m in members]
     if items:
         Item.prefetch_parent_items(items)
+        Item.prefetch_credits(items)
         Rating.attach_to_items(items)
         marks = Mark.get_marks_by_items(target, items, request.user)
         for m in members:


### PR DESCRIPTION
## Summary

- `render_list` in `journal/views/common.py` prefetched items + `external_resources` but not credits. Each card's `item.role_credits` access in `_item_card_metadata_*.html` then fired a `catalog_itemcredit` join query — an N+1 across the user mark/tagmember/review list pages.
- Fix: call `Item.prefetch_credits(items)` right after `Item.prefetch_parent_items`, mirroring what `Collection.get_members` already does. This loads all credits for the page in one query (with `select_related("person")`).

## Test plan

- [ ] Load `/users/<name>/complete/movie/` and confirm only one `catalog_itemcredit` query in Django Debug Toolbar (was N).
- [ ] Verify the cards still render director/actor (movies/tvseason), author/translator/publisher (books), host (podcasts), etc.
- [ ] Spot-check other `render_list` callers: tagmember list, review-by-category list.

Fixes EGGPLANT-1CN.