### PR TITLE
feat: publish profile, marks and reviews as ATProto records

### DIFF
--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -1,4 +1,4 @@
-name: publish lexicons
+name: Publish Lexicons
 
 on:
   push:

--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -1,0 +1,29 @@
+name: publish lexicons
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/lexicons/**"
+      - ".github/workflows/publish-lexicons.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'neodb-social/neodb'
+    env:
+      ATPROTO_APP_PASSWORD: ${{ secrets.ATPROTO_APP_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Publish lexicons to ATProto
+        # skipped until the ATPROTO_APP_PASSWORD secret is configured,
+        # i.e. publishing the schema is an explicit opt-in
+        if: env.ATPROTO_APP_PASSWORD != ''
+        run: uv run docs/lexicons/publish.py --handle neodb.net

--- a/catalog/models/item.py
+++ b/catalog/models/item.py
@@ -1551,11 +1551,14 @@ _CONTENT_TYPE_LIST = None
 def item_content_types() -> dict[type[Item], int]:
     global _CONTENT_TYPE_LIST
     if _CONTENT_TYPE_LIST is None:
-        _CONTENT_TYPE_LIST = {}
+        # populate a local dict first: assigning the global before it is
+        # fully filled lets concurrent threads see a partial mapping
+        d: dict[type[Item], int] = {}
         for cls in Item.__subclasses__():
-            _CONTENT_TYPE_LIST[cls] = ContentType.objects.get(
+            d[cls] = ContentType.objects.get(
                 app_label="catalog", model=cls.__name__.lower()
             ).id
+        _CONTENT_TYPE_LIST = d
     return _CONTENT_TYPE_LIST
 
 
@@ -1565,13 +1568,15 @@ _CATEGORY_LIST: dict[ItemCategory, list[type[Item]]] | None = None
 def item_categories() -> dict[ItemCategory, list[type[Item]]]:
     global _CATEGORY_LIST
     if _CATEGORY_LIST is None:
-        _CATEGORY_LIST = {}
+        # same as above: never expose a partially-populated mapping
+        d: dict[ItemCategory, list[type[Item]]] = {}
         for cls in Item.__subclasses__():
             c = getattr(cls, "category", None)
             if c is None:
                 continue
-            if c not in _CATEGORY_LIST:
-                _CATEGORY_LIST[c] = [cls]
+            if c not in d:
+                d[c] = [cls]
             else:
-                _CATEGORY_LIST[c].append(cls)
+                d[c].append(cls)
+        _CATEGORY_LIST = d
     return _CATEGORY_LIST

--- a/docs/development.md
+++ b/docs/development.md
@@ -169,11 +169,11 @@ Applications
 Main Django apps for NeoDB:
 
  - `users` manages user in typical Django fashion
- - `mastodon` this leverages [Mastodon API](https://docs.joinmastodon.org/client/intro/), [Threads API](https://developers.facebook.com/docs/threads/) and [ATProto}(https://atproto.com) for user login and data sync
+ - `mastodon` this leverages [Mastodon API](https://docs.joinmastodon.org/client/intro/), [Threads API](https://developers.facebook.com/docs/threads/) and [ATProto}(https://atproto.com) for user login and data sync. see [internals/atproto.md](internals/federation.md) for customization of ATProto
  - `catalog` manages different types of items user may collect, and scrapers to fetch from external resources, see [catalog.md](internals/catalog.md) for more details
  - `journal` manages user created content(review/ratings) and lists(collection/shelf/tag/note), see [journal.md](internals/journal.md) for more details
  - `social` present timeline and notification for local users
- - `takahe` communicate with Takahe (a separate Django server, run side by side with this server, code in the `neodb-takahe` folder of this repo), see [federation.md](internals/federation.md) for customization of ActivityPub protocol
+ - `takahe` communicate with Takahe (a separate Django server, run side by side with this server, code in the `neodb-takahe` folder of this repo), see [internals/federation.md](internals/federation.md) for customization of ActivityPub protocol
  - `legacy` this is only used by instances upgraded from 0.4.x and earlier, to provide a link mapping from old urls to new ones. If your journey starts with 0.5 and later, feel free to ignore it.
 
 

--- a/docs/internals/atproto-lexicon.md
+++ b/docs/internals/atproto-lexicon.md
@@ -1,0 +1,142 @@
+# NeoDB ATProto Lexicon
+
+NeoDB can publish a user's marks and reviews (with ratings embedded) to their
+ATProto Personal Data Server (PDS) as structured records, in addition to
+crossposting a human-readable skeet to Bluesky. This lets other ATProto
+applications read a user's NeoDB activity directly from their repository.
+
+The lexicon is project-owned under the `net.neodb.*` namespace (reverse of
+`neodb.net`), so it is shared by every NeoDB instance. The schema files live in
+[`docs/lexicons/net/neodb/`](../lexicons/net/neodb).
+
+## Record types
+
+| Collection (NSID)  | Written from         | Purpose                                   |
+| ------------------ | -------------------- | ----------------------------------------- |
+| `net.neodb.mark`   | a shelf entry        | status (+ optional rating/comment/tags)   |
+| `net.neodb.review` | a review             | long-form review (+ optional rating)      |
+
+### Subject
+
+NeoDB catalog items are not themselves ATProto records, so a work cannot be
+referenced with a `com.atproto.repo.strongRef`. Instead every record embeds a
+`net.neodb.defs#subject` describing the work inline:
+
+```json
+{
+  "uri": "https://neodb.social/tv/season/abc123",
+  "category": "tv",
+  "type": "TVSeason",
+  "title": "Shogun Season 1",
+  "cover": "https://neodb.social/m/item/.../cover.jpg",
+  "sources": ["https://www.themoviedb.org/tv/12345/season/1"],
+  "identifiers": [{ "type": "imdb", "value": "tt2788316" }]
+}
+```
+
+- `uri` is the item's permalink on the originating instance.
+- `category` is the broad media category (`book`, `movie`, `tv`, `music`,
+  `game`, `podcast`, `performance`, `people`) -- declared as an open set
+  (`knownValues`) so future categories do not break validation.
+- `type` is the specific NeoDB item class (same vocabulary as the NeoDB API
+  schema), so entities that share a category stay distinguishable —
+  `TVShow` / `TVSeason` / `TVEpisode`, `Podcast` / `PodcastEpisode`,
+  `Performance` / `PerformanceProduction`, plus `Edition`, `Movie`, `Album`,
+  `Game`.
+- `cover` is included only when the item has a non-default cover.
+- `sources` lists the external source records (IMDB, TMDB, Douban, Goodreads,
+  ...) the work was matched from, **referenced by URL, not raw id**, for
+  cross-instance matching.
+- `identifiers` additionally lists **standardized identifiers** of the work --
+  only types from `IdealIdTypes` (ISBN, CUBN, ASIN, GTIN, ISRC, OCLC,
+  MusicBrainz, RSS, IMDB, Steam, Itch, WikiData, TMDB person) qualify;
+  site-specific ids stay URL-only via `sources`.
+
+### Rating
+
+A rating is a `net.neodb.defs#rating` object, `{ "value": 1..10, "max": 10 }`,
+embedded inline in a mark or review. There is deliberately no standalone
+rating record: the value would only duplicate what the mark and review
+already carry.
+
+## Record keys and statelessness
+
+Every record is keyed by the journal **piece's own uuid** (the mark's or the
+review's), which is deterministic and derivable from the piece itself:
+
+```
+at://<did>/net.neodb.mark/<mark-uuid>
+at://<did>/net.neodb.review/<review-uuid>
+```
+
+Keying by the piece rather than the subject item keeps the AT-URI stable
+across catalog item merges, and lets distinct pieces (e.g. multiple reviews
+of one work, if allowed in the future) map to distinct records.
+
+Because the key is derivable, NeoDB stores **no** record bookkeeping in its
+database. On every sync the relevant piece is reconciled against the PDS:
+
+- `put_record` (idempotent by key) writes each record that should currently
+  exist, overwriting in place on edit;
+- `delete_record` (idempotent; no error if absent) removes any managed
+  collection that should not exist -- e.g. every record when a piece is made
+  non-public or deleted.
+
+`Piece.atproto_collections()` declares which collections a piece manages and
+`Piece.to_atproto_records()` returns the records that should exist now;
+`Piece._sync_records_to_bluesky()` performs the reconciliation.
+
+## When records are published
+
+Records are reconciled on the same path as Bluesky crossposting
+(`Piece.sync_to_bluesky`), so they require a linked Bluesky/ATProto account and
+are only written for **public** pieces (PDS records are world-readable). When a
+piece's visibility leaves public, its records are deleted. When a piece is
+deleted, its records are removed by the async crosspost-deletion job.
+
+## Publishing the lexicon
+
+Publishing the schemas is **not required** for writes to work: a PDS accepts
+records in collections it does not know without validating them. The JSON
+files in this repository are the authoritative spec for now.
+
+To make `net.neodb.*` resolvable -- so tools, appviews and other developers can
+discover and validate the schemas -- ATProto lexicon resolution needs:
+
+1. a project-controlled ATProto account (the official `@neodb.net` account);
+2. each schema JSON published as a `com.atproto.lexicon.schema` record in that
+   account's repo, with the record key set to the NSID (e.g. `net.neodb.mark`);
+3. a DNS TXT record at `_lexicon.neodb.net` pointing to the account's DID
+   (`did=did:plc:...`).
+
+Step 2 is automated: the `publish lexicons` GitHub Actions workflow runs on
+every push to `main` of `neodb-social/neodb` that touches `docs/lexicons/`,
+publishing via the standalone script [`docs/lexicons/publish.py`](../lexicons/publish.py)
+(no Django or database required). Publishing is an explicit opt-in: the
+workflow skips the publish step until the `ATPROTO_APP_PASSWORD` repository
+secret (an app password for the `@neodb.net` account) is configured. The
+script also verifies step 3 and prints the exact TXT record to add when
+missing.
+
+To run it manually:
+
+```
+ATPROTO_APP_PASSWORD=... uv run docs/lexicons/publish.py --handle neodb.net
+```
+
+### Updating a published lexicon
+
+Publishing reruns automatically on merge to `main` whenever the schema files
+change; `put_record` overwrites the records in place (same rkey), so
+resolution always serves the latest files from this repository.
+
+Schema evolution must be **backwards-compatible**: adding new optional fields
+is fine; never remove or rename fields, change a field's type, make an
+optional field required, or tighten constraints. Records already written to
+user repos are not rewritten when the lexicon changes -- they refresh to the
+current shape on the owner's next sync of that piece (stable rkey, put
+overwrites) -- so old-shape records remain readable in the meantime and must
+stay valid. A change that cannot be made compatibly needs a new NSID (e.g.
+`net.neodb.mark2`) rather than a breaking edit. Note that once the lexicon is
+published and resolvable, PDS hosts may start validating new writes against
+it, so the published schemas must always match what the code writes.

--- a/docs/internals/atproto.md
+++ b/docs/internals/atproto.md
@@ -1,4 +1,4 @@
-# NeoDB ATProto Lexicon
+# NeoDB ATProto Implementation
 
 NeoDB can publish a user's marks and reviews (with ratings embedded) to their
 ATProto Personal Data Server (PDS) as structured records, in addition to
@@ -96,47 +96,13 @@ deleted, its records are removed by the async crosspost-deletion job.
 
 ## Publishing the lexicon
 
-Publishing the schemas is **not required** for writes to work: a PDS accepts
-records in collections it does not know without validating them. The JSON
-files in this repository are the authoritative spec for now.
+Schema is being published as a `com.atproto.lexicon.schema` record in `@neodb.net`,
+with a DNS TXT record at `_lexicon.neodb.net` pointing its DID.
 
-To make `net.neodb.*` resolvable -- so tools, appviews and other developers can
-discover and validate the schemas -- ATProto lexicon resolution needs:
-
-1. a project-controlled ATProto account (the official `@neodb.net` account);
-2. each schema JSON published as a `com.atproto.lexicon.schema` record in that
-   account's repo, with the record key set to the NSID (e.g. `net.neodb.mark`);
-3. a DNS TXT record at `_lexicon.neodb.net` pointing to the account's DID
-   (`did=did:plc:...`).
-
-Step 2 is automated: the `publish lexicons` GitHub Actions workflow runs on
-every push to `main` of `neodb-social/neodb` that touches `docs/lexicons/`,
-publishing via the standalone script [`docs/lexicons/publish.py`](../lexicons/publish.py)
-(no Django or database required). Publishing is an explicit opt-in: the
-workflow skips the publish step until the `ATPROTO_APP_PASSWORD` repository
-secret (an app password for the `@neodb.net` account) is configured. The
-script also verifies step 3 and prints the exact TXT record to add when
-missing.
-
-To run it manually:
+To publish manually:
 
 ```
 ATPROTO_APP_PASSWORD=... uv run docs/lexicons/publish.py --handle neodb.net
 ```
 
-### Updating a published lexicon
-
-Publishing reruns automatically on merge to `main` whenever the schema files
-change; `put_record` overwrites the records in place (same rkey), so
-resolution always serves the latest files from this repository.
-
-Schema evolution must be **backwards-compatible**: adding new optional fields
-is fine; never remove or rename fields, change a field's type, make an
-optional field required, or tighten constraints. Records already written to
-user repos are not rewritten when the lexicon changes -- they refresh to the
-current shape on the owner's next sync of that piece (stable rkey, put
-overwrites) -- so old-shape records remain readable in the meantime and must
-stay valid. A change that cannot be made compatibly needs a new NSID (e.g.
-`net.neodb.mark2`) rather than a breaking edit. Note that once the lexicon is
-published and resolvable, PDS hosts may start validating new writes against
-it, so the published schemas must always match what the code writes.
+Or automatically on merge to `main` whenever the schema files change.

--- a/docs/internals/atproto.md
+++ b/docs/internals/atproto.md
@@ -11,10 +11,11 @@ The lexicon is project-owned under the `net.neodb.*` namespace (reverse of
 
 ## Record types
 
-| Collection (NSID)  | Written from         | Purpose                                   |
-| ------------------ | -------------------- | ----------------------------------------- |
-| `net.neodb.mark`   | a shelf entry        | status (+ optional rating/comment/tags)   |
-| `net.neodb.review` | a review             | long-form review (+ optional rating)      |
+| Collection (NSID)   | Written from         | Purpose                                   |
+| ------------------- | -------------------- | ----------------------------------------- |
+| `net.neodb.mark`    | a shelf entry        | status (+ optional rating/comment/tags)   |
+| `net.neodb.review`  | a review             | long-form review (+ optional rating)      |
+| `net.neodb.profile` | the linked account   | verifiable link to the NeoDB identity     |
 
 ### Subject
 
@@ -58,6 +59,27 @@ A rating is a `net.neodb.defs#rating` object, `{ "value": 1..10, "max": 10 }`,
 embedded inline in a mark or review. There is deliberately no standalone
 rating record: the value would only duplicate what the mark and review
 already carry.
+
+### Profile
+
+`net.neodb.profile` (record key `self`) links the ATProto account to the
+owner's NeoDB identity (DID, AP actor id, profile URL, handle), so records
+are attributable and the link is verifiable in both directions. It is
+modeled on [FEP-c390] identity proofs with the direction mirrored: the
+record living in the DID's repo proves the DID side (only the DID holder
+can write there), while a [W3C Data Integrity] style `proof` signed with
+the identity's RSA federation key (published in the ActivityPub actor
+document at `proof.verificationMethod`) proves the NeoDB side. The
+cryptosuite `rsa-pkcs1-sha256-jcs` follows the `eddsa-jcs-2022` procedure
+with RSA; the signed document includes the `did` so a record cannot be
+replayed in another repo. See the lexicon for the exact verification steps.
+
+It is only written while the identity is **publicly discoverable**, deleted
+otherwise, and synced on the account refresh path (login and periodic sync)
+rather than on crossposting; disconnecting the account removes it.
+
+[FEP-c390]: https://codeberg.org/fediverse/fep/src/branch/main/fep/c390/fep-c390.md
+[W3C Data Integrity]: https://www.w3.org/TR/vc-data-integrity/
 
 ## Record keys and statelessness
 

--- a/docs/lexicons/net/neodb/defs.json
+++ b/docs/lexicons/net/neodb/defs.json
@@ -1,0 +1,92 @@
+{
+  "lexicon": 1,
+  "id": "net.neodb.defs",
+  "defs": {
+    "subject": {
+      "type": "object",
+      "description": "Inline reference to a catalog work. NeoDB items are not ATProto records, so a work is referenced by URL (its NeoDB permalink and source site URLs) rather than a strongRef.",
+      "required": ["uri", "category", "type", "title"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "Permalink to the work on the originating NeoDB instance."
+        },
+        "category": {
+          "type": "string",
+          "description": "Broad media category of the work. Open set; future NeoDB versions may add values.",
+          "knownValues": [
+            "book",
+            "movie",
+            "tv",
+            "music",
+            "game",
+            "podcast",
+            "performance",
+            "people"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Specific NeoDB item class (mirrors the NeoDB API schema), distinguishing entities that share a category, e.g. TVShow / TVSeason / TVEpisode, Podcast / PodcastEpisode, Performance / PerformanceProduction, Edition, Movie, Album, Game."
+        },
+        "title": {
+          "type": "string",
+          "maxLength": 2000,
+          "maxGraphemes": 1000,
+          "description": "Display title of the work."
+        },
+        "cover": {
+          "type": "string",
+          "format": "uri",
+          "description": "Absolute URL of the work's cover image, when present."
+        },
+        "sources": {
+          "type": "array",
+          "description": "URLs of the external source records the work was matched from (IMDB, TMDB, Douban, Goodreads, etc.), referenced by URL rather than raw id.",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "description": "Standardized identifiers of the work. Only standard, site-independent identifier types are included (e.g. isbn, imdb, wikidata, asin, gtin, isrc); site-specific ids are conveyed as URLs in sources instead.",
+          "items": {
+            "type": "ref",
+            "ref": "net.neodb.defs#identifier"
+          }
+        }
+      }
+    },
+    "identifier": {
+      "type": "object",
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Identifier namespace, e.g. isbn, imdb, wikidata."
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "rating": {
+      "type": "object",
+      "description": "A numeric rating on a 1..max scale.",
+      "required": ["value", "max"],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/lexicons/net/neodb/mark.json
+++ b/docs/lexicons/net/neodb/mark.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "net.neodb.mark",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A shelf entry recording a user's status toward a catalog work, with optional rating, comment and tags.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["subject", "status", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "net.neodb.defs#subject"
+          },
+          "status": {
+            "type": "string",
+            "description": "Shelf the work is on.",
+            "enum": ["wishlist", "progress", "complete", "dropped"]
+          },
+          "rating": {
+            "type": "ref",
+            "ref": "net.neodb.defs#rating"
+          },
+          "comment": {
+            "type": "string",
+            "maxLength": 10000,
+            "description": "Short comment in plain text."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 640,
+              "maxGraphemes": 64
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/lexicons/net/neodb/profile.json
+++ b/docs/lexicons/net/neodb/profile.json
@@ -1,0 +1,82 @@
+{
+  "lexicon": 1,
+  "id": "net.neodb.profile",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Link from this ATProto account to the owner's NeoDB identity, modeled on FEP-c390 identity proofs with the direction mirrored: the record living in the DID's repo proves the DID side (only the DID holder can write here), while the proof, signed with the ActivityPub actor's federation key, proves the NeoDB side. Verifiers must check that 'did' equals the repo's DID and that the proof's verificationMethod belongs to 'actor'.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["did", "actor", "url", "handle", "createdAt"],
+        "properties": {
+          "did": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of this repo; bound into the signed statement so the record cannot be replayed in another repo."
+          },
+          "actor": {
+            "type": "string",
+            "format": "uri",
+            "description": "ActivityPub actor id of the owner's NeoDB identity."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Profile page on the originating NeoDB instance."
+          },
+          "handle": {
+            "type": "string",
+            "description": "Fediverse handle of the identity, user@instance."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the ATProto account was linked to the NeoDB identity."
+          },
+          "proof": {
+            "type": "ref",
+            "ref": "net.neodb.profile#proof"
+          }
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "description": "W3C Data Integrity style proof (cf. FEP-c390 / FEP-8b32). Cryptosuite rsa-pkcs1-sha256-jcs follows the eddsa-jcs-2022 procedure with RSA, since ActivityPub federation keys are RSA: the signature is RSASSA-PKCS1-v1_5 with SHA-256 over sha256(JCS(proof minus proofValue)) || sha256(JCS(record minus proof)), JCS canonicalization per RFC 8785, proofValue base64-encoded. verificationMethod is the actor's public key as published in its ActivityPub actor document.",
+      "required": [
+        "type",
+        "cryptosuite",
+        "created",
+        "verificationMethod",
+        "proofPurpose",
+        "proofValue"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "knownValues": ["DataIntegrityProof"]
+        },
+        "cryptosuite": {
+          "type": "string",
+          "knownValues": ["rsa-pkcs1-sha256-jcs"]
+        },
+        "created": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "verificationMethod": {
+          "type": "string",
+          "format": "uri"
+        },
+        "proofPurpose": {
+          "type": "string",
+          "knownValues": ["assertionMethod"]
+        },
+        "proofValue": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/lexicons/net/neodb/review.json
+++ b/docs/lexicons/net/neodb/review.json
@@ -1,0 +1,43 @@
+{
+  "lexicon": 1,
+  "id": "net.neodb.review",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A long-form review of a catalog work, authored on a NeoDB instance.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["subject", "title", "body", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "net.neodb.defs#subject"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 2000,
+            "maxGraphemes": 500
+          },
+          "body": {
+            "type": "string",
+            "description": "Review body in Markdown."
+          },
+          "rating": {
+            "type": "ref",
+            "ref": "net.neodb.defs#rating",
+            "description": "Optional rating accompanying the review."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/lexicons/publish.py
+++ b/docs/lexicons/publish.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["atproto>=0.0.55", "dnspython>=2.7.0"]
+# ///
+"""Publish net.neodb.* lexicon schemas for ATProto lexicon resolution.
+
+Standalone script (no Django): run it with ``uv run docs/lexicons/publish.py``
+or any Python with ``atproto`` and ``dnspython`` installed.
+
+Each JSON file in this directory tree is written to the project ATProto
+account's repo as a ``com.atproto.lexicon.schema`` record keyed by its NSID.
+Together with a ``_lexicon.<authority domain>`` DNS TXT record pointing at the
+account's DID, this makes the schemas resolvable by tools and appviews.
+Re-running overwrites the records in place, so publishing an updated lexicon
+is the same command again.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import dns.resolver
+from atproto import Client
+from atproto_client import models
+from atproto_identity.did.resolver import DidResolver
+from atproto_identity.handle.resolver import HandleResolver
+
+LEXICON_DIR = Path(__file__).resolve().parent
+LEXICON_COLLECTION = "com.atproto.lexicon.schema"
+
+
+def load_lexicons(lexicon_dir: Path = LEXICON_DIR) -> list[tuple[str, dict[str, Any]]]:
+    docs = []
+    for path in sorted(lexicon_dir.glob("**/*.json")):
+        doc = json.loads(path.read_text())
+        nsid = doc.get("id")
+        if doc.get("lexicon") != 1 or not nsid:
+            raise ValueError(f"{path}: not a valid lexicon document")
+        docs.append((nsid, doc))
+    return docs
+
+
+def authority_domain(nsid: str) -> str:
+    """Authority domain of an NSID, e.g. net.neodb.mark -> neodb.net."""
+    return ".".join(reversed(nsid.split(".")[:-1]))
+
+
+def check_dns(domain: str, did: str) -> bool:
+    name = f"_lexicon.{domain}"
+    expected = f"did={did}"
+    try:
+        answers = dns.resolver.resolve(name, "TXT")
+        values = [b"".join(r.strings).decode() for r in answers]  # type: ignore[attr-defined]
+    except Exception:
+        values = []
+    if expected in values:
+        print(f'DNS OK: {name} TXT "{expected}"')
+        return True
+    print(f'WARNING: DNS record missing: add TXT at {name} with value "{expected}"')
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--handle",
+        default="neodb.net",
+        help="handle of the ATProto account hosting the schemas",
+    )
+    parser.add_argument(
+        "--password",
+        default=None,
+        help="app password; defaults to ATPROTO_APP_PASSWORD env var",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="list lexicon documents without publishing",
+    )
+    args = parser.parse_args(argv)
+
+    docs = load_lexicons()
+    if not docs:
+        print(f"no lexicon files found in {LEXICON_DIR}", file=sys.stderr)
+        return 1
+    for nsid, _ in docs:
+        print(f"found {nsid}")
+    if args.dry_run:
+        return 0
+
+    password = args.password or os.environ.get("ATPROTO_APP_PASSWORD")
+    if not password:
+        print("provide --password or set ATPROTO_APP_PASSWORD", file=sys.stderr)
+        return 1
+    did = HandleResolver(timeout=5).resolve(args.handle)
+    if not did:
+        print(f"cannot resolve handle {args.handle}", file=sys.stderr)
+        return 1
+    did_doc = DidResolver().resolve(did)
+    if not did_doc:
+        print(f"cannot resolve did {did}", file=sys.stderr)
+        return 1
+    client = Client(did_doc.get_pds_endpoint())
+    client.login(args.handle, password)
+    for nsid, doc in docs:
+        r = client.com.atproto.repo.put_record(
+            models.ComAtprotoRepoPutRecord.Data(
+                repo=did,
+                collection=LEXICON_COLLECTION,
+                rkey=nsid,
+                record={**doc, "$type": LEXICON_COLLECTION},
+            )
+        )
+        print(f"published {r.uri}")
+    for domain in sorted({authority_domain(nsid) for nsid, _ in docs}):
+        check_dns(domain, did)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/lexicons/publish.py
+++ b/docs/lexicons/publish.py
@@ -36,7 +36,7 @@ LEXICON_COLLECTION = "com.atproto.lexicon.schema"
 def load_lexicons(lexicon_dir: Path = LEXICON_DIR) -> list[tuple[str, dict[str, Any]]]:
     docs = []
     for path in sorted(lexicon_dir.glob("**/*.json")):
