### PR TITLE
Add RSS feed for user's public articles

### DIFF
--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 17:45-0400\n"
+"POT-Creation-Date: 2026-06-11 21:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1664,7 +1664,7 @@ msgstr ""
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
-#: journal/templates/user_article_list.html:52
+#: journal/templates/user_article_list.html:58
 #: journal/templates/user_collection_list.html:52
 #: journal/templates/user_follow_list_items.html:65
 #: journal/templates/user_item_list_base.html:27
@@ -1967,8 +1967,8 @@ msgstr ""
 
 #: catalog/views/edit.py:214 catalog/views/edit.py:268
 #: catalog/views/edit.py:386 catalog/views/edit.py:475
-#: catalog/views/edit.py:507 journal/views/article.py:33
-#: journal/views/article.py:114 journal/views/collection.py:238
+#: catalog/views/edit.py:507 journal/views/article.py:37
+#: journal/views/article.py:118 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
 #: journal/views/collection.py:451 journal/views/collection.py:489
@@ -3671,8 +3671,8 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/profile.py:486
-#: journal/views/review.py:186
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:166
+#: journal/views/profile.py:486 journal/views/review.py:186
 msgid "Login required"
 msgstr ""
 
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:148
+#: journal/models/article.py:148 journal/views/article.py:180
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5203,7 +5203,7 @@ msgstr ""
 msgid "Boost this post?"
 msgstr ""
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:687
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:700
 msgid "Boost"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 
 #: journal/templates/profile.html:138
 #: journal/templates/user_article_list.html:14
-#: journal/templates/user_article_list.html:32
+#: journal/templates/user_article_list.html:38
 msgid "Articles"
 msgstr ""
 
@@ -5604,7 +5604,7 @@ msgstr ""
 msgid "Delete this tag"
 msgstr ""
 
-#: journal/templates/user_article_list.html:26
+#: journal/templates/user_article_list.html:32
 msgid "Compose new article"
 msgstr ""
 
@@ -5650,6 +5650,20 @@ msgstr ""
 #: journal/templates/wrapped_share.html:31
 #, python-format
 msgid "#%(year)s_report"
+msgstr ""
+
+#: journal/views/article.py:148 journal/views/review.py:168
+msgid "User not local"
+msgstr ""
+
+#: journal/views/article.py:154 journal/views/article.py:168
+#, python-brace-format
+msgid "Articles by {0}"
+msgstr ""
+
+#: journal/views/article.py:156 journal/views/article.py:164
+#: journal/views/review.py:176 journal/views/review.py:184
+msgid "Link invalid"
 msgstr ""
 
 #: journal/views/collection.py:57 journal/views/collection.py:94
@@ -5753,17 +5767,9 @@ msgstr ""
 msgid "Invalid post"
 msgstr ""
 
-#: journal/views/review.py:168
-msgid "User not local"
-msgstr ""
-
 #: journal/views/review.py:174 journal/views/review.py:188
 #, python-brace-format
 msgid "Reviews by {0}"
-msgstr ""
-
-#: journal/views/review.py:176 journal/views/review.py:184
-msgid "Link invalid"
 msgstr ""
 
 #: journal/views/review.py:197
@@ -5894,7 +5900,7 @@ msgstr ""
 msgid "max toot len"
 msgstr ""
 
-#: mastodon/models/mastodon.py:688
+#: mastodon/models/mastodon.py:701
 msgid "New Post"
 msgstr ""
 

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-11 21:09-0400\n"
+"POT-Creation-Date: 2026-06-11 21:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3657,7 +3657,8 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:109 common/utils.py:150 users/views/actions.py:37
+#: common/utils.py:109 common/utils.py:150 journal/views/article.py:150
+#: journal/views/review.py:170 users/views/actions.py:37
 #: users/views/actions.py:123
 msgid "User not found"
 msgstr ""
@@ -3671,8 +3672,8 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:166
-#: journal/views/profile.py:486 journal/views/review.py:186
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:168
+#: journal/views/profile.py:486 journal/views/review.py:188
 msgid "Login required"
 msgstr ""
 
@@ -4444,7 +4445,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:148 journal/views/article.py:180
+#: journal/models/article.py:148 journal/views/article.py:182
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5656,13 +5657,13 @@ msgstr ""
 msgid "User not local"
 msgstr ""
 
-#: journal/views/article.py:154 journal/views/article.py:168
+#: journal/views/article.py:156 journal/views/article.py:170
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr ""
 
