### PR TITLE
fix(journal): tag category dropdown renders empty for logged-in users

### DIFF
--- a/journal/templates/_sidebar_user_tag_filter.html
+++ b/journal/templates/_sidebar_user_tag_filter.html
@@ -20,11 +20,28 @@
       <select name="category" id="category" onchange="filter()">
         <option value="" {% if not category %}selected{% endif %}>{% trans "All Categories" %}</option>
         {% visible_categories as cats %}
-        {% for c in cats %}
-          {% if c.value != 'people' and c.value != 'collection' %}
-            <option value="{{ c.value }}" {% if category == c %}selected{% endif %}>{{ c.label }}</option>
-          {% endif %}
-        {% endfor %}
+        {% if 'book' in cats %}
+          <option value="book" {% if category == 'book' %}selected{% endif %}>{% trans "Book" %}</option>
+        {% endif %}
+        {% if 'movie' in cats %}
+          <option value="movie" {% if category == 'movie' %}selected{% endif %}>{% trans "Movie" %}</option>
+        {% endif %}
+        {% if 'tv' in cats %}
+          <option value="tv" {% if category == 'tv' %}selected{% endif %}>{% trans "TV" %}</option>
+        {% endif %}
+        {% if 'podcast' in cats %}
+          <option value="podcast" {% if category == 'podcast' %}selected{% endif %}>{% trans "Podcast" %}</option>
+        {% endif %}
+        {% if 'music' in cats %}
+          <option value="music" {% if category == 'music' %}selected{% endif %}>{% trans "Music" %}</option>
+        {% endif %}
+        {% if 'game' in cats %}
+          <option value="game" {% if category == 'game' %}selected{% endif %}>{% trans "Game" %}</option>
+        {% endif %}
+        {% if 'performance' in cats %}
+          <option value="performance"
+                  {% if category == 'performance' %}selected{% endif %}>{% trans "Performance" %}</option>
+        {% endif %}
       </select>
     </fieldset>
   </form>

--- a/tests/journal/test_pages.py
+++ b/tests/journal/test_pages.py
@@ -84,6 +84,18 @@ def test_tag_pages_category_filter():
     # an invalid category is ignored, not an error
     assert client.get(list_url, {"category": "bogus"}).status_code == 200
 
+    # The category dropdown must render real option values/labels even on a
+    # repeat request, when visible_categories is served from the session cache
+    # as plain strings (regression: dropdown rendered blank/empty options).
+    response = client.get(list_url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    select_html = content.split('id="category"', 1)[1].split("</select>", 1)[0]
+    assert 'value="book"' in select_html
+    assert "Book" in select_html
+    assert 'value="people"' not in select_html
+    assert 'value="collection"' not in select_html
+
     member_url = reverse("journal:user_tag_member_list", args=[handle, "mixed"])
     response = client.get(member_url)
     assert response.status_code == 200


### PR DESCRIPTION
## Bug

On the user tag pages, the category dropdown rendered with **empty/blank options** for logged-in users (see report). Only "All Categories" had a visible label.

## Cause

`visible_categories()` caches the category list in `request.session["p_categories"]`. Django's session serializer turns the `ItemCategory` enum members into plain **strings**, so on every request after the first, the template received strings. The dropdown template used `{{ c.value }}` / `{{ c.label }}`, which resolve to empty on a plain string — hence blank options.

This only affected authenticated users (the unauthenticated path returns real enum members from `default_visible_categories()`), which is why it slipped through earlier checks.

## Fix

Switch `_sidebar_user_tag_filter.html` to the same membership-test pattern already used by `_sidebar_user_mark_list.html` — hardcoded option values with `{% trans %}` labels and `{% if 'book' in cats %}` guards. Membership works whether `cats` holds enum members or strings. People and Collection remain excluded.

## Test

Extended `test_tag_pages_category_filter` to request the list page again (hitting the session-cached path) and assert that real option values/labels render inside the `#category` select. This test fails on the old template and passes on the fix.

- `uv run pre-commit run -a` (ruff, djLint, ty) passes
- Tag + page tests pass under the Docker (Python 3.14) runner