### PR TITLE
chore(ci): make codecov PR statuses informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,11 @@ coverage:
   status:
     project:
       default:
+        informational: true
         branches:
           - "!main"
     patch:
       default:
+        informational: true
         branches:
           - "!main"


### PR DESCRIPTION
## What

Set both `project` and `patch` coverage statuses in `codecov.yml` to `informational: true`.

```yaml
coverage:
  status:
    project:
      default:
        informational: true
        branches:
          - "!main"
    patch:
      default:
        informational: true
        branches:
          - "!main"
```

## Why

Small PRs were getting a red X from Codecov. The culprit is the `codecov/patch` status: a small diff that adds a couple of untested lines reads as a low/zero patch-coverage percentage and fails, regardless of how trivial the change is.

Codecov has **no setting that gates on the number of lines changed**, so there's no native "fail big diffs but not small ones." Percentage `threshold` doesn't help, because tiny diffs are exactly where coverage percentages swing hardest. Making the statuses `informational` is the practical lever: Codecov still comments and posts the `project`/`patch` checks on PRs, but they always report success — no red X.

The existing `!main` scoping is unchanged, so nothing posts on `main` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)