### PR TITLE
fix(douban-importer): downgrade non-URL inputs from error to warning

### DIFF
--- a/journal/importers/douban.py
+++ b/journal/importers/douban.py
@@ -272,13 +272,21 @@ class DoubanImporter(Task):
 
     def get_item_by_url(self, url):
         item = None
-        if not url:
+        if not url or not isinstance(url, str) or not url.strip():
             logger.warning("URL empty")
             return None
+        url = url.strip()
         try:
             site = SiteManager.get_site_by_url(url)
-            if not site:
-                raise ValueError(f"URL unrecognized {url}")
+        except Exception as e:
+            logger.warning(f"URL unrecognized: {url}", extra={"exception": e})
+            self.metadata["failed_urls"].append(str(url))
+            return None
+        if not site:
+            logger.warning(f"URL unrecognized: {url}")
+            self.metadata["failed_urls"].append(str(url))
+            return None
+        try:
             item = site.get_item()
             if not item:
                 logger.info(f"fetching {url}")


### PR DESCRIPTION
## Summary
- Pasting non-URL text into the Douban importer was routed through the generic `except Exception` in `get_item_by_url`, which logged at `error` level and flooded Sentry with grouped events that carried no actionable signal.
- Validate the input up front (empty / non-string / whitespace) and run `SiteManager.get_site_by_url` in its own try block, so unrecognized or unparseable URLs log a `warning` and skip — while genuine fetch failures inside `site.get_item()` / `site.get_resource_ready()` still log at `error` as before.

## Test plan
- [ ] Import a Douban export that contains a row with a non-URL value; confirm the importer skips it, records it in `failed_urls`, and emits only a `URL unrecognized` warning (no Sentry error).
- [ ] Import a row whose URL points to an unsupported host; same expected behavior.
- [ ] Import a row that triggers a real `DownloadError` / unexpected exception inside `site.get_item()`; confirm it still surfaces as an `error` in Sentry.