-        doc = json.loads(path.read_text())
+        doc = json.loads(path.read_text(encoding="utf-8"))
         nsid = doc.get("id")
         if doc.get("lexicon") != 1 or not nsid:
             raise ValueError(f"{path}: not a valid lexicon document")

--- a/journal/models/atproto.py
+++ b/journal/models/atproto.py
@@ -1,0 +1,90 @@
+"""Builders for NeoDB-owned ATProto records published to a user's PDS.
+
+These records live under the project-controlled ``net.neodb.*`` lexicon
+namespace so other ATProto applications can read a user's NeoDB marks and
+reviews (with ratings embedded) directly from their repository. The lexicon
+definitions are documented under ``docs/lexicons/net/neodb/``.
+
+NeoDB catalog items are not themselves ATProto records, so a work is
+referenced inline via :func:`build_subject` (NeoDB permalink, source URLs
+and standardized identifiers) rather than a ``com.atproto.repo.strongRef``.
+"""
+
+from datetime import datetime
+from datetime import timezone as dt_timezone
+from typing import TYPE_CHECKING, Any
+
+from catalog.models import IdealIdTypes
+
+if TYPE_CHECKING:
+    from catalog.models import Item
+
+NAMESPACE = "net.neodb"
+REVIEW_NSID = f"{NAMESPACE}.review"
+MARK_NSID = f"{NAMESPACE}.mark"
+
+RATING_MAX = 10
+
+# (collection NSID, record body) for records that should currently exist.
+# The record key is derived centrally from Piece.atproto_rkey() (the piece's
+# own uuid) rather than carried here.
+AtprotoRecord = tuple[str, dict[str, Any]]
+
+
+def format_datetime(dt: datetime) -> str:
+    """Render a datetime as an RFC3339 / ATProto timestamp (UTC, ``Z``)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=dt_timezone.utc)
+    return (
+        dt.astimezone(dt_timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def build_subject(item: "Item") -> dict[str, Any]:
+    """Inline reference to a catalog item used as a record's subject.
+
+    The work and its external sources are referenced by URL -- the NeoDB
+    permalink (``uri``) and each source site's resource URL (``sources``) --
+    never by site-specific raw ids; standardized identifiers (IdealIdTypes,
+    e.g. ISBN / IMDB / WikiData) are additionally listed in ``identifiers``.
+    Field names mirror NeoDB's API schema: ``category`` is the broad media
+    category while ``type`` is the specific NeoDB class, so TV show / season
+    / episode (and podcast / episode, performance / production) remain
+    distinguishable.
+    """
+    subject: dict[str, Any] = {
+        "uri": item.absolute_url,
+        "category": str(item.category) if item.category else "",
+        "type": item.ap_object_type,
+        "title": item.display_title,
+    }
+    if item.has_cover():
+        subject["cover"] = item.cover_image_url
+    sources: list[str] = []
+    identifiers: dict[str, str] = {}
+    for res in item.external_resources.order_by("id_type", "id_value"):
+        if res.url:
+            sources.append(res.url)
+        lookup_ids = dict(res.other_lookup_ids or {})
+        lookup_ids[res.id_type] = res.id_value
+        for t, v in lookup_ids.items():
+            if v and t in IdealIdTypes:
+                identifiers[t] = v
+    if item.primary_lookup_id_type in IdealIdTypes and item.primary_lookup_id_value:
+        identifiers[item.primary_lookup_id_type] = item.primary_lookup_id_value
+    if sources:
+        subject["sources"] = sources
+    if identifiers:
+        subject["identifiers"] = [
+            {"type": t, "value": identifiers[t]} for t in sorted(identifiers)
+        ]
+    return subject
+
+
+def build_rating(grade: int | None) -> dict[str, Any] | None:
+    """Render a 1-10 grade as a rating object, or ``None`` when unset."""
+    if not grade:
+        return None
+    return {"value": grade, "max": RATING_MAX}

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -39,6 +39,7 @@ from .mixins import UserOwnedObjectMixin
 if TYPE_CHECKING:
     from takahe.models import Post
 
+    from .atproto import AtprotoRecord
     from .itemlist import ListMember
     from .like import Like
 
@@ -339,6 +340,36 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         """
         return {}
 
