### PR TITLE
fix(catalog): link credits in sibling-dedup path, simplify helper

### DIFF
--- a/catalog/common/sites.py
+++ b/catalog/common/sites.py
@@ -523,10 +523,15 @@ class SiteManager:
                             f"reused sibling person {sibling} for "
                             f"{id_type}:{id_value} on {resource.item}"
                         )
-                        # update_content may have expanded the sibling's
-                        # localized_name; link any newly matching unlinked
-                        # credits on the requester item before moving on,
-                        # since this path skips the fan-out below.
+                        # update_content only writes new_res.metadata; the
+                        # sibling's own localized_name (and bio, etc.) stay
+                        # stale. Merge from new_res so any names brought in
+                        # by this source land on the sibling -- mirroring
+                        # the get_item() path's behavior when an existing
+                        # item is matched. Without this merge, credits on
+                        # the requester item whose names match a new
+                        # localized_name would be missed below.
+                        sibling.merge_data_from_external_resource(new_res)
                         cls._link_requester_credits(resource.item, sibling)
                         continue
             if linked_site:

--- a/catalog/common/sites.py
+++ b/catalog/common/sites.py
@@ -385,22 +385,30 @@ class SiteManager:
             return 0
         # Re-check person__isnull in the UPDATE WHERE clause so a concurrent
         # worker that linked the same row to a different person between our
-        # SELECT and our UPDATE is not silently overwritten. After the UPDATE,
-        # only the rows we actually own (person == self) drive the
-        # ItemPeopleRelation creation loop.
-        ItemCredit.objects.filter(pk__in=ids, person__isnull=True).update(person=person)
-        newly_linked = ItemCredit.objects.filter(
-            pk__in=ids, person=person
-        ).select_related("item")
-        linked_count = 0
-        for credit in newly_linked:
-            linked_count += 1
-            role = People._credit_role_to_people_role(credit.role)
+        # SELECT and our UPDATE is not silently overwritten. The returned
+        # count reflects only rows we actually changed; a concurrent worker
+        # that linked the same row to a different person is excluded.
+        linked_count = ItemCredit.objects.filter(
+            pk__in=ids, person__isnull=True
+        ).update(person=person)
+        # Create ItemPeopleRelation once per distinct role across all credits
+        # now linking person to requester_item (including ones a concurrent
+        # worker may have linked).
+        roles = (
+            ItemCredit.objects.filter(pk__in=ids, person=person)
+            .values_list("role", flat=True)
+            .distinct()
+        )
+        for credit_role in roles:
+            role = People._credit_role_to_people_role(credit_role)
             if role:
                 ItemPeopleRelation.objects.get_or_create(
-                    item=credit.item, people=person, role=role
+                    item=requester_item, people=person, role=role
                 )
-        logger.info(f"Linked {linked_count} credits on {requester_item} to {person}")
+        if linked_count:
+            logger.info(
+                f"Linked {linked_count} credits on {requester_item} to {person}"
+            )
         return linked_count
 
     @staticmethod
@@ -515,6 +523,11 @@ class SiteManager:
                             f"reused sibling person {sibling} for "
                             f"{id_type}:{id_value} on {resource.item}"
                         )
+                        # update_content may have expanded the sibling's
+                        # localized_name; link any newly matching unlinked
+                        # credits on the requester item before moving on,
+                        # since this path skips the fan-out below.
+                        cls._link_requester_credits(resource.item, sibling)
                         continue
             if linked_site:
                 try:

--- a/tests/catalog/test_backfill_people.py
+++ b/tests/catalog/test_backfill_people.py
@@ -348,6 +348,79 @@ class TestFetchLinkedResourcesSibling:
         assert tmdb_res.ready
         assert tmdb_res.metadata.get("localized_name")
 
+    def test_sibling_dedup_links_credits_under_expanded_names(self):
+        """When sibling-dedup attaches a new resource that brings additional
+        localized names (e.g. a Chinese translation), credits on the requester
+        item whose names match those new entries must also get linked. The
+        sibling's own metadata is merged from the new resource so the
+        subsequent link sees the expanded name set.
+
+        Test settings restrict TMDB scraping to a single language, so we
+        stub TMDB_Person.scrape with a multi-lingual ResourceContent to
+        exercise the cross-language linking path explicitly."""
+        from catalog.common import ResourceContent
+        from catalog.sites.tmdb import TMDB_Person
+
+        movie, resource, existing_person = self._movie_with_credit_and_person(
+            {
+                "id_type": IdType.DoubanPersonage,
+                "id_value": "27228768",
+                "url": "https://www.douban.com/personage/27228768/",
+            }
+        )
+        # Pre-merge, the sibling's localized_name only has the English entry,
+        # so this credit cannot be matched by name alone.
+        cn_credit = ItemCredit.objects.create(
+            item=movie,
+            role=CreditRole.Actor,
+            name="布莱恩·克兰斯顿",
+            order=1,
+        )
+
+        def _stub_scrape(self):
+            return ResourceContent(
+                metadata={
+                    "localized_name": [
+                        {"lang": "en", "text": "Bryan Cranston"},
+                        {"lang": "zh-cn", "text": "布莱恩·克兰斯顿"},
+                    ],
+                    "localized_bio": [],
+                    "title": "Bryan Cranston",
+                }
+            )
+
+        orig_scrape = TMDB_Person.scrape
+        setattr(TMDB_Person, "scrape", _stub_scrape)
+        try:
+            SiteManager.fetch_linked_resources(
+                resource,
+                [
+                    {
+                        "model": "People",
+                        "id_type": IdType.TMDB_Person,
+                        "id_value": "17419",
+                        "url": "https://www.themoviedb.org/person/17419",
+                        "title": "Bryan Cranston",
+                    }
+                ],
+                ExternalResource.LinkType.CHILD,
+            )
+        finally:
+            setattr(TMDB_Person, "scrape", orig_scrape)
+
+        # The Chinese-language credit on the requester item is now linked to
+        # the sibling, because merging new_res into the sibling brought in
+        # the "布莱恩·克兰斯顿" localized_name entry.
+        cn_credit.refresh_from_db()
+        assert cn_credit.person == existing_person
+        existing_person.refresh_from_db()
+        texts = {
+            n.get("text")
+            for n in (existing_person.localized_name or [])
+            if isinstance(n, dict)
+        }
+        assert "布莱恩·克兰斯顿" in texts
+
     @use_local_response
     def test_reuses_sibling_for_url_only_link(self):
         """Douban author/musician links come through as URL-only entries that


### PR DESCRIPTION
Follow-up to #1559, addressing two post-merge review comments.

## Summary

- **Bug fix (Sentry, MEDIUM)**: In `fetch_linked_resources`, the sibling-deduplication path returned via `continue` without invoking `_link_requester_credits`. After `update_content` may have expanded the sibling person's `localized_name`, unlinked credits on the requester item that match the newly added names were left unlinked.
- **Optimization (gemini-code-assist)**: Simplify `_link_requester_credits` to (1) use the `UPDATE` return value as the newly-linked count (matching the docstring), (2) iterate distinct roles instead of every credit row to avoid redundant `get_or_create` calls, and (3) reference `requester_item` directly instead of re-selecting it via `select_related` on each row.

## Test plan

- [x] `tests/catalog/test_backfill_people.py::TestLinkRequesterCredits` (6 tests) pass
- [x] `tests/catalog/test_people.py::TestLinkCreditsMultiLingual` (2 tests) pass
- [x] Full `tests/catalog/test_backfill_people.py` + `tests/catalog/test_people.py` (131 tests) pass
- [x] `pre-commit run --files catalog/common/sites.py` passes