### PR TITLE
perf(users): parallelize MastodonUserSync with backoff and circuit breaker

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -226,14 +226,14 @@ services:
 
   neodb-worker:
     <<: *neodb-service
-    command: neodb-manage rqworker-pool --num-workers ${NEODB_RQ_WORKER_NUM:-4} import export mastodon fetch crawl ap cron
+    command: neodb-manage rqworker-pool --num-workers ${NEODB_RQ_WORKER_NUM:-4} mastodon fetch ap crawl import export cron
     depends_on:
       migration:
         condition: service_completed_successfully
 
   neodb-worker-extra:
     <<: *neodb-service
-    command: neodb-manage rqworker-pool --num-workers ${NEODB_RQ_WORKER_NUM:-4} mastodon fetch crawl ap
+    command: neodb-manage rqworker-pool --num-workers ${NEODB_RQ_WORKER_NUM:-4} mastodon fetch ap crawl
     depends_on:
       migration:
         condition: service_completed_successfully

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -335,7 +335,7 @@ class BlueskyAccount(SocialAccount):
                 BlueskyAccount.objects.filter(
                     domain=Bluesky._DOMAIN, uid__in=accts
                 ).values_list("user__identity", flat=True)
-            )
+            ) - {None}
 
         me = self.user.identity.pk
 

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -338,15 +338,18 @@ class BlueskyAccount(SocialAccount):
             )
 
         me = self.user.identity.pk
-        for target_identity in get_identity_ids(self.following):
-            if not Takahe.get_is_following(me, target_identity):
-                Takahe.follow(me, target_identity, True)
-                c += 1
 
-        for target_identity in get_identity_ids(self.mutes):
-            if not Takahe.get_is_muting(me, target_identity):
-                Takahe.mute(me, target_identity)
-                c += 1
+        follow_targets = get_identity_ids(self.following)
+        already_following = Takahe.get_existing_following_ids(me, follow_targets)
+        for target_identity in follow_targets - already_following:
+            Takahe.follow(me, target_identity, True)
+            c += 1
+
+        mute_targets = get_identity_ids(self.mutes)
+        already_muting = Takahe.get_existing_muting_ids(me, mute_targets)
+        for target_identity in mute_targets - already_muting:
+            Takahe.mute(me, target_identity)
+            c += 1
 
         return c
 

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -210,6 +210,10 @@ class SocialAccount(TypedModel):
             self._record_domain_failure()
             self._emit_sync_result("fail_alive")
             return False
+        # check_alive succeeded: the domain is reachable regardless of whether
+        # this account's refresh ends up succeeding, so clear domain-level fail
+        # state independently to avoid blocking healthy accounts on the domain.
+        self._record_domain_success()
         if not self.refresh():
             logger.warning(f"{self} refresh failed")
             self._record_account_failure()
@@ -218,7 +222,6 @@ class SocialAccount(TypedModel):
         if not skip_graph:
             self.refresh_graph()
         logger.debug(f"{self} refreshed")
-        self._record_domain_success()
         self._record_account_success()
         self._emit_sync_result("ok")
         return True

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -1,11 +1,27 @@
 from datetime import timedelta
 
+from django.core.cache import cache
 from django.db import models
 from django.db.models.functions import Lower
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
 from typedmodels.models import TypedModel
+
+from common.sentry import count as sentry_count
+
+# Domain-level circuit breaker — covers webfinger / check_alive failures
+# (i.e. the instance itself is unreachable).
+_DOMAIN_FAILURE_WINDOW = 3600  # 1h sliding window for failure counts
+_DOMAIN_FAILURE_THRESHOLD = 5  # failures in the window before tripping
+_DOMAIN_OPEN_COOLDOWN = 1800  # how long the breaker stays open
+
+# Per-account circuit breaker — covers refresh failures (revoked tokens,
+# deleted accounts) that are specific to one (uid, domain) pair on a server
+# that is otherwise reachable.
+_ACCOUNT_FAILURE_WINDOW = 7 * 86400  # 7d sliding window
+_ACCOUNT_FAILURE_THRESHOLD = 3  # failures in the window before tripping
+_ACCOUNT_OPEN_COOLDOWN = 86400  # 24h cooldown once tripped
 
 
 class Platform(models.TextChoices):
@@ -104,11 +120,72 @@ class SocialAccount(TypedModel):
     def refresh_graph(self, save=True) -> bool:
         return False
 