+    def atproto_collections(self) -> set[str]:
+        """ATProto collections (NSIDs) this piece manages on the owner's PDS.
+
+        Every collection listed here is reconciled on sync: its record is
+        written when present in :meth:`to_atproto_records`, or deleted
+        otherwise. The default manages nothing.
+        """
+        return set()
+
+    def atproto_rkey(self) -> str:
+        """Record key for this piece's PDS records: the piece's own uuid.
+
+        Derivable from the piece itself (no stored state), stable across
+        edits and across item merges (unlike a subject-derived key), and
+        distinct pieces -- e.g. future multiple reviews of one work -- map
+        to distinct records.
+        """
+        return self.uuid
+
+    def to_atproto_records(self) -> "list[AtprotoRecord]":
+        """Structured ``net.neodb.*`` records that should currently exist on
+        the owner's PDS, as ``(collection, record)`` pairs.
+
+        The record key comes from :meth:`atproto_rkey`, so records are
+        reconstructable and never need to be tracked in the database; updates
+        overwrite in place. Subclasses with a portable representation (review,
+        mark) override this; the default publishes nothing.
+        """
+        return []
+
     @classmethod
     def update_by_ap_object(
         cls,
@@ -402,7 +433,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         return p
 
     @classmethod
-    def _delete_crossposts(cls, user_pk, metadata: dict):
+    def _delete_crossposts(cls, user_pk, metadata: dict, record_refs=None):
         user = User.objects.get(pk=user_pk)
         toot_id = metadata.get("mastodon_id")
         if toot_id and user.mastodon:
@@ -413,11 +444,37 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 user.bluesky.delete_post(post_id)
             except Exception as e:
                 logger.warning(f"Delete {user.bluesky} post {post_id} error {e}")
+        if record_refs and user.bluesky:
+            for collection, rkey in record_refs:
+                try:
+                    user.bluesky.delete_record(collection, rkey)
+                except Exception as e:
+                    logger.warning(
+                        f"Delete {user.bluesky} record {collection}/{rkey} error {e}"
+                    )
 
     def delete_crossposts(self):
-        if hasattr(self, "metadata") and self.metadata:
+        metadata = (
+            self.metadata.copy() if hasattr(self, "metadata") and self.metadata else {}
+        )
+        # record keys are derived here while the piece still exists so the
+        # async job can clean up the PDS without stored state.
+        # not gated on metadata: records may exist even when no skeet was
+        # ever posted (e.g. the feed post failed but put_record succeeded)
+        record_refs = (
+            [
+                [collection, self.atproto_rkey()]
+                for collection in self.atproto_collections()
+            ]
+            if self.owner.user_id and self.owner.user.bluesky
+            else []
+        )
+        if metadata or record_refs:
             django_rq.get_queue("mastodon").enqueue(
-                self._delete_crossposts, self.owner.user_id, self.metadata
+                self._delete_crossposts,
+                self.owner.user_id,
+                metadata,
+                record_refs,
             )
 
     def get_crosspost_params(self):
@@ -469,7 +526,12 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         # skip non-public post as Bluesky does not support it
         # update_mode 0 will act like 1 as bsky.app does not support edit
         bluesky = self.owner.user.bluesky
-        if params["visibility"] != 0 or not bluesky:
+        if not bluesky:
+            return False
+        if params["visibility"] != 0:
+            # piece is no longer public: drop any records previously written
+            # to the PDS, since PDS records are world-readable
+            self._sync_records_to_bluesky(bluesky, drop=True)
             return False
         if update_mode in [0, 1]:
             post_id = self.metadata.get("bluesky_id")
@@ -505,7 +567,39 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             sentry_count("crosspost.success", attributes=attrs)
         else:
             sentry_count("crosspost.failure", attributes=attrs)
+        self._sync_records_to_bluesky(bluesky)
         return True
+
+    def _sync_records_to_bluesky(self, bluesky, drop: bool = False):
+        """Reconcile this piece's net.neodb.* records on the owner's PDS.
+
+        For every collection the piece manages, the record is written (keyed
+        by :meth:`atproto_rkey`, so put_record overwrites in place on edit)
+        when present, or deleted otherwise -- including the case where the
+        piece is no longer public (``drop``). No state is stored: records are
+        reconstructable from the piece, and put/delete are both idempotent.
+        """
+        collections = self.atproto_collections()
+        if not collections:
+            return
+        rkey = self.atproto_rkey()
+        try:
+            present = (
+                {} if drop else {c: record for c, record in self.to_atproto_records()}
+            )
+        except Exception as e:
+            logger.warning(f"{self} build atproto records error {e}")
+            return
+        for collection in collections:
+            try:
+                if collection in present:
+                    bluesky.put_record(collection, rkey, present[collection])
+                else:
+                    bluesky.delete_record(collection, rkey)
+            except Exception as e:
+                logger.warning(
+                    f"{self} sync record {collection} to {bluesky} error {e}"
+                )
 
     def sync_to_threads(self, params, update_mode):
         # skip non-public post as Threads does not support it

--- a/journal/models/review.py
+++ b/journal/models/review.py
@@ -163,7 +163,12 @@ class Review(Content):
             "body": self.body,
             "createdAt": format_datetime(self.created_time),
         }
