### PR TITLE
fix(qidian): omit localized_description when brief is empty

### DIFF
--- a/catalog/sites/qidian.py
+++ b/catalog/sites/qidian.py
@@ -42,7 +42,9 @@ class Qidian(AbstractSite):
                 "localized_title": [{"lang": "zh-cn", "text": title}],
                 "author": authors,
                 "format": Edition.BookFormat.WEB,
-                "localized_description": [{"lang": "zh-cn", "text": brief}],
+                "localized_description": (
+                    [{"lang": "zh-cn", "text": brief}] if brief else []
+                ),
                 "cover_image_url": img_url,
             }
         )

--- a/test_data/https___book_qidian_com_info_1035420986_
+++ b/test_data/https___book_qidian_com_info_1035420986_
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head><title>Qidian book without description</title></head>
+<body>
+<div>
+<div></div><div></div><div></div>
+<div>
+<div>
+<div></div>
+<div>
+<h1><span><a>测试作者</a></span></h1>
+</div>
+</div>
+</div>
+<div>
+<h1 id="bookName">没有简介的书</h1>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/tests/catalog/test_book.py
+++ b/tests/catalog/test_book.py
@@ -539,6 +539,22 @@ class TestQidian:
         assert isinstance(site.resource.item, Edition)
         assert site.resource.item.author[0] == "爱潜水的乌贼"
 
+    @use_local_response
+    def test_scrape_without_description(self):
+        # A page whose description paragraph is missing must not produce a
+        # localized_description entry with text=None, which would fail
+        # EditionSchema validation (NEODB-SOCIAL-7KK).
+        t_url = "https://book.qidian.com/info/1035420986/"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready is True
+        assert site.resource is not None
+        assert site.resource.metadata["localized_description"] == []
+        assert site.resource.item is not None
+        assert isinstance(site.resource.item, Edition)
+        assert site.resource.item.localized_description == []
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestStoryGraph:


### PR DESCRIPTION
## Summary

Fixes an `EditionSchema` validation error when scraping Qidian books whose description paragraph is absent (Sentry **NEODB-SOCIAL-7KK**).

The Qidian scraper unconditionally emitted:

```python
"localized_description": [{"lang": "zh-cn", "text": brief}],
```

When the description xpath matches nothing, `brief` is `None`, producing a `{"text": None}` entry. Pydantic then rejects it (`Input should be a valid string ... input_value=None`). On a re-fetch the merge appends the bad entry after an existing description, which is why Sentry reported it at `localized_description.1.text`; a fresh create fails at index 0.

Qidian was the only one of ~15 site scrapers that didn't guard against an empty brief.

## Fix

```python
"localized_description": (
    [{"lang": "zh-cn", "text": brief}] if brief else []
),
```

This matches the exact pattern already used by goodreads, openlibrary, imdb, douban_*, storygraph, bgg, google_books, etc.

## Testing

- Added `TestQidian::test_scrape_without_description` with a minimal fixture (a Qidian page with a title but no description).
- Verified the test **fails** on the pre-fix code with the same validation error and **passes** with the fix.
- Full `TestQidian` class: 3 passed.
- `pre-commit` (ruff, ruff-format, `ty`) passes on all changed files.

Fixes NEODB-SOCIAL-7KK

🤖 Generated with [Claude Code](https://claude.com/claude-code)