### PR TITLE
fix(journal): recover from duplicate TagMember insert race

### DIFF
--- a/journal/models/itemlist.py
+++ b/journal/models/itemlist.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import django.dispatch
 import django_rq
-from django.db import models, transaction
+from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from loguru import logger
@@ -107,12 +107,23 @@ class List(Piece):
         p = {"parent": self}
         p.update(params)
         lm = ml.last()
-        member = self.MEMBER_CLASS.objects.create(
-            owner=self.owner,
-            position=lm.position + 1 if lm else 1,
-            item=item,
-            **p,
-        )
+        try:
+            with transaction.atomic():
+                member = self.MEMBER_CLASS.objects.create(
+                    owner=self.owner,
+                    position=lm.position + 1 if lm else 1,
+                    item=item,
+                    **p,
+                )
+        except IntegrityError:
+            # Concurrent append for the same (list, item) lost the race on
+            # the parent+item unique constraint (TagMember / CollectionMember)
+            # or owner+item (ShelfMember). The append is idempotent for the
+            # caller, so re-fetch and return the row the winner inserted.
+            existing = self.get_member_for_item(item)
+            if existing is None:
+                raise
+            return existing, False
         list_add.send(sender=self.__class__, instance=self, item=item, member=member)
         return member, True
 

--- a/journal/models/tag.py
+++ b/journal/models/tag.py
@@ -156,11 +156,11 @@ class TagManager:
             [m.parent.title for m in TagMember.objects.filter(owner=owner, item=item)]
         )
         for title in titles - current_titles:
-            tag = Tag.objects.filter(owner=owner, title=title).first()
-            if not tag:
-                tag = Tag.objects.create(
-                    owner=owner, title=title, visibility=default_visibility
-                )
+            tag, _ = Tag.objects.get_or_create(
+                owner=owner,
+                title=title,
+                defaults={"visibility": default_visibility},
+            )
             tag.append_item(item, visibility=default_visibility)
         for title in current_titles - titles:
             tag = Tag.objects.filter(owner=owner, title=title).first()

--- a/tests/journal/test_tag.py
+++ b/tests/journal/test_tag.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 
 from catalog.models import Edition
-from journal.models import Tag
+from journal.models import Tag, TagManager
+from journal.models.tag import TagMember
 from users.models import User
 
 
@@ -23,3 +26,48 @@ def test_attach_to_items_sets_public_tags():
 
     assert tagged.tags == ["sci fi"]
     assert untagged.tags == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_append_item_recovers_from_duplicate_race():
+    """A concurrent insert that wins the parent+item unique race must not
+    surface to the caller — append_item is idempotent (Sentry NEODB-SOCIAL-3JG)."""
+    owner = User.register(email="race@example.com", username="raceowner")
+    book = Edition.objects.create(title="Raced Book")
+    tag = Tag.objects.create(owner=owner.identity, title="raced", visibility=0)
+
+    winner, created = tag.append_item(book)
+    assert created
+    assert winner is not None
+
+    # Simulate the race: only the *pre-check* `get_member_for_item` sees
+    # None (as a losing transaction would before the winner committed) —
+    # the post-IntegrityError recovery call must still see the row.
+    real_get = Tag.get_member_for_item
+    call_count = {"n": 0}
+
+    def stubbed(self_inst, item):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return None
+        return real_get(self_inst, item)
+
+    with patch.object(Tag, "get_member_for_item", autospec=True, side_effect=stubbed):
+        recovered, created_again = tag.append_item(book)
+    assert created_again is False
+    assert recovered.pk == winner.pk
+    assert TagMember.objects.filter(parent=tag, item=book).count() == 1
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_tag_item_for_owner_is_idempotent():
+    """Repeated tag_item_for_owner calls must not raise on the Tag
+    (owner, title) or TagMember (parent, item) unique constraints."""
+    owner = User.register(email="idem@example.com", username="idemowner")
+    book = Edition.objects.create(title="Idempotent Book")
+
+    TagManager.tag_item_for_owner(owner.identity, book, ["alpha", "beta"])
+    TagManager.tag_item_for_owner(owner.identity, book, ["alpha", "beta"])
+
+    assert Tag.objects.filter(owner=owner.identity).count() == 2
+    assert TagMember.objects.filter(owner=owner.identity, item=book).count() == 2


### PR DESCRIPTION
## Summary

- Concurrent POSTs to `/mark/{item_uuid}` (double-submits, retries) race on the `TagMember(parent, item)` unique constraint and surface an `IntegrityError` to the user (Sentry [NEODB-SOCIAL-3JG](https://neodb.sentry.io/issues/NEODB-SOCIAL-3JG)). `List.append_item` now wraps the insert in `transaction.atomic()` and recovers by re-fetching the existing member.
- Closes the matching race on `Tag(owner, title)` by switching `TagManager.tag_item_for_owner` from filter-then-create to `get_or_create`.
- Adds regression tests for both the race-recovery path and idempotent re-tagging.

Fixes NEODB-SOCIAL-3JG

## Test plan

- [x] `pytest tests/journal/test_tag.py tests/journal/test_mark.py tests/journal/test_collection.py` — 33 pass, including 2 new tests
- [x] `pre-commit run -a` clean
- [ ] Re-tag an item that already has the same tag in the UI; no 500
- [ ] Double-submit `/mark/{item_uuid}` with tags; no 500 in either response