-        if self.edited_time and self.edited_time != self.created_time:
+        # created_time is set at instantiation but edited_time (auto_now) at DB
+        # write, so they always differ by a sliver; only a real gap is an edit
+        if (
+            self.edited_time
+            and (self.edited_time - self.created_time).total_seconds() > 1
+        ):
             record["updatedAt"] = format_datetime(self.edited_time)
         rating = build_rating(self.rating_grade)
         if rating:

--- a/journal/models/review.py
+++ b/journal/models/review.py
@@ -15,6 +15,13 @@ from catalog.models import Item
 from takahe.utils import Takahe
 from users.models import APIdentity
 
+from .atproto import (
+    REVIEW_NSID,
+    AtprotoRecord,
+    build_rating,
+    build_subject,
+    format_datetime,
+)
 from .common import Content
 from .rating import Rating
 from .renderers import has_spoiler, render_md, render_post_with_macro, render_rating
@@ -144,6 +151,24 @@ class Review(Content):
         )
         params = {"content": content, "obj": self, "rating": self.rating_grade}
         return params
+
+    def atproto_collections(self) -> set[str]:
+        return {REVIEW_NSID}
+
+    def to_atproto_records(self) -> list[AtprotoRecord]:
+        record: dict[str, Any] = {
+            "$type": REVIEW_NSID,
+            "subject": build_subject(self.item),
+            "title": self.title,
+            "body": self.body,
+            "createdAt": format_datetime(self.created_time),
+        }
+        if self.edited_time and self.edited_time != self.created_time:
+            record["updatedAt"] = format_datetime(self.edited_time)
+        rating = build_rating(self.rating_grade)
+        if rating:
+            record["rating"] = rating
+        return [(REVIEW_NSID, record)]
 
     def to_post_params(self):
         item_link = f"{settings.SITE_INFO['site_url']}/~neodb~{self.item.url}"

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -14,6 +14,13 @@ from common.models import jsondata
 from takahe.utils import Takahe
 from users.models import APIdentity
 
