### PR TITLE
chore(deps): bump pyld fork for thread-safe context caches (EGGPLANT-153)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,11 @@ dev = [
 ]
 
 [tool.uv.sources]
-# Forked to add thread-safety to module-level LRUCache (NEODB-SOCIAL-4P0,
-# EGGPLANT-7K). Tracks upstream master @ 1889cab + neodb-social/pyld@neodb-on-master-1889cab.
-pyld = { git = "https://github.com/neodb-social/pyld.git", rev = "a4834df24c8163b15cee3a27a55a2af5d3fbbd75" }
+# Forked to make pyld's cachetools LRU caches thread-safe: the module-level
+# inverse/resolved-context caches (NEODB-SOCIAL-4P0, EGGPLANT-7K) and the
+# per-ResolvedContext processed cache (EGGPLANT-153). Tracks upstream master
+# @ a7d380ff + neodb-social/pyld@neodb-on-master-a7d380f.
+pyld = { git = "https://github.com/neodb-social/pyld.git", rev = "e1de216d9fba39cf5f01223e862a010e05d33223" }
 
 [tool.ty.src]
 exclude = ["neodb-takahe", "data-svc"]

--- a/uv.lock
+++ b/uv.lock
@@ -1845,7 +1845,7 @@ requires-dist = [
     { name = "pycountry", specifier = ">=23.12.11" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
-    { name = "pyld", git = "https://github.com/neodb-social/pyld.git?rev=a4834df24c8163b15cee3a27a55a2af5d3fbbd75" },
+    { name = "pyld", git = "https://github.com/neodb-social/pyld.git?rev=e1de216d9fba39cf5f01223e862a010e05d33223" },
     { name = "pymemcache", specifier = ">=4.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "pywebpush", specifier = ">=2.0.0" },
@@ -2312,7 +2312,7 @@ wheels = [
 [[package]]
 name = "pyld"
 version = "3.1.0.dev0"
-source = { git = "https://github.com/neodb-social/pyld.git?rev=a4834df24c8163b15cee3a27a55a2af5d3fbbd75#a4834df24c8163b15cee3a27a55a2af5d3fbbd75" }
+source = { git = "https://github.com/neodb-social/pyld.git?rev=e1de216d9fba39cf5f01223e862a010e05d33223#e1de216d9fba39cf5f01223e862a010e05d33223" }
 dependencies = [
     { name = "cachetools" },
     { name = "frozendict" },


### PR DESCRIPTION
## What

Bumps the vendored **pyld** fork pin (root `pyproject.toml` + `uv.lock`) to `neodb-social/pyld@e1de216` — branch `neodb-on-master-a7d380f`, rebased onto upstream `digitalbazaar/pyld` `master@a7d380ff`.

The new fork tip adds one commit on top of the rebased thread-safety patch:

- **Make per-`ResolvedContext` processed cache thread-safe (EGGPLANT-153).** Each `ResolvedContext` carries its own `cachetools.LRUCache` and is itself stored in the shared, module-level resolved-context cache — so it is reused across threads. Concurrent `set_processed`/`get_processed` raced on `__setitem__`/`popitem`, corrupting the underlying `OrderedDict`. This surfaced as `RuntimeError: OrderedDict mutated during iteration` from `core/ld.py:canonicalise` under `runstator`'s `ThreadPoolExecutor`.

The earlier fork (`a4834df`, EGGPLANT-7K) only made the two **module-level** caches thread-safe; it missed this per-context one. The fix centralizes the lock-protected `ThreadSafeLRUCache` in `resolved_context.py` and uses it everywhere.

## Why this is the only change here

`runstator` runs in the production image built from the root `Dockerfile` (`uv sync` → root `uv.lock`), and CI resolves the unified project, so the root pin is what delivers the fix. The legacy `neodb-takahe/requirements*.lock` are not used by NeoDB's build/CI (`.dockerignore`s the standalone takahe docker; orphaned since the venv-unify commit) and are intentionally left untouched.

## Verification

- pyld's own suite: 195 passed, 1 xfailed.
- Reproduced the exact crash on a plain `LRUCache` (`RuntimeError: OrderedDict mutated during iteration`); **0 errors** on `ThreadSafeLRUCache` (8 threads x 30k iters).
- End-to-end concurrent `expand`/`compact`: 9,600 ops, 0 errors.
- Re-verified against the commit as fetched from GitHub by `uv`.

Fixes EGGPLANT-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
