### PR TITLE
fix(shell): reload SiteConfig on shell startup

### DIFF
--- a/common/management/commands/shell.py
+++ b/common/management/commands/shell.py
@@ -1,5 +1,7 @@
 from django.core.management.commands import shell
 
+from common.models import SiteConfig
+
 
 class Command(shell.Command):
     def get_auto_imports(self):
@@ -7,3 +9,7 @@ class Command(shell.Command):
         if imps is not None:
             imps.remove("catalog.models.collection.Collection")
         return imps
+
+    def handle(self, **options):
+        SiteConfig.reload()
+        return super().handle(**options)


### PR DESCRIPTION
## Summary
- `manage.py shell` now calls `SiteConfig.reload()` before launching the interpreter, so interactive sessions see the live site-wide config (and have it applied to `settings`), matching the bootstrap done for RQ jobs and the request cycle.

## Test plan
- [ ] `docker compose --profile dev run --rm dev-shell /neodb-venv/bin/python manage.py shell --command "from common.models import SiteConfig; print(SiteConfig.system.site_name)"` prints the configured site name without manual `reload()`.
- [ ] `pre-commit run -a` is clean.