+from .atproto import (
+    MARK_NSID,
+    AtprotoRecord,
+    build_rating,
+    build_subject,
+    format_datetime,
+)
 from .common import q_item_in_category
 from .itemlist import List, ListMember
 from .renderers import render_post_with_macro, render_rating, render_spoiler_text
@@ -446,6 +453,29 @@ class ShelfMember(ListMember):
             "summary": spoiler,
             "sensitive": spoiler is not None,
         }
+
+    def atproto_collections(self) -> set[str]:
+        return {MARK_NSID}
+
+    def to_atproto_records(self) -> list[AtprotoRecord]:
+        record: dict[str, Any] = {
+            "$type": MARK_NSID,
+            "subject": build_subject(self.item),
+            "status": str(self.shelf_type),
+            "createdAt": format_datetime(self.created_time),
+        }
+        if self.sibling_comment and self.sibling_comment.text:
+            record["comment"] = self.sibling_comment.text
+        # PDS records are world-readable; never include private tags
+        tags = self.owner.tag_manager.get_item_tags(self.item, public_only=True)
+        if tags:
+            record["tags"] = tags
+        rating = build_rating(
+            self.sibling_rating.grade if self.sibling_rating else None
+        )
+        if rating:
+            record["rating"] = rating
+        return [(MARK_NSID, record)]
 
     def get_ap_data(self):
         data = super().get_ap_data()

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -464,15 +464,16 @@ class ShelfMember(ListMember):
             "status": str(self.shelf_type),
             "createdAt": format_datetime(self.created_time),
         }
-        if self.sibling_comment and self.sibling_comment.text:
-            record["comment"] = self.sibling_comment.text
+        # comment_text/rating_grade use the manager's subquery annotations
+        # when present, avoiding extra queries per record build
+        comment = self.comment_text
+        if comment:
+            record["comment"] = comment
         # PDS records are world-readable; never include private tags
         tags = self.owner.tag_manager.get_item_tags(self.item, public_only=True)
         if tags:
             record["tags"] = tags
-        rating = build_rating(
-            self.sibling_rating.grade if self.sibling_rating else None
-        )
+        rating = build_rating(self.rating_grade)
         if rating:
             record["rating"] = rating
         return [(MARK_NSID, record)]

--- a/journal/models/tag.py
+++ b/journal/models/tag.py
@@ -253,12 +253,11 @@ class TagManager:
         titles = tags.values_list("title", flat=True)
         return titles
 
-    def get_item_tags(self, item: Item):
-        return sorted(
-            TagMember.objects.filter(parent__owner=self.owner, item=item).values_list(
-                "parent__title", flat=True
-            )
-        )
+    def get_item_tags(self, item: Item, public_only: bool = False):
+        qs = TagMember.objects.filter(parent__owner=self.owner, item=item)
+        if public_only:
+            qs = qs.filter(parent__visibility=0)
+        return sorted(qs.values_list("parent__title", flat=True))
 
     def get_items_tags(self, item_ids: list[int]) -> dict[int, list[str]]:
         """Batch-fetch user's tags for multiple items."""

