### PR TITLE
fix(users): show Bluesky form when its reauth link opens the login page

### DIFF
--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -4,6 +4,7 @@ import json
 import re
 import typing
 from functools import cached_property
+from urllib.parse import quote
 
 from atproto import Client, SessionEvent, client_utils
 from atproto_client import models
@@ -102,7 +103,10 @@ class BlueskyAccount(SocialAccount):
     avatar = jsondata.CharField(json_field_name="account_data", default="")
 
     def get_reauthorize_url(self) -> str:
-        return reverse("users:login") + "?method=bluesky"
+        url = reverse("users:login") + "?method=bluesky"
+        if self.handle:
+            url += "&username=" + quote(self.handle)
+        return url
 
     def on_session_change(self, event, session) -> None:
         if event in (SessionEvent.CREATE, SessionEvent.REFRESH):

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -102,7 +102,7 @@ class BlueskyAccount(SocialAccount):
     avatar = jsondata.CharField(json_field_name="account_data", default="")
 
     def get_reauthorize_url(self) -> str:
-        return reverse("users:login") + "?method=atproto"
+        return reverse("users:login") + "?method=bluesky"
 
     def on_session_change(self, event, session) -> None:
         if event in (SessionEvent.CREATE, SessionEvent.REFRESH):

--- a/neodb/tests/users/test_login_view.py
+++ b/neodb/tests/users/test_login_view.py
@@ -1,0 +1,54 @@
+import pytest
+from django.urls import reverse
+
+from mastodon.models import BlueskyAccount, MastodonAccount
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestLoginMethodSelection:
+    def test_no_method(self, client):
+        response = client.get(reverse("users:login"))
+        assert response.status_code == 200
+        assert response.context["selected_method"] == ""
+
+    def test_bluesky_method(self, client):
+        response = client.get(reverse("users:login"), {"method": "bluesky"})
+        assert response.status_code == 200
+        assert response.context["selected_method"] == "bluesky"
+        assert b"var selected_method = 'bluesky'" in response.content
+
+    def test_atproto_aliased_to_bluesky(self, client):
+        # old notification messages persisted reauth URLs with ?method=atproto
+        response = client.get(reverse("users:login"), {"method": "atproto"})
+        assert response.status_code == 200
+        assert response.context["selected_method"] == "bluesky"
+
+    def test_unknown_method_ignored(self, client):
+        response = client.get(reverse("users:login"), {"method": "x'</script>"})
+        assert response.status_code == 200
+        assert response.context["selected_method"] == ""
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReauthorizeUrl:
+    def test_bluesky_points_to_bluesky_login_form(self):
+        user = User.register(email="reauth@example.com", username="reauthuser")
+        account = BlueskyAccount.objects.create(
+            handle="reauth.bsky.social", user=user, domain="bsky.social", uid="1"
+        )
+        assert account.get_reauthorize_url() == reverse("users:login") + (
+            "?method=bluesky"
+        )
+
+    def test_mastodon_points_to_oauth_flow(self):
+        user = User.register(email="reauth2@example.com", username="reauthuser2")
+        account = MastodonAccount.objects.create(
+            handle="reauthuser2@mast.social",
+            user=user,
+            domain="mast.social",
+            uid="2",
+        )
+        assert account.get_reauthorize_url() == reverse("mastodon:login") + (
+            "?domain=mast.social"
+        )

--- a/neodb/tests/users/test_login_view.py
+++ b/neodb/tests/users/test_login_view.py
@@ -29,6 +29,23 @@ class TestLoginMethodSelection:
         assert response.status_code == 200
         assert response.context["selected_method"] == ""
 
+    def test_username_prefilled(self, client):
+        response = client.get(
+            reverse("users:login"),
+            {"method": "bluesky", "username": "alice.bsky.social"},
+        )
+        assert response.status_code == 200
+        assert response.context["selected_username"] == "alice.bsky.social"
+        assert b"var selected_username = 'alice.bsky.social'" in response.content
+
+    def test_invalid_username_ignored(self, client):
+        response = client.get(
+            reverse("users:login"),
+            {"method": "bluesky", "username": "x'</script>@example.com"},
+        )
+        assert response.status_code == 200
+        assert response.context["selected_username"] == ""
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestReauthorizeUrl:
@@ -38,7 +55,7 @@ class TestReauthorizeUrl:
             handle="reauth.bsky.social", user=user, domain="bsky.social", uid="1"
         )
         assert account.get_reauthorize_url() == reverse("users:login") + (
-            "?method=bluesky"
+            "?method=bluesky&username=reauth.bsky.social"
         )
 
     def test_mastodon_points_to_oauth_flow(self):

