### PR TITLE
fix(manage): use Yes/No labels for boolean settings

### DIFF
--- a/common/views_manage.py
+++ b/common/views_manage.py
@@ -46,9 +46,7 @@ class SiteConfigSettingsPage(FormView):
             if annotation is bool:
                 form_field = partial(
                     forms.BooleanField,
-                    widget=forms.Select(
-                        choices=[(True, _("Enabled")), (False, _("Disabled"))]
-                    ),
+                    widget=forms.Select(choices=[(True, _("Yes")), (False, _("No"))]),
                 )
             elif annotation is str:
                 choices = details.get("choices")

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-07 02:13+0200\n"
+"POT-Creation-Date: 2026-06-08 18:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1553,12 +1553,12 @@ msgid "Item has been marked by users."
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
 msgid "Yes"
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
 msgid "No"
 msgstr ""
 
@@ -3674,14 +3674,6 @@ msgstr ""
 #: common/utils.py:103 common/utils.py:105 journal/views/profile.py:486
 #: journal/views/review.py:186
 msgid "Login required"
-msgstr ""
-
-#: common/views_manage.py:50
-msgid "Enabled"
-msgstr ""
-
-#: common/views_manage.py:50
-msgid "Disabled"
 msgstr ""
 
 #: common/views_manage.py:144 common/views_manage.py:295

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-07 02:13+0200\n"
+"POT-Creation-Date: 2026-06-08 18:34-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1552,12 +1552,12 @@ msgid "Item has been marked by users."
 msgstr "条目已被用户标记过。"
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
 msgid "Yes"
 msgstr "是"
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
 msgid "No"
 msgstr "否"
 
@@ -3695,14 +3695,6 @@ msgstr "访问被拒绝"
 #: journal/views/review.py:186
 msgid "Login required"
 msgstr "登录后访问"
-
-#: common/views_manage.py:50
-msgid "Enabled"
-msgstr "已启用"
-
-#: common/views_manage.py:50
-msgid "Disabled"
-msgstr "已禁用"
 
 #: common/views_manage.py:144 common/views_manage.py:295
 msgid "Branding"


### PR DESCRIPTION
## Summary

- The site-config admin form renders every boolean field with **Enabled / Disabled** choices, which reads as a confusing double-negative for negatively-phrased labels (e.g. *Disable Default Relay: Enabled* — does it mean the relay is on or off?).
- Switch the choice labels to **Yes / No** so the value always answers the label as a question regardless of phrasing.
- Affected labels include: Disable Default Relay, Invite Only, Show Local Only, Show Popular Posts, Filter by Preferred Languages, Dampen Heavy Shelvers, etc.
- Translations: `Yes`/`No` were already translated in `zh_Hans`; obsolete `Enabled`/`Disabled` entries removed by `makemessages --no-obsolete`.

## Test plan

- [ ] Visit `/manage/federation` and confirm *Disable Default Relay* shows **Yes / No** instead of **Enabled / Disabled**
- [ ] Toggle the value, save, reload — confirm the persisted state matches the selection
- [ ] Spot-check other boolean settings pages (access, discover, recommendations) render Yes/No
- [ ] Switch UI language to zh_Hans and verify 是/否 render correctly