-#: journal/views/article.py:156 journal/views/article.py:164
-#: journal/views/review.py:176 journal/views/review.py:184
+#: journal/views/article.py:158 journal/views/article.py:166
+#: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr ""
 
@@ -5767,17 +5768,17 @@ msgstr ""
 msgid "Invalid post"
 msgstr ""
 
-#: journal/views/review.py:174 journal/views/review.py:188
+#: journal/views/review.py:176 journal/views/review.py:190
 #, python-brace-format
 msgid "Reviews by {0}"
 msgstr ""
 
-#: journal/views/review.py:197
+#: journal/views/review.py:199
 #, python-brace-format
 msgid "{review_title} - a review of {item_title}"
 msgstr ""
 
-#: journal/views/review.py:201
+#: journal/views/review.py:203
 msgid "may contain spoiler or triggering content"
 msgstr ""
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-09 17:45-0400\n"
+"POT-Creation-Date: 2026-06-11 21:09-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1663,7 +1663,7 @@ msgstr "热门标签"
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
-#: journal/templates/user_article_list.html:52
+#: journal/templates/user_article_list.html:58
 #: journal/templates/user_collection_list.html:52
 #: journal/templates/user_follow_list_items.html:65
 #: journal/templates/user_item_list_base.html:27
@@ -1966,8 +1966,8 @@ msgstr "条目不可被删除。"
 
 #: catalog/views/edit.py:214 catalog/views/edit.py:268
 #: catalog/views/edit.py:386 catalog/views/edit.py:475
-#: catalog/views/edit.py:507 journal/views/article.py:33
-#: journal/views/article.py:114 journal/views/collection.py:238
+#: catalog/views/edit.py:507 journal/views/article.py:37
+#: journal/views/article.py:118 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
 #: journal/views/collection.py:451 journal/views/collection.py:489
@@ -3691,8 +3691,8 @@ msgstr "用户不存在了"
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/profile.py:486
-#: journal/views/review.py:186
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:166
+#: journal/views/profile.py:486 journal/views/review.py:186
 msgid "Login required"
 msgstr "登录后访问"
 
@@ -4464,7 +4464,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:148
+#: journal/models/article.py:148 journal/views/article.py:180
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -5223,7 +5223,7 @@ msgstr "全部分类"
 msgid "Boost this post?"
 msgstr "转播这则帖文吗？"
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:687
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:700
 msgid "Boost"
 msgstr "转播"
 
@@ -5624,7 +5624,7 @@ msgstr "年度小结"
 
 #: journal/templates/profile.html:138
 #: journal/templates/user_article_list.html:14
-#: journal/templates/user_article_list.html:32
+#: journal/templates/user_article_list.html:38
 msgid "Articles"
 msgstr "文章"
 
@@ -5669,7 +5669,7 @@ msgstr "个人标签不被包括在条目的公共索引中，但如果公开标
 msgid "Delete this tag"
 msgstr "删除这个标签"
 
-#: journal/templates/user_article_list.html:26
+#: journal/templates/user_article_list.html:32
 msgid "Compose new article"
 msgstr "撰写新文章"
 
@@ -5716,6 +5716,20 @@ msgstr "分享年度小结"
 #, python-format
 msgid "#%(year)s_report"
 msgstr "#我的#%(year)s书影音"
+
+#: journal/views/article.py:148 journal/views/review.py:168
+msgid "User not local"
+msgstr "用户不在本站"
+
+#: journal/views/article.py:154 journal/views/article.py:168
+#, python-brace-format
+msgid "Articles by {0}"
+msgstr "{0} 的文章"
+
+#: journal/views/article.py:156 journal/views/article.py:164
+#: journal/views/review.py:176 journal/views/review.py:184
+msgid "Link invalid"
+msgstr "链接无效"
 
 #: journal/views/collection.py:57 journal/views/collection.py:94
 #, python-brace-format
@@ -5818,18 +5832,10 @@ msgstr "无效选择"
 msgid "Invalid post"
 msgstr "无效帖文"
 
-#: journal/views/review.py:168
-msgid "User not local"
-msgstr "用户不在本站"
-
 #: journal/views/review.py:174 journal/views/review.py:188
 #, python-brace-format
 msgid "Reviews by {0}"
 msgstr "{0} 的评论"
