### PR TITLE
feat(sentry): crosspost delivery and user.activity metrics

### DIFF
--- a/common/sentry.py
+++ b/common/sentry.py
@@ -42,3 +42,11 @@ def count(
         metrics_count(key, value, attributes=_clean_attributes(attributes))
     except Exception:
         return
+
+
+def record_activity(action: str, source: str) -> None:
+    """Emit a `user.activity` counter for a user-initiated content action.
+
+    ``source`` is ``"api"`` or ``"web"``; importers should not call this.
+    """
+    count("user.activity", attributes={"action": action, "source": source})

--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -20,6 +20,7 @@ from common.api import (
     Result,
     api,
 )
+from common.sentry import record_activity
 from journal.models.common import q_piece_visible_to_user
 
 from ..models import Collection, FeaturedCollection, ShelfMember, ShelfType
@@ -189,6 +190,7 @@ def create_collection(request, c_in: CollectionInSchema):
     )
     c.application_id_when_save = getattr(request, "application_id", None)
     c.save()
+    record_activity("collection", "api")
     return c
 
 
@@ -216,6 +218,7 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     c.query = q
     c.application_id_when_save = getattr(request, "application_id", None)
     c.save()
+    record_activity("collection", "api")
     return c
 
 

--- a/journal/apis/note.py
+++ b/journal/apis/note.py
@@ -7,6 +7,7 @@ from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
 from common.api import NOT_FOUND, OK, PageNumberPagination, Result, api
+from common.sentry import record_activity
 
 from ..models import Note
 
@@ -75,6 +76,7 @@ def add_note_for_item(request, item_uuid: str, n_in: NoteInSchema):
     note.crosspost_when_save = n_in.post_to_fediverse
     note.application_id_when_save = getattr(request, "application_id", None)
     note.save()
+    record_activity("note", "api")
     return note
 
 
@@ -99,6 +101,7 @@ def update_note(request, note_uuid: str, n_in: NoteInSchema):
     note.crosspost_when_save = n_in.post_to_fediverse
     note.application_id_when_save = getattr(request, "application_id", None)
     note.save()
+    record_activity("note", "api")
     return note
 
 

--- a/journal/apis/review.py
+++ b/journal/apis/review.py
@@ -7,6 +7,7 @@ from ninja.pagination import paginate
 
 from catalog.models import AvailableItemCategory, Item, ItemSchema
 from common.api import OptionalOAuthAccessTokenAuth, PageNumberPagination, Result, api
+from common.sentry import record_activity
 
 from ..models import (
     Review,
@@ -98,6 +99,7 @@ def review_item(request, item_uuid: str, review: ReviewInSchema):
         share_to_mastodon=review.post_to_fediverse,
         application_id=getattr(request, "application_id", None),
     )
+    record_activity("review", "api")
     return Status(200, {"message": "OK"})
 
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -16,6 +16,7 @@ from catalog.models import (
     ItemSchema,
 )
 from common.api import PageNumberPagination, Result, api
+from common.sentry import record_activity
 from common.utils import get_uuid_or_404
 from journal.models.common import (
     max_visiblity_to_user,
@@ -280,6 +281,7 @@ def mark_item(request, item_uuid: str, mark: MarkInSchema):
         share_to_mastodon=mark.post_to_fediverse,
         application_id=getattr(request, "application_id", None),
     )
+    record_activity("mark", "api")
     return Status(200, {"message": "OK"})
 
 

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -514,13 +514,14 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         if params["visibility"] != 0 or not threads:
             return False
         attrs = {"platform": "threads", "mode": "post"}
+        r = None
         try:
             r = threads.post(**params)
         except RequestAborted:
             logger.warning(f"{self} post to {threads} failed")
             messages.error(threads.user, _("A recent post was not posted to Threads."))
