### PR TITLE
fix(mastodon): detect star_mode by checking all star emojis during site check

### DIFF
--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -590,6 +590,8 @@ class MastodonApplication(models.Model):
             j = response.json()
             max_chars = (
                 j.get("configuration", {}).get("statuses", {}).get("max_characters")
+                if isinstance(j, dict)
+                else None
             )
             if max_chars:
                 self.max_status_len = max_chars
@@ -598,9 +600,9 @@ class MastodonApplication(models.Model):
         if response.status_code == 200:
             j = response.json()
             shortcodes = {
-                e.get("shortcode")
+                e["shortcode"]
                 for e in (j if isinstance(j, list) else [])
-                if isinstance(e, dict)
+                if isinstance(e, dict) and isinstance(e.get("shortcode"), str)
             }
             required = {
                 settings.STAR_SOLID.strip(":"),

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -582,7 +582,7 @@ class MastodonApplication(models.Model):
     def __str__(self):
         return self.domain_name
 
-    def detect_configurations(self):
+    def detect_configurations(self) -> None:
         api_domain = self.api_domain or self.domain_name
         url = f"https://{api_domain}/api/v1/instance"
         response = get(url, headers={"User-Agent": settings.NEODB_USER_AGENT})
@@ -597,8 +597,19 @@ class MastodonApplication(models.Model):
         response = get(url, headers={"User-Agent": settings.NEODB_USER_AGENT})
         if response.status_code == 200:
             j = response.json()
-            if next(filter(lambda e: e["shortcode"] == "star_half", j), None):
-                self.star_mode = 1
+            shortcodes = {
+                e.get("shortcode")
+                for e in (j if isinstance(j, list) else [])
+                if isinstance(e, dict)
+            }
+            required = {
+                settings.STAR_SOLID.strip(":"),
+                settings.STAR_HALF.strip(":"),
+                settings.STAR_EMPTY.strip(":"),
+            }
+            # use custom emoji only if every star used by render_rating exists,
+            # and reset to unicode if any was removed since last check
+            self.star_mode = 1 if required <= shortcodes else 0
 
     def verify(self):
         return verify_client(self)

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -173,10 +173,16 @@ class TestDetectConfigurations:
         response.json.return_value = json_data
         return response
 
-    def _detect(self, app: MastodonApplication, emoji_response: Mock) -> None:
-        instance_response = self._response(
-            200, {"configuration": {"statuses": {"max_characters": 1000}}}
-        )
+    def _detect(
+        self,
+        app: MastodonApplication,
+        emoji_response: Mock,
+        instance_response: Mock | None = None,
+    ) -> None:
+        if instance_response is None:
+            instance_response = self._response(
+                200, {"configuration": {"statuses": {"max_characters": 1000}}}
+            )
 
         def fake_get(url, **kwargs):
             if url.endswith("/api/v1/instance"):
@@ -216,3 +222,16 @@ class TestDetectConfigurations:
         app = MastodonApplication(domain_name="social.example")
         self._detect(app, self._response(200, []))
         assert app.max_status_len == 1000
+
+    def test_malformed_instance_payload_keeps_max_status_len(self):
+        app = MastodonApplication(domain_name="social.example")
+        self._detect(
+            app, self._response(200, []), instance_response=self._response(200, [])
+        )
+        assert app.max_status_len == 500
+
+    def test_emoji_entries_without_string_shortcode_ignored(self):
+        app = MastodonApplication(domain_name="social.example", star_mode=1)
+        emojis = [{"shortcode": None}, {"url": "x"}, "junk"]
+        self._detect(app, self._response(200, emojis))
+        assert app.star_mode == 0

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -1,7 +1,9 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.conf import settings
 
-from mastodon.models import MastodonAccount, Platform
+from mastodon.models import MastodonAccount, MastodonApplication, Platform
 from mastodon.models.mastodon import (
     TootVisibilityEnum,
     _force_recreate_app,
@@ -156,3 +158,61 @@ class TestMastodonAccount:
         # MastodonAccount.check_alive() uses network, but sync skips via sleep_hours logic
         result = self.account.sync(skip_graph=True, sleep_hours=24)
         assert result is False
+
+
+class TestDetectConfigurations:
+    STAR_CODES = [
+        settings.STAR_SOLID.strip(":"),
+        settings.STAR_HALF.strip(":"),
+        settings.STAR_EMPTY.strip(":"),
+    ]
+
+    def _response(self, status_code: int, json_data) -> Mock:
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = json_data
+        return response
+
+    def _detect(self, app: MastodonApplication, emoji_response: Mock) -> None:
+        instance_response = self._response(
+            200, {"configuration": {"statuses": {"max_characters": 1000}}}
+        )
+
+        def fake_get(url, **kwargs):
+            if url.endswith("/api/v1/instance"):
+                return instance_response
+            return emoji_response
+
+        with patch("mastodon.models.mastodon.get", side_effect=fake_get):
+            app.detect_configurations()
+
+    def test_all_star_emojis_enable_custom_mode(self):
+        app = MastodonApplication(domain_name="social.example")
+        emojis = [{"shortcode": c} for c in self.STAR_CODES]
+        self._detect(app, self._response(200, emojis))
+        assert app.star_mode == 1
+
+    def test_star_half_alone_keeps_unicode_mode(self):
+        app = MastodonApplication(domain_name="social.example")
+        self._detect(app, self._response(200, [{"shortcode": "star_half"}]))
+        assert app.star_mode == 0
+
+    def test_missing_emojis_reset_stale_custom_mode(self):
+        app = MastodonApplication(domain_name="social.example", star_mode=1)
+        self._detect(app, self._response(200, [{"shortcode": "stardewvalley"}]))
+        assert app.star_mode == 0
+
+    def test_unreachable_emoji_endpoint_keeps_existing_mode(self):
+        app = MastodonApplication(domain_name="social.example", star_mode=1)
+        self._detect(app, self._response(503, None))
+        assert app.star_mode == 1
+
+    def test_malformed_emoji_payload_resets_to_unicode(self):
+        app = MastodonApplication(domain_name="social.example", star_mode=1)
+        self._detect(app, self._response(200, {"error": "unexpected"}))
+        assert app.star_mode == 0
+
+    def test_max_status_len_updated_from_instance(self):
+        app = MastodonApplication(domain_name="social.example")
+        self._detect(app, self._response(200, []))
+        assert app.max_status_len == 1000


### PR DESCRIPTION
## Problem

Crossposted ratings can render as raw text like `:star_solid: :star_solid: :star_solid: :star_empty: :star_empty:` on instances that do not have these custom emojis (e.g. mastodon.social today has none of them).

Two causes in `MastodonApplication.detect_configurations()`:

- it only checked for the `star_half` shortcode, while `render_rating()` emits `:star_solid:`, `:star_half:` and `:star_empty:`;
- it could only upgrade `star_mode` to 1, never reset it to 0, so an instance that removed the emojis kept a stale `star_mode=1` forever.

## Change

- `detect_configurations()` now sets `star_mode = 1` only when all three shortcodes used by `render_rating` (derived from `settings.STAR_SOLID/STAR_HALF/STAR_EMPTY`) exist on the instance, and resets it to 0 otherwise. The daily `MastodonSiteCheck` refresh therefore both detects and self-heals stale sites.
- A failed `custom_emojis` request leaves the stored value unchanged; malformed payloads are handled defensively.
- Added `TestDetectConfigurations` covering: all emojis present, `star_half` alone (regression for the report above), stale-mode downgrade, unreachable endpoint, malformed payload, and `max_status_len` parsing.

## Test

- `pytest tests/mastodon/ tests/journal/test_renderers.py` passes (the 3 failures in `test_lexicons.py` are pre-existing: the test imports `/docs/lexicons/publish.py`, which is not mounted into the dev container after the repo layout change).
- `pre-commit run -a` passes.