--- a/neodb/users/templates/users/login.html
+++ b/neodb/users/templates/users/login.html
@@ -275,11 +275,15 @@
     $(()=>{
       var selected_domain = '{{selected_domain}}';
       var selected_method = '{{selected_method}}';
+      var selected_username = '{{selected_username}}';
       var method = localStorage.login_method;
       if (!!selected_method) {
         method = selected_method;
-        $('#domain').val(localStorage.mastodon_domain);
+        $('#domain').val(selected_domain || localStorage.mastodon_domain);
         $('#email').val(localStorage.email);
+        if (!!selected_username) {
+          $('#login-bluesky input[name=username]').val(selected_username);
+        }
       } else if (!!selected_domain) {
         method = "mastodon";
         $('#domain').val(selected_domain);

--- a/neodb/users/templates/users/login.html
+++ b/neodb/users/templates/users/login.html
@@ -274,8 +274,13 @@
     }
     $(()=>{
       var selected_domain = '{{selected_domain}}';
+      var selected_method = '{{selected_method}}';
       var method = localStorage.login_method;
-      if (!!selected_domain) {
+      if (!!selected_method) {
+        method = selected_method;
+        $('#domain').val(localStorage.mastodon_domain);
+        $('#email').val(localStorage.email);
+      } else if (!!selected_domain) {
         method = "mastodon";
         $('#domain').val(selected_domain);
       } else if (!!method) {

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -35,6 +35,13 @@ from ..models import User
 @require_http_methods(["GET"])
 def login(request):
     selected_domain = request.GET.get("domain", default="")
+    # "atproto" kept as an alias for "bluesky": reauth URLs using it are
+    # persisted in old notification messages
+    selected_method = request.GET.get("method", default="")
+    if selected_method == "atproto":
+        selected_method = "bluesky"
+    if selected_method not in ("passkey", "email", "mastodon", "threads", "bluesky"):
+        selected_method = ""
     sites = Mastodon.get_sites()
     next_url = sanitize_next_url(request.GET.get("next"))
     if next_url:
@@ -54,6 +61,7 @@ def login(request):
             "sites": sites,
             "scope": quote(SiteConfig.system.mastodon_client_scope),
             "selected_domain": selected_domain,
+            "selected_method": selected_method,
             "allow_any_site": len(SiteConfig.system.mastodon_login_whitelist) == 0,
             "enable_email": settings.ENABLE_LOGIN_EMAIL,
             "enable_threads": SiteConfig.system.enable_login_threads,

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 from urllib.parse import quote
 
@@ -42,6 +43,10 @@ def login(request):
         selected_method = "bluesky"
     if selected_method not in ("passkey", "email", "mastodon", "threads", "bluesky"):
         selected_method = ""
+    # ATProto handle to prefill the Bluesky form, e.g. from a reauth link
+    selected_username = request.GET.get("username", default="")
+    if not re.fullmatch(r"[A-Za-z0-9.\-]+", selected_username):
+        selected_username = ""
     sites = Mastodon.get_sites()
     next_url = sanitize_next_url(request.GET.get("next"))
     if next_url:
@@ -62,6 +67,7 @@ def login(request):
             "scope": quote(SiteConfig.system.mastodon_client_scope),
             "selected_domain": selected_domain,
             "selected_method": selected_method,
+            "selected_username": selected_username,
             "allow_any_site": len(SiteConfig.system.mastodon_login_whitelist) == 0,
             "enable_email": settings.ENABLE_LOGIN_EMAIL,
             "enable_threads": SiteConfig.system.enable_login_threads,


### PR DESCRIPTION
## Problem

The "Re-authorize" link for an expired Bluesky session (shown in crosspost-failure notifications and on the crossposts page) landed users on the Mastodon login form.

`BlueskyAccount.get_reauthorize_url()` pointed to the login page with `?method=atproto`, but nothing consumed that parameter: the login view never read it, and the form-picker JS only looks at `localStorage.login_method` (valid ids: `passkey`/`email`/`mastodon`/`threads`/`bluesky`). So the page showed whatever form the browser last remembered, typically Mastodon.

## Fix

- login view reads `?method=` from the query string, whitelists it against the known form ids, and passes it to the template
- form-picker JS gives the server-provided method top priority over `selected_domain` and `localStorage`
- Bluesky reauth URL now uses `?method=bluesky` to match the form ids; `atproto` is kept as an alias since old notification messages persisted such URLs
- Bluesky reauth URL also carries the account handle as `?username=`, which the login page prefills into the Bluesky form (validated server-side against the handle charset); Mastodon reauth needs no equivalent since it links straight into the OAuth flow with `?domain=`

## Tests

New `tests/users/test_login_view.py` covers method selection, the `atproto` alias, rejection of unknown values, handle prefill and its validation, and both platforms' reauth URLs. Related suites (`tests/users`, `tests/mastodon`, `tests/journal/test_crosspost.py`) pass; the 3 `test_lexicons.py` failures are pre-existing in the test image and fail on a clean tree as well.