-
-#: journal/views/review.py:176 journal/views/review.py:184
-msgid "Link invalid"
-msgstr "链接无效"
 
 #: journal/views/review.py:197
 #, python-brace-format
@@ -5976,7 +5982,7 @@ msgstr "0: 月亮表情; 1: 定制表情"
 msgid "max toot len"
 msgstr "帖文长度限制"
 
-#: mastodon/models/mastodon.py:688
+#: mastodon/models/mastodon.py:701
 msgid "New Post"
 msgstr "新帖文"
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-11 21:09-0400\n"
+"POT-Creation-Date: 2026-06-11 21:36-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -3677,7 +3677,8 @@ msgstr "你"
 msgid "unavailable"
 msgstr "不可用"
 
-#: common/utils.py:109 common/utils.py:150 users/views/actions.py:37
+#: common/utils.py:109 common/utils.py:150 journal/views/article.py:150
+#: journal/views/review.py:170 users/views/actions.py:37
 #: users/views/actions.py:123
 msgid "User not found"
 msgstr "用户不存在"
@@ -3691,8 +3692,8 @@ msgstr "用户不存在了"
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:166
-#: journal/views/profile.py:486 journal/views/review.py:186
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:168
+#: journal/views/profile.py:486 journal/views/review.py:188
 msgid "Login required"
 msgstr "登录后访问"
 
@@ -4464,7 +4465,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:148 journal/views/article.py:180
+#: journal/models/article.py:148 journal/views/article.py:182
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -5721,13 +5722,13 @@ msgstr "#我的#%(year)s书影音"
 msgid "User not local"
 msgstr "用户不在本站"
 
-#: journal/views/article.py:154 journal/views/article.py:168
+#: journal/views/article.py:156 journal/views/article.py:170
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr "{0} 的文章"
 
-#: journal/views/article.py:156 journal/views/article.py:164
-#: journal/views/review.py:176 journal/views/review.py:184
+#: journal/views/article.py:158 journal/views/article.py:166
+#: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr "链接无效"
 
@@ -5832,17 +5833,17 @@ msgstr "无效选择"
 msgid "Invalid post"
 msgstr "无效帖文"
 
-#: journal/views/review.py:174 journal/views/review.py:188
+#: journal/views/review.py:176 journal/views/review.py:190
 #, python-brace-format
 msgid "Reviews by {0}"
 msgstr "{0} 的评论"
 
-#: journal/views/review.py:197
+#: journal/views/review.py:199
 #, python-brace-format
 msgid "{review_title} - a review of {item_title}"
 msgstr "{review_title} - 关于 {item_title} 的评论"
 
-#: journal/views/review.py:201
+#: journal/views/review.py:203
 msgid "may contain spoiler or triggering content"
 msgstr "可能包含剧透或敏感内容"
 

--- a/neodb/journal/templates/profile_common.html
+++ b/neodb/journal/templates/profile_common.html
@@ -10,6 +10,10 @@
         type="application/rss+xml"
         title="{{ site_name }} - @{{ identity.handle }} - Reviews"
         href="{{ identity.url }}feed/reviews/">
+  <link rel="alternate"
+        type="application/rss+xml"
+        title="{{ site_name }} - @{{ identity.handle }} - Articles"
+        href="{{ identity.url }}feed/articles/">
 {% else %}
   <meta name="robots" content="noindex">
 {% endif %}

--- a/neodb/journal/templates/user_article_list.html
+++ b/neodb/journal/templates/user_article_list.html
@@ -13,6 +13,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ site_name }} - {{ identity.display_name }} - {% trans "Articles" %}</title>
     {% include "common_libs.html" %}
+    {% if identity.local and identity.anonymous_viewable %}
+      <link rel="alternate"
+            type="application/rss+xml"
+            title="{{ site_name }} - @{{ identity.handle }} - Articles"
+            href="{{ identity.url }}feed/articles/">
+    {% endif %}
   </head>
   <body>
     {% include "_header.html" %}

--- a/neodb/journal/urls.py
+++ b/neodb/journal/urls.py
@@ -232,6 +232,7 @@ urlpatterns = [
         name="profile_posts_data",
     ),
     path("users/<str:username>/feed/reviews/", ReviewFeed(), name="review_feed"),
+    path("users/<str:username>/feed/articles/", ArticleFeed(), name="article_feed"),
     path("wrapped/", WrappedView.as_view(), name="wrapped_current_year"),
     path("wrapped/<int:year>/", WrappedView.as_view(), name="wrapped"),
     path("wrapped/<int:year>/share", WrappedShareView.as_view(), name="wrapped_share"),

