### PR TITLE
fix(catalog): reduce slow DB queries on people works and search

### DIFF
--- a/catalog/search/index.py
+++ b/catalog/search/index.py
@@ -54,7 +54,7 @@ class CatalogQueryParser(QueryParser):
         "query_by": "title, people, company, lookup_id, extra_title",
         "sort_by": "_text_match(bucket_size:20):desc,mark_count:desc",
         "per_page": 20,
-        "include_fields": "id, item_id",
+        "include_fields": "id, item_id, tag",
         "highlight_fields": "",
         "facet_by": "item_class",
     }
@@ -133,8 +133,21 @@ class CatalogSearchResult(SearchResult):
 
         if not self:
             return []
-        ids = [int(hit["document"]["id"]) for hit in self.response["hits"]]
-        return Item.get_final_items(Item.get_by_ids(ids))
+        hits = self.response["hits"]
+        ids = [int(hit["document"]["id"]) for hit in hits]
+        # Public tags are maintained in the index (Item.to_indexable_doc), so
+        # reuse them here instead of re-aggregating journal_tagmember per request
+        # (NEODB-SOCIAL-7KW). Keyed by the indexed item pk; merged items whose
+        # final pk differs keep the per-item ``Item.tags`` fallback.
+        tags_by_id = {
+            int(hit["document"]["id"]): (hit["document"].get("tag") or [])
+            for hit in hits
+        }
+        items = Item.get_final_items(Item.get_by_ids(ids))
+        for item in items:
+            if item.pk in tags_by_id:
+                item.tags = tags_by_id[item.pk]
+        return items
 
     def __iter__(self):
         return iter(self.items)

--- a/catalog/views/search.py
+++ b/catalog/views/search.py
@@ -275,7 +275,8 @@ def search(request):
         Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
     )
     Rating.attach_to_items(all_items)
-    Tag.attach_to_items(all_items)
+    # Public tags come from the search index (attached in CatalogSearchResult.items),
+    # so we skip the per-request journal_tagmember aggregation here (NEODB-SOCIAL-7KW).
     if request.user.is_authenticated:
         Mark.attach_to_items(request.user.identity, all_items, request.user)
     return render(

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -210,7 +210,15 @@ def people_works(request, item_path, item_uuid, role):
     if works_items:
         prefetch_related_objects(
             works_items,
-            "external_resources",
+            # Card partials only read url/site_name/site_label (derived from
+            # id_type/id_value), so skip the large metadata/other_lookup_ids
+            # JSON columns that made this prefetch a slow query (EGGPLANT-1DX).
+            Prefetch(
+                "external_resources",
+                queryset=ExternalResource.objects.only(
+                    "id", "item_id", "id_type", "id_value", "url"
+                ),
+            ),
             Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
         )
         Item.prefetch_parent_items(works_items)

--- a/tests/catalog/test_search_n_plus_one.py
+++ b/tests/catalog/test_search_n_plus_one.py
@@ -33,15 +33,22 @@ class TestSearchTVShowDedupNoNPlusOne:
             for i in range(1, 4)
         ]
 
-    def _patched_query_index(self, items_in_index):
+    def _patched_query_index(self, items_in_index, tags_by_pk=None):
         """Run ``query_index`` while the search index is mocked to return
         ``items_in_index``. Returns ``(items, captured_queries)``.
+
+        ``tags_by_pk`` optionally seeds the indexed ``tag`` field per item pk,
+        mirroring what Typesense returns for ``include_fields``.
         """
         # Build a CatalogSearchResult from a synthetic response so the real
         # ``CatalogSearchResult.items`` cached_property runs (which is what
         # exercises Item.get_by_ids polymorphic load).
+        tags_by_pk = tags_by_pk or {}
         response = {
-            "hits": [{"document": {"id": str(it.pk)}} for it in items_in_index],
+            "hits": [
+                {"document": {"id": str(it.pk), "tag": tags_by_pk.get(it.pk, [])}}
+                for it in items_in_index
+            ],
             "found": len(items_in_index),
             "page": 1,
             "request_params": {"per_page": 20, "q": "Sample"},
@@ -94,6 +101,36 @@ class TestSearchTVShowDedupNoNPlusOne:
             f"query_index fired {len(offending)} per-season catalog_tvshow "
             f"FK lookup(s); expected 0. First offending SQL: "
             f"{offending[0]['sql'] if offending else 'n/a'}"
+        )
+
+    def test_dupe_to_items_carry_indexed_tags_without_tagmember_query(self):
+        """NEODB-SOCIAL-7KW: dropping ``Tag.attach_to_items`` from the search
+        view must not reintroduce a per-``dupe_to`` tag query. ``dupe_to`` items
+        are members of ``CatalogSearchResult.items`` (the deduped result reuses
+        those same instances), so they already carry the indexed ``tag`` list.
+        """
+        tags = {self.seasons[0].pk: ["sci-fi"], self.show.pk: ["drama"]}
+        items, queries = self._patched_query_index(
+            [self.seasons[0], self.show], tags_by_pk=tags
+        )
+
+        # Primary item (season) and the show deduped onto its dupe_to both
+        # carry their indexed tags.
+        assert items[0].pk == self.seasons[0].pk
+        assert items[0].tags == ["sci-fi"]
+        dupes = getattr(items[0], "dupe_to", [])
+        assert [d.pk for d in dupes] == [self.show.pk]
+        # Reading the dupe's tags (as the template would) must not hit the DB.
+        with CaptureQueriesContext(connection) as ctx:
+            dupe_tags = dupes[0].tags
+        assert dupe_tags == ["drama"]
+        assert ctx.captured_queries == []
+
+        # And nothing in the whole query_index path aggregated journal_tagmember.
+        offending = [q for q in queries if "journal_tagmember" in q["sql"]]
+        assert offending == [], (
+            "query_index fired a journal_tagmember aggregation; dupe_to tags "
+            f"should come from the index. First: {offending[0]['sql'] if offending else 'n/a'}"
         )
 
 

