### PR TITLE
fix(catalog): guard localized label text/lang against None across site scrapers

### DIFF
--- a/catalog/sites/bangumi.py
+++ b/catalog/sites/bangumi.py
@@ -328,6 +328,7 @@ class Bangumi(AbstractSite):
         localized_title = [
             {"lang": lang or detect_language(t), "text": t}
             for t, lang in titles.items()
+            if t
         ]
         localized_desc = (
             [{"lang": detect_language(brief), "text": brief}] if brief else []

--- a/catalog/sites/bookstw.py
+++ b/catalog/sites/bookstw.py
@@ -115,7 +115,9 @@ class BooksTW(AbstractSite):
             "title": title,
             "subtitle": subtitle,
             "localized_title": [{"lang": "zh-tw", "text": title}],
-            "localized_subtitle": [{"lang": "zh-tw", "text": subtitle}],
+            "localized_subtitle": (
+                [{"lang": "zh-tw", "text": subtitle}] if subtitle else []
+            ),
             "localized_description": [{"lang": "zh-tw", "text": brief}],
             "orig_title": orig_title,
             "author": authors,

--- a/catalog/sites/discogs.py
+++ b/catalog/sites/discogs.py
@@ -28,6 +28,8 @@ class DiscogsRelease(AbstractSite):
     def scrape(self):
         release = get_discogs_data("releases", self.id_value)
         title = release.get("title")
+        if not title:
+            raise ParseError(self, "title")
         artist = [artist.get("name") for artist in release.get("artists")]
         genre = release.get("genres", [])
         track_list = [track.get("title") for track in release.get("tracklist")]
@@ -89,6 +91,8 @@ class DiscogsMaster(AbstractSite):
     def scrape(self):
         master_release = get_discogs_data("masters", self.id_value)
         title = master_release.get("title")
+        if not title:
+            raise ParseError(self, "title")
         artist = [artist.get("name") for artist in master_release.get("artists")]
         genre = master_release.get("genres", [])
         track_list = [track.get("title") for track in master_release.get("tracklist")]

--- a/catalog/sites/douban_book.py
+++ b/catalog/sites/douban_book.py
@@ -236,7 +236,9 @@ class DoubanBook(AbstractSite):
             "title": title,
             "subtitle": subtitle,
             "localized_title": [{"lang": lang, "text": title}],
-            "localized_subtitle": [{"lang": lang, "text": subtitle}],
+            "localized_subtitle": (
+                [{"lang": lang, "text": subtitle}] if subtitle else []
+            ),
             "localized_description": [{"lang": lang, "text": brief}] if brief else [],
             "orig_title": orig_title,
             "author": authors,

--- a/catalog/sites/google_books.py
+++ b/catalog/sites/google_books.py
@@ -8,7 +8,7 @@ from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import isbn_10_to_13
 from catalog.search import *
-from common.models import SiteConfig
+from common.models import SiteConfig, detect_language
 
 
 @SiteManager.register
@@ -86,12 +86,19 @@ class GoogleBooks(AbstractSite):
         isbn = isbn13 if isbn13 is not None else isbn_10_to_13(isbn10)
 
         raw_img, ext = BasicImageDownloader.download_image(img_url, None, headers={})
+        # `language` is "" when the volume omits a language tag; the localized
+        # label `lang` must be a non-empty string, so fall back to detection.
+        label_lang = (
+            language
+            if isinstance(language, str) and language
+            else detect_language(title)
+        )
         data = {
             "title": title,
-            "localized_title": [{"lang": language, "text": title}],
+            "localized_title": [{"lang": label_lang, "text": title}],
             "subtitle": subtitle,
             "localized_subtitle": (
-                [{"lang": language, "text": subtitle}] if subtitle else []
+                [{"lang": label_lang, "text": subtitle}] if subtitle else []
             ),
             "orig_title": None,
             "author": authors,
@@ -105,7 +112,7 @@ class GoogleBooks(AbstractSite):
             "isbn": isbn,
             # "brief": brief,
             "localized_description": (
-                [{"lang": language, "text": brief}] if brief else []
+                [{"lang": label_lang, "text": brief}] if brief else []
             ),
             "contents": None,
             "other_info": other,

--- a/catalog/sites/igdb.py
+++ b/catalog/sites/igdb.py
@@ -100,6 +100,8 @@ class IGDB(AbstractSite):
         if not r:
             raise ParseError(self, "no data")
         r = r[0]
+        if not r.get("name"):
+            raise ParseError(self, "no name")
         brief = r["summary"] if "summary" in r else ""
         brief += "\n\n" + r["storyline"] if "storyline" in r else ""
         developer = None

--- a/catalog/sites/mobygames.py
+++ b/catalog/sites/mobygames.py
@@ -56,7 +56,11 @@ class MobyGames(AbstractSite):
         if isinstance(alt_names, str):
             alt_names = [alt_names]
         for alt in alt_names:
-            if alt and not any(e["text"] == alt for e in localized_title):
+            if (
+                isinstance(alt, str)
+                and alt
+                and not any(e["text"] == alt for e in localized_title)
+            ):
                 localized_title.append({"lang": detect_language(alt), "text": alt})
 
         # Description from the in-page description block (preferred) or meta tag

--- a/catalog/sites/mobygames.py
+++ b/catalog/sites/mobygames.py
@@ -56,7 +56,7 @@ class MobyGames(AbstractSite):
         if isinstance(alt_names, str):
             alt_names = [alt_names]
         for alt in alt_names:
-            if not any(e["text"] == alt for e in localized_title):
+            if alt and not any(e["text"] == alt for e in localized_title):
                 localized_title.append({"lang": detect_language(alt), "text": alt})
 
         # Description from the in-page description block (preferred) or meta tag

--- a/catalog/sites/spotify.py
+++ b/catalog/sites/spotify.py
@@ -48,6 +48,8 @@ class Spotify(AbstractSite):
         txt: str = content.xpath("//script[@type='application/ld+json']/text()")[0]
         schema_data = json.loads(txt)
         title = schema_data["name"]
+        if not title:
+            raise ParseError(self, "title")
         localized_title = [{"lang": detect_language(title), "text": title}]
         localized_desc = []
         release_date = schema_data.get("datePublished", None)
@@ -82,6 +84,8 @@ class Spotify(AbstractSite):
             artist.append(artist_dict["name"])
 
         title = res_data["name"]
+        if not title:
+            raise ParseError(self, "title")
 
         genre = res_data.get("genres", [])
 

--- a/catalog/sites/worldcat.py
+++ b/catalog/sites/worldcat.py
@@ -189,7 +189,7 @@ class WorldCat(AbstractSite):
         lang = (
             normalize_language(in_language)
             if in_language
-            else detect_language(title + " " + description)
+            else detect_language((title or "") + " " + (description or ""))
         )
 
         # Try to get cover image from Open Graph or other meta tags

--- a/catalog/sites/worldcat.py
+++ b/catalog/sites/worldcat.py
@@ -185,12 +185,12 @@ class WorldCat(AbstractSite):
         if isinstance(in_language, dict):
             in_language = in_language.get("name", "")
 
-        # Fallback to detection if not provided
+        # Fall back to detection when the language is missing, not a string
+        # (e.g. a JSON-LD list of languages), or unrecognized -- otherwise
+        # normalize_language() can return None and fail LocalizedLabelSchema.
         lang = (
-            normalize_language(in_language)
-            if in_language
-            else detect_language((title or "") + " " + (description or ""))
-        )
+            normalize_language(in_language) if isinstance(in_language, str) else None
+        ) or detect_language((title or "") + " " + (description or ""))
 
         # Try to get cover image from Open Graph or other meta tags
         cover_image_url = None

--- a/test_data/https___www_googleapis_com_books_v1_volumes_nolang_test_id
+++ b/test_data/https___www_googleapis_com_books_v1_volumes_nolang_test_id
@@ -1,0 +1,16 @@
+{
+  "kind": "books#volume",
+  "id": "nolang_test_id",
+  "volumeInfo": {
+    "title": "A Book Without Language",
+    "authors": ["Test Author"],
+    "publishedDate": "2020",
+    "description": "A description used only to detect a fallback language.",
+    "industryIdentifiers": [
+      {"type": "ISBN_13", "identifier": "9780000000001"}
+    ],
+    "imageLinks": {
+      "thumbnail": "https://books.google.com/nolang_test_id_cover.jpg"
+    }
+  }
+}

--- a/tests/catalog/test_book.py
+++ b/tests/catalog/test_book.py
@@ -315,6 +315,25 @@ class TestGoogleBooks:
         ]
         assert site.resource.item.display_title == "1984 Nineteen Eighty-Four"
 
