### PR TITLE
feat(social): collapse consecutive same-author marks in home feed

### DIFF
--- a/locale/django.pot
+++ b/locale/django.pot
@@ -6044,6 +6044,13 @@ msgstr ""
 msgid "New article"
 msgstr ""
 
+#: social/templates/_event_mark_group.html:21
+#, python-format
+msgid "marked %(counter)s item"
+msgid_plural "marked %(counter)s items"
+msgstr[0] ""
+msgstr[1] ""
+
 #: social/templates/_event_post.html:20
 msgid "boosted"
 msgstr ""

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6126,6 +6126,13 @@ msgstr "新帖文"
 msgid "New article"
 msgstr "新文章"
 
+#: social/templates/_event_mark_group.html:21
+#, python-format
+msgid "marked %(counter)s item"
+msgid_plural "marked %(counter)s items"
+msgstr[0] "标记了 %(counter)s 个条目"
+msgstr[1] "标记了 %(counter)s 个条目"
+
 #: social/templates/_event_post.html:20
 msgid "boosted"
 msgstr "转播了"

--- a/social/feed_grouping.py
+++ b/social/feed_grouping.py
@@ -1,0 +1,155 @@
+"""Collapse runs of consecutive same-author mark posts in the in-app home feed.
+
+When a user bulk-marks many catalog items (e.g. importing from Douban/Goodreads),
+each mark becomes its own ``takahe.models.TimelineEvent`` and would otherwise flood
+followers' home feed with one card per mark. ``group_feed_events`` folds a run of
+consecutive same-author mark events into a single :class:`FeedEventGroup` that the
+feed template renders as one "marked N items" card with a cover carousel.
+
+This is a presentation-only concern: it operates on the already-fetched events of
+``social.views.data`` and changes nothing about the underlying posts or their
+ActivityPub representation.
+"""
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+# Minimum length of a consecutive same-author mark run to collapse into a card.
+# Runs shorter than this render as individual cards, unchanged from before.
+GROUP_THRESHOLD = 3
+
+# When True, a mark carrying a written comment renders on its own (and breaks a
+# run) so authored text is never hidden inside a collapsed group. Flip to False
+# to group commented marks too.
+GROUP_STANDALONE_COMMENTED = True
+
+
+class FeedEvent(Protocol):
+    """The subset of ``takahe.models.TimelineEvent`` that grouping reads.
+
+    Declared as a Protocol so grouping is honest about duck-typing: real timeline
+    events and lightweight test doubles both satisfy it structurally. (Django's
+    implicit ``id``/foreign-key ``_id`` attributes are not visible to the type
+    checker on the concrete model, so a nominal annotation would be inaccurate.)
+    """
+
+    id: int
+    type: str
+    published: Any
+    subject_identity: Any
+    subject_identity_id: int
+    subject_post: Any
+
+
+class FeedEventGroup:
+    """Presentation-only collapse of consecutive same-author mark events.
+
+    Not persisted. Duck-types the parts of ``takahe.models.TimelineEvent`` that
+    ``feed_events.html`` touches, so the template can branch on ``is_group``.
+    """
+
+    is_group = True
+    type = "post"
+
+    def __init__(self, events: Sequence[FeedEvent]) -> None:
+        # events are newest-first, matching the feed query (order_by -id).
+        self.events = events
+        first = events[0]
+        self.identity = first.subject_identity
+        self.author = first.subject_post.author
+        self.published = first.published
+        self.posts = [e.subject_post for e in events]
+        # Distinct marked items, newest-first (re-shelving can link several posts
+        # to the same item over time; dedupe so a cover is not shown twice).
+        seen: set[int] = set()
+        items: list = []
+        for post in self.posts:
+            item = getattr(post, "item", None)
+            if item is not None and item.pk not in seen:
+                seen.add(item.pk)
+                items.append(item)
+        self.items = items
+        self.count = len(items)
+
+    @property
+    def pk(self) -> int:
+        # Oldest underlying event id. The HTMX "load more" sentinel uses the last
+        # rendered row's pk as ?last=<id> and the view filters id__lt=<id>, so the
+        # cursor must be the smallest id in the group to continue without skips.
+        return min(e.id for e in self.events)
+
+
+def _is_mark_event(event: FeedEvent) -> bool:
+    """True for a (non-boost) post whose piece is a shelf mark."""
+    if getattr(event, "type", None) != "post":
+        return False
+    post = getattr(event, "subject_post", None)
+    if post is None:
+        return False
+    piece = getattr(post, "piece", None)  # attached by prefetch_pieces_for_posts
+    return piece is not None and getattr(piece, "classname", None) == "shelfmember"
+
+
+def _has_comment(event: FeedEvent) -> bool:
+    """True if the mark post carries a written comment.
+
+    Detected from the already-loaded ``type_data`` (no extra queries): a comment
+    appears as a ``{"type": "Comment", ...}`` entry in
+    ``type_data["object"]["relatedWith"]`` (see ``ShelfMember.get_ap_data``).
+    """
+    post = getattr(event, "subject_post", None)
+    type_data = getattr(post, "type_data", None)
+    obj = type_data.get("object") if isinstance(type_data, dict) else None
+    related = obj.get("relatedWith") if isinstance(obj, dict) else None
+    if not isinstance(related, list):
+        return False
+    return any(isinstance(r, dict) and r.get("type") == "Comment" for r in related)
+
+
+def _groupable(event: FeedEvent) -> bool:
+    if not _is_mark_event(event):
+        return False
+    if GROUP_STANDALONE_COMMENTED and _has_comment(event):
+        return False
+    return True
+
+
+def group_feed_events(
+    events: Sequence[FeedEvent],
+) -> list[FeedEvent | FeedEventGroup]:
+    """Collapse maximal runs of consecutive same-author groupable mark events.
+
+    A run of length >= ``GROUP_THRESHOLD`` becomes one :class:`FeedEventGroup`;
+    everything else (boosts, notes, reviews, articles, replies, commented marks,
+    and sub-threshold runs) passes through unchanged and in order. A run is broken
+    by a different author, a non-mark post, a boost, or a commented mark.
+
+    Grouping is intentionally per page: the view fetches a fixed ``PAGE_SIZE``
+    slice and we group only within it. A burst larger than a page naturally splits
+    across pages ("cap and split"), which keeps the query cost fixed and the HTMX
+    cursor trivially correct (``FeedEventGroup.pk`` returns the oldest id).
+    """
+    result: list[FeedEvent | FeedEventGroup] = []
+    i = 0
+    n = len(events)
+    while i < n:
+        event = events[i]
+        if not _groupable(event):
+            result.append(event)
+            i += 1
+            continue
+        author_id = event.subject_identity_id
+        j = i + 1
+        while (
+            j < n
+            and _groupable(events[j])
+            and events[j].subject_identity_id == author_id
+        ):
+            j += 1
+        run = events[i:j]
+        if len(run) >= GROUP_THRESHOLD:
+            result.append(FeedEventGroup(run))
+        else:
+            result.extend(run)
+        i = j
+    return result

