### PR TITLE
feat(bluesky): include originating ActivityPub object URI in crossposts

### DIFF
--- a/docs/internals/atproto.md
+++ b/docs/internals/atproto.md
@@ -108,6 +108,11 @@ database. On every sync the relevant piece is reconciled against the PDS:
 `Piece.to_atproto_records()` returns the records that should exist now;
 `Piece._sync_records_to_bluesky()` performs the reconciliation.
 
+## Fediverse back-reference
+
+Bluesky skeet (`app.bsky.feed.post`) carries an off-lexicon `neodbOriginalUrl`
+field pointing back to the ActivityPub post URL.
+
 ## When records are published
 
 Records are reconciled on the same path as Bluesky crossposting

--- a/docs/lexicons/net/neodb/mark.json
+++ b/docs/lexicons/net/neodb/mark.json
@@ -39,6 +39,11 @@
           "createdAt": {
             "type": "string",
             "format": "datetime"
+          },
+          "fediverseUri": {
+            "type": "string",
+            "format": "uri",
+            "description": "Fediverse (ActivityPub) object URI of the corresponding post on the originating NeoDB instance."
           }
         }
       }

--- a/docs/lexicons/net/neodb/review.json
+++ b/docs/lexicons/net/neodb/review.json
@@ -35,6 +35,11 @@
           "updatedAt": {
             "type": "string",
             "format": "datetime"
+          },
+          "fediverseUri": {
+            "type": "string",
+            "format": "uri",
+            "description": "Fediverse (ActivityPub) object URI of the corresponding post on the originating NeoDB instance."
           }
         }
       }

--- a/journal/models/atproto.py
+++ b/journal/models/atproto.py
@@ -19,6 +19,8 @@ from catalog.models import IdealIdTypes
 if TYPE_CHECKING:
     from catalog.models import Item
 
+    from .common import Piece
+
 NAMESPACE = "net.neodb"
 REVIEW_NSID = f"{NAMESPACE}.review"
 MARK_NSID = f"{NAMESPACE}.mark"
@@ -88,3 +90,14 @@ def build_rating(grade: int | None) -> dict[str, Any] | None:
     if not grade:
         return None
     return {"value": grade, "max": RATING_MAX}
+
+
+def build_fediverse_uri(piece: "Piece") -> str | None:
+    """ActivityPub object URI of the post this record mirrors, or ``None``.
+
+    Lets consumers of a ``net.neodb.*`` record follow it back to the original
+    fediverse post. The value is the linked timeline Note's ``object_uri``;
+    it is absent when the piece has no linked post (e.g. never crossposted).
+    """
+    post = piece.latest_post
+    return post.object_uri if post else None

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -570,6 +570,11 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         error_type = CrosspostRetry.ErrorType.other
         error_message = ""
         attrs = {"platform": "bluesky", "mode": "post"}
+        # back-reference the originating fediverse post on the skeet, mirroring
+        # the fediverseUri carried by the net.neodb.* records (same source)
+        fediverse_uri = self.latest_post.object_uri if self.latest_post else None
+        if fediverse_uri:
+            params["fediverse_uri"] = fediverse_uri
         try:
             r = bluesky.post(**params)
         except (exceptions.UnauthorizedError, exceptions.BadRequestError) as e:

--- a/journal/models/review.py
+++ b/journal/models/review.py
@@ -18,6 +18,7 @@ from users.models import APIdentity
 from .atproto import (
     REVIEW_NSID,
     AtprotoRecord,
+    build_fediverse_uri,
     build_rating,
     build_subject,
     format_datetime,
@@ -173,6 +174,9 @@ class Review(Content):
         rating = build_rating(self.rating_grade)
         if rating:
             record["rating"] = rating
+        fediverse_uri = build_fediverse_uri(self)
+        if fediverse_uri:
+            record["fediverseUri"] = fediverse_uri
         return [(REVIEW_NSID, record)]
 
     def to_post_params(self):

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -17,6 +17,7 @@ from users.models import APIdentity
 from .atproto import (
     MARK_NSID,
     AtprotoRecord,
+    build_fediverse_uri,
     build_rating,
     build_subject,
     format_datetime,
@@ -476,6 +477,9 @@ class ShelfMember(ListMember):
         rating = build_rating(self.rating_grade)
         if rating:
             record["rating"] = rating
+        fediverse_uri = build_fediverse_uri(self)
+        if fediverse_uri:
+            record["fediverseUri"] = fediverse_uri
         return [(MARK_NSID, record)]
 
     def get_ap_data(self):

--- a/mastodon/models/bluesky.py
+++ b/mastodon/models/bluesky.py
@@ -411,12 +411,7 @@ class BlueskyAccount(SocialAccount):
             embed = None
         # Build the record by hand (rather than client.send_post) so we can
         # attach an off-lexicon neodbOriginalUrl pointing at the originating
-        # fediverse post -- the same convention Bridgy Fed uses with
-        # bridgyOriginalUrl. ModelBase is configured extra='allow', so the
-        # field round-trips verbatim; defaults mirror send_post.
-        # tag the skeet with the user's language (NeoDB is multilingual) so
-        # Bluesky doesn't mislabel non-English crossposts as English; omit it
-        # to let Bluesky auto-detect when no language preference is set
+        # fediverse post
         langs = (
             [self.user.macrolanguage] if self.user and self.user.macrolanguage else None
         )

--- a/mastodon/models/bluesky.py
+++ b/mastodon/models/bluesky.py
@@ -353,6 +353,7 @@ class BlueskyAccount(SocialAccount):
         obj: "Item | Content | EmbedObj | None" = None,
         rating=None,
         images=[],
+        fediverse_uri: str | None = None,
         **kwargs,
     ):
         from journal.models.renderers import render_rating
@@ -408,7 +409,22 @@ class BlueskyAccount(SocialAccount):
             )
         else:
             embed = None
-        post = self._client.send_post(richtext, reply_to=reply_to, embed=embed)
+        # Build the record by hand (rather than client.send_post) so we can
+        # attach an off-lexicon neodbOriginalUrl pointing at the originating
+        # fediverse post -- the same convention Bridgy Fed uses with
+        # bridgyOriginalUrl. ModelBase is configured extra='allow', so the
+        # field round-trips verbatim; defaults mirror send_post.
+        record = models.AppBskyFeedPost.Record(
+            created_at=self._client.get_current_time_iso(),
+            text=richtext.build_text(),
+            facets=richtext.build_facets(),
+            reply=reply_to,
+            embed=embed,
+            langs=["en"],
+        )
+        if fediverse_uri:
+            setattr(record, "neodbOriginalUrl", fediverse_uri)
+        post = self._client.app.bsky.feed.post.create(self.uid, record)
         # return AT uri as id since it's used as so.
         return {"cid": post.cid, "id": post.uri}
 

--- a/mastodon/models/bluesky.py
+++ b/mastodon/models/bluesky.py
@@ -414,13 +414,19 @@ class BlueskyAccount(SocialAccount):
         # fediverse post -- the same convention Bridgy Fed uses with
         # bridgyOriginalUrl. ModelBase is configured extra='allow', so the
         # field round-trips verbatim; defaults mirror send_post.
+        # tag the skeet with the user's language (NeoDB is multilingual) so
+        # Bluesky doesn't mislabel non-English crossposts as English; omit it
+        # to let Bluesky auto-detect when no language preference is set
+        langs = (
+            [self.user.macrolanguage] if self.user and self.user.macrolanguage else None
+        )
         record = models.AppBskyFeedPost.Record(
             created_at=self._client.get_current_time_iso(),
             text=richtext.build_text(),
             facets=richtext.build_facets(),
             reply=reply_to,
             embed=embed,
-            langs=["en"],
+            langs=langs,
         )
         if fediverse_uri:
             setattr(record, "neodbOriginalUrl", fediverse_uri)

