### PR TITLE
Publish site.standard.document records for Review and Article when crossposting to ATProto

### DIFF
--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -13,6 +13,7 @@ from markdownify import markdownify as md
 from takahe.utils import Takahe
 from users.models import APIdentity
 
+from .atproto import DOCUMENT_NSID, build_document
 from .common import Piece, VisibilityType
 from .renderers import render_md
 from .tag import Tag as TagModel
@@ -210,6 +211,21 @@ class Article(Piece):
             body += "..."
         content = f"{self.title}\n\n{body}\n\n{self.absolute_url}"
         return {"content": content, "spoiler_text": self.summary or None}
+
+    def atproto_document_collections(self) -> set[str]:
+        return {DOCUMENT_NSID}
+
+    def to_atproto_document(self) -> dict[str, Any]:
+        # display_summary carries the sensitive-content marker when set, so
+        # external previews keep the cue; fall back to the body excerpt
+        return build_document(
+            self,
+            title=self.title,
+            body=self.body,
+            text=self.plain_content,
+            description=self.display_summary or self.excerpt,
+            tags=self.normalized_tags,
+        )
 
     def to_indexable_doc(self) -> dict[str, Any]:
         return {

--- a/neodb/journal/models/atproto.py
+++ b/neodb/journal/models/atproto.py
@@ -40,6 +40,10 @@ MARKPUB_TEXT_NSID = "at.markpub.text"
 
 RATING_MAX = 10
 
+# the lexicon caps these fields in graphemes; enforcing the caps on
+# code-point length is strictly conservative (a grapheme is one or more
+# code points), so records stay within spec without a grapheme library --
+# at worst a pathological description is cut inside an emoji cluster
 DOCUMENT_DESCRIPTION_MAX_GRAPHEMES = 3000
 DOCUMENT_TAG_MAX_GRAPHEMES = 128
 

--- a/neodb/journal/models/atproto.py
+++ b/neodb/journal/models/atproto.py
@@ -141,8 +141,14 @@ def build_document_rkey(piece: "Piece") -> str:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=dt_timezone.utc)
     micros = (dt.astimezone(dt_timezone.utc) - _EPOCH) // timedelta(microseconds=1)
+    pk = piece.pk or 0
+    # mix the pk's high bits into the (sub-millisecond) timestamp and its low
+    # bits into the clock id, so pieces sharing one creation time (date-only
+    # backdated imports land on the exact same microsecond) can never derive
+    # the same key; clamp pre-1970 times to zero instead of mask-wrapping
+    micros = max(0, micros) + (pk >> _TID_CLOCKID_BITS)
     micros &= (1 << _TID_TIMESTAMP_BITS) - 1
-    clockid = (piece.pk or 0) % (1 << _TID_CLOCKID_BITS)
+    clockid = pk % (1 << _TID_CLOCKID_BITS)
     n = (micros << _TID_CLOCKID_BITS) | clockid
     chars = []
     for _ in range(_TID_LENGTH):

--- a/neodb/journal/models/atproto.py
+++ b/neodb/journal/models/atproto.py
@@ -5,14 +5,20 @@ namespace so other ATProto applications can read a user's NeoDB marks and
 reviews (with ratings embedded) directly from their repository. The lexicon
 definitions are documented under ``docs/lexicons/net/neodb/``.
 