--- a/social/templates/_event_mark_group.html
+++ b/social/templates/_event_mark_group.html
@@ -1,0 +1,43 @@
+{% load i18n %}
+{% load duration %}
+<section class="activity post mark-group">
+  <div style="display:flex;">
+    <div>
+      <div class="avatar" style="margin:0.6em 0.6em 0.6em 0;">
+        <a href="{{ group.author.url }}">
+          <img src="{{ group.author.local_icon_url }}"
+               alt="@{{ group.author.handle }}">
+        </a>
+      </div>
+    </div>
+    <div style="flex-grow:1;">
+      <span class="action">
+        <span class="post_timestamp">{{ group.published|naturaldelta }}</span>
+      </span>
+      <span class="post_author">
+        <a href="{{ group.author.url }}"
+           class="nickname"
+           title="@{{ group.author.handle }}">{{ group.author.name|default:group.author.username }}</a>
+        {% blocktrans count counter=group.count %}marked {{ counter }} item{% plural %}marked {{ counter }} items{% endblocktrans %}
+      </span>
+      <div class="mark-group-covers"
+           style="display:flex;
+                  overflow-x:auto;
+                  gap:0.5em;
+                  padding:0.4em 0">
+        {% for item in group.items %}
+          <a href="{{ item.url }}"
+             title="{{ item.display_title }}"
+             style="flex:0 0 auto">
+            <img src="{{ item.cover_image_url|default:default_cover_url|relative_uri }}"
+                 alt="{% trans 'cover' %}"
+                 loading="lazy"
+                 style="height:120px;
+                        width:auto;
+                        border-radius:4px">
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</section>

--- a/social/templates/_event_mark_group.html
+++ b/social/templates/_event_mark_group.html
@@ -12,7 +12,13 @@
     </div>
     <div style="flex-grow:1;">
       <span class="action">
-        <span class="post_timestamp">{{ group.published|naturaldelta }}</span>
+        <span class="post_timestamp timestamp">{{ group.published|naturaldelta }}</span>
+        <span>
+          <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
+        </span>
+        <span>
+          <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
+        </span>
       </span>
       <span class="post_author">
         <a href="{{ group.author.url }}"