+    @use_local_response
+    def test_scrape_without_language(self):
+        # A volume that omits the `language` tag must not crash: the localized
+        # label `lang` falls back to detection instead of an empty list, which
+        # would fail LocalizedLabelSchema (lang must be a string).
+        t_url = "https://books.google.com/books?id=nolang_test_id"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready is True
+        assert site.resource is not None
+        assert site.resource.item is not None
+        assert isinstance(site.resource.item, Edition)
+        lt = site.resource.item.localized_title
+        assert len(lt) == 1
+        assert lt[0]["text"] == "A Book Without Language"
+        assert isinstance(lt[0]["lang"], str) and lt[0]["lang"]
+        assert site.resource.item.display_title == "A Book Without Language"
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestBooksTW:


### PR DESCRIPTION
## Summary

Follow-up to #1574 (NEODB-SOCIAL-7KK). I audited **all** of `catalog/sites/*.py` for the same bug class: a scraper building a `localized_title` / `localized_description` entry whose `text` is `None` — or a non-string `lang`, or feeding `None` into `detect_language()`. Any of these fails `LocalizedLabelSchema` (both `lang` and `text` must be non-null strings) during `item.ap_object` validation and aborts the whole fetch.

Only `localized_title` and `localized_description` are validated by the ninja schema and feed the required `display_title` / `display_description: str`. `localized_subtitle` is **not** in `EditionSchema` and `subtitle` is nullable, so a `None` there does not crash — but it still stores junk, so it's guarded too.