--- a/tests/catalog/test_search_n_plus_one.py
+++ b/tests/catalog/test_search_n_plus_one.py
@@ -7,7 +7,7 @@ import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
-from catalog.models import TVSeason, TVShow
+from catalog.models import Edition, TVSeason, TVShow
 from catalog.search.index import CatalogIndex, CatalogSearchResult
 from catalog.search.utils import query_index
 
@@ -95,3 +95,45 @@ class TestSearchTVShowDedupNoNPlusOne:
             f"FK lookup(s); expected 0. First offending SQL: "
             f"{offending[0]['sql'] if offending else 'n/a'}"
         )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSearchReusesIndexedTags:
+    """NEODB-SOCIAL-7KW: ``CatalogSearchResult.items`` attaches the public tags
+    stored in the search index onto each item, so search no longer re-aggregates
+    ``journal_tagmember`` (a slow query for heavily-tagged items) per request.
+    """
+
+    def _result(self, document):
+        response = {
+            "hits": [{"document": document}],
+            "found": 1,
+            "page": 1,
+            "request_params": {"per_page": 20, "q": "x"},
+        }
+        mock_index = MagicMock(spec=CatalogIndex)
+        return CatalogSearchResult(mock_index, cast(Any, response))
+
+    def test_indexed_tags_attached_without_tagmember_query(self):
+        book = Edition.objects.create(title="Indexed Tags Book")
+        result = self._result({"id": str(book.pk), "tag": ["fiction", "scifi"]})
+        with CaptureQueriesContext(connection) as ctx:
+            items = result.items
+            tags = items[0].tags
+        assert [i.pk for i in items] == [book.pk]
+        assert tags == ["fiction", "scifi"]
+        offending = [q for q in ctx.captured_queries if "journal_tagmember" in q["sql"]]
+        assert offending == [], (
+            "search hydration fired a journal_tagmember aggregation; tags should "
+            f"come from the index. First offending SQL: {offending[0]['sql'] if offending else 'n/a'}"
+        )
+
+    def test_missing_tag_field_defaults_to_empty(self):
+        book = Edition.objects.create(title="No Tags Book")
+        result = self._result({"id": str(book.pk)})
+        with CaptureQueriesContext(connection) as ctx:
+            items = result.items
+            tags = items[0].tags
+        assert tags == []
+        offending = [q for q in ctx.captured_queries if "journal_tagmember" in q["sql"]]
+        assert offending == []


### PR DESCRIPTION
Addresses two Sentry **slow DB query** performance issues.

## EGGPLANT-1DX — `catalog_externalresource` prefetch on `/people/.../works/{role}`

`people_works` prefetched **every** `ExternalResource` column, including the large `metadata` / `other_lookup_ids` JSON blobs (full scraped payloads), even though the card partials (`_item_card*.html`) only render `url`, `site_name`, and `site_label` (derived from `id_type` / `id_value`). Transferring and deserializing those blobs for a page of items is what made the prefetch a slow query.

Fix: limit the prefetch to the columns actually used:

```python
Prefetch("external_resources",
         queryset=ExternalResource.objects.only("id", "item_id", "id_type", "id_value", "url"))
```

## NEODB-SOCIAL-7KW — tag-frequency aggregation on `/search`

`/search` called `Tag.attach_to_items`, which runs a `COUNT(parent__owner) ... GROUP BY item_id, title` over **every public `TagMember`** for the items on the page — slow for heavily-tagged items, on a hot path.

The same public-tag list is already maintained in the search index (`Item.to_indexable_doc` stores the `tag` field, produced by the same `deep_cleanup_title` logic). So instead of re-aggregating per request:

- add `tag` to the search `include_fields`;
- attach each hit's indexed `tag` list onto the hydrated item in `CatalogSearchResult.items` (merged items whose final pk differs keep the per-item `Item.tags` fallback);
- drop the now-redundant `Tag.attach_to_items(all_items)` call in the search view.

Display output is unchanged. The expensive aggregation stays where it already ran — the async reindexer — off the request path.

## Tests

- New `TestSearchReusesIndexedTags` in `tests/catalog/test_search_n_plus_one.py` asserts indexed tags are attached with no `journal_tagmember` query (and that a missing `tag` field defaults to `[]`).
- Verified locally: 125 tests pass across search (incl. `test_index.py` against live Typesense), `people_works`, tag, and N+1 suites; `pre-commit run -a` clean (ruff, format, djLint, ty).