@@ -21,14 +27,6 @@
         {% blocktrans count counter=group.count %}marked {{ counter }} item{% plural %}marked {{ counter }} items{% endblocktrans %}
       </span>
       <div class="shelf">
-        <span class="action">
-          <span>
-            <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
-          </span>
-          <span>
-            <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
-          </span>
-        </span>
         <ul class="cards mark-group-covers">
           {% for item in group.items %}
             <li class="card">

--- a/social/templates/_event_mark_group.html
+++ b/social/templates/_event_mark_group.html
@@ -20,23 +20,27 @@
            title="@{{ group.author.handle }}">{{ group.author.name|default:group.author.username }}</a>
         {% blocktrans count counter=group.count %}marked {{ counter }} item{% plural %}marked {{ counter }} items{% endblocktrans %}
       </span>
-      <div class="mark-group-covers"
-           style="display:flex;
-                  overflow-x:auto;
-                  gap:0.5em;
-                  padding:0.4em 0">
-        {% for item in group.items %}
-          <a href="{{ item.url }}"
-             title="{{ item.display_title }}"
-             style="flex:0 0 auto">
-            <img src="{{ item.cover_image_url|default:default_cover_url|relative_uri }}"
-                 alt="{% trans 'cover' %}"
-                 loading="lazy"
-                 style="height:120px;
-                        width:auto;
-                        border-radius:4px">
-          </a>
-        {% endfor %}
+      <div class="shelf">
+        <span class="action">
+          <span>
+            <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
+          </span>
+          <span>
+            <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
+          </span>
+        </span>
+        <ul class="cards mark-group-covers">
+          {% for item in group.items %}
+            <li class="card">
+              <a href="{{ item.url }}" title="{{ item.display_title }}">
+                <img src="{{ item.cover_image_url|default:default_cover_url|relative_uri }}"
+                     alt="{{ item.display_title }}"
+                     loading="lazy">
+                <div>{{ item.display_title }}</div>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
       </div>
     </div>
   </div>

--- a/social/templates/feed_events.html
+++ b/social/templates/feed_events.html
@@ -8,7 +8,11 @@
 {% load user_actions %}
 {% load duration %}
 {% for event in events %}
-  {% include "_event_post.html" with post=event.subject_post piece=event.subject_post.piece item=event.subject_post.item %}
+  {% if event.is_group %}
+    {% include "_event_mark_group.html" with group=event %}
+  {% else %}
+    {% include "_event_post.html" with post=event.subject_post piece=event.subject_post.piece item=event.subject_post.item %}
+  {% endif %}
   {% if forloop.last %}
     <div class="htmx-indicator"
          style="margin-left: 60px"

--- a/social/views.py
+++ b/social/views.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
@@ -10,6 +12,7 @@ from common.models.misc import int_
 from journal.models import CrosspostRetry, Piece, ShelfType
 from journal.models.common import prefetch_pieces_for_posts
 from journal.search import JournalIndex, JournalQueryParser
+from social.feed_grouping import FeedEvent, group_feed_events
 from takahe.models import Post, PostInteraction, TimelineEvent
 from takahe.utils import Takahe
 from users.models import APIdentity
@@ -174,10 +177,13 @@ def data(request):
     )
     _add_interaction_to_events(events, identity_id)
     prefetch_pieces_for_posts([e.subject_post for e in events if e.subject_post_id])
+    # events are TimelineEvent rows; the type checker can't see Django's implicit
+    # id/_id attributes that FeedEvent declares, so assert the shape at this boundary.
+    grouped = group_feed_events(cast(list[FeedEvent], events))
     return render(
         request,
         "feed_events.html",
-        {"feed_type": typ, "events": events},
+        {"feed_type": typ, "events": grouped},
     )
 
 