--- a/neodb/journal/views/__init__.py
+++ b/neodb/journal/views/__init__.py
@@ -1,4 +1,4 @@
-from .article import article_edit, article_retrieve, user_article_list
+from .article import ArticleFeed, article_edit, article_retrieve, user_article_list
 from .collection import (
     add_to_collection,
     collection_add_featured,
@@ -69,6 +69,7 @@ from .tag import user_tag_edit, user_tag_list, user_tag_member_list
 from .wrapped import WrappedShareView, WrappedView
 
 __all__ = [
+    "ArticleFeed",
     "article_edit",
     "article_retrieve",
     "user_article_list",

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied
+from django.contrib.syndication.views import Feed
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -9,6 +11,8 @@ from django.views.decorators.http import require_http_methods
 from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404, target_identity_required
 from takahe.utils import Takahe
+from users.middlewares import activate_language_for_user
+from users.models.apidentity import APIdentity
 
 from ..forms import ArticleForm
 from ..models import Article
@@ -124,6 +128,76 @@ def article_retrieve(request, article_uuid: str):
         "article.html",
         {"article": article, "quotes_count": post_quotes_count(article.latest_post)},
     )
+
+
+MAX_FEED_ITEMS = 10
+
+
+class ArticleFeed(Feed):
+    def __call__(self, request, *args, **kwargs):
+        # redirect to the canonical handle if a linked handle is used
+        try:
+            linked_id = APIdentity.get_by_linked_handle(kwargs["username"])
+            return redirect(linked_id.url + "feed/articles/", permanent=True)
+        except ObjectDoesNotExist:
+            return super().__call__(request, *args, **kwargs)
+
+    def get_object(self, request, *args, **kwargs):
+        o = APIdentity.get_by_handle(kwargs["username"])
+        if not o.local:
+            raise ObjectDoesNotExist(_("User not local"))
+        activate_language_for_user(o.user)
+        return o
+
+    def title(self, owner):
+        return (
+            _("Articles by {0}").format(owner.display_name)
+            if owner
+            else _("Link invalid")
+        )
+
+    def link(self, owner: APIdentity):
+        return owner.url if owner else settings.SITE_INFO["site_url"]
+
+    def description(self, owner: APIdentity):
+        if not owner:
+            return _("Link invalid")
+        elif not owner.anonymous_viewable:
+            return _("Login required")
+        else:
+            return _("Articles by {0}").format(owner.display_name)
+
+    def items(self, owner: APIdentity):
+        if owner is None or not owner.anonymous_viewable:
+            return []
+        return Article.objects.filter(owner=owner, visibility=0).order_by(
+            "-created_time"
+        )[:MAX_FEED_ITEMS]
+
+    def item_title(self, item: Article):
+        s = item.title
+        if item.sensitive:
+            s += " " + _("(may contain sensitive content)")
+        return s
+
+    def item_description(self, item: Article):
+        return item.html_content
+
+    # item_link is only needed if NewsItem has no get_absolute_url method.
+    def item_link(self, item: Article):
+        return str(item.absolute_url)
+
+    def item_categories(self, item: Article):
+        return item.normalized_tags
+
+    def item_pubdate(self, item: Article):
+        return item.created_time
+
+    def item_updateddate(self, item: Article):
+        return item.edited_time
+
+    def item_comments(self, item: Article):
+        return item.absolute_url
 
 
 @target_identity_required

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -146,6 +146,8 @@ class ArticleFeed(Feed):
         o = APIdentity.get_by_handle(kwargs["username"])
         if not o.local:
             raise ObjectDoesNotExist(_("User not local"))
+        if not o.user or not o.user.is_active:
+            raise ObjectDoesNotExist(_("User not found"))
         activate_language_for_user(o.user)
         return o
 

--- a/neodb/journal/views/review.py
+++ b/neodb/journal/views/review.py
@@ -166,6 +166,8 @@ class ReviewFeed(Feed):
         o = APIdentity.get_by_handle(kwargs["username"])
         if not o.local:
             raise ObjectDoesNotExist(_("User not local"))
+        if not o.user or not o.user.is_active:
+            raise ObjectDoesNotExist(_("User not found"))
         activate_language_for_user(o.user)
         return o
 

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -710,3 +710,16 @@ class TestArticleFeed:
         assert resp.status_code == 200
         body = resp.content.decode()
         assert "Touchy Subject (may contain sensitive content)" in body
+
+    def test_feed_404_when_user_deactivated(self):
+        Article.update_local_article(
+            owner=self.identity,
+            title="Gone Soon",
+            body="body",
+            visibility=0,
+        )
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+        assert self.client.get(self.feed_url).status_code == 404
+        # ReviewFeed shares the same guard
+        assert self.client.get(f"{self.identity.url}feed/reviews/").status_code == 404

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -622,3 +622,91 @@ class TestArticleDeleteCascade:
         # Simulate the post-delete signal (as fired after Mastodon-API delete).
         post_deleted(post_id, True, None)
         assert not Article.objects.filter(pk=article_pk).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestArticleFeed:
+    """``/users/<handle>/feed/articles/`` serves an RSS feed of the user's
+    public articles, mirroring ``ReviewFeed``."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="art_feed@test.com", username="art_feed")
+        self.identity = self.user.identity
+        self.client = Client()
+        self.feed_url = f"{self.identity.url}feed/articles/"
+
+    def test_feed_renders_public_articles(self):
+        older = Article.update_local_article(
+            owner=self.identity,
+            title="Older Public",
+            body="**bold** body",
+            tags=["alpha"],
+            visibility=0,
+        )
+        newer = Article.update_local_article(
+            owner=self.identity,
+            title="Newer Public",
+            body="newer body",
+            visibility=0,
+        )
+        newer.created_time = older.created_time + timedelta(hours=1)
+        newer.save(update_fields=["created_time"], post_when_save=False)
+        resp = self.client.get(self.feed_url)
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"].startswith("application/rss+xml")
+        body = resp.content.decode()
+        assert "Older Public" in body
+        assert "Newer Public" in body
+        # markdown body rendered to HTML (escaped inside the description CDATA-less RSS)
+        assert "&lt;strong&gt;bold&lt;/strong&gt;" in body
+        # newest first
+        assert body.index("Newer Public") < body.index("Older Public")
+        # tags emitted as categories
+        assert "<category>alpha</category>" in body
+
+    def test_feed_excludes_non_public_articles(self):
+        Article.update_local_article(
+            owner=self.identity,
+            title="Followers Only",
+            body="hidden",
+            visibility=1,
+        )
+        Article.update_local_article(
+            owner=self.identity,
+            title="Self Only",
+            body="hidden",
+            visibility=2,
+        )
+        resp = self.client.get(self.feed_url)
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Followers Only" not in body
+        assert "Self Only" not in body
+
+    def test_feed_empty_when_not_anonymous_viewable(self):
+        Article.update_local_article(
+            owner=self.identity,
+            title="Public But Hidden Profile",
+            body="body",
+            visibility=0,
+        )
+        self.identity.anonymous_viewable = False
+        self.identity.save(update_fields=["anonymous_viewable"])
+        resp = self.client.get(self.feed_url)
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Public But Hidden Profile" not in body
+
+    def test_feed_marks_sensitive_articles(self):
+        Article.update_local_article(
+            owner=self.identity,
+            title="Touchy Subject",
+            body="body",
+            sensitive=True,
+            visibility=0,
+        )
+        resp = self.client.get(self.feed_url)
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Touchy Subject (may contain sensitive content)" in body


### PR DESCRIPTION
## Summary
- Add `/users/<handle>/feed/articles/` RSS feed serving a user's public articles, mirroring the existing `ReviewFeed`
- Feed includes only public (`visibility=0`) articles, newest first, capped at 10; empty when the profile is not anonymously viewable; linked (legacy) handles 301-redirect to the canonical handle like the reviews feed
- Sensitive articles get "(may contain sensitive content)" appended to the title (reuses the existing msgid); tags are emitted as RSS categories; description is the rendered markdown body
- Add RSS autodiscovery `<link rel="alternate">` for the article feed on profile pages and the user article list page
- Add zh_Hans translation for the new "Articles by {0}" phrase

## Test plan
- New `TestArticleFeed` in `tests/journal/test_article.py`: public articles render with HTML content / newest-first ordering / categories; followers-only and private articles excluded; feed is empty when `anonymous_viewable` is off; sensitive marker in title
- Full suite passes in Docker (1520 passed; the 3 `test_lexicons` failures are a pre-existing container mount limitation, they pass locally)
- `pre-commit run -a` green (ruff, djLint, ty)