--- a/mastodon/models/bluesky.py
+++ b/mastodon/models/bluesky.py
@@ -177,21 +177,55 @@ class BlueskyAccount(SocialAccount):
                 update_fields=[
                     "access_data",
                     "account_data",
-                    "last_reachable",
+                    "last_refresh",
+                    "handle",
                 ]
             )
         return True
 
+    def _paginate_dids(
+        self,
+        fetch: "typing.Callable[[str | None], typing.Any]",
+        attr: str,
+        max_pages: int = 200,
+    ) -> list[str]:
+        """Accumulate DIDs across every page of a cursored graph listing.
+
+        ``fetch(cursor)`` returns a response exposing ``.cursor`` and a list
+        attribute named ``attr``. ``max_pages`` (100 entries per page) bounds
+        the loop against a non-terminating cursor; truncation is logged rather
+        than failing silently.
+        """
+        dids: list[str] = []
+        cursor: str | None = None
+        for _ in range(max_pages):
+            r = fetch(cursor)
+            dids += [p.did for p in getattr(r, attr)]
+            cursor = r.cursor
+            if not cursor:
+                break
+        else:
+            logger.warning(
+                f"{self} graph listing '{attr}' truncated at {len(dids)} entries"
+            )
+        return dids
+
     def refresh_graph(self, save=True) -> bool:
         try:
-            r = self._client.get_followers(self.uid)
-            self.followers = [p.did for p in r.followers]
-            r = self._client.get_follows(self.uid)
-            self.following = [p.did for p in r.follows]
-            r = self._client.app.bsky.graph.get_mutes(
-                models.AppBskyGraphGetMutes.Params(cursor=None, limit=None)
+            self.following = self._paginate_dids(
+                lambda c: self._client.get_follows(self.uid, cursor=c, limit=100),
+                "follows",
             )
-            self.mutes = [p.did for p in r.mutes]
+            self.followers = self._paginate_dids(
+                lambda c: self._client.get_followers(self.uid, cursor=c, limit=100),
+                "followers",
+            )
+            self.mutes = self._paginate_dids(
+                lambda c: self._client.app.bsky.graph.get_mutes(
+                    models.AppBskyGraphGetMutes.Params(cursor=c, limit=100)
+                ),
+                "mutes",
+            )
         except AtProtocolError as e:
             logger.warning(f"{self} refresh_graph error: {e}")
             return False
@@ -296,6 +330,33 @@ class BlueskyAccount(SocialAccount):
 
     def delete_post(self, post_uri):
         self._client.delete_post(post_uri)
+
+    def put_record(
+        self, collection: str, rkey: str, record: dict[str, typing.Any]
+    ) -> dict[str, str]:
+        """Create or overwrite a record in the user's repo.
+
+        Idempotent: the same ``rkey`` updates the existing record in place,
+        so editing a NeoDB piece overwrites its record rather than duplicating
+        it. ``record`` must contain a ``$type`` field.
+        """
+        r = self._client.com.atproto.repo.put_record(
+            models.ComAtprotoRepoPutRecord.Data(
+                repo=self.uid,
+                collection=collection,
+                rkey=rkey,
+                record=record,
+            )
+        )
+        return {"uri": r.uri, "cid": r.cid}
+
+    def delete_record(self, collection: str, rkey: str) -> None:
+        """Delete a record by key. Idempotent: no error if it does not exist."""
+        self._client.com.atproto.repo.delete_record(
+            models.ComAtprotoRepoDeleteRecord.Data(
+                repo=self.uid, collection=collection, rkey=rkey
+            )
+        )
 
 
 class EmbedObj:

--- a/mastodon/models/bluesky.py
+++ b/mastodon/models/bluesky.py
@@ -1,3 +1,6 @@
+import base64
+import hashlib
+import json
 import re
 import typing
 from functools import cached_property
@@ -7,6 +10,8 @@ from atproto_client import models
 from atproto_client.exceptions import AtProtocolError
 from atproto_identity.did.resolver import DidResolver
 from atproto_identity.handle.resolver import HandleResolver
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from django.conf import settings
 from django.utils import timezone
 from loguru import logger
@@ -19,6 +24,9 @@ from .common import SocialAccount
 if typing.TYPE_CHECKING:
     from catalog.models import Item
     from journal.models.common import Content
+
+
+PROFILE_NSID = "net.neodb.profile"
 
 
 class Bluesky:
@@ -181,7 +189,79 @@ class BlueskyAccount(SocialAccount):
                     "handle",
                 ]
             )
+        self.sync_profile_record()
         return True