+    def _sync_metric_attrs(self, result: str) -> dict:
+        return {
+            "platform": self.platform.value,
+            "domain": self.domain,
+            "result": result,
+        }
+
+    def _emit_sync_result(self, result: str) -> None:
+        sentry_count(
+            "mastodon.usersync.account", attributes=self._sync_metric_attrs(result)
+        )
+
+    def _domain_circuit_key(self) -> str:
+        return f"sync_open:{self.platform.value}:{self.domain}"
+
+    def _domain_fail_key(self) -> str:
+        return f"sync_fail:{self.platform.value}:{self.domain}"
+
+    def _account_circuit_key(self) -> str:
+        return f"sync_open_acct:{self.pk}"
+
+    def _account_fail_key(self) -> str:
+        return f"sync_fail_acct:{self.pk}"
+
+    def _domain_circuit_open(self) -> bool:
+        return bool(cache.get(self._domain_circuit_key()))
+
+    def _account_circuit_open(self) -> bool:
+        return bool(cache.get(self._account_circuit_key()))
+
+    def _record_domain_failure(self) -> None:
+        key = self._domain_fail_key()
+        fails = (cache.get(key) or 0) + 1
+        cache.set(key, fails, timeout=_DOMAIN_FAILURE_WINDOW)
+        if fails >= _DOMAIN_FAILURE_THRESHOLD:
+            cache.set(self._domain_circuit_key(), 1, timeout=_DOMAIN_OPEN_COOLDOWN)
+
+    def _record_domain_success(self) -> None:
+        cache.delete_many([self._domain_fail_key(), self._domain_circuit_key()])
+
+    def _record_account_failure(self) -> None:
+        key = self._account_fail_key()
+        fails = (cache.get(key) or 0) + 1
+        cache.set(key, fails, timeout=_ACCOUNT_FAILURE_WINDOW)
+        if fails >= _ACCOUNT_FAILURE_THRESHOLD:
+            cache.set(self._account_circuit_key(), 1, timeout=_ACCOUNT_OPEN_COOLDOWN)
+
+    def _record_account_success(self) -> None:
+        cache.delete_many([self._account_fail_key(), self._account_circuit_key()])
+
     def sync(self, skip_graph=False, sleep_hours=0) -> bool:
         if self.last_refresh and self.last_refresh > timezone.now() - timedelta(
             hours=sleep_hours
         ):
             logger.debug(f"{self} skip refreshing as it's done recently")
+            self._emit_sync_result("skip_ttl")
+            return False
+        if self._domain_circuit_open():
+            logger.debug(
+                f"{self} skip refreshing, domain circuit open for {self.domain}"
+            )
+            self._emit_sync_result("skip_circuit_domain")
+            return False
+        if self._account_circuit_open():
+            logger.debug(f"{self} skip refreshing, account circuit open")
+            self._emit_sync_result("skip_circuit_account")
             return False
         if not self.check_alive():
             d = (
@@ -117,13 +194,20 @@ class SocialAccount(TypedModel):
                 else "unknown"
             )
             logger.warning(f"{self} unreachable for {d} days")
+            self._record_domain_failure()
+            self._emit_sync_result("fail_alive")
             return False
         if not self.refresh():
             logger.warning(f"{self} refresh failed")
+            self._record_account_failure()
+            self._emit_sync_result("fail_refresh")
             return False
         if not skip_graph:
             self.refresh_graph()
         logger.debug(f"{self} refreshed")
+        self._record_domain_success()
+        self._record_account_success()
+        self._emit_sync_result("ok")
         return True
 
     def sync_graph(self) -> int:

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -150,10 +150,23 @@ class SocialAccount(TypedModel):
     def _account_circuit_open(self) -> bool:
         return bool(cache.get(self._account_circuit_key()))
 
+    @staticmethod
+    def _bump_failure_counter(key: str, window: int) -> int:
+        # `cache.add` initialises the key (and TTL) atomically only when missing;
+        # `cache.incr` then bumps the counter without resetting the TTL, so the
+        # window stays fixed instead of sliding with every failure.
+        if cache.add(key, 1, timeout=window):
+            return 1
+        try:
+            return int(cache.incr(key))
+        except ValueError:
+            cache.set(key, 1, timeout=window)
+            return 1
+
     def _record_domain_failure(self) -> None:
-        key = self._domain_fail_key()
-        fails = (cache.get(key) or 0) + 1
-        cache.set(key, fails, timeout=_DOMAIN_FAILURE_WINDOW)
+        fails = self._bump_failure_counter(
+            self._domain_fail_key(), _DOMAIN_FAILURE_WINDOW
+        )
         if fails >= _DOMAIN_FAILURE_THRESHOLD:
             cache.set(self._domain_circuit_key(), 1, timeout=_DOMAIN_OPEN_COOLDOWN)
 