--- a/tests/social/test_feed_grouping.py
+++ b/tests/social/test_feed_grouping.py
@@ -1,0 +1,249 @@
+"""Tests for collapsing consecutive same-author mark posts in the home feed."""
+
+import pytest
+
+from social.feed_grouping import (
+    GROUP_THRESHOLD,
+    FeedEventGroup,
+    group_feed_events,
+)
+
+# --- lightweight fakes for the pure-function grouping tests (no DB needed) ---
+
+
+class _Item:
+    def __init__(self, pk: int) -> None:
+        self.pk = pk
+
+
+class _Piece:
+    def __init__(self, classname: str) -> None:
+        self.classname = classname
+
+
+class _Post:
+    def __init__(
+        self, author_id: int, classname: str | None, item_pk: int, comment: bool
+    ) -> None:
+        self.author = author_id
+        self.piece = _Piece(classname) if classname else None
+        self.item = _Item(item_pk)
+        related: list = [{"type": "Status"}]
+        if comment:
+            related.append({"type": "Comment"})
+        self.type_data = {"object": {"relatedWith": related}}
+
+
+class _Event:
+    def __init__(
+        self,
+        id: int,
+        author_id: int = 1,
+        *,
+        type: str = "post",
+        classname: str | None = "shelfmember",
+        item_pk: int | None = None,
+        comment: bool = False,
+    ) -> None:
+        self.id = id
+        self.subject_identity_id = author_id
+        self.subject_identity = author_id
+        self.published = None
+        self.type = type
+        self.subject_post = _Post(
+            author_id, classname, item_pk if item_pk is not None else id, comment
+        )
+
+
+def mark(
+    id: int, author_id: int = 1, *, item_pk: int | None = None, comment: bool = False
+) -> _Event:
+    return _Event(id, author_id, item_pk=item_pk, comment=comment)
+
+
+def boost(id: int, author_id: int = 1) -> _Event:
+    return _Event(id, author_id, type="boost")
+
+
+def note(id: int, author_id: int = 1) -> _Event:
+    return _Event(id, author_id, classname="note")
+
+
+def review(id: int, author_id: int = 1) -> _Event:
+    return _Event(id, author_id, classname="review")
+
+
+def _types(result: list) -> list:
+    """Map a grouping result to a readable shape: 'group(n)' or the event id."""
+    out = []
+    for r in result:
+        if isinstance(r, FeedEventGroup):
+            out.append(f"group({len(r.events)})")
+        else:
+            out.append(r.id)
+    return out
+
+
+class TestGroupFeedEvents:
+    def test_run_at_threshold_groups(self):
+        events = [mark(30), mark(20), mark(10)]  # newest-first
+        result = group_feed_events(events)
+        assert len(result) == 1
+        group = result[0]
+        assert isinstance(group, FeedEventGroup)
+        assert group.count == 3
+        assert group.is_group is True
+
+    def test_below_threshold_passes_through(self):
+        events = [mark(20), mark(10)]
+        result = group_feed_events(events)
+        assert _types(result) == [20, 10]
+        assert not any(isinstance(r, FeedEventGroup) for r in result)
+
+    def test_threshold_constant_is_three(self):
+        assert GROUP_THRESHOLD == 3
+
+    def test_pk_is_oldest_event_id(self):
+        events = [mark(30), mark(20), mark(10)]
+        group = group_feed_events(events)[0]
+        assert isinstance(group, FeedEventGroup)
+        assert group.pk == 10  # smallest id -> correct ?last= cursor
+
+    def test_author_change_breaks_run(self):
+        # two short runs by different authors -> neither reaches threshold
+        events = [mark(40, 1), mark(30, 1), mark(20, 2), mark(10, 2)]
+        result = group_feed_events(events)
+        assert _types(result) == [40, 30, 20, 10]
+
+    def test_two_full_runs_by_different_authors(self):
+        events = [
+            mark(60, 1),
+            mark(50, 1),
+            mark(40, 1),
+            mark(30, 2),
+            mark(20, 2),
+            mark(10, 2),
+        ]
+        result = group_feed_events(events)
+        assert _types(result) == ["group(3)", "group(3)"]
+
+    def test_boost_breaks_run(self):
+        events = [mark(50), mark(40), boost(30), mark(20), mark(10)]
+        # two sub-threshold runs split by a boost -> nothing groups
+        result = group_feed_events(events)
+        assert _types(result) == [50, 40, 30, 20, 10]
+
+    def test_boost_separates_two_groups(self):
+        events = [
+            mark(70),
+            mark(60),
+            mark(50),
+            boost(40),
+            mark(30),
+            mark(20),
+            mark(10),
+        ]
+        result = group_feed_events(events)
+        assert _types(result) == ["group(3)", 40, "group(3)"]
+
+    def test_note_and_review_break_runs(self):
+        events = [mark(50), mark(40), note(30), review(20), mark(10)]
+        result = group_feed_events(events)
+        assert _types(result) == [50, 40, 30, 20, 10]
+
+    def test_commented_mark_stays_standalone_and_breaks_run(self):
+        events = [
+            mark(70),
+            mark(60),
+            mark(50),
+            mark(40, comment=True),
+            mark(30),
+            mark(20),
+            mark(10),
+        ]
+        result = group_feed_events(events)
+        assert _types(result) == ["group(3)", 40, "group(3)"]
+
+    def test_commented_marks_do_not_group(self):
+        events = [
+            mark(30, comment=True),
+            mark(20, comment=True),
+            mark(10, comment=True),
+        ]
+        result = group_feed_events(events)
+        assert _types(result) == [30, 20, 10]
+
+    def test_dedupe_items_in_group(self):
+        # three events, two reference the same catalog item
+        events = [
+            mark(30, item_pk=100),
+            mark(20, item_pk=100),
+            mark(10, item_pk=200),
+        ]
+        group = group_feed_events(events)[0]
+        assert isinstance(group, FeedEventGroup)
+        assert len(group.events) == 3
+        assert group.count == 2  # distinct items
+        assert [it.pk for it in group.items] == [100, 200]
+
+    def test_empty_input(self):
+        assert group_feed_events([]) == []
+
+    def test_single_mark_passes_through(self):
+        events = [mark(10)]
+        result = group_feed_events(events)
+        assert _types(result) == [10]
+
+
+# --- integration test against the real /timeline/data view ---
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+class TestFeedGroupingIntegration:
+    def _make_user(self, email: str, username: str):
+        from users.models import User
+
+        return User.register(email=email, username=username)
+
+    def test_bulk_comment_less_marks_render_as_one_group(self):
+        from django.test import Client
+
+        from catalog.models import Edition
+        from journal.models import Mark, ShelfType
+
+        user = self._make_user("grouping@example.com", "grouper")
+        books = [Edition.objects.create(title=f"Group Book {i}") for i in range(5)]
+        for book in books:
+            Mark(user.identity, book).update(ShelfType.WISHLIST, visibility=0)
+
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get("/timeline/data")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        # the 5 marks collapse into exactly one group card
+        assert content.count('class="activity post mark-group"') == 1
+        # all five covers are present in the carousel
+        assert content.count("mark-group-covers") == 1
+        for book in books:
+            assert book.display_title in content
+
+    def test_few_marks_are_not_grouped(self):
+        from django.test import Client
+
+        from catalog.models import Edition
+        from journal.models import Mark, ShelfType
+
+        user = self._make_user("nogroup@example.com", "ungrouped")
+        books = [Edition.objects.create(title=f"Solo Book {i}") for i in range(2)]
+        for book in books:
+            Mark(user.identity, book).update(ShelfType.WISHLIST, visibility=0)
+
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get("/timeline/data")
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "mark-group" not in content