## Real crash paths fixed

| Site | Problem |
|------|---------|
| **google_books** | `language` is `[]` when a volume omits its language tag, so `localized_title`'s `lang` was an empty **list**, not a `str`. Now uses a guaranteed string `label_lang` (declared language, else `detect_language(title)`). **Reachable** on any volume without a language tag. |
| **discogs** (Release + Master) | `title = .get("title")` could be `None` → now raises `ParseError`. |
| **igdb** (Game) | guards missing/`None` `name` with `ParseError` before use. |
| **bangumi** | skips falsy titles when building `localized_title` (avoids `detect_language(None)` and `text=None`). Matches the resolved `TVSeasonSchema` error class (NEODB-SOCIAL-4MQ). |
| **mobygames** | skips null `alternateName` entries. |
| **spotify** (web + api) | raises `ParseError` on missing/`None` name. |
| **worldcat** | coerces `None` name/description before the `detect_language` concat (would `TypeError`). |

## Cosmetic (no crash, but stored `{text: None}`)

- **bookstw**: `subtitle` is always `None` → guard so `localized_subtitle` is `[]`.
- **douban_book**: guard `localized_subtitle` like its sibling description.

## Testing

- Added `TestGoogleBooks::test_scrape_without_language` with a fixture volume that omits `language`. It **fails** on the pre-fix code with `ValidationError: localized_title.0.lang` and **passes** with the fix.
- Full catalog suite (`test_book`, `test_music`, `test_game`, `test_movie`, `test_tv`, `test_worldcat`): **97 passed**.
- `pre-commit` (ruff, ruff-format, `ty`) passes on all changed files.

## Notes
- Sentry grounding: of this whole class, only NEODB-SOCIAL-7KK (qidian, #1574) and the resolved NEODB-SOCIAL-4MQ (bgm/TVSeason) have actually fired. The google_books/discogs paths are vulnerable in code but their current Sentry entries are unrelated `No space left on device` infra errors.
- The remaining sites (igdb, bangumi, mobygames, spotify, worldcat) are hardened defensively against null API/JSON-LD fields; their happy paths are unchanged and covered by existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)