### PR TITLE
feat(journal): collapse sidebar profile by default on tag pages

### DIFF
--- a/journal/templates/user_tag_list.html
+++ b/journal/templates/user_tag_list.html
@@ -40,7 +40,7 @@
           {% endfor %}
         </div>
       </div>
-      {% include "_sidebar.html" with show_profile=1 sidebar_template="_sidebar_user_tag_filter.html" %}
+      {% include "_sidebar.html" with show_profile=1 collapse_profile=1 sidebar_template="_sidebar_user_tag_filter.html" %}
     </main>
     {% include "_footer.html" %}
   </body>

--- a/journal/templates/user_tagmember_list.html
+++ b/journal/templates/user_tagmember_list.html
@@ -30,5 +30,5 @@
   <br>
 {% endblock %}
 {% block sidebar %}
-  {% include "_sidebar.html" with show_profile=1 sidebar_template="_sidebar_user_tag_filter.html" %}
+  {% include "_sidebar.html" with show_profile=1 collapse_profile=1 sidebar_template="_sidebar_user_tag_filter.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary

On the user tag list page and the tag member page, the sidebar profile section now starts **collapsed** by default, so the category filter and tag content sit higher up / above the fold.

## Implementation

Pass `collapse_profile=1` to the `_sidebar.html` include on both pages. `_sidebar.html` already supports this flag (it omits `class="auto-collapse" open` on the profile `<details>` when set) — the same mechanism `article_edit.html` already uses. No template or JS changes needed.

## Test

- Verified on a running instance: the profile `<details>` on both tag pages renders without `open` (collapsed), while other pages (e.g. the profile home) keep it expanded.
- djLint passes; existing tag + page tests pass under the Docker (Python 3.14) runner.