### PR TITLE
fix(search): handle httpx transport errors in all Typesense operations

### DIFF
--- a/common/search/index.py
+++ b/common/search/index.py
@@ -338,20 +338,24 @@ class Index:
                 c += 1
         return c
 
-    def insert_docs(self, docs: List[dict]):
+    def insert_docs(self, docs: List[dict]) -> int:
         if not docs:
-            return False
+            return 0
         try:
             rs = self.write_collection.documents.import_(docs)
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
-            return
+            return 0
+        c = 0
         for r in rs:
             e = r.get("error", None)
             if e:
                 logger.error(f"Typesense: {self.name} import error {e}")
                 if settings.DEBUG:
                     logger.error(f"Typesense: {r}")
+            else:
+                c += 1
+        return c
 
     def delete_docs(self, field: str, values: Iterable[int | str] | int | str) -> int:
         v: str = (
@@ -410,7 +414,11 @@ class Index:
             logger.error(f"Typesense: error {e}")
             return self._error_result(str(e))
         results = r.get("results") if isinstance(r, dict) else None
-        if not results:
+        if (
+            not isinstance(results, list)
+            or not results
+            or not isinstance(results[0], dict)
+        ):
             logger.error(f"Typesense: search {self.name} invalid response {r}")
             return self._error_result("invalid response")
         sr = self.search_result_class(self, results[0])

--- a/common/search/index.py
+++ b/common/search/index.py
@@ -1,8 +1,10 @@
 import re
 from functools import cached_property
+from json import JSONDecodeError
 from time import sleep
 from typing import Iterable, List, Self, cast
 
+import httpx
 from django.conf import settings
 from loguru import logger
 from requests import RequestException
@@ -18,6 +20,19 @@ from typesense.types.document import MultiSearchCommonParameters, SearchResponse
 from typesense.types.multi_search import MultiSearchRequestSchema
 
 from common.models.site_config import SiteConfig
+
+# Exceptions that any Typesense network operation may raise.
+# typesense 2.x uses httpx for transport and, after exhausting node retries,
+# re-raises the underlying httpx error (httpx.HTTPError and subclasses such as
+# ConnectError and TimeoutException) -- which is neither a TypesenseClientError
+# nor a requests.RequestException. JSONDecodeError can escape when the server
+# returns a non-JSON body on a 2xx response. RequestException is kept defensively.
+TYPESENSE_ERRORS = (
+    RequestException,
+    TypesenseClientError,
+    httpx.HTTPError,
+    JSONDecodeError,
+)
 
 
 def _backtick(s: str | int) -> str:
@@ -308,7 +323,7 @@ class Index:
             return 0
         try:
             rs = self.write_collection.documents.import_(docs, {"action": "upsert"})
-        except (RequestException, TypesenseClientError) as e:
+        except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return 0
         c = 0
@@ -328,7 +343,7 @@ class Index:
             return False
         try:
             rs = self.write_collection.documents.import_(docs)
-        except (RequestException, TypesenseClientError) as e:
+        except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return
         for r in rs:
@@ -346,7 +361,7 @@ class Index:
         )
         try:
             r = self.write_collection.documents.delete({"filter_by": f"{field}:{v}"})
-        except (RequestException, TypesenseClientError) as e:
+        except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return 0
         return (r or {}).get("num_deleted", 0)
@@ -359,11 +374,21 @@ class Index:
             self.write_collection.documents.update(
                 partial_doc, {"filter_by": doc_filter}
             )
-        except (RequestException, TypesenseClientError) as e:
+        except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
 
-    def get_doc(self, doc_id: int | str):
-        return self.read_collection.documents[str(doc_id)].retrieve()
+    def get_doc(self, doc_id: int | str) -> dict | None:
+        try:
+            return self.read_collection.documents[str(doc_id)].retrieve()
+        except ObjectNotFound:
+            # a missing document is an expected result, not a failure
+            raise
+        except TYPESENSE_ERRORS as e:
+            logger.error(f"Typesense: error {e}")
+            return None
+
+    def _error_result(self, error: str) -> SearchResult:
+        return self.search_result_class(self, {"error": error, "code": -1})  # type:ignore
 
     def search(
         self,
@@ -381,10 +406,14 @@ class Index:
                     {"collection": self.read_collection.name},
                 ),
             )
-        except (RequestException, TypesenseClientError) as e:
+        except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
-            return self.search_result_class(self, {"error": str(e), "code": -1})  # type:ignore
-        sr = self.search_result_class(self, r["results"][0])
+            return self._error_result(str(e))
+        results = r.get("results") if isinstance(r, dict) else None
+        if not results:
+            logger.error(f"Typesense: search {self.name} invalid response {r}")
+            return self._error_result("invalid response")
+        sr = self.search_result_class(self, results[0])
         if sr.error:
             logger.error(f"Typesense: search error {sr.error}")
         elif settings.DEBUG:

--- a/tests/catalog/test_people_index.py
+++ b/tests/catalog/test_people_index.py
@@ -177,5 +177,6 @@ class TestCatalogExcludesPeople:
 
     def test_people_indexed_in_people_collection(self):
         doc = PeopleIndex.instance().get_doc(self.person.pk)
+        assert doc is not None
         assert doc["people_type"] == "person"
         assert "Some Person" in doc["name"]


### PR DESCRIPTION
## Problem

Sentry **NEODB-SOCIAL-7KZ** and similar issues: unhandled exceptions escaping Typesense operations.

`a6bf3f25` bumped **typesense 0.21 -> 2.0.0**, which switched the HTTP transport from `requests` to **httpx**. After exhausting node retries the client re-raises the underlying httpx exception (`httpx.ConnectError`, `httpx.TimeoutException`, `httpx.HTTPError`, `httpx.RequestError`) — none of which subclass `requests.RequestException` or `TypesenseClientError`. Every handler in `common/search/index.py` caught only `(RequestException, TypesenseClientError)`, so these escaped. With `connection_timeout_seconds: 2`, a brief Typesense slowdown/restart raised them straight up the stack from search views, federation post indexing (`takahe/ap_handlers.py` -> `replace_posts`), and index-update worker tasks.

`common/search/index.py` is the single chokepoint — no other module touches the Typesense client directly.

## Changes

- Add a shared `TYPESENSE_ERRORS = (RequestException, TypesenseClientError, httpx.HTTPError, JSONDecodeError)` tuple. `httpx.HTTPError` is the base for all connect/timeout/network/status errors; `JSONDecodeError` covers a non-JSON 2xx body.
- Broaden all runtime data handlers (`search`, `replace_docs`, `insert_docs`, `delete_docs`, `patch_docs`) to catch `TYPESENSE_ERRORS`.
- Harden `search()` response parsing — the `r["results"][0]` access (previously outside the `try`) now guards a missing/empty `results` and returns an error result instead of raising `KeyError`/`IndexError`.
- Harden `get_doc()` against transient transport errors, **preserving** the intentional `ObjectNotFound` not-found contract (relied on by `test_people_not_indexed_in_catalog_after_save`).
- Admin/schema-only methods (`check`, `create_collection`, `delete_collection`, `update_schema`) are left raising — their management-command callers already wrap them in `try/except`.

All caught errors are logged at ERROR via loguru, so they still surface in Sentry (via `LoguruIntegration`) — now as graceful log events instead of unhandled 500s.

## Test

- `tests/catalog/test_people_index.py`: added `assert doc is not None` to narrow `get_doc`'s now-`Optional` return for the type checker.
- `uv run pre-commit run -a` passes fully (ruff, ruff format, djLint, `ty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)