### PR TITLE
fix(journal): keep original link on Article crossposts via obj macros

### DIFF
--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -102,7 +102,11 @@ class Article(Piece):
 
     @property
     def brief_description(self) -> str:
-        return self.plain_content[:155]
+        """Short teaser used in link-preview cards (e.g. the Bluesky embed):
+        the author summary (with sensitive marker, so a sensitive article
+        previews as its marker rather than its body) when present, else the
+        body's leading plain text."""
+        return (self.display_summary or self.plain_content)[:155]
 
     @property
     def excerpt(self) -> str:
@@ -206,11 +210,15 @@ class Article(Piece):
         }
 
     def to_crosspost_params(self) -> dict[str, Any]:
+        # ##obj## renders as a title link on Bluesky (which also gets an
+        # external embed card for the article) and as plain title text on
+        # Mastodon/Threads, where ##obj_link_if_plain## then carries the URL;
+        # an inline URL would be lost to Bluesky's grapheme-limit truncation
         body = self.plain_content[:300]
         if len(self.plain_content) > 300:
             body += "..."
-        content = f"{self.title}\n\n{body}\n\n{self.absolute_url}"
-        return {"content": content, "spoiler_text": self.summary or None}
+        content = f"##obj##\n\n{body}\n##obj_link_if_plain##"
+        return {"content": content, "obj": self, "spoiler_text": self.summary or None}
 
     def atproto_document_collections(self) -> set[str]:
         return {DOCUMENT_NSID}

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -220,6 +220,12 @@ class Review(Content):
     def delete_url(self) -> str:
         return reverse("journal:review_delete", args=[self.uuid])
 
+    @property
+    def cover(self):
+        """Reviewed item's cover, surfaced for link-preview embeds: the
+        Bluesky external card reads ``obj.cover`` for its thumbnail."""
+        return self.item.cover
+
     @cached_property
     def mark(self):
         from .mark import Mark

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -36,6 +36,49 @@ class TestArticleModel:
         assert article.normalized_tags == ["alpha", "beta"]
         assert article.url.startswith("/article/")
 
+    def test_article_crosspost_params_link_via_obj_macros(self):
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="Hello",
+            body="word " * 100,  # long enough to trigger Bluesky truncation
+            visibility=0,
+        )
+        params = article.to_crosspost_params()
+        # the link must ride on the obj macros (link facet + embed card on
+        # Bluesky, plain URL on Mastodon/Threads), never inline in content
+        # where Bluesky's grapheme-limit truncation could cut it off
+        assert params["obj"] is article
+        assert params["content"].startswith("##obj##\n")
+        assert params["content"].rstrip().endswith("##obj_link_if_plain##")
+        assert article.absolute_url not in params["content"]
+
+    def test_article_brief_description_prefers_summary(self):
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="Hello",
+            body="body text",
+            summary="hand-written teaser",
+            visibility=0,
+        )
+        # preview cards (e.g. Bluesky embed) show the author summary
+        assert article.brief_description == "hand-written teaser"
+
+        plain = Article.update_local_article(
+            owner=self.identity, title="T2", body="body text", visibility=0
+        )
+        assert plain.brief_description.strip() == "body text"
+
+        sensitive = Article.update_local_article(
+            owner=self.identity,
+            title="T3",
+            body="secret body",
+            sensitive=True,
+            visibility=0,
+        )
+        # marker only: a sensitive article must not leak its body in previews
+        assert "secret body" not in sensitive.brief_description
+        assert sensitive.brief_description  # the marker itself
+
     def test_article_ap_object_uses_markdown_source(self):
         article = Article.update_local_article(
             owner=self.identity,

--- a/neodb/tests/journal/test_crosspost.py
+++ b/neodb/tests/journal/test_crosspost.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from catalog.models import Edition
-from journal.models import Comment, CrosspostRetry, Piece
+from journal.models import Comment, CrosspostRetry, Piece, Review
 from mastodon.models import BlueskyAccount, MastodonAccount, ThreadsAccount
 from users.jobs.cleanup import prune_crosspost_retries
 from users.models import User
@@ -307,6 +307,17 @@ class TestCrosspostViews:
         session.save()
         response = client.get(url)
         assert b"passkey-nudge" not in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_crosspost_obj_exposes_item_cover(user):
+    book = Edition.objects.create(title="Test Book")
+    review = Review.update_item_review(book, user.identity, "T", "body")
+    assert review is not None
+    params = review.to_crosspost_params()
+    # the Bluesky embed card reads obj.cover for its thumbnail
+    assert params["obj"] is review
+    assert review.cover == book.cover
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Follow-up to #1604.

## Problem

Article crossposts placed the article URL inline at the end of the post content. Bluesky's grapheme-limit truncation cuts content from the end, so any long article lost its link entirely -- e.g. [this skeet](https://bsky.app/profile/neodb.net/post/3mo2nxkakoa2l) ends in `……` with no facets and no embed, leaving readers no way back to the original.

## Fix

- `Article.to_crosspost_params` now uses the `##obj##` macro system like Review/Comment/ShelfMember: on Bluesky the title renders as a link facet (truncation reserves room for it) plus an `app.bsky.embed.external` preview card for the article; on Mastodon/Threads `##obj_link_if_plain##` appends the plain URL.
- `Article.brief_description` (the embed card description) now prefers the author summary -- including the sensitive-content marker, so a sensitive article previews as its marker instead of leaking body text -- falling back to the body excerpt.

## Test plan

- 2 new tests: crosspost params carry the link via obj macros (never inline where truncation can eat it); brief_description preference incl. the sensitive case.
- Full `tests/journal/` suite passes (574); `pre-commit run -a` clean.

- Bonus: \`Review\` now exposes the reviewed item cover as \`obj.cover\`, so review embed cards on Bluesky get a thumbnail (they previously shipped without an image).