-            sentry_count("crosspost.failure", attributes=attrs)
-            return False
+        except Exception as e:
+            logger.warning(f"Post to {threads} error {e}")
         if r:
             self.metadata.update({"threads_" + k: v for k, v in r.items()})
             sentry_count("crosspost.success", attributes=attrs)

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -28,6 +28,7 @@ from catalog.models import (
     item_categories,
     item_content_types,
 )
+from common.sentry import count as sentry_count
 from takahe.utils import Takahe
 from users.middlewares import activate_language_for_user
 from users.models import APIdentity, User
@@ -477,6 +478,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 except Exception as e:
                     logger.warning(f"Delete {bluesky} post {post_id} error {e}")
         r = None
+        attrs = {"platform": "bluesky", "mode": "post"}
         try:
             r = bluesky.post(**params)
         except (exceptions.UnauthorizedError, exceptions.BadRequestError) as e:
@@ -499,6 +501,9 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             logger.warning(f"Post to {bluesky} error {e}")
         if r:
             self.metadata.update({"bluesky_" + k: v for k, v in r.items()})
+            sentry_count("crosspost.success", attributes=attrs)
+        else:
+            sentry_count("crosspost.failure", attributes=attrs)
         return True
 
     def sync_to_threads(self, params, update_mode):
@@ -508,14 +513,19 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         # return
         if params["visibility"] != 0 or not threads:
             return False
+        attrs = {"platform": "threads", "mode": "post"}
         try:
             r = threads.post(**params)
         except RequestAborted:
             logger.warning(f"{self} post to {threads} failed")
             messages.error(threads.user, _("A recent post was not posted to Threads."))
+            sentry_count("crosspost.failure", attributes=attrs)
             return False
         if r:
             self.metadata.update({"threads_" + k: v for k, v in r.items()})
+            sentry_count("crosspost.success", attributes=attrs)
+        else:
+            sentry_count("crosspost.failure", attributes=attrs)
         return True
 
     def sync_to_mastodon(self, params, update_mode):
@@ -541,6 +551,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         mastodon = self.owner.user.mastodon
         if not mastodon:
             return False
+        attrs = {"platform": "mastodon", "mode": "post"}
         try:
             r = mastodon.post(**params)
         except PermissionDenied:
@@ -549,14 +560,17 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 _("A recent post was not posted to Mastodon, please re-authorize."),
                 meta={"url": mastodon.get_reauthorize_url()},
             )
+            sentry_count("crosspost.failure", attributes=attrs)
             return False
         except RequestAborted:
             logger.warning(f"{self} post to {mastodon} failed")
             messages.error(
                 mastodon.user, _("A recent post was not posted to Mastodon.")
             )
+            sentry_count("crosspost.failure", attributes=attrs)
             return False
         self.metadata.update({"mastodon_" + k: v for k, v in r.items()})
+        sentry_count("crosspost.success", attributes=attrs)
         return True
 
     def get_ap_data(self):

--- a/journal/views/article.py
+++ b/journal/views/article.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404, target_identity_required
 from takahe.utils import Takahe
 
@@ -86,6 +87,7 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
         article=article,
         share_to_mastodon=bool(form.cleaned_data.get("share_to_mastodon", False)),
     )
+    record_activity("article", "web")
     return redirect(reverse("journal:article_retrieve", args=[article.uuid]))
 
 

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_http_methods
 
 from catalog.models import Item
 from common.models import int_