### PR DESCRIPTION
## Context

From a known UX issue raised on the fediverse ([discussion](https://mastodon.social/@neodb/116716128752536872)): when a user bulk-marks many items (e.g. importing from Douban/Goodreads, or marking a batch quickly), the in-app home feed ("好友动态") shows **one card per mark**, flooding followers. The maintainer noted this is a known issue to improve, possibly with a Phanpy-style grouped presentation.

## What this does

Collapses a run of **3+ consecutive same-author mark posts** in the home feed into a single **"marked N items"** card with a horizontal cover carousel.

- **Presentation-only**: operates on the already-fetched events in `social.views.data`; nothing about the underlying posts or their ActivityPub representation changes.
- **Threshold**: runs of 1–2 marks render individually, unchanged.
- **Comments preserved**: a mark carrying a written comment renders on its own (and breaks a run), so authored text is never hidden inside a group (toggle via `GROUP_STANDALONE_COMMENTED`).
- **Pagination**: grouping is per page (`PAGE_SIZE`), so a burst larger than a page splits across pages ("cap and split") while the HTMX "load more" cursor stays correct (`FeedEventGroup.pk` returns the oldest underlying event id).
- A run is broken by a different author, a non-mark post (note/review/article/reply), a boost, or a commented mark.

## Files

- `social/feed_grouping.py` (new) — `group_feed_events`, `FeedEventGroup`, and a `FeedEvent` Protocol for the duck-typed input
- `social/views.py` — wire grouping into `data()`
- `social/templates/_event_mark_group.html` (new) — grouped card with cover carousel
- `social/templates/feed_events.html` — branch on `event.is_group`
- `tests/social/test_feed_grouping.py` (new) — 14 unit + 2 integration tests
- `locale/django.pot`, `locale/zh_Hans/.../django.po` — one new translatable phrase

## Testing

- `pytest tests/social/test_feed_grouping.py` — 16 passing (incl. 2 integration tests hitting `/timeline/data`: a comment-less burst collapses into one group card; a small batch stays individual).
- `pre-commit run` clean across all hooks (ruff, ruff-format, djLint, ty, check-ast, …).
- Manually verified against a seeded dev instance: a 6-mark run renders as one "marked 6 items" carousel card, with the commented mark and sub-threshold marks shown individually.
