### PR TITLE
fix(ci): mirror only main branch and tags to Codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,21 +1,31 @@
 name: Mirror to Codeberg
 
-on: [push, delete]
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  delete:
 
 permissions:
   contents: read
 
 jobs:
   to_codeberg:
-    if: github.repository_owner == 'neodb-social'
+    if: github.repository_owner == 'neodb-social' && (github.event_name != 'delete' || github.event.ref_type == 'tag')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pixta-dev/repository-mirroring-action@v1
-        with:
-          target_repo_url:
-            git@codeberg.org:NeoDB/neodb.git
-          ssh_private_key:
-            ${{ secrets.CODEBERG_SSH_PRIVATEKEY }}
+      - name: Push main and tags to Codeberg
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.CODEBERG_SSH_PRIVATEKEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_codeberg
+          chmod 600 ~/.ssh/id_codeberg
+          ssh-keyscan codeberg.org >> ~/.ssh/known_hosts
+          export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_codeberg'
+          git push --prune git@codeberg.org:NeoDB/neodb.git \
+            '+refs/remotes/origin/main:refs/heads/main' \
+            '+refs/tags/*:refs/tags/*'


### PR DESCRIPTION
## Summary
- Trigger the Codeberg mirror only on pushes to `main`, tag pushes, and tag deletions — feature/PR branch pushes and branch deletions no longer trigger it
- Replace `pixta-dev/repository-mirroring-action` (which pushes all branches via `+refs/remotes/origin/*:refs/heads/*`) with an explicit `git push` of only `refs/heads/main` and `refs/tags/*`
- `--prune` on the tag refspec removes deleted tags from the mirror

## Notes
- Branches previously mirrored to Codeberg by the old full-mirror action will linger there; they need one-time manual deletion on Codeberg (this workflow will never push them again)

## Test plan
- pre-commit YAML checks pass
- After merge: push to main triggers the mirror; pushing a feature branch does not; the mirror receives only `main` and tags