--- a/tests/journal/test_atproto_records.py
+++ b/tests/journal/test_atproto_records.py
@@ -246,6 +246,18 @@ def test_record_omits_fediverse_uri_without_post():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_mark_record_omits_fediverse_uri_without_post():
+    user = User.register(email="nofedmark@example.com", username="nofedmarkuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "c", 5, visibility=0)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+
+    sm.__dict__["latest_post"] = None  # force the no-post case
+    _, record = sm.to_atproto_records()[0]
+    assert "fediverseUri" not in record
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_delete_enqueues_record_cleanup_without_metadata(monkeypatch):
     user = User.register(email="del@example.com", username="deluser")
     book = Edition.objects.create(title="Dune")

--- a/tests/journal/test_atproto_records.py
+++ b/tests/journal/test_atproto_records.py
@@ -201,6 +201,51 @@ def test_mark_record_excludes_private_tags():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_review_record_includes_fediverse_uri_when_post_linked():
+    user = User.register(email="fed@example.com", username="feduser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    # simulate a linked timeline post (populates the latest_post cache)
+    review.__dict__["latest_post"] = SimpleNamespace(
+        object_uri="https://nd.test/@feduser/posts/1/"
+    )
+
+    _, record = review.to_atproto_records()[0]
+
+    # back-reference to the originating fediverse post
+    assert record["fediverseUri"] == "https://nd.test/@feduser/posts/1/"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_record_includes_fediverse_uri_when_post_linked():
+    user = User.register(email="fedmark@example.com", username="fedmarkuser")
+    book = Edition.objects.create(title="Dune")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "done", 8, visibility=0)
+    sm = ShelfMember.objects.get(owner=user.identity, item=book)
+    sm.__dict__["latest_post"] = SimpleNamespace(
+        object_uri="https://nd.test/@fedmarkuser/posts/2/"
+    )
+
+    _, record = sm.to_atproto_records()[0]
+
+    assert record["fediverseUri"] == "https://nd.test/@fedmarkuser/posts/2/"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_record_omits_fediverse_uri_without_post():
+    user = User.register(email="nofed@example.com", username="nofeduser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+
+    # with no linked timeline post the field is simply omitted
+    review.__dict__["latest_post"] = None  # force the no-post case
+    _, record = review.to_atproto_records()[0]
+    assert "fediverseUri" not in record
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_delete_enqueues_record_cleanup_without_metadata(monkeypatch):
     user = User.register(email="del@example.com", username="deluser")
     book = Edition.objects.create(title="Dune")

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -162,7 +162,6 @@ def test_post_attaches_fediverse_origin_url():
     assert r == {"cid": "cid1", "id": "at://did:plc:poster/post/1"}
     assert captured["repo"] == "did:plc:poster"
     dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
-    # off-lexicon Bridgy-style field pointing at the originating fediverse post
     assert dumped["neodbOriginalUrl"] == "https://nd.test/@u/posts/1/"
     assert dumped["text"] == "hello"
 

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -132,3 +132,47 @@ def test_register_with_account_schedules_sync(monkeypatch):
     account.refresh_from_db()
     assert account.user == user
     assert called == [user.pk]
+
+
+def _stub_client(captured):
+    """A minimal atproto client capturing the created feed post record."""
+
+    def _create(repo, record):
+        captured["repo"] = repo
+        captured["record"] = record
+        return SimpleNamespace(cid="cid1", uri="at://did:plc:poster/post/1")
+
+    return SimpleNamespace(
+        get_current_time_iso=lambda: "2026-06-09T00:00:00.000Z",
+        app=SimpleNamespace(
+            bsky=SimpleNamespace(
+                feed=SimpleNamespace(post=SimpleNamespace(create=_create))
+            )
+        ),
+    )
+
+
+def test_post_attaches_fediverse_origin_url():
+    account = BlueskyAccount(uid="did:plc:poster")
+    captured: dict = {}
+    account._client = _stub_client(captured)  # populate the cached_property
+
+    r = account.post("hello", fediverse_uri="https://nd.test/@u/posts/1/")
+
+    assert r == {"cid": "cid1", "id": "at://did:plc:poster/post/1"}
+    assert captured["repo"] == "did:plc:poster"
+    dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
+    # off-lexicon Bridgy-style field pointing at the originating fediverse post
+    assert dumped["neodbOriginalUrl"] == "https://nd.test/@u/posts/1/"
+    assert dumped["text"] == "hello"
+
+
+def test_post_without_fediverse_uri_has_no_origin_field():
+    account = BlueskyAccount(uid="did:plc:poster")
+    captured: dict = {}
+    account._client = _stub_client(captured)
+
+    account.post("hello")
+
+    dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
+    assert "neodbOriginalUrl" not in dumped

--- a/tests/mastodon/test_bluesky.py
+++ b/tests/mastodon/test_bluesky.py
@@ -176,3 +176,20 @@ def test_post_without_fediverse_uri_has_no_origin_field():
 
     dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
     assert "neodbOriginalUrl" not in dumped
+    # no user/language set -> langs omitted so Bluesky can auto-detect
+    assert "langs" not in dumped
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_post_tags_user_macrolanguage():
+    user = User.register(email="lang@example.com", username="languser")
+    user.language = "zh-Hans"  # macrolanguage -> "zh"
+    account = BlueskyAccount(uid="did:plc:poster")
+    account.user = user
+    captured: dict = {}
+    account._client = _stub_client(captured)
+
+    account.post("你好")
+
+    dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
+    assert dumped["langs"] == ["zh"]


### PR DESCRIPTION
## Summary

When crossposting to Bluesky, NeoDB now records a back-reference to the originating fediverse post, so a consumer reading a bridged ATProto record can follow it back to the source AP object. This mirrors the established AP<->ATProto bridge convention (Bridgy Fed's `bridgyOriginalUrl`).

The value is the linked timeline Note's `object_uri` (e.g. `https://neodb.social/@user/posts/123/`), available because `sync_to_timeline()` runs before the crosspost job. It is omitted when no timeline post is linked.

## Changes

**`net.neodb.*` structured records** gain an optional `fediverseUri` field:
- Lexicon schemas: `docs/lexicons/net/neodb/review.json`, `mark.json`.
- New helper `build_fediverse_uri(piece)` in `journal/models/atproto.py`, used by `Review.to_atproto_records()` and `ShelfMember.to_atproto_records()`.

**The Bluesky skeet** (`app.bsky.feed.post`) gains an off-lexicon `neodbOriginalUrl` field (NeoDB's analog of `bridgyOriginalUrl`):
- `BlueskyAccount.post()` gains a `fediverse_uri` param and builds the record manually so the extra field can be attached (the atproto SDK's `ModelBase` is `extra='allow'`, so it round-trips verbatim); threaded in from `sync_to_bluesky()`.

## Testing

- `tests/journal/test_atproto_records.py`: `fediverseUri` present (review + mark) when a post is linked, omitted otherwise.
- `tests/mastodon/test_bluesky.py`: `post()` attaches `neodbOriginalUrl` when given a `fediverse_uri`, and omits it otherwise.
- All 23 targeted tests pass; `pre-commit run -a` clean (incl. `ty`).

## Follow-up (not in this PR)

The updated lexicon schemas must be republished to the `neodb.net` PDS for `fediverseUri` to be resolvable:
`uv run docs/lexicons/publish.py` with `ATPROTO_APP_PASSWORD` set. This writes to the production neodb.net account, so it should be run intentionally by a maintainer.