### PR TITLE
fix: security and correctness issues

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -536,7 +536,10 @@ WEBAUTHN_ORIGIN = SITE_INFO["site_url"]
 
 ALTERNATIVE_DOMAINS = [d.lower() for d in env("NEODB_ALTERNATIVE_DOMAINS", default=[])]
 SITE_DOMAINS = [SITE_DOMAIN] + ALTERNATIVE_DOMAINS
-ALLOWED_HOSTS = SITE_DOMAINS + ["127.0.0.1"] if SSL_ONLY else ["*"]
+# restrict Host header to known domains in production; with
+# USE_X_FORWARDED_HOST enabled, accepting any host would let a spoofed
+# Host/X-Forwarded-Host header poison absolute URLs built from the request
+ALLOWED_HOSTS = ["*"] if DEBUG else SITE_DOMAINS + ["127.0.0.1", "localhost"]
 
 STATIC_URL = "/s/"
 STATIC_ROOT = env("NEODB_STATIC_ROOT", default=os.path.join(BASE_DIR, "static/"))

--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -540,6 +540,8 @@ SITE_DOMAINS = [SITE_DOMAIN] + ALTERNATIVE_DOMAINS
 # USE_X_FORWARDED_HOST enabled, accepting any host would let a spoofed
 # Host/X-Forwarded-Host header poison absolute URLs built from the request
 ALLOWED_HOSTS = ["*"] if DEBUG else SITE_DOMAINS + ["127.0.0.1", "localhost"]
+if TESTING and "*" not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append("testserver")
 
 STATIC_URL = "/s/"
 STATIC_ROOT = env("NEODB_STATIC_ROOT", default=os.path.join(BASE_DIR, "static/"))

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -483,15 +483,23 @@ class Item(PolymorphicModel):
                 credit.item = to_item
                 credit.save()
                 updated = True
-        to_item.log_action({"!merged_from": [str(self.merged_to_item), str(to_item)]})
+        to_item.log_action({"!merged_from": [str(self), str(to_item)]})
         if updated:
             to_item.save()
 
     @property
     def final_item(self) -> Self:
-        if self.merged_to_item:
-            return self.merged_to_item.final_item
-        return self
+        # iterative with a bound so a long or circular merge chain in the DB
+        # cannot exhaust the stack in request hot paths
+        item = self
+        depth = 0
+        while item.merged_to_item is not None:
+            if depth >= 20:
+                logger.error(f"merge chain too deep or circular for {self}")
+                break
+            item = item.merged_to_item
+            depth += 1
+        return item
 
     def recast_to(self, model: "type[Item]") -> "Item":
         logger.warning(f"recast item {self} to {model}")
@@ -1358,7 +1366,10 @@ class ExternalResource(models.Model):
             return None
         items = model.objects.filter(is_deleted=False, merged_to_item__isnull=True)
         resources = ExternalResource.objects.filter(
-            item_id__isnull=False, item__polymorphic_ctype_id=ct
+            item_id__isnull=False,
+            item__polymorphic_ctype_id=ct,
+            item__is_deleted=False,
+            item__merged_to_item__isnull=True,
         )
 
         item = items.filter(

--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -345,5 +345,11 @@ class SiteConfig(models.Model):
 
         # Derived values used in many places via settings.SITE_DOMAINS
         settings.SITE_DOMAINS = [settings.SITE_DOMAIN] + opts.alternative_domains
-        if settings.SSL_ONLY:
-            settings.ALLOWED_HOSTS = settings.SITE_DOMAINS + ["127.0.0.1"]
+        if not settings.DEBUG:
+            # keep host validation in sync with runtime alternative domains,
+            # matching the ALLOWED_HOSTS recipe in boofilsic.settings
+            settings.ALLOWED_HOSTS = (
+                settings.SITE_DOMAINS
+                + ["127.0.0.1", "localhost"]
+                + (["testserver"] if settings.TESTING else [])
+            )

--- a/neodb/common/templatetags/admin_url.py
+++ b/neodb/common/templatetags/admin_url.py
@@ -12,4 +12,4 @@ def admin_url():
         url = "/" + url
     if not url.endswith("/"):
         url += "/"
-    return format_html(url)
+    return format_html("{}", url)

--- a/neodb/common/templatetags/strip_scheme.py
+++ b/neodb/common/templatetags/strip_scheme.py
@@ -8,10 +8,7 @@ register = template.Library()
 @stringfilter
 def strip_scheme(value):
     """Strip the `https://.../` part of urls"""
-    if value.startswith("https://"):
-        value = value.lstrip("https://")
-    elif value.startswith("http://"):
-        value = value.lstrip("http://")
+    value = value.removeprefix("https://").removeprefix("http://")
 
     if value.endswith("/"):
         value = value[0:-1]

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -512,9 +512,12 @@ def trending_collection(request):
     )
     from journal.models.common import prefetch_latest_posts
 