+from common.sentry import record_activity
 from common.utils import (
     AuthedHttpRequest,
     PageLinksGenerator,
@@ -592,6 +593,7 @@ def collection_edit(request: AuthedHttpRequest, collection_uuid=None):
                 form.instance.owner = request.user.identity
             form.instance.brief = sanitize_md_images(form.instance.brief)
             form.save()
+            record_activity("collection", "web")
             return redirect(
                 reverse("journal:collection_retrieve", args=[form.instance.uuid])
             )

--- a/journal/views/mark.py
+++ b/journal/views/mark.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from catalog.models import *
 from common.models.lang import translate
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404
 
 from ..forms import MarkForm
@@ -33,6 +34,7 @@ def wish(request: AuthedHttpRequest, item_uuid):
         mark.update(
             ShelfType.WISHLIST, application_id=getattr(request, "application_id", None)
         )
+    record_activity("mark", "web")
     if request.GET.get("back"):
         referer = request.META.get("HTTP_REFERER") or ""
         if not url_has_allowed_host_and_scheme(
@@ -56,6 +58,7 @@ def follow(request: AuthedHttpRequest, item_uuid):
         mark.update(
             ShelfType.PROGRESS, application_id=getattr(request, "application_id", None)
         )
+    record_activity("mark", "web")
     return HttpResponseRedirect(item.url)
 
 
@@ -133,6 +136,7 @@ def mark(request: AuthedHttpRequest, item_uuid):
                             "secondary_msg": err,
                         },
                     )
+                record_activity("mark", "web")
                 referer = request.META.get("HTTP_REFERER") or ""
                 if not url_has_allowed_host_and_scheme(
                     referer,

--- a/journal/views/note.py
+++ b/journal/views/note.py
@@ -10,6 +10,7 @@ from django.views.decorators.http import require_http_methods
 
 from catalog.models import Item
 from common.forms import NeoModelForm
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404
 
 from ..models import Note
@@ -111,6 +112,7 @@ def note_edit(request: AuthedHttpRequest, item_uuid: str, note_uuid: str = ""):
         raise BadRequest(_("Invalid form data"))
     form.instance.crosspost_when_save = form.cleaned_data["share_to_mastodon"]
     note = form.save()
+    record_activity("note", "web")
     referer = request.META.get("HTTP_REFERER") or ""
     if not url_has_allowed_host_and_scheme(
         referer,

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from common.models.lang import LOCALE_CHOICES, translate
 from common.models.misc import int_
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404
 from journal.models.renderers import bleach_post_content
 from takahe.models import Post
@@ -117,6 +118,7 @@ def post_reply(request: AuthedHttpRequest, post_id: int):
         if mentions_to_prepend and not content.startswith(mentions_to_prepend):
             content = mentions_to_prepend + content
     Takahe.reply_post(post_id, request.user.identity.pk, content, visibility)
+    record_activity("post", "web")
     replies = Takahe.get_replies_for_posts([post_id], request.user.identity.pk)
     reply_prepend = ""
     if post:
@@ -186,6 +188,7 @@ def post_quote(request: AuthedHttpRequest, post_id: int):
                 visibility,
                 quote_url=post.object_uri,
             )
+            record_activity("post", "web")
             submitted = True
     elif request.method == "POST":
         raise PermissionDenied(_("Insufficient permission"))
@@ -361,6 +364,7 @@ def post_compose(request: AuthedHttpRequest):
         language=language or "",
         attachments=attachments if attachments else None,
     )
+    record_activity("post", "web")
     referer = request.META.get("HTTP_REFERER") or ""
     if not url_has_allowed_host_and_scheme(
         referer,
@@ -419,6 +423,7 @@ def post_edit(request: AuthedHttpRequest, post_id: int):
         language=language or "",
         post_pk=post.pk,
     )
+    record_activity("post", "web")
     referer = request.META.get("HTTP_REFERER") or ""
     if not url_has_allowed_host_and_scheme(
         referer,

--- a/journal/views/review.py
+++ b/journal/views/review.py
@@ -15,6 +15,7 @@ from django.views.decorators.http import require_http_methods
 
 from catalog.models import *
 from common.models.lang import translate
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404
 from users.middlewares import activate_language_for_user
 from users.models.apidentity import APIdentity
@@ -139,6 +140,7 @@ def review_edit(request: AuthedHttpRequest, item_uuid, review_uuid=None):
             )
             if not review:
                 raise BadRequest(_("Invalid parameter"))
