### PR TITLE
fix(catalog): avoid IndexError in query_str on empty xpath match

### DIFF
--- a/catalog/common/sites.py
+++ b/catalog/common/sites.py
@@ -133,7 +133,8 @@ class AbstractSite:
 
     @staticmethod
     def query_str(content, query: str) -> str:
-        return content.xpath(query)[0].strip()
+        r = content.xpath(query)
+        return r[0].strip() if r else ""
 
     @staticmethod
     def query_list(content, query: str) -> list:

--- a/catalog/sites/bandcamp.py
+++ b/catalog/sites/bandcamp.py
@@ -60,12 +60,9 @@ class Bandcamp(AbstractSite):
     def scrape(self):
         assert self.url
         content = BasicDownloader2(self.url).download().html()
-        try:
-            title = self.query_str(content, "//h2[@class='trackTitle']/text()")
-            artist = [
-                self.query_str(content, "//div[@id='name-section']/h3/span/a/text()")
-            ]
-        except IndexError:
+        title = self.query_str(content, "//h2[@class='trackTitle']/text()")
+        artist = [self.query_str(content, "//div[@id='name-section']/h3/span/a/text()")]
+        if not title or not artist[0]:
             raise ValueError("given url contains no valid info")
 
         genre = []  # TODO: parse tags

--- a/tests/catalog/test_common.py
+++ b/tests/catalog/test_common.py
@@ -1,7 +1,8 @@
 import pytest
+from lxml import html
 
 from catalog.common.downloaders import use_local_response
-from catalog.common.sites import SiteManager
+from catalog.common.sites import AbstractSite, SiteManager
 from catalog.models import Edition, Movie
 
 
@@ -94,3 +95,20 @@ class TestCatalogItem:
         assert edition1.pages == 194
         assert sorted(edition1.language) == ["cn"]
         assert edition1.has_cover()
+
+
+class TestQueryStr:
+    def test_match_returns_stripped_value(self):
+        content = html.fromstring(
+            '<html><body><span class="year">  2024  </span></body></html>'
+        )
+        assert AbstractSite.query_str(content, '//span[@class="year"]/text()') == "2024"
+
+    def test_missing_element_returns_empty_string(self):
+        # Regression for NEODB-SOCIAL-4H7: an empty xpath result must not
+        # raise IndexError so callers' `if not src:` guards can fire.
+        content = html.fromstring("<html><body></body></html>")
+        assert (
+            AbstractSite.query_str(content, '//script[@id="__NEXT_DATA__"]/text()')
+            == ""
+        )

--- a/tests/catalog/test_music.py
+++ b/tests/catalog/test_music.py
@@ -165,6 +165,34 @@ class TestBandcamp:
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.genre == []
 
+    def test_scrape_rejects_page_without_title(self, monkeypatch):
+        # Regression for NEODB-SOCIAL-4H7: query_str now returns "" instead
+        # of raising IndexError on a missing element, so the scraper must
+        # reject pages lacking title/artist explicitly rather than silently
+        # saving empty metadata.
+        from lxml import html as lxml_html
+
+        from catalog.sites import bandcamp
+
+        class _FakeResponse:
+            def html(self):
+                return lxml_html.fromstring("<html><body></body></html>")
+
+        class _FakeDownloader:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def download(self):
+                return _FakeResponse()
+
+        monkeypatch.setattr(bandcamp, "BasicDownloader2", _FakeDownloader)
+        site = SiteManager.get_site_by_url(
+            "https://intlanthem.bandcamp.com/album/in-these-times"
+        )
+        assert site is not None
+        with pytest.raises(ValueError, match="no valid info"):
+            site.scrape()
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestDiscogsRelease:


### PR DESCRIPTION
## Summary

Fixes Sentry issue **NEODB-SOCIAL-4H7** (`IndexError: list index out of range` in `fetch_episodes_for_season_task`).

`AbstractSite.query_str` did `content.xpath(query)[0].strip()`, raising an unhandled `IndexError` when the xpath matched nothing. The IMDB, Goodreads and bibliotek.dk scrapers already guard the missing-`__NEXT_DATA__` case with `if not src: raise ParseError(...)`, but that guard was **dead code** — `query_str` crashed before it could return a falsy value.

The crash path: IMDB occasionally serves a page that contains the literal string `__NEXT_DATA__` (so `IMDBDownloader.validate_response` passes) but has no `<script id="__NEXT_DATA__">` text node, so `query_str`'s xpath returns `[]` and `[0]` throws inside the `fetch_episodes_for_season` RQ job.

## Fix

`query_str` now returns `""` on an empty match instead of crashing. This activates the existing `if not src:` guards so they raise a clean `ParseError`, which `fetch_episodes_for_season` already catches and skips per-episode. Non-empty matches are byte-for-byte unchanged, so the other callers (bgg, bandcamp, douban_*) only gain graceful degradation.

## Test

- Added `TestQueryStr` regression tests in `tests/catalog/test_common.py` (empty match -> `""`, match -> stripped value).
- `tests/catalog/test_common.py`: 6 passed (incl. `test_merge`, which exercises the goodreads/douban `query_str` scrape path).
- `tests/catalog/test_tv.py`: 19 passed (the exact `scrape_imdb` -> `query_str` `__NEXT_DATA__` path).
- `pre-commit` (ruff lint, ruff format, `ty`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)