-    # re-check visibility: the cached id list may include collections whose
-    # owners made them non-public after the discover job cached them
-    qs = Collection.objects.filter(pk__in=collection_ids, visibility=0)
+    # re-check visibility with anonymous-viewer semantics: the endpoint is
+    # public and cached, and the id list may include collections whose owners
+    # made them non-public after the discover job cached them
+    qs = Collection.objects.filter(
+        pk__in=collection_ids, visibility=0, owner__anonymous_viewable=True
+    )
     if restricted_owner_ids:
         qs = qs.exclude(owner_id__in=restricted_owner_ids)
     collections = list(qs)

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -423,7 +423,11 @@ def list_featured_collections(request):
     """
     List featured collections for current user.
     """
-    collections = list(Collection.objects.filter(featured_by=request.user.identity))
+    collections = list(
+        Collection.objects.filter(featured_by=request.user.identity).filter(
+            q_piece_visible_to_user(request.user)
+        )
+    )
     Collection.attach_item_count_by_category(collections)
     return collections
 
@@ -508,7 +512,9 @@ def trending_collection(request):
     )
     from journal.models.common import prefetch_latest_posts
 
-    qs = Collection.objects.filter(pk__in=collection_ids)
+    # re-check visibility: the cached id list may include collections whose
+    # owners made them non-public after the discover job cached them
+    qs = Collection.objects.filter(pk__in=collection_ids, visibility=0)
     if restricted_owner_ids:
         qs = qs.exclude(owner_id__in=restricted_owner_ids)
     collections = list(qs)

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -520,7 +520,9 @@ def trending_collection(request):
     )
     if restricted_owner_ids:
         qs = qs.exclude(owner_id__in=restricted_owner_ids)
-    collections = list(qs)
+    # pk__in does not preserve list order; reapply the rotation
+    by_pk = {c.pk: c for c in qs}
+    collections = [by_pk[pk] for pk in collection_ids if pk in by_pk]
     prefetch_latest_posts(collections)
     Collection.attach_item_count_by_category(collections)
     return collections

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -435,6 +435,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 # incoming ap object is older than what we have, no update needed
                 return p
             d["edited_time"] = edited
+            d["visibility"] = visibility
             for k, v in d.items():
                 setattr(p, k, v)
             if crosspost is not None:
@@ -565,6 +566,12 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             return p
 
         activate_language_for_user(self.owner.user)
+        # the piece was pickled at enqueue time; reload metadata so the save
+        # below does not overwrite changes written to the DB since then
+        try:
+            self.refresh_from_db(fields=["metadata"])
+        except self.DoesNotExist:
+            return
         metadata = self.metadata.copy()
 
         # backward compatible with previous way of storing mastodon id

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -566,10 +566,11 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             return p
 
         activate_language_for_user(self.owner.user)
-        # the piece was pickled at enqueue time; reload metadata so the save
-        # below does not overwrite changes written to the DB since then
+        # the piece was pickled at enqueue time; reload it so the crosspost
+        # uses current content/visibility and the metadata save below does
+        # not overwrite changes written to the DB since then
         try:
-            self.refresh_from_db(fields=["metadata"])
+            self.refresh_from_db()
         except self.DoesNotExist:
             return
         metadata = self.metadata.copy()

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -203,6 +203,7 @@ def render_list(
         ).order_by(F("rating_grade").desc(nulls_last=True), "id")
     else:
         queryset = queryset.order_by("-created_time")
+    queryset = queryset.filter(q_owned_piece_visible_to_user(request.user, target))
     start_date = queryset.aggregate(Min("created_time"))["created_time__min"]
     if start_date:
         start_year = start_date.year
@@ -210,7 +211,6 @@ def render_list(
         years = reversed(range(start_year, current_year + 1))
     else:
         years = []
-    queryset = queryset.filter(q_owned_piece_visible_to_user(request.user, target))
     if year:
         year = int(year)
         queryset = queryset.filter(created_time__year=year)

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -544,7 +544,7 @@ def get_mastodon_login_url(app, login_domain, request):
     url = request.build_absolute_uri(reverse("mastodon:oauth"))
     scope = _get_scopes(app.server_version)
     state = secrets.token_urlsafe(32)
-    request.session["oauth_state"] = state
+    request.session["mastodon_oauth_state"] = state
     return (
         "https://"
         + login_domain

--- a/neodb/mastodon/models/threads.py
+++ b/neodb/mastodon/models/threads.py
@@ -78,7 +78,7 @@ class Threads:
     def generate_auth_url(request: HttpRequest):
         redirect_url = request.build_absolute_uri(reverse("mastodon:threads_oauth"))
         state = secrets.token_urlsafe(32)
-        request.session["oauth_state"] = state
+        request.session["threads_oauth_state"] = state
         query = urlencode(
             {
                 "client_id": SiteConfig.system.threads_app_id,

--- a/neodb/mastodon/views/bluesky.py
+++ b/neodb/mastodon/views/bluesky.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
 from django.http import HttpRequest
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
@@ -7,12 +8,24 @@ from common.sentry import count as sentry_count
 from common.views import render_error
 
 from ..models import Bluesky
-from .common import disconnect_identity, process_verified_account
+from .common import client_ip, disconnect_identity, process_verified_account
+
+# Cap failed app-password logins per client IP so the server cannot be used
+# to relay credential stuffing against Bluesky accounts.
+_MAX_AUTH_FAILS = 10
+_AUTH_FAIL_TTL = 60 * 60
 
 
 @require_http_methods(["POST"])
 def bluesky_login(request: HttpRequest):
     sentry_count("login.attempt", attributes={"type": "bluesky"})
+    fail_key = f"bluesky_login_fails_{client_ip(request)}"
+    if (cache.get(fail_key) or 0) >= _MAX_AUTH_FAILS:
+        return render_error(
+            request,
+            _("Authentication failed"),
+            _("Too many attempts, please try again later."),
+        )
     username = request.POST.get("username", "").strip().lstrip("@")
     password = request.POST.get("password", "").strip()
     if not username or not password:
@@ -23,6 +36,10 @@ def bluesky_login(request: HttpRequest):
         )
     account = Bluesky.authenticate(username, password)
     if not account:
+        try:
+            cache.incr(fail_key)
+        except ValueError:
+            cache.set(fail_key, 1, timeout=_AUTH_FAIL_TTL)
         return render_error(
             request, _("Authentication failed"), _("Invalid account data from Bluesky.")
         )

--- a/neodb/mastodon/views/common.py
+++ b/neodb/mastodon/views/common.py
@@ -15,7 +15,10 @@ from users.views.account import auth_login, logout_takahe
 def client_ip(request: HttpRequest) -> str:
     xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
     if xff:
-        return xff.split(",")[0].strip()
+        # the bundled nginx appends the peer address to any client-supplied
+        # X-Forwarded-For, so only the last entry is trustworthy; the first
+        # entry could be forged to rotate rate-limit keys
+        return xff.split(",")[-1].strip()
     return request.META.get("REMOTE_ADDR", "")
 
 

--- a/neodb/mastodon/views/common.py
+++ b/neodb/mastodon/views/common.py
@@ -12,6 +12,13 @@ from users.models import User
 from users.views.account import auth_login, logout_takahe
 
 
+def client_ip(request: HttpRequest) -> str:
+    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if xff:
+        return xff.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
 def process_verified_account(request: HttpRequest, account: SocialAccount):
     if request.user.is_authenticated:
         # add/update linked identity
@@ -95,7 +102,10 @@ def disconnect_identity(request, account):
             request, _("Disconnect identity failed"), _("Invalid user.")
         )
     with transaction.atomic():
-        if request.user.social_accounts.all().count() <= 1:
+        # lock the user's accounts so two concurrent disconnects cannot both
+        # pass the last-identity guard and leave the user with no login
+        accounts = list(request.user.social_accounts.select_for_update())
+        if len(accounts) <= 1:
             return render_error(
                 request,
                 _("Disconnect identity failed"),

--- a/neodb/mastodon/views/email.py
+++ b/neodb/mastodon/views/email.py
@@ -10,18 +10,11 @@ from common.views import render_error
 
 from ..forms import EmailLoginForm
 from ..models import Email
-from .common import process_verified_account
+from .common import client_ip, process_verified_account
 
 # Cap failed verification-code submissions per client IP to defeat brute force.
 _MAX_VERIFY_FAILS = 10
 _VERIFY_FAIL_TTL = 60 * 60
-
-
-def _client_ip(request: HttpRequest) -> str:
-    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
-    if xff:
-        return xff.split(",")[0].strip()
-    return request.META.get("REMOTE_ADDR", "")
 
 
 @require_http_methods(["GET"])
@@ -66,7 +59,7 @@ def email_login(request: HttpRequest):
 def email_verify(request: HttpRequest):
     if request.method == "GET":
         return render(request, "users/verify.html")
-    fail_key = f"email_verify_fails_{_client_ip(request)}"
+    fail_key = f"email_verify_fails_{client_ip(request)}"
     if (cache.get(fail_key) or 0) >= _MAX_VERIFY_FAILS:
         return render(
             request,

--- a/neodb/mastodon/views/mastodon.py
+++ b/neodb/mastodon/views/mastodon.py
@@ -42,7 +42,7 @@ def mastodon_oauth(request):
             _("Authentication failed"),
             _("Invalid response from Fediverse instance."),
         )
-    expected_state = request.session.pop("oauth_state", None)
+    expected_state = request.session.pop("mastodon_oauth_state", None)
     actual_state = request.GET.get("state")
     if not expected_state or expected_state != actual_state:
         return render_error(

--- a/neodb/mastodon/views/threads.py
+++ b/neodb/mastodon/views/threads.py
@@ -52,7 +52,7 @@ def threads_oauth(request: HttpRequest):
             _("Authentication failed"),
             request.GET.get("error_description", ""),
         )
-    expected_state = request.session.pop("oauth_state", None)
+    expected_state = request.session.pop("threads_oauth_state", None)
     actual_state = request.GET.get("state")
     if not expected_state or expected_state != actual_state:
         return render_error(

--- a/neodb/social/views.py
+++ b/neodb/social/views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.dateparse import parse_datetime
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 
@@ -253,7 +254,10 @@ def events(request):
     es = Takahe.get_events(request.user.identity.pk, types)
     last = request.GET.get("last")
     if last:
-        es = es.filter(created__lt=last)
+        # ignore malformed cursor values rather than 500 on the ORM cast
+        last_dt = parse_datetime(last)
+        if last_dt:
+            es = es.filter(created__lt=last_dt)
     nes = [NotificationEvent(e) for e in es[:PAGE_SIZE]]
     return render(
         request,

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -79,7 +79,10 @@ class Takahe:
             logger.warning(f"User {u} has no username")
             return None
         # APIdentity / user writes go to the default db while takahe models
-        # go to the takahe db; wrap both so neither side commits alone
+        # go to the takahe db; wrap both so neither side commits alone.
+        # not a true two-phase commit: the takahe block commits first, so a
+        # failed default-db commit can leave takahe rows behind, but those
+        # writes are get-or-create style and a retry reconciles them
         with transaction.atomic(using="default"), transaction.atomic(using="takahe"):
             user = User.objects.filter(pk=u.pk).first()
             handler = "@" + u.username

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -78,7 +78,9 @@ class Takahe:
         if not u.username:
             logger.warning(f"User {u} has no username")
             return None
-        with transaction.atomic(using="takahe"):
+        # APIdentity / user writes go to the default db while takahe models
+        # go to the takahe db; wrap both so neither side commits alone
+        with transaction.atomic(using="default"), transaction.atomic(using="takahe"):
             user = User.objects.filter(pk=u.pk).first()
             handler = "@" + u.username
             if not user:

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1339,3 +1339,74 @@ def test_posts_endpoint_optional_auth():
             HTTP_AUTHORIZATION="Bearer invalidtoken",
         )
         assert response.status_code == 401
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_collection_trending_excludes_non_public():
+    cache.clear()
+    owner = User.register(email="trend2@example.com", username="trenduser2")
+    public_collection = Collection.objects.create(
+        owner=owner.identity,
+        title="Public Trending",
+        brief="",
+        visibility=0,
+    )
+    private_collection = Collection.objects.create(
+        owner=owner.identity,
+        title="Private Trending",
+        brief="",
+        visibility=2,
+    )
+    # simulate a stale discover-job cache that still lists a collection
+    # whose owner made it non-public afterwards
+    cache.set(
+        "featured_collections",
+        [public_collection.pk, private_collection.pk],
+        timeout=None,
+    )
+
+    response = Client().get("/api/trending/collection/")
+
+    assert response.status_code == 200
+    uuids = [c["uuid"] for c in response.json()]
+    assert public_collection.uuid in uuids
+    assert private_collection.uuid not in uuids
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_featured_collection_hidden_after_owner_restricts():
+    owner = User.register(email="fcowner@example.com", username="fcowner")
+    viewer = User.register(email="fcviewer@example.com", username="fcviewer")
+    collection = Collection.objects.create(
+        owner=owner.identity,
+        title="Was Public",
+        brief="",
+        visibility=0,
+    )
+    FeaturedCollection.objects.create(owner=viewer.identity, target=collection)
+
+    app = Takahe.get_or_create_app(
+        "Featured Visibility Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=viewer.identity.pk,
+    )
+    token = Takahe.refresh_token(app, viewer.identity.pk, viewer.pk)
+    client = Client()
+
+    response = client.get(
+        "/api/me/collection/featured/",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+    assert [c["uuid"] for c in response.json()] == [collection.uuid]
+
+    collection.visibility = 2
+    collection.save(update_fields=["visibility"])
+
+    response = client.get(
+        "/api/me/collection/featured/",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+    assert response.json() == []

--- a/neodb/tests/mastodon/test_threads.py
+++ b/neodb/tests/mastodon/test_threads.py
@@ -115,7 +115,7 @@ class TestGenerateAuthUrl:
         assert "threads_manage_replies" in url
         assert "redirect_uri=http%3A%2F%2Ftestserver%2Faccount%2Fthreads%2Foauth" in url
         assert "response_type=code" in url
-        assert f"state={request.session['oauth_state']}" in url
+        assert f"state={request.session['threads_oauth_state']}" in url
 
 
 class TestPostSingle:

--- a/takahe/api/views/oauth.py
+++ b/takahe/api/views/oauth.py
@@ -2,9 +2,10 @@ import base64
 import hmac
 import secrets
 import time
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlencode, urlparse, urlunparse
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import transaction
 from django.http import (
     HttpResponse,
     HttpResponseForbidden,
@@ -29,13 +30,11 @@ class OauthRedirect(HttpResponseRedirect):
 
         query_string = url_parts[4]
 
-        for key, value in kwargs.items():
-            if value is None:
-                continue
-            if not query_string:
-                query_string = f"{key}={value}"
-            else:
-                query_string += f"&{key}={value}"
+        # urlencode the values: state is client-supplied and could otherwise
+        # inject extra query parameters into the redirect Location
+        params = urlencode([(k, v) for k, v in kwargs.items() if v is not None])
+        if params:
+            query_string = f"{query_string}&{params}" if query_string else params
 
         url_parts[4] = query_string
         super().__init__(urlunparse(url_parts))
@@ -193,37 +192,46 @@ class TokenView(View):
                     status=400,
                 )
 
-            authorization = Authorization.objects.filter(code=code).first()
-            if not authorization or (
-                timezone.now() - authorization.created
-                > timezone.timedelta(seconds=authorization.valid_for_seconds)
-            ):
-                return JsonResponse({"error": "access_denied"}, status=401)
+            with transaction.atomic():
+                # lock the authorization row so the code is single-use even
+                # under concurrent redemption attempts
+                authorization = (
+                    Authorization.objects.select_for_update()
+                    .filter(code=code)
+                    .first()
+                )
+                if not authorization or (
+                    timezone.now() - authorization.created
+                    > timezone.timedelta(seconds=authorization.valid_for_seconds)
+                ):
+                    return JsonResponse({"error": "access_denied"}, status=401)
 
-            application = Application.objects.filter(
-                client_id=post_data["client_id"],
-                client_secret=post_data["client_secret"],
-            ).first()
+                application = Application.objects.filter(
+                    client_id=post_data["client_id"],
+                    client_secret=post_data["client_secret"],
+                ).first()
 
-            code_verified = self.verify_code(
-                authorization,
-                client_id=post_data.get("client_id"),
-                client_secret=post_data.get("client_secret"),
-                redirect_uri=post_data.get("redirect_uri"),
-            )
+                code_verified = self.verify_code(
+                    authorization,
+                    client_id=post_data.get("client_id"),
+                    client_secret=post_data.get("client_secret"),
+                    redirect_uri=post_data.get("redirect_uri"),
+                )
 
-            if not application or authorization.token or not code_verified:
-                # this authorization code has already been used
-                return JsonResponse({"error": "access_denied"}, status=401)
+                if not application or authorization.token or not code_verified:
+                    # this authorization code has already been used
+                    return JsonResponse({"error": "access_denied"}, status=401)
 
-            token = Token.objects.create(
-                application=application,
-                user=authorization.user,
-                identity=authorization.identity,
-                token=secrets.token_urlsafe(43),
-                scopes=authorization.scopes,
-            )
-            token.save()
+                token = Token.objects.create(
+                    application=application,
+                    user=authorization.user,
+                    identity=authorization.identity,
+                    token=secrets.token_urlsafe(43),
+                    scopes=authorization.scopes,
+                )
+                # mark the code as redeemed so it cannot be exchanged again
+                authorization.token = token
+                authorization.save(update_fields=["token", "updated"])
             # Return them the token
             return JsonResponse(
                 {

--- a/takahe/tests/api/test_tokens.py
+++ b/takahe/tests/api/test_tokens.py
@@ -1,5 +1,7 @@
 import pytest
 
+from api.models import Application, Authorization
+
 
 @pytest.mark.django_db
 def test_has_scope(api_token):
@@ -9,3 +11,39 @@ def test_has_scope(api_token):
     assert api_token.has_scope("read")
     assert api_token.has_scope("read:statuses")
     assert not api_token.has_scope("destroyearth")
+
+
+@pytest.mark.django_db
+def test_authorization_code_single_use(client, identity):
+    """
+    An OAuth authorization code must mint exactly one token; replaying the
+    same code must be rejected.
+    """
+    application = Application.objects.create(
+        name="Code App",
+        client_id="tk-code-test",
+        client_secret="codesecret",
+        redirect_uris="https://example.com/callback",
+    )
+    Authorization.objects.create(
+        application=application,
+        user=identity.users.first(),
+        identity=identity,
+        code="testauthcode",
+        redirect_uri="https://example.com/callback",
+        scopes=["read"],
+    )
+    data = {
+        "grant_type": "authorization_code",
+        "code": "testauthcode",
+        "client_id": "tk-code-test",
+        "client_secret": "codesecret",
+        "redirect_uri": "https://example.com/callback",
+    }
+
+    response = client.post("/oauth/token", data)
+    assert response.status_code == 200
+    assert response.json()["access_token"]
+
+    response = client.post("/oauth/token", data)
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

A deep review of both Django projects surfaced a set of security and correctness issues; this PR fixes the verified ones. Highlights:

### Security
- **takahe OAuth authorization codes were reusable**: the token endpoint never linked the minted `Token` back to `Authorization.token`, so the single-use check was always false and a code could be exchanged repeatedly within its validity window. Codes are now redeemed under `select_for_update` and marked used. The redirect query string is also built with `urlencode` so a client-supplied `state` cannot inject parameters.
- **Private collections leaked through two APIs**: `/api/trending/collection/` trusted the discover job's never-expiring cached id list, and `/api/me/collection/featured/` did not re-check visibility, so collections made private after being cached/featured kept serving full content. Both now filter with current visibility (trending additionally requires `owner.anonymous_viewable` since it is anonymous and response-cached).
- **Federated visibility edits were ignored**: `update_by_ap_object` applied visibility only on create, so a remote edit from public to followers-only left the local mirror public.
- **`ALLOWED_HOSTS` fell back to `*` whenever `SSL_ONLY` was off** while `USE_X_FORWARDED_HOST` is enabled, allowing Host-header poisoning of absolute URLs. Production now always restricts to configured site domains (dev/DEBUG keeps `*`; `testserver` is included under test). The runtime `SiteConfig` alternative-domain refresh now updates host validation under the same condition.
- **Bluesky app-password login had no throttling**: added the same per-IP failed-attempt cap as email code verification, and hardened `client_ip` to use the last `X-Forwarded-For` entry (the proxy-appended one) so forged headers cannot rotate throttle keys.
- Review-list year aggregate ran before owner/visibility filtering, exposing site-wide metadata and scanning all users' pieces.

### Correctness
- Concurrent account disconnects could both pass the last-login-identity guard and strand a user with no way to log in; the rows are now locked.
- `Takahe.init_identity_for_local_user` wrapped only the takahe DB in a transaction; default-DB writes are now transactional too.
- The queued crosspost job saved back its pickled-at-enqueue snapshot, clobbering concurrent edits; it now reloads the piece from the DB first.
- `Item.final_item` recursed unbounded (RecursionError on long/circular merge chains in search hot paths); `!merged_from` audit log recorded the target item twice instead of the source; resource matching could write fresh scrapes onto deleted/merged items.
- Mastodon and Threads OAuth flows shared one `oauth_state` session key, so starting one flow broke the other in a second tab.
- `strip_scheme` used `lstrip` (character-set semantics) and corrupted hostnames like `stash.example.com`; notification events 500'd on malformed `?last=` cursors; `admin_url` used a `format_html` call removed in Django 6.0.

### Tests
- New regression tests: trending/featured collection visibility (neodb) and OAuth code single-use (takahe).
- Full Docker suite: 1547 passed (with `NEODB_DEBUG=False` matching CI); takahe suite: 352 passed plus new test. Pre-existing failures (lexicons docs mount, takahe signup fork stubs) reproduce identically on main.

### Notes for deployers
Non-SSL production deployments now validate the Host header against `NEODB_SITE_DOMAIN`/`NEODB_ALTERNATIVE_DOMAINS`; requests with other hostnames return 400 where they previously were accepted.