+            record_activity("review", "web")
             return redirect(reverse("journal:review_retrieve", args=[review.uuid]))
         else:
             raise BadRequest(_("Invalid parameter"))

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -23,6 +23,7 @@ from django.utils.translation import gettext_lazy as _
 from loguru import logger
 
 from common.models import SiteConfig, jsondata
+from common.sentry import count as sentry_count
 from takahe.utils import Takahe
 
 from .common import SocialAccount
@@ -95,6 +96,9 @@ def get_api_domain(domain):
 # low level api below
 
 
+_BOOST_METRIC_ATTRS = {"platform": "mastodon", "mode": "boost"}
+
+
 def boost_toot(domain, token, toot_url):
     headers = {
         "User-Agent": USER_AGENT,
@@ -113,6 +117,7 @@ def boost_toot(domain, token, toot_url):
             logger.warning(
                 f"Error search {toot_url} on {domain} {response.status_code}"
             )
+            sentry_count("crosspost.failure", attributes=_BOOST_METRIC_ATTRS)
             return None
         j = response.json()
         if "statuses" in j and len(j["statuses"]) > 0:
@@ -123,10 +128,13 @@ def boost_toot(domain, token, toot_url):
                 logger.warning(
                     f"Error status url mismatch {s['uri']} or {s['uri']} != {toot_url}"
                 )
+                sentry_count("crosspost.failure", attributes=_BOOST_METRIC_ATTRS)
                 return None
             if s["reblogged"]:
                 logger.warning(f"Already boosted {toot_url}")
                 # TODO unboost and boost again?
+                # treat already-boosted as success (idempotent)
+                sentry_count("crosspost.success", attributes=_BOOST_METRIC_ATTRS)
                 return None
             url = (
                 "https://"
@@ -141,10 +149,15 @@ def boost_toot(domain, token, toot_url):
                 logger.warning(
                     f"Error search {toot_url} on {domain} {response.status_code}"
                 )
+                sentry_count("crosspost.failure", attributes=_BOOST_METRIC_ATTRS)
                 return None
+            sentry_count("crosspost.success", attributes=_BOOST_METRIC_ATTRS)
             return response.json()
+        sentry_count("crosspost.failure", attributes=_BOOST_METRIC_ATTRS)
+        return None
     except Exception:
         logger.warning(f"Error search {toot_url} on {domain}")
+        sentry_count("crosspost.failure", attributes=_BOOST_METRIC_ATTRS)
         return None
 
 


### PR DESCRIPTION
## Summary
- Emit `crosspost.success` / `crosspost.failure` Sentry counters with `{platform, mode}` attributes from auto-crosspost (Bluesky/Threads/Mastodon) and Mastodon boost paths, so we can monitor external delivery health.
- Add a lean `record_activity(action, source)` helper and instrument user-facing entry points to emit a `user.activity` counter with `{action, source}` attributes. Covers `post|article|mark|review|note|collection` in both API and web views. Importers are intentionally not instrumented.

Counters are no-ops when Sentry is not configured, matching the existing `common.sentry.count` helper behavior.

## Test plan
- [ ] Verify pre-commit (ruff/ruff-format/djLint/ty) passes locally.
- [ ] Trigger a marked/reviewed/noted/collected/article/post action from the web UI and confirm a `user.activity` metric is recorded in Sentry with the correct `action` and `source=web`.
- [ ] Repeat against the JSON API endpoints (OAuth bearer) and confirm `source=api`.
- [ ] Trigger a crosspost to a misconfigured Mastodon/Bluesky/Threads account and confirm a `crosspost.failure` metric is recorded with the right `platform` and `mode`.
- [ ] Trigger a successful crosspost / boost and confirm `crosspost.success` is recorded.
- [ ] Run a Douban/Goodreads/Letterboxd/etc import and confirm imports do NOT emit `user.activity`.