@@ -161,9 +174,9 @@ class SocialAccount(TypedModel):
         cache.delete_many([self._domain_fail_key(), self._domain_circuit_key()])
 
     def _record_account_failure(self) -> None:
-        key = self._account_fail_key()
-        fails = (cache.get(key) or 0) + 1
-        cache.set(key, fails, timeout=_ACCOUNT_FAILURE_WINDOW)
+        fails = self._bump_failure_counter(
+            self._account_fail_key(), _ACCOUNT_FAILURE_WINDOW
+        )
         if fails >= _ACCOUNT_FAILURE_THRESHOLD:
             cache.set(self._account_circuit_key(), 1, timeout=_ACCOUNT_OPEN_COOLDOWN)
 

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -900,14 +900,14 @@ class MastodonAccount(SocialAccount):
                 MastodonAccount.objects.filter(handle__in=accts).values_list(
                     "user__identity", flat=True
                 )
-            )
+            ) - {None}
 
         def get_identity_ids_in_domains(domains: list):
             return set(
                 MastodonAccount.objects.filter(domain__in=domains).values_list(
                     "user__identity", flat=True
                 )
-            )
+            ) - {None}
 
         me = self.user.identity.pk
 

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -910,25 +910,26 @@ class MastodonAccount(SocialAccount):
             )
 
         me = self.user.identity.pk
-        for target_identity in get_identity_ids(self.following):
-            if not Takahe.get_is_following(me, target_identity):
-                Takahe.follow(me, target_identity, True)
-                c += 1
 
-        for target_identity in get_identity_ids(self.blocks):
-            if not Takahe.get_is_blocking(me, target_identity):
-                Takahe.block(me, target_identity)
-                c += 1
+        follow_targets = get_identity_ids(self.following)
+        already_following = Takahe.get_existing_following_ids(me, follow_targets)
+        for target_identity in follow_targets - already_following:
+            Takahe.follow(me, target_identity, True)
+            c += 1
 
-        for target_identity in get_identity_ids_in_domains(self.domain_blocks):
-            if not Takahe.get_is_blocking(me, target_identity):
-                Takahe.block(me, target_identity)
-                c += 1
+        block_targets = get_identity_ids(self.blocks) | get_identity_ids_in_domains(
+            self.domain_blocks
+        )
+        already_blocking = Takahe.get_existing_blocking_ids(me, block_targets)
+        for target_identity in block_targets - already_blocking:
+            Takahe.block(me, target_identity)
+            c += 1
 
-        for target_identity in get_identity_ids(self.mutes):
-            if not Takahe.get_is_muting(me, target_identity):
-                Takahe.mute(me, target_identity)
-                c += 1
+        mute_targets = get_identity_ids(self.mutes)
+        already_muting = Takahe.get_existing_muting_ids(me, mute_targets)
+        for target_identity in mute_targets - already_muting:
+            Takahe.mute(me, target_identity)
+            c += 1
 
         return c
 

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -267,6 +267,44 @@ class Takahe:
         ).exists()
 
     @staticmethod
