### PR TITLE
fix(catalog): guard MusicBrainz tracks with null length

### DIFF
--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -292,9 +292,13 @@ class MusicBrainzReleaseGroup(AbstractSite):
 
                         track_list.append(track_entry)
 
-                        # Add duration if available (in milliseconds)
-                        if "length" in track:
-                            total_duration += int(track["length"])
+                        # Add duration if available (in milliseconds). MB
+                        # returns "length": null for tracks of unknown
+                        # length, so the key can be present with a None value;
+                        # guard the value rather than just key presence.
+                        length = track.get("length")
+                        if length is not None:
+                            total_duration += int(length)
 
         return {
             "track_list": "\n".join(track_list) if track_list else None,
@@ -480,9 +484,13 @@ class MusicBrainzRelease(AbstractSite):
 
                         track_list.append(track_entry)
 
-                        # Add duration if available (in milliseconds)
-                        if "length" in track:
-                            total_duration += int(track["length"])
+                        # Add duration if available (in milliseconds). MB
+                        # returns "length": null for tracks of unknown
+                        # length, so the key can be present with a None value;
+                        # guard the value rather than just key presence.
+                        length = track.get("length")
+                        if length is not None:
+                            total_duration += int(length)
 
         return {
             "track_list": "\n".join(track_list) if track_list else None,

--- a/neodb/tests/catalog/test_musicbrainz.py
+++ b/neodb/tests/catalog/test_musicbrainz.py
@@ -163,6 +163,26 @@ class TestMusicBrainzReleaseGroup:
         assert track_info["track_list"] == "1-1. Track 1\n2-1. Track 2"
         assert track_info["duration"] == 380000
 
+    def test_extract_track_info_null_length(self):
+        """MB returns "length": null for tracks of unknown length; the key is
+        present but the value is None, which int() can't take (EGGPLANT-1E4)."""
+        site = MusicBrainzReleaseGroup()
+        release_data = {
+            "media": [
+                {
+                    "position": 1,
+                    "tracks": [
+                        {"position": 1, "title": "Known", "length": 284000},
+                        {"position": 2, "title": "Unknown", "length": None},
+                        {"position": 3, "title": "Missing"},
+                    ],
+                }
+            ]
+        }
+        track_info = site._extract_track_info(release_data)
+        assert track_info["track_list"] == "1. Known\n2. Unknown\n3. Missing"
+        assert track_info["duration"] == 284000
+
     def test_extract_label_info(self):
         """Test label information extraction"""
         site = MusicBrainzReleaseGroup()
@@ -380,6 +400,25 @@ class TestMusicBrainzRelease:
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1. First Track\n2. Second Track"
         assert track_info["duration"] == 390000
+
+    def test_track_extraction_null_length(self):
+        """A release whose tracks carry "length": null must not crash on
+        int(None) while summing duration (EGGPLANT-1E4)."""
+        site = MusicBrainzRelease()
+        release_data = {
+            "media": [
+                {
+                    "position": 1,
+                    "tracks": [
+                        {"position": 1, "title": "First Track", "length": 210000},
+                        {"position": 2, "title": "Second Track", "length": None},
+                    ],
+                }
+            ]
+        }
+        track_info = site._extract_track_info(release_data)
+        assert track_info["track_list"] == "1. First Track\n2. Second Track"
+        assert track_info["duration"] == 210000
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Problem

Parsing a MusicBrainz release (e.g. `https://musicbrainz.org/release/8a10ec27-c4a6-4efd-8ad5-a5d724cb2695`) crashed in the `fetch` rqworker with:

```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

## Root cause

`_extract_track_info` summed track durations with:

```python
if "length" in track:
    total_duration += int(track["length"])
```

MusicBrainz returns `"length": null` for tracks of unknown duration. The key *is* present, so the `in` check passed, but the value was `None`, and `int(None)` raised. The same bug existed in both `MusicBrainzRelease` and `MusicBrainzReleaseGroup`.

## Fix

Guard on the value instead of key presence:

```python
length = track.get("length")
if length is not None:
    total_duration += int(length)
```

## Tests

- Added regression tests for present-but-null and missing `length` in both classes.
- `tests/catalog/test_musicbrainz.py`: 36 passed.
- `pre-commit` (ruff / format / ty) passes.

Fixes EGGPLANT-1E4