+Long-form pieces (reviews and articles) are additionally published as
+``site.standard.document`` records (https://standard.site/) so generic
+ATProto publishing apps can read them; see :func:`build_document`.
+
 NeoDB catalog items are not themselves ATProto records, so a work is
 referenced inline via :func:`build_subject` (NeoDB permalink, source URLs
 and standardized identifiers) rather than a ``com.atproto.repo.strongRef``.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
 
 from catalog.models import IdealIdTypes
 
@@ -25,7 +31,23 @@ NAMESPACE = "net.neodb"
 REVIEW_NSID = f"{NAMESPACE}.review"
 MARK_NSID = f"{NAMESPACE}.mark"
 
+# standard.site lexicon (https://standard.site/docs/lexicons/document) for
+# long-form documents, plus the at.markpub.markdown convention carried in
+# the document's open ``content`` union (https://markpub.at/)
+DOCUMENT_NSID = "site.standard.document"
+MARKPUB_MARKDOWN_NSID = "at.markpub.markdown"
+MARKPUB_TEXT_NSID = "at.markpub.text"
+
 RATING_MAX = 10
+
+DOCUMENT_DESCRIPTION_MAX_GRAPHEMES = 3000
+DOCUMENT_TAG_MAX_GRAPHEMES = 128
+
+_TID_ALPHABET = "234567abcdefghijklmnopqrstuvwxyz"  # base32-sortable
+_TID_CLOCKID_BITS = 10
+_TID_TIMESTAMP_BITS = 53
+_TID_LENGTH = 13
+_EPOCH = datetime(1970, 1, 1, tzinfo=dt_timezone.utc)
 
 # (collection NSID, record body) for records that should currently exist.
 # The record key is derived centrally from Piece.atproto_rkey() (the piece's
@@ -101,3 +123,78 @@ def build_fediverse_uri(piece: "Piece") -> str | None:
     """
     post = piece.latest_post
     return post.object_uri if post else None
+
+
+def build_document_rkey(piece: "Piece") -> str:
+    """Deterministic TID record key for a piece's ``site.standard.document``.
+
+    The lexicon requires ``tid`` record keys, so the piece uuid (used for
+    ``net.neodb.*`` records) is not acceptable. A TID is derived from the
+    piece itself -- creation time as the timestamp bits, primary key as the
+    clock-id bits -- so it needs no stored state and stays idempotent across
+    sync retries. ``created_time`` is user-editable, so the first successful
+    sync freezes the key in ``metadata["atproto_document_rkey"]`` (see
+    ``Piece.atproto_document_rkey``) to keep later backdating from orphaning
+    the PDS record.
+    """
+    dt = piece.created_time
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=dt_timezone.utc)
+    micros = (dt.astimezone(dt_timezone.utc) - _EPOCH) // timedelta(microseconds=1)
+    micros &= (1 << _TID_TIMESTAMP_BITS) - 1
+    clockid = (piece.pk or 0) % (1 << _TID_CLOCKID_BITS)
+    n = (micros << _TID_CLOCKID_BITS) | clockid
+    chars = []
+    for _ in range(_TID_LENGTH):
+        chars.append(_TID_ALPHABET[n & 0x1F])
+        n >>= 5
+    return "".join(reversed(chars))
+
+
+def build_document(
+    piece: "Piece",
+    *,
+    title: str,
+    body: str,
+    text: str,
+    description: str = "",
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """``site.standard.document`` record for a long-form piece.
+
+    Published as a "loose" document: ``site`` is the instance base URL and
+    ``path`` the piece's local path, so ``site + path`` reconstructs the
+    canonical NeoDB URL. The full markdown ``body`` travels in the open
+    ``content`` union (``at.markpub.markdown``) next to the plaintext
+    ``textContent``, and the crossposted skeet (when one exists) is linked
+    via ``bskyPostRef`` so off-platform comments stay discoverable.
+    """
+    record: dict[str, Any] = {
+        "$type": DOCUMENT_NSID,
+        "site": settings.SITE_INFO["site_url"].rstrip("/"),
+        "path": piece.url,
+        "title": title,
+        "publishedAt": format_datetime(piece.created_time),
+        "textContent": text,
+        "content": {
+            "$type": MARKPUB_MARKDOWN_NSID,
+            "text": {"$type": MARKPUB_TEXT_NSID, "markdown": body},
+        },
+    }
+    # created_time is set at instantiation but edited_time at a later DB
+    # write, so they always differ by a sliver; only a real gap is an edit
+    if (
+        piece.edited_time
+        and (piece.edited_time - piece.created_time).total_seconds() > 1
+    ):
+        record["updatedAt"] = format_datetime(piece.edited_time)
+    if description:
+        record["description"] = description[:DOCUMENT_DESCRIPTION_MAX_GRAPHEMES]
+    if tags:
+        record["tags"] = [t for t in tags if len(t) <= DOCUMENT_TAG_MAX_GRAPHEMES]
+    metadata = getattr(piece, "metadata", None) or {}
+    post_uri = metadata.get("bluesky_id")
+    post_cid = metadata.get("bluesky_cid")
+    if post_uri and post_cid:
+        record["bskyPostRef"] = {"uri": post_uri, "cid": post_cid}
+    return record

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -34,6 +34,7 @@ from users.middlewares import activate_language_for_user
 from users.models import APIdentity, User
 
 from ..search import JournalIndex
+from .atproto import build_document_rkey
 from .crosspost import CrosspostRetry
 from .mixins import UserOwnedObjectMixin
 
@@ -155,6 +156,8 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         likes: models.QuerySet["Like"]
         metadata: models.JSONField[Any, Any]
         post_relations: models.QuerySet["PiecePost"]
+        created_time: models.DateTimeField[Any, Any]
+        edited_time: models.DateTimeField[Any, Any]
     url_path = "p"  # subclass must specify this
     uid = models.UUIDField(default=uuid.uuid4, editable=False, db_index=True)
     local = models.BooleanField(default=True)
@@ -371,6 +374,37 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         """
         return []
 
+    def atproto_document_collections(self) -> set[str]:
+        """Long-form document collections this piece manages on the PDS.
+
+        Long-form subclasses (review, article) return ``site.standard.document``
+        so standard.site-aware ATProto apps can read them. Unlike
+        :meth:`atproto_collections` these records are keyed by
+        :meth:`atproto_document_rkey` (a TID, as the lexicon requires).
+        The default manages nothing.
+        """
+        return set()
+
+    def atproto_document_rkey(self) -> str:
+        """Record key for this piece's ``site.standard.document``.
+
+        The TID frozen in ``metadata`` by the first successful sync, falling
+        back to the deterministic derivation when never synced -- so the key
+        survives a ``created_time`` edit once the record exists, yet needs no
+        stored state before then.
+        """
+        metadata = getattr(self, "metadata", None) or {}
+        return metadata.get("atproto_document_rkey") or build_document_rkey(self)
+
+    def to_atproto_document(self) -> "dict[str, Any] | None":
+        """``site.standard.document`` record that should currently exist on
+        the owner's PDS, or ``None``.
+
+        Long-form subclasses (review, article) override this; the default
+        publishes nothing.
+        """
+        return None
+
     @classmethod
     def update_by_ap_object(
         cls,
@@ -466,6 +500,10 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             [
                 [collection, self.atproto_rkey()]
                 for collection in self.atproto_collections()
+            ]
+            + [
+                [collection, self.atproto_document_rkey()]
+                for collection in self.atproto_document_collections()
             ]
             if self.owner.user_id and self.owner.user.bluesky
             else []
@@ -606,34 +644,74 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         return True
 
     def _sync_records_to_bluesky(self, bluesky, drop: bool = False):
-        """Reconcile this piece's net.neodb.* records on the owner's PDS.
+        """Reconcile this piece's ATProto records on the owner's PDS.
 
         For every collection the piece manages, the record is written (keyed
         by :meth:`atproto_rkey`, so put_record overwrites in place on edit)
         when present, or deleted otherwise -- including the case where the
         piece is no longer public (``drop``). No state is stored: records are
         reconstructable from the piece, and put/delete are both idempotent.
+
+        Long-form pieces also manage a ``site.standard.document`` record,
+        reconciled the same way but keyed by :meth:`atproto_document_rkey`
+        (a TID); see :meth:`_sync_document_to_bluesky`.
         """
         collections = self.atproto_collections()
+        if collections:
+            rkey = self.atproto_rkey()
+            try:
+                present = (
+                    {}
+                    if drop
+                    else {c: record for c, record in self.to_atproto_records()}
+                )
+            except Exception as e:
+                logger.warning(f"{self} build atproto records error {e}")
+                present = None
+            if present is not None:
+                for collection in collections:
+                    try:
+                        if collection in present:
+                            bluesky.put_record(collection, rkey, present[collection])
+                        else:
+                            bluesky.delete_record(collection, rkey)
+                    except Exception as e:
+                        logger.warning(
+                            f"{self} sync record {collection} to {bluesky} error {e}"
+                        )
+        self._sync_document_to_bluesky(bluesky, drop)
+
+    def _sync_document_to_bluesky(self, bluesky, drop: bool = False):
+        """Reconcile this piece's ``site.standard.document`` on the owner's PDS.
+
+        Written when the piece is public and :meth:`to_atproto_document`
+        yields a record, deleted otherwise. On first write the TID record
+        key is frozen in ``metadata["atproto_document_rkey"]`` (persisted by
+        the caller's metadata save) so a later ``created_time`` edit cannot
+        orphan the record.
+        """
+        collections = self.atproto_document_collections()
         if not collections:
             return
-        rkey = self.atproto_rkey()
-        try:
-            present = (
-                {} if drop else {c: record for c, record in self.to_atproto_records()}
-            )
-        except Exception as e:
-            logger.warning(f"{self} build atproto records error {e}")
-            return
+        document = None
+        if not drop:
+            try:
+                document = self.to_atproto_document()
+            except Exception as e:
+                logger.warning(f"{self} build atproto document error {e}")
+                return
+        rkey = self.atproto_document_rkey()
         for collection in collections:
             try:
-                if collection in present:
-                    bluesky.put_record(collection, rkey, present[collection])
+                if document:
+                    bluesky.put_record(collection, rkey, document)
+                    self.metadata.setdefault("atproto_document_rkey", rkey)
                 else:
                     bluesky.delete_record(collection, rkey)
+                    self.metadata.pop("atproto_document_rkey", None)
             except Exception as e:
                 logger.warning(
-                    f"{self} sync record {collection} to {bluesky} error {e}"
+                    f"{self} sync document {collection} to {bluesky} error {e}"
                 )
 
     def sync_to_threads(self, params, update_mode):

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -602,6 +602,10 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             if post_id:
                 try:
                     bluesky.delete_post(post_id)
+                    # the skeet is gone; drop the ids now so a failed repost
+                    # below cannot leave a stale bskyPostRef on the document
+                    self.metadata.pop("bluesky_id", None)
+                    self.metadata.pop("bluesky_cid", None)
                 except Exception as e:
                     logger.warning(f"Delete {bluesky} post {post_id} error {e}")
         r = None

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -16,8 +16,10 @@ from takahe.utils import Takahe
 from users.models import APIdentity
 
 from .atproto import (
+    DOCUMENT_NSID,
     REVIEW_NSID,
     AtprotoRecord,
+    build_document,
     build_fediverse_uri,
     build_rating,
     build_subject,
@@ -178,6 +180,21 @@ class Review(Content):
         if fediverse_uri:
             record["fediverseUri"] = fediverse_uri
         return [(REVIEW_NSID, record)]
+
+    def atproto_document_collections(self) -> set[str]:
+        return {DOCUMENT_NSID}
+
+    def to_atproto_document(self) -> dict[str, Any]:
+        # description is the spoiler-safe auto-summary ("a review of X"),
+        # not a body excerpt, so external previews cannot leak spoilers;
+        # the item subject and rating stay on the net.neodb.review record
+        return build_document(
+            self,
+            title=self.title,
+            body=self.body,
+            text=self.plain_content,
+            description=self.display_summary,
+        )
 
     def to_post_params(self):
         item_link = f"{settings.SITE_INFO['site_url']}/~neodb~{self.item.url}"

--- a/neodb/tests/journal/test_atproto_records.py
+++ b/neodb/tests/journal/test_atproto_records.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
 from types import SimpleNamespace
 
 import pytest
@@ -373,6 +374,24 @@ def test_document_rkey_is_valid_tid():
     assert build_document_rkey(review) != build_document_rkey(article)
 
 
+def test_document_rkey_unique_for_equal_created_time():
+    # date-only backdated imports land many pieces on the same microsecond;
+    # keys must still be unique per piece, even for pks 1024 apart (sharing
+    # the low clock-id bits) and for pre-1970 times (clamped, not wrapped)
+    for dt in (
+        datetime(2020, 5, 1, tzinfo=dt_timezone.utc),
+        datetime(1932, 1, 1, tzinfo=dt_timezone.utc),
+    ):
+        keys = [
+            build_document_rkey(Review(pk=pk, created_time=dt))
+            for pk in (1, 2, 1025, 2049, 1024 * 1024 + 1)
+        ]
+        assert len(set(keys)) == len(keys)
+        for rkey in keys:
+            assert len(rkey) == 13
+            assert all(c in _TID_ALPHABET for c in rkey)
+
+
 @pytest.mark.django_db(databases="__all__")
 def test_sync_writes_document_and_freezes_rkey():
     user = User.register(email="freeze@example.com", username="freezeuser")
@@ -453,3 +472,65 @@ def test_delete_enqueues_document_cleanup(monkeypatch):
     _func, _user_id, _metadata, record_refs = calls[0]
     assert [REVIEW_NSID, review.uuid] in record_refs
     assert [DOCUMENT_NSID, build_document_rkey(review)] in record_refs
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_sync_and_drop_document():
+    user = User.register(email="artsync@example.com", username="artsyncuser")
+    article = Article.update_local_article(user.identity, "T", "body")
+
+    fake = FakeBluesky()
+    article._sync_records_to_bluesky(fake)
+
+    rkey = article.metadata["atproto_document_rkey"]
+    assert (DOCUMENT_NSID, rkey) in fake.puts
+
+    article._sync_records_to_bluesky(fake, drop=True)
+
+    assert (DOCUMENT_NSID, rkey) in fake.deletes
+    assert "atproto_document_rkey" not in article.metadata
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_failed_repost_drops_stale_bsky_post_ref(monkeypatch):
+    user = User.register(email="stale@example.com", username="staleuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="stale.example"
+    )
+    # a previous sync posted a skeet
+    Review.objects.filter(pk=review.pk).update(
+        metadata={
+            "bluesky_id": "at://did:plc:fake/app.bsky.feed.post/3old",
+            "bluesky_cid": "oldcid",
+        }
+    )
+    review.refresh_from_db()
+
+    fake = FakeBluesky()
+    deleted_posts = []
+    monkeypatch.setattr(
+        BlueskyAccount, "delete_post", lambda self, uri: deleted_posts.append(uri)
+    )
+
+    def fail_post(self, **kwargs):
+        raise RuntimeError("pds down")
+
+    monkeypatch.setattr(BlueskyAccount, "post", fail_post)
+    monkeypatch.setattr(BlueskyAccount, "put_record", fake.put_record)
+    monkeypatch.setattr(BlueskyAccount, "delete_record", fake.delete_record)
+
+    review._sync_to_social_accounts(0)
+
+    # the old skeet was deleted and reposting failed: the document must not
+    # carry a bskyPostRef pointing at the deleted post
+    assert deleted_posts == ["at://did:plc:fake/app.bsky.feed.post/3old"]
+    doc = next(rec for (c, _), rec in fake.puts.items() if c == DOCUMENT_NSID)
+    assert "bskyPostRef" not in doc
+    # changes made during sync (dropped ids, frozen rkey) are persisted
+    review.refresh_from_db()
+    assert "bluesky_id" not in review.metadata
+    assert "bluesky_cid" not in review.metadata
+    assert review.metadata["atproto_document_rkey"] == build_document_rkey(review)

--- a/neodb/tests/journal/test_atproto_records.py
+++ b/neodb/tests/journal/test_atproto_records.py
@@ -2,12 +2,23 @@ from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
+from django.conf import settings
 
 from catalog.models import Edition, ExternalResource, TVSeason, TVShow
-from journal.models import Mark, Rating, Review, ShelfMember, ShelfType, Tag
-from journal.models.atproto import MARK_NSID, REVIEW_NSID, build_subject
+from journal.models import Article, Mark, Rating, Review, ShelfMember, ShelfType, Tag
+from journal.models.atproto import (
+    DOCUMENT_NSID,
+    MARK_NSID,
+    MARKPUB_MARKDOWN_NSID,
+    MARKPUB_TEXT_NSID,
+    REVIEW_NSID,
+    build_document_rkey,
+    build_subject,
+)
 from mastodon.models import BlueskyAccount
 from users.models import User
+
+_TID_ALPHABET = "234567abcdefghijklmnopqrstuvwxyz"
 
 
 class FakeBluesky:
@@ -280,3 +291,165 @@ def test_delete_enqueues_record_cleanup_without_metadata(monkeypatch):
     _func, _user_id, metadata, record_refs = calls[0]
     assert metadata == {}
     assert record_refs == [[MARK_NSID, sm.uuid]]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_atproto_document():
+    user = User.register(email="doc@example.com", username="docuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(
+        book, user.identity, "Loved it", "A **great** read."
+    )
+    assert review is not None
+
+    doc = review.to_atproto_document()
+
+    assert doc["$type"] == DOCUMENT_NSID
+    # loose document: site + path reconstructs the canonical NeoDB URL
+    assert doc["site"] == settings.SITE_INFO["site_url"].rstrip("/")
+    assert doc["site"] + doc["path"] == review.absolute_url
+    assert doc["title"] == "Loved it"
+    assert doc["publishedAt"].endswith("Z")
+    assert "updatedAt" not in doc  # creation jitter is not an edit
+    # full markdown in the open content union, plaintext alongside
+    assert doc["content"]["$type"] == MARKPUB_MARKDOWN_NSID
+    assert doc["content"]["text"]["$type"] == MARKPUB_TEXT_NSID
+    assert doc["content"]["text"]["markdown"] == "A **great** read."
+    assert " ".join(doc["textContent"].split()) == "A great read."
+    # spoiler-safe auto-summary, not a body excerpt
+    assert doc["description"] == review.display_summary
+    assert review.atproto_document_collections() == {DOCUMENT_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_atproto_document():
+    user = User.register(email="artdoc@example.com", username="artdocuser")
+    article = Article.update_local_article(
+        user.identity,
+        "My Essay",
+        "Some **bold** thoughts.",
+        tags=["essay", "life"],
+    )
+
+    doc = article.to_atproto_document()
+
+    assert doc["$type"] == DOCUMENT_NSID
+    assert doc["site"] + doc["path"] == article.absolute_url
+    assert doc["title"] == "My Essay"
+    assert doc["content"]["text"]["markdown"] == "Some **bold** thoughts."
+    assert doc["tags"] == ["essay", "life"]
+    # no author summary: description falls back to the body excerpt
+    assert doc["description"] == article.excerpt
+    assert article.atproto_document_collections() == {DOCUMENT_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_document_description_prefers_summary():
+    user = User.register(email="artsum@example.com", username="artsumuser")
+    article = Article.update_local_article(
+        user.identity, "T", "body", summary="hand-written teaser"
+    )
+
+    doc = article.to_atproto_document()
+
+    assert doc["description"] == "hand-written teaser"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_document_rkey_is_valid_tid():
+    user = User.register(email="tid@example.com", username="tiduser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    article = Article.update_local_article(user.identity, "T", "body")
+
+    for piece in (review, article):
+        rkey = build_document_rkey(piece)
+        # the site.standard.document lexicon requires tid record keys
+        assert len(rkey) == 13
+        assert all(c in _TID_ALPHABET for c in rkey)
+        assert rkey[0] in "234567abcdefghij"  # top bit of a TID is 0
+        assert build_document_rkey(piece) == rkey  # deterministic
+    assert build_document_rkey(review) != build_document_rkey(article)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_writes_document_and_freezes_rkey():
+    user = User.register(email="freeze@example.com", username="freezeuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+
+    fake = FakeBluesky()
+    review._sync_records_to_bluesky(fake)
+
+    rkey = build_document_rkey(review)
+    assert (DOCUMENT_NSID, rkey) in fake.puts
+    # both the structured review record and the document are written
+    assert (REVIEW_NSID, review.uuid) in fake.puts
+    # the key is frozen so a later created_time edit cannot orphan the record
+    assert review.metadata["atproto_document_rkey"] == rkey
+    review.created_time = review.created_time - timedelta(days=30)
+    assert review.atproto_document_rkey() == rkey
+    review._sync_records_to_bluesky(fake)
+    assert len([k for k in fake.puts if k[0] == DOCUMENT_NSID]) == 1
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_drop_deletes_document():
+    user = User.register(email="dropdoc@example.com", username="dropdocuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    fake = FakeBluesky()
+    review._sync_records_to_bluesky(fake)
+    rkey = review.metadata["atproto_document_rkey"]
+
+    review._sync_records_to_bluesky(fake, drop=True)
+
+    assert (DOCUMENT_NSID, rkey) in fake.deletes
+    assert (REVIEW_NSID, review.uuid) in fake.deletes
+    assert "atproto_document_rkey" not in review.metadata
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_document_includes_bsky_post_ref():
+    user = User.register(email="ref@example.com", username="refuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+
+    doc = review.to_atproto_document()
+    assert "bskyPostRef" not in doc  # no skeet was posted
+
+    review.metadata.update(
+        {"bluesky_id": "at://did:plc:fake/app.bsky.feed.post/3k", "bluesky_cid": "c1"}
+    )
+    doc = review.to_atproto_document()
+    assert doc["bskyPostRef"] == {
+        "uri": "at://did:plc:fake/app.bsky.feed.post/3k",
+        "cid": "c1",
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_delete_enqueues_document_cleanup(monkeypatch):
+    user = User.register(email="deldoc@example.com", username="deldocuser")
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="deldoc.example"
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        "journal.models.common.django_rq.get_queue",
+        lambda name: SimpleNamespace(enqueue=lambda *a, **kw: calls.append(a)),
+    )
+    review.delete_crossposts()
+
+    assert len(calls) == 1
+    _func, _user_id, _metadata, record_refs = calls[0]
+    assert [REVIEW_NSID, review.uuid] in record_refs
+    assert [DOCUMENT_NSID, build_document_rkey(review)] in record_refs


### PR DESCRIPTION
## Summary

When crossposting to ATProto, long-form pieces (Review and the new standalone Article) now also write a [`site.standard.document`](https://standard.site/docs/lexicons/document) record to the owner's PDS, alongside the existing `net.neodb.*` records, so standard.site-aware apps (Leaflet etc.) can read them.

## Design

- **Loose documents**: `site` is the instance base URL and `path` the piece's local path, so `site + path` reconstructs the canonical NeoDB URL; no `site.standard.publication` record is created (possible follow-up).
- **Content**: full markdown body travels in the document's open `content` union using the [`at.markpub.markdown`](https://markpub.at/) convention, with plaintext in `textContent`. Reviews use the spoiler-safe auto-summary ("a review of X") as `description` so external previews cannot leak spoilers; articles carry `tags` and the author summary (with sensitive-content marker).
- **Record keys**: the lexicon requires `tid` rkeys, so the piece uuid scheme used by `net.neodb.*` does not apply. A deterministic TID is derived from `created_time` (timestamp bits) plus pk (mixed into clock-id and sub-millisecond bits, so same-timestamp backdated imports cannot collide), then frozen in `metadata["atproto_document_rkey"]` on first write so a later `created_time` edit cannot orphan the PDS record.
- **Lifecycle**: documents follow the existing reconciliation -- only public pieces are written, going private deletes the record, piece deletion cleans it up asynchronously. `bskyPostRef` links the crossposted skeet; on update the old skeet's ids are dropped immediately after deletion so a failed repost cannot leave a stale ref.

## Test plan

- 11 new tests in `tests/journal/test_atproto_records.py`: document field correctness for Review and Article, description fallbacks, TID validity/determinism/collision-resistance (incl. pre-1970 clamp), rkey freezing across created_time edits, drop-on-private, delete cleanup, and the failed-repost path through `_sync_to_social_accounts` (metadata persistence included).
- Full suite passes (1519 passed; the 3 `test_lexicons.py` failures in Docker are a pre-existing volume-mount gap and pass locally). `pre-commit run -a` clean.