+    def get_existing_following_ids(source_pk: int, target_pks) -> set[int]:
+        if not target_pks:
+            return set()
+        return set(
+            Follow.objects.filter(
+                source_id=source_pk,
+                target_id__in=target_pks,
+                state="accepted",
+            ).values_list("target_id", flat=True)
+        )
+
+    @staticmethod
+    def get_existing_blocking_ids(source_pk: int, target_pks) -> set[int]:
+        if not target_pks:
+            return set()
+        return set(
+            Block.objects.filter(
+                source_id=source_pk,
+                target_id__in=target_pks,
+                state__in=["new", "sent", "awaiting_expiry"],
+                mute=False,
+            ).values_list("target_id", flat=True)
+        )
+
+    @staticmethod
+    def get_existing_muting_ids(source_pk: int, target_pks) -> set[int]:
+        if not target_pks:
+            return set()
+        return set(
+            Block.objects.filter(
+                source_id=source_pk,
+                target_id__in=target_pks,
+                state__in=["new", "sent", "awaiting_expiry"],
+                mute=True,
+            ).values_list("target_id", flat=True)
+        )
+
+    @staticmethod
     def get_following_ids(identity_pk: int):
         targets = Follow.objects.filter(
             source_id=identity_pk, state="accepted"

--- a/neodb/users/jobs/sync.py
+++ b/neodb/users/jobs/sync.py
@@ -1,11 +1,19 @@
 from datetime import timedelta
 
+import django_rq
 from django.db.models import F
 from django.utils import timezone
 from loguru import logger
 
 from common.models import BaseJob, JobManager
+from common.sentry import count as sentry_count
 from users.models import User
+
+_NON_EMAIL_ACCOUNT_TYPES = [
+    "mastodon.mastodonaccount",
+    "mastodon.threadsaccount",
+    "mastodon.blueskyaccount",
+]
 
 
 @JobManager.register
@@ -17,7 +25,6 @@ class MastodonUserSync(BaseJob):
         return timedelta(hours=cls.interval_hours)
 
     def run(self):
-        inactive_threshold = timezone.now() - timedelta(days=30)
         batches = (24 + self.interval_hours - 1) // self.interval_hours
         if batches < 1:
             batches = 1
@@ -31,16 +38,29 @@ class MastodonUserSync(BaseJob):
             .filter(
                 username__isnull=False,
                 is_active=True,
+                social_accounts__type__in=_NON_EMAIL_ACCOUNT_TYPES,
             )
             .annotate(idmod=F("id") % batches)
             .filter(idmod=batch)
+            .distinct()
+            .values_list("id", flat=True)
         )
-        for user in qs.iterator():
-            skip_graph = False
-            if not user.last_login or user.last_login < inactive_threshold:
-                last_usage = user.last_usage
-                if not last_usage or last_usage < inactive_threshold:
-                    skip_graph = True
-            logger.debug(f"User accounts sync for {user}, skip_graph:{skip_graph}")
-            user.sync_accounts(skip_graph, self.interval_hours)
-        logger.info("User accounts sync job finished.")
+        queue = django_rq.get_queue("cron")
+        dispatched = 0
+        for user_id in qs.iterator():
+            queue.enqueue(
+                User.sync_accounts_task,
+                user_id,
+                sleep_hours=self.interval_hours,
+                inactive_days=30,
+                job_id=f"sync-user-{user_id}",
+            )
+            dispatched += 1
+        sentry_count(
+            "mastodon.usersync.dispatched",
+            dispatched,
+            attributes={"batch": str(batch)},
+        )
+        logger.info(
+            f"User accounts sync dispatched {dispatched} users (batch {batch + 1} of {batches})"
+        )

--- a/neodb/users/jobs/sync.py
+++ b/neodb/users/jobs/sync.py
@@ -53,7 +53,6 @@ class MastodonUserSync(BaseJob):
                 user_id,
                 sleep_hours=self.interval_hours,
                 inactive_days=30,
-                job_id=f"sync-user-{user_id}",
             )
             dispatched += 1
         sentry_count(

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -325,11 +325,7 @@ class User(AbstractUser):
         logger.info(f"{user} accounts sync end")
 
     def sync_accounts_later(self):
-        django_rq.get_queue("mastodon").enqueue(
-            User.sync_accounts_task,
-            self.pk,
-            job_id=f"sync-user-{self.pk}",
-        )
+        django_rq.get_queue("mastodon").enqueue(User.sync_accounts_task, self.pk)
 
     @cached_property
     def unread_announcements(self):

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -1,4 +1,5 @@
 import re
+from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar
 
@@ -12,7 +13,7 @@ from django.core.files.base import ContentFile
 from django.db import IntegrityError, models, transaction
 from django.db.models.functions import Lower
 from django.urls import reverse
-from django.utils import translation
+from django.utils import timezone, translation
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
@@ -287,7 +288,8 @@ class User(AbstractUser):
 
     def sync_accounts(self, skip_graph=False, sleep_hours=0):
         """Try refresh account data from 3p server"""
-        for account in self.social_accounts.all():
+        accounts = list(self.social_accounts.all())
+        for account in accounts:
             account.sync(skip_graph=skip_graph, sleep_hours=sleep_hours)
         if not self.preference.mastodon_skip_userinfo:
             self.sync_identity()
@@ -295,20 +297,39 @@ class User(AbstractUser):
             return
         if not self.preference.mastodon_skip_relationship:
             c = 0
-            for account in self.social_accounts.all():
+            for account in accounts:
                 c += account.sync_graph()
             if c:
                 logger.debug(f"{self} graph updated with {c} new relationship.")
 
     @staticmethod
-    def sync_accounts_task(user_id):
-        user = User.objects.get(pk=user_id)
-        logger.info(f"{user} accounts sync start")
-        user.sync_accounts()
+    def sync_accounts_task(
+        user_id: int,
+        sleep_hours: int = 0,
+        inactive_days: int | None = None,
+    ):
+        user = (
+            User.objects.select_related("preference", "identity")
+            .prefetch_related("social_accounts")
+            .get(pk=user_id)
+        )
+        skip_graph = False
+        if inactive_days is not None:
+            inactive_threshold = timezone.now() - timedelta(days=inactive_days)
+            if not user.last_login or user.last_login < inactive_threshold:
+                last_usage = user.last_usage
+                if not last_usage or last_usage < inactive_threshold:
+                    skip_graph = True
+        logger.info(f"{user} accounts sync start (skip_graph={skip_graph})")
+        user.sync_accounts(skip_graph=skip_graph, sleep_hours=sleep_hours)
         logger.info(f"{user} accounts sync end")
 
     def sync_accounts_later(self):
-        django_rq.get_queue("mastodon").enqueue(User.sync_accounts_task, self.pk)
+        django_rq.get_queue("mastodon").enqueue(
+            User.sync_accounts_task,
+            self.pk,
+            job_id=f"sync-user-{self.pk}",
+        )
 
     @cached_property
     def unread_announcements(self):

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -308,11 +308,15 @@ class User(AbstractUser):
         sleep_hours: int = 0,
         inactive_days: int | None = None,
     ):