+
+    @staticmethod
+    def _jcs(data: dict) -> bytes:
+        # JCS (RFC 8785) canonicalization; sorted compact JSON is equivalent
+        # for objects whose values are all strings, as is the case here
+        return json.dumps(
+            data, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+
+    def _build_profile_record(self) -> dict[str, typing.Any]:
+        from journal.models.atproto import format_datetime
+
+        identity = self.user.identity
+        takahe_identity = identity.takahe_identity
+        record: dict[str, typing.Any] = {
+            "$type": PROFILE_NSID,
+            "did": self.uid,
+            "actor": identity.actor_uri,
+            "url": settings.SITE_INFO["site_url"] + identity.url,
+            "handle": identity.full_handle,
+            "createdAt": format_datetime(self.created),
+        }
+        if takahe_identity.private_key and takahe_identity.public_key_id:
+            # sign the statement with the actor's federation key so the link
+            # verifies in both directions: the record living in the DID's
+            # repo proves the DID side, the signature proves the actor side.
+            # modeled on FEP-c390 / W3C Data Integrity (eddsa-jcs-2022
+            # procedure with an RSA suite, as AP federation keys are RSA)
+            key = serialization.load_pem_private_key(
+                takahe_identity.private_key.encode(), password=None
+            )
+            if isinstance(key, rsa.RSAPrivateKey):
+                proof: dict[str, typing.Any] = {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "rsa-pkcs1-sha256-jcs",
+                    "created": record["createdAt"],
+                    "verificationMethod": takahe_identity.public_key_id,
+                    "proofPurpose": "assertionMethod",
+                }
+                data = (
+                    hashlib.sha256(self._jcs(proof)).digest()
+                    + hashlib.sha256(self._jcs(record)).digest()
+                )
+                signature = key.sign(data, padding.PKCS1v15(), hashes.SHA256())
+                proof["proofValue"] = base64.b64encode(signature).decode()
+                record["proof"] = proof
+        return record
+
+    def sync_profile_record(self) -> None:
+        """Reconcile the net.neodb.profile record linking this DID to the
+        owner's NeoDB identity.
+
+        Written only while the identity is publicly discoverable -- PDS
+        records are world-readable -- and deleted otherwise (both idempotent).
+        """
+        identity = self.user.identity if self.user else None
+        if not identity:
+            return
+        try:
+            if identity.discoverable:
+                self.put_record(PROFILE_NSID, "self", self._build_profile_record())
+            else:
+                self.delete_record(PROFILE_NSID, "self")
+        except Exception as e:
+            logger.warning(f"{self} profile record sync error {e}")
+
+    def on_disconnect(self) -> None:
+        try:
+            self.delete_record(PROFILE_NSID, "self")
+        except Exception as e:
+            logger.warning(f"{self} profile record cleanup error {e}")
 
     def _paginate_dids(
         self,

--- a/mastodon/models/common.py
+++ b/mastodon/models/common.py
@@ -128,3 +128,7 @@ class SocialAccount(TypedModel):
 
     def sync_graph(self) -> int:
         return 0
+
+    def on_disconnect(self) -> None:
+        """platform-specific cleanup when the account is unlinked from a user"""
+        pass

--- a/mastodon/views/common.py
+++ b/mastodon/views/common.py
@@ -102,6 +102,9 @@ def disconnect_identity(request, account):
                 _("You cannot disconnect last login identity."),
             )
         account.delete()
+    # platform-specific cleanup (e.g. remove the net.neodb.profile record
+    # from the PDS); best-effort, runs outside the transaction
+    account.on_disconnect()
     messages.add_message(
         request,
         messages.INFO,

--- a/tests/journal/test_atproto_records.py
+++ b/tests/journal/test_atproto_records.py
@@ -1,0 +1,205 @@
+from types import SimpleNamespace
+
+import pytest
+
+from catalog.models import Edition, ExternalResource, TVSeason, TVShow
+from journal.models import Mark, Rating, Review, ShelfMember, ShelfType, Tag
+from journal.models.atproto import MARK_NSID, REVIEW_NSID, build_subject
+from mastodon.models import BlueskyAccount
+from users.models import User
+
+
+class FakeBluesky:
+    """Stand-in for BlueskyAccount capturing record writes/deletes."""
+
+    def __init__(self):
+        self.uid = "did:plc:fake"
+        self.puts: dict[tuple[str, str], dict] = {}
+        self.deletes: list[tuple[str, str]] = []
+
+    def put_record(self, collection, rkey, record):
+        self.puts[(collection, rkey)] = record
+        return {"uri": f"at://{self.uid}/{collection}/{rkey}", "cid": "cid"}
+
+    def delete_record(self, collection, rkey):
+        self.deletes.append((collection, rkey))
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_atproto_record():
+    user = User.register(email="rev@example.com", username="revuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(
+        book, user.identity, "Loved it", "A **great** read."
+    )
+    assert review is not None
+    records = review.to_atproto_records()
+    assert len(records) == 1
+    collection, record = records[0]
+    assert collection == REVIEW_NSID
+    assert record["$type"] == REVIEW_NSID
+    assert record["title"] == "Loved it"
+    assert record["body"] == "A **great** read."
+    assert record["subject"]["uri"] == book.absolute_url
+    assert record["subject"]["category"] == "book"
+    assert record["subject"]["type"] == "Edition"
+    assert record["subject"]["title"] == "Dune"
+    assert record["createdAt"].endswith("Z")
+    assert review.atproto_collections() == {REVIEW_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_subject_differentiates_tv_types_and_uses_source_urls():
+    show = TVShow.objects.create(title="The Show")
+    season = TVSeason.objects.create(title="Season 1")
+    ExternalResource.objects.create(
+        item=season,
+        id_type="tmdb_tvseason",
+        id_value="100-1",
+        url="https://www.themoviedb.org/tv/100/season/1",
+    )
+    ExternalResource.objects.create(
+        item=season,
+        id_type="imdb",
+        id_value="tt100",
+        url="https://www.imdb.com/title/tt100/",
+    )
+
+    show_subject = build_subject(show)
+    season_subject = build_subject(season)
+
+    # broad category is shared; specific type differentiates them
+    assert show_subject["category"] == season_subject["category"] == "tv"
+    assert show_subject["type"] == "TVShow"
+    assert season_subject["type"] == "TVSeason"
+    # external sources are referenced by URL, not raw id
+    assert season_subject["sources"] == [
+        "https://www.imdb.com/title/tt100/",
+        "https://www.themoviedb.org/tv/100/season/1",
+    ]
+    assert "sources" not in show_subject
+    # only standardized (IdealIdTypes) identifiers are listed:
+    # imdb qualifies, the site-specific tmdb season id does not
+    assert season_subject["identifiers"] == [{"type": "imdb", "value": "tt100"}]
+    assert "identifiers" not in show_subject
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_atproto_record_embeds_rating():
+    user = User.register(email="mark@example.com", username="markuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(
+        ShelfType.COMPLETE, "finished", 9, tags=["scifi"], visibility=0
+    )
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+    records = sm.to_atproto_records()
+    assert len(records) == 1
+    collection, record = records[0]
+    assert collection == MARK_NSID
+    assert record["status"] == "complete"
+    assert record["comment"] == "finished"
+    assert record["rating"] == {"value": 9, "max": 10}
+    assert record["tags"] == ["scifi"]
+    assert sm.atproto_collections() == {MARK_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_record_keyed_by_review_uuid():
+    user = User.register(email="rkey@example.com", username="rkeyuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "Title", "body")
+    assert review is not None
+
+    fake = FakeBluesky()
+    review._sync_records_to_bluesky(fake)
+
+    # keyed by the review's own uuid so multiple reviews per work can coexist
+    assert (REVIEW_NSID, review.uuid) in fake.puts
+    assert (REVIEW_NSID, book.uuid) not in fake.puts
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_writes_record_keyed_by_piece_uuid():
+    user = User.register(email="sync@example.com", username="syncuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "great", 7, visibility=0)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+
+    fake = FakeBluesky()
+    sm._sync_records_to_bluesky(fake)
+
+    # keyed by the mark's own uuid, stable across item merges
+    assert (MARK_NSID, sm.uuid) in fake.puts
+    assert (MARK_NSID, book.uuid) not in fake.puts
+    assert fake.deletes == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_drops_embedded_rating_when_rating_removed():
+    user = User.register(email="rm@example.com", username="rmuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "great", 7, visibility=0)
+    # remove the rating directly (mark.update treats rating_grade=None as no-op)
+    Rating.update_item_rating(book, user.identity, None)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+
+    fake = FakeBluesky()
+    sm._sync_records_to_bluesky(fake)
+
+    record = fake.puts[(MARK_NSID, sm.uuid)]
+    assert "rating" not in record
+    assert fake.deletes == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_drop_deletes_record():
+    user = User.register(email="drop@example.com", username="dropuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "great", 7, visibility=0)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+
+    fake = FakeBluesky()
+    sm._sync_records_to_bluesky(fake, drop=True)
+
+    assert fake.puts == {}
+    assert (MARK_NSID, sm.uuid) in fake.deletes
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_record_excludes_private_tags():
+    user = User.register(email="tags@example.com", username="taguser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(
+        ShelfType.COMPLETE, None, None, tags=["pub", "secret"], visibility=0
+    )
+    Tag.objects.filter(owner=user.identity, title="secret").update(visibility=2)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+
+    records = dict(sm.to_atproto_records())
+
+    assert records[MARK_NSID]["tags"] == ["pub"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_delete_enqueues_record_cleanup_without_metadata(monkeypatch):
+    user = User.register(email="del@example.com", username="deluser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, None, None, visibility=0)
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="del.example"
+    )
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+    assert not sm.metadata  # no skeet was ever posted
+
+    calls = []
+    monkeypatch.setattr(
+        "journal.models.common.django_rq.get_queue",
+        lambda name: SimpleNamespace(enqueue=lambda *a, **kw: calls.append(a)),
+    )
+    sm.delete_crossposts()
+
+    # cleanup must be enqueued even though crosspost metadata is empty
+    assert len(calls) == 1
+    _func, _user_id, metadata, record_refs = calls[0]
+    assert metadata == {}
+    assert record_refs == [[MARK_NSID, sm.uuid]]

--- a/tests/journal/test_atproto_records.py
+++ b/tests/journal/test_atproto_records.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -46,6 +47,25 @@ def test_review_atproto_record():
     assert record["subject"]["title"] == "Dune"
     assert record["createdAt"].endswith("Z")
     assert review.atproto_collections() == {REVIEW_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_updated_at_only_for_real_edits():
+    user = User.register(email="upd@example.com", username="upduser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+
+    _, record = review.to_atproto_records()[0]
+    # creation jitter between created_time and edited_time is not an edit
+    assert "updatedAt" not in record
+
+    Review.objects.filter(pk=review.pk).update(
+        edited_time=review.created_time + timedelta(minutes=5)
+    )
+    review.refresh_from_db()
+    _, record = review.to_atproto_records()[0]
+    assert record["updatedAt"].endswith("Z")
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from mastodon.models.bluesky import BlueskyAccount
+
+
+def _page(attr, dids, cursor):
+    return SimpleNamespace(
+        cursor=cursor, **{attr: [SimpleNamespace(did=d) for d in dids]}
+    )
+
+
+def test_paginate_dids_walks_cursor():
+    account = BlueskyAccount()
+    pages = [
+        _page("follows", ["did:a", "did:b"], "c1"),
+        _page("follows", ["did:c"], None),
+    ]
+    seen: list[str | None] = []
+
+    def fetch(cursor):
+        seen.append(cursor)
+        return pages.pop(0)
+
+    dids = account._paginate_dids(fetch, "follows")
+
+    assert dids == ["did:a", "did:b", "did:c"]
+    assert seen == [None, "c1"]  # second call carries the first page's cursor
+
+
+def test_paginate_dids_bounded_by_max_pages():
+    account = BlueskyAccount()
+
+    def fetch(cursor):  # never-ending cursor
+        return _page("mutes", ["did:x"], "more")
+
+    dids = account._paginate_dids(fetch, "mutes", max_pages=3)
+
+    assert dids == ["did:x", "did:x", "did:x"]

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -1,6 +1,21 @@
+import base64
+import hashlib
+import json
 from types import SimpleNamespace
 
-from mastodon.models.bluesky import BlueskyAccount
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from mastodon.models.bluesky import PROFILE_NSID, BlueskyAccount
+from users.models import User
+
+
+def _jcs(data: dict) -> bytes:
+    # independent JCS (RFC 8785) canonicalization for verification
+    return json.dumps(
+        data, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode()
 
 
 def _page(attr, dids, cursor):
@@ -36,3 +51,66 @@ def test_paginate_dids_bounded_by_max_pages():
     dids = account._paginate_dids(fetch, "mutes", max_pages=3)
 
     assert dids == ["did:x", "did:x", "did:x"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_record_signed_and_verifiable(monkeypatch):
+    user = User.register(email="prof@example.com", username="profuser")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:prof", handle="prof.example"
+    )
+    puts: dict = {}
+    monkeypatch.setattr(
+        account,
+        "put_record",
+        lambda c, rk, r: puts.update({(c, rk): r}) or {"uri": "u", "cid": "c"},
+    )
+    monkeypatch.setattr(account, "delete_record", lambda c, rk: None)
+
+    account.sync_profile_record()
+
+    identity = user.identity
+    record = puts[(PROFILE_NSID, "self")]
+    assert record["did"] == "did:plc:prof"  # bound against cross-repo replay
+    assert record["actor"] == identity.actor_uri
+    assert record["handle"] == identity.full_handle
+    assert record["url"].endswith(identity.url)
+    proof = dict(record["proof"])
+    assert proof["type"] == "DataIntegrityProof"
+    assert proof["cryptosuite"] == "rsa-pkcs1-sha256-jcs"
+    assert proof["proofPurpose"] == "assertionMethod"
+    assert proof["verificationMethod"] == identity.takahe_identity.public_key_id
+    # re-run the documented verification procedure against the actor's
+    # published public key; verify() raises InvalidSignature otherwise
+    proof_value = proof.pop("proofValue")
+    document = {k: v for k, v in record.items() if k != "proof"}
+    data = (
+        hashlib.sha256(_jcs(proof)).digest() + hashlib.sha256(_jcs(document)).digest()
+    )
+    public_key = serialization.load_pem_public_key(
+        identity.takahe_identity.public_key.encode()
+    )
+    assert isinstance(public_key, rsa.RSAPublicKey)
+    public_key.verify(
+        base64.b64decode(proof_value), data, padding.PKCS1v15(), hashes.SHA256()
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_record_removed_when_not_discoverable(monkeypatch):
+    user = User.register(email="hid@example.com", username="hiduser")
+    takahe_identity = user.identity.takahe_identity
+    takahe_identity.discoverable = False
+    takahe_identity.save()
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:hid", handle="hid.example"
+    )
+    deletes: list = []
+    monkeypatch.setattr(
+        account, "put_record", lambda c, rk, r: {"uri": "u", "cid": "c"}
+    )
+    monkeypatch.setattr(account, "delete_record", lambda c, rk: deletes.append((c, rk)))
+
+    account.sync_profile_record()
+
+    assert (PROFILE_NSID, "self") in deletes

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -114,3 +114,21 @@ def test_profile_record_removed_when_not_discoverable(monkeypatch):
     account.sync_profile_record()
 
     assert (PROFILE_NSID, "self") in deletes
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_register_with_account_schedules_sync(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        User, "sync_accounts_later", lambda self: called.append(self.pk)
+    )
+    account = BlueskyAccount.objects.create(
+        domain="-", uid="did:plc:reg", handle="reg.example"
+    )
+    user = User.register(username="reguser", account=account)
+
+    # the account is linked and a sync is scheduled so the profile
+    # record gets published now that the user exists
+    account.refresh_from_db()
+    assert account.user == user
+    assert called == [user.pk]

--- a/tests/mastodon/test_lexicons.py
+++ b/tests/mastodon/test_lexicons.py
@@ -17,6 +17,7 @@ def test_load_lexicons_lists_valid_documents():
     nsids = [nsid for nsid, doc in mod.load_lexicons()]
     assert "net.neodb.defs" in nsids
     assert "net.neodb.mark" in nsids
+    assert "net.neodb.profile" in nsids
     assert "net.neodb.review" in nsids
 
 

--- a/tests/mastodon/test_lexicons.py
+++ b/tests/mastodon/test_lexicons.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "docs" / "lexicons" / "publish.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("publish_lexicons", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_lexicons_lists_valid_documents():
+    mod = _load_script()
+    nsids = [nsid for nsid, doc in mod.load_lexicons()]
+    assert "net.neodb.defs" in nsids
+    assert "net.neodb.mark" in nsids
+    assert "net.neodb.review" in nsids
+
+
+def test_dry_run_does_not_publish():
+    mod = _load_script()
+    assert mod.main(["--dry-run"]) == 0  # exits before any network access
+
+
+def test_authority_domain_derivation():
+    mod = _load_script()
+    assert mod.authority_domain("net.neodb.mark") == "neodb.net"

--- a/users/models/user.py
+++ b/users/models/user.py
@@ -354,7 +354,12 @@ class User(AbstractUser):
             if account and not new_user.is_superuser:
                 _check_auto_promote_superuser(new_user, account)
             new_user.identity.shelf_manager
-            return new_user
+        if account:
+            # the account was authenticated before the user existed, so
+            # sync it again now that it is linked (e.g. to publish the
+            # net.neodb.profile record on the user's PDS)
+            new_user.sync_accounts_later()
+        return new_user
 
     def reconnect_account(self, account: SocialAccount):
         with transaction.atomic():


### PR DESCRIPTION
## Summary

When a public mark or review is crossposted to Bluesky, NeoDB now also writes a structured record to the user's ATProto repo (PDS), making NeoDB activity readable by other ATProto applications:

- `net.neodb.mark` — shelf status, with optional rating / comment / public tags
- `net.neodb.review` — long-form review, with optional rating embedded

### Design

- **Subject by URL, not raw id**: the work is referenced by its NeoDB permalink plus source site URLs; standardized identifiers (IdealIdTypes: ISBN, IMDB, WikiData, ...) are additionally listed. `category`/`type` mirror the NeoDB API schema so TV show/season/episode stay distinguishable.
- **Stateless**: records are keyed by the piece's own uuid — deterministic, stable across item merges, ready for multiple reviews per work. Nothing is stored in the DB; sync reconciles via idempotent `put_record`/`delete_record` (overwrites on edit, prunes on visibility loss or deletion, cleanup not gated on crosspost metadata).
- **Privacy**: records are written for public pieces only, and only public tags are included (PDS records are world-readable).

### Lexicon publishing

Schemas live in `docs/lexicons/net/neodb/` with an internals doc covering record shapes, keying and evolution rules. A standalone script (PEP 723, no Django) publishes them as `com.atproto.lexicon.schema` records to the `@neodb.net` account and verifies the `_lexicon.neodb.net` DNS TXT record; a GitHub Action runs it on merges to main touching the lexicon files. **Publishing is opt-in**: the step is skipped until the `ATPROTO_APP_PASSWORD` repo secret is configured (one-time DNS TXT record is the other manual step).

### Fixes included

- `BlueskyAccount.refresh()` persisted untouched `last_reachable` while dropping the just-set `last_refresh` and `handle`, so the sync sleep-throttle never engaged
- graph sync (`get_follows`/`get_followers`/`get_mutes`) only fetched the first 100 entries; now paginates with cursors, bounded with a logged truncation warning

## Test plan

- 11 new tests: record builders (subject URL/identifier rules, TV type differentiation, private-tag exclusion), stateless reconcile (piece-uuid keying, drop, embedded-rating removal, metadata-independent cleanup), graph pagination, lexicon script dry-run
- full `tests/journal` + `tests/mastodon` suites pass (569); ruff / ty / pre-commit clean