### PR TITLE
fix(catalog): avoid VariableDoesNotExist on performance productions without a parent

### DIFF
--- a/catalog/templates/_item_card_metadata_performanceproduction.html
+++ b/catalog/templates/_item_card_metadata_performanceproduction.html
@@ -25,7 +25,11 @@
   </div>
   <div>
     {% if not hide_brief %}
-      {{ item.display_description | default:item.parent_item.display_description | linebreaksbr }}
+      {% if item.display_description %}
+        {{ item.display_description | linebreaksbr }}
+      {% elif item.parent_item.display_description %}
+        {{ item.parent_item.display_description | linebreaksbr }}
+      {% endif %}
     {% endif %}
   </div>
 {% endblock full %}

--- a/catalog/templates/_item_card_metadata_performanceproduction.html
+++ b/catalog/templates/_item_card_metadata_performanceproduction.html
@@ -27,7 +27,7 @@
     {% if not hide_brief %}
       {% if item.display_description %}
         {{ item.display_description | linebreaksbr }}
-      {% elif item.parent_item.display_description %}
+      {% elif item.parent_item and item.parent_item.display_description %}
         {{ item.parent_item.display_description | linebreaksbr }}
       {% endif %}
     {% endif %}


### PR DESCRIPTION
## Summary
- The performance production card template did `item.display_description | default:item.parent_item.display_description`. Django's `default` filter eagerly evaluates the second argument, so when `item.parent_item` is `None` (production with no parent performance), the attribute lookup raises `VariableDoesNotExist` and is reported to Sentry on every `/people/<uuid>/works/<role>` render that includes such an item.
- Switched to the same `{% if %}/{% elif %}` pattern already used in `item_base.html` (lines 268-271). Django's `{% if %}` tag swallows `VariableDoesNotExist`, so the lookup against a `None` parent is safe.

Fixes EGGPLANT-1CQ.

## Test plan
- [ ] Visit `/people/<uuid>/works/<role>` for a person who has performance productions without a `parent_item` and confirm the page renders without errors.
- [ ] Confirm the description still falls back to the parent performance's description when the production has none.