-        user = (
-            User.objects.select_related("preference", "identity")
-            .prefetch_related("social_accounts")
-            .get(pk=user_id)
-        )
+        try:
+            user = (
+                User.objects.select_related("preference", "identity")
+                .prefetch_related("social_accounts")
+                .get(pk=user_id)
+            )
+        except User.DoesNotExist:
+            logger.info(f"User {user_id} not found, skipping sync")
+            return
         skip_graph = False
         if inactive_days is not None:
             inactive_threshold = timezone.now() - timedelta(days=inactive_days)


### PR DESCRIPTION
## Summary

- `MastodonUserSync` becomes a dispatcher: per-shard, it enumerates eligible users and enqueues `User.sync_accounts_task` per user on the `cron` rq queue with a per-user `job_id` so it coordinates (dedups) with login-triggered `sync_accounts_later`. Email-only users are filtered out at the queryset level.
- `MastodonAccount.sync_graph` and `BlueskyAccount.sync_graph` no longer issue an `.exists()` per target identity. New `Takahe.get_existing_{following,blocking,muting}_ids` helpers do one bulk `target_id__in` lookup per relationship type; the loops only write the diff.
- `SocialAccount.sync` gains two Redis-backed circuit breakers (no schema change):
  - **Per-domain** for webfinger / `check_alive` failures (instance unreachable). 5 failures in 1h trip a 30min cooldown.
  - **Per-account** for `refresh` failures (revoked tokens, deleted upstream accounts). 3 failures in 7d trip a 24h cooldown. Kept separate from the domain breaker so bad-token accounts don't block healthy accounts on the same server.
- `User.sync_accounts` resolves `social_accounts` once and iterates the list twice instead of re-querying. `sync_accounts_task` prefetches `preference`, `identity`, and `social_accounts` and computes `skip_graph` worker-side from `last_login` / `last_usage` so the dispatcher loop stays tiny.
- Sentry counters: `mastodon.usersync.dispatched` (per shard) and `mastodon.usersync.account` with `{platform, domain, result}` for each terminal outcome (`ok` / `skip_ttl` / `skip_circuit_domain` / `skip_circuit_account` / `fail_alive` / `fail_refresh`).
- `compose.yml` queue ordering: `neodb-worker` now lists `mastodon fetch ap crawl import export cron`; `neodb-worker-extra` lists `mastodon fetch ap crawl`. Higher-volume queues come first so workers pick them up before slow batch queues.

## Test plan

- [x] `uv run pre-commit run -a`
- [x] `docker compose --profile dev run --rm dev-shell /neodb-venv/bin/pytest --reuse-db tests/users tests/mastodon tests/social` — 97 passed.
- [ ] Manual smoke: trigger `MastodonUserSync().run()` in a dev shell, confirm jobs appear in the `cron` queue and `mastodon.usersync.dispatched` shows up in Sentry.
- [ ] Manual smoke: point a `MastodonAccount` at a non-existent domain, run `sync_accounts_later()` repeatedly, confirm `sync_fail:*` and then `sync_open:*` cache keys appear in Redis and subsequent calls short-circuit.