### PR TITLE
perf: fix N+1 and slow DB queries flagged by Sentry

### DIFF
--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -441,17 +441,21 @@ class SiteManager:
             merged_to_item__isnull=True,
             metadata__localized_name__contains=[{"text": name}],
         )
-        candidate_ids: set[int] = set()
+        candidates = []
+        candidate_pks: set[int] = set()
         for branch in (
-            base.filter(credited_items__item=parent_item),
-            base.filter(item_relations__item=parent_item),
+            base.filter(credited_items__item=parent_item).distinct(),
+            base.filter(item_relations__item=parent_item).distinct(),
         ):
-            candidate_ids.update(branch.values_list("pk", flat=True).distinct()[:2])
-            if len(candidate_ids) > 1:
+            for person in branch[:2]:
+                if person.pk not in candidate_pks:
+                    candidate_pks.add(person.pk)
+                    candidates.append(person)
+            if len(candidates) > 1:
                 break
-        if len(candidate_ids) != 1:
+        if len(candidates) != 1:
             return None
-        c = People.objects.get(pk=next(iter(candidate_ids)))
+        c = candidates[0]
         if c.external_resources.filter(id_type=link_id_type).exists():
             return None
         return c

--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -427,22 +427,31 @@ class SiteManager:
         link_id_type = linked_resource.get("id_type")
         if not link_id_type:
             return None
-        from django.db.models import Q
-
         from ..models import People
 
-        candidates = list(
-            People.objects.filter(
-                Q(credited_items__item=parent_item)
-                | Q(item_relations__item=parent_item),
-                is_deleted=False,
-                merged_to_item__isnull=True,
-                metadata__localized_name__contains=[{"text": name}],
-            ).distinct()[:2]
+        # People already attached to parent_item (via credit or relation) whose
+        # localized_name contains the link's display name. The credit/relation
+        # condition is split into two index-driven queries instead of a single
+        # OR across both join tables: the OR plan degraded into a slow scan over
+        # catalog_people with DISTINCT (EGGPLANT-1CV, ~1.4s), whereas each branch
+        # drives from the itemcredit/itempeoplerelation (item) index over the
+        # handful of people attached to one item.
+        base = People.objects.filter(
+            is_deleted=False,
+            merged_to_item__isnull=True,
+            metadata__localized_name__contains=[{"text": name}],
         )
-        if len(candidates) != 1:
+        candidate_ids: set[int] = set()
+        for branch in (
+            base.filter(credited_items__item=parent_item),
+            base.filter(item_relations__item=parent_item),
+        ):
+            candidate_ids.update(branch.values_list("pk", flat=True).distinct()[:2])
+            if len(candidate_ids) > 1:
+                break
+        if len(candidate_ids) != 1:
             return None
-        c = candidates[0]
+        c = People.objects.get(pk=next(iter(candidate_ids)))
         if c.external_resources.filter(id_type=link_id_type).exists():
             return None
         return c

--- a/neodb/catalog/models/people.py
+++ b/neodb/catalog/models/people.py
@@ -233,30 +233,58 @@ class People(Item):
         name = self.display_name
         return uniq([t["text"] for t in self.localized_name if t["text"] != name])
 
+    #: Number of related items rendered per role on the people page; the rest
+    #: are reachable via the "people_works" link.
+    RELATED_ITEMS_DISPLAY_LIMIT = 10
+
     @cached_property
-    def related_items_by_role(self) -> "list[tuple[str, StrOrPromise, list]]":
-        """Return related items grouped by role, as (role_value, role_label, items) tuples."""
+    def related_items_by_role(
+        self,
+    ) -> "list[tuple[str, StrOrPromise, int, list]]":
+        """Related items grouped by role as (role, role_label, count, items).
+
+        ``count`` is the total live items in that role; ``items`` holds only the
+        first ``RELATED_ITEMS_DISPLAY_LIMIT`` of them, downcast to their concrete
+        subclass for rendering. The total count is derived from ids without
+        polymorphic downcasting, so a prolific person no longer fetches and
+        resolves hundreds of full item rows per page render (EGGPLANT-1DP).
+        """
         from .item import Item
 
+        limit = self.RELATED_ITEMS_DISPLAY_LIMIT
         relations = self.item_relations.order_by("role").values_list("role", "item_id")
         role_item_ids: OrderedDict[str, list[int]] = OrderedDict()
         for role, item_id in relations:
             role_item_ids.setdefault(role, []).append(item_id)
         all_ids = [i for ids in role_item_ids.values() for i in ids]
-        items_by_id = {
-            item.pk: item
-            for item in Item.objects.filter(
+        if not all_ids:
+            return []
+        # Cheap id-only pass (values_list skips polymorphic downcast) to drop
+        # deleted/merged items before deciding what to count and render.
+        live_ids = set(
+            Item.objects.filter(
                 pk__in=all_ids, is_deleted=False, merged_to_item__isnull=True
-            )
+            ).values_list("pk", flat=True)
+        )
+        role_live_ids: OrderedDict[str, list[int]] = OrderedDict()
+        display_ids: list[int] = []
+        for role, ids in role_item_ids.items():
+            live = [i for i in ids if i in live_ids]
+            if live:
+                role_live_ids[role] = live
+                display_ids.extend(live[:limit])
+        # Downcast only the items actually shown.
+        items_by_id = {
+            item.pk: item for item in Item.objects.filter(pk__in=display_ids)
         }
         return [
             (
                 role,
                 PeopleRole(role).label,
-                [items_by_id[i] for i in ids if i in items_by_id],
+                len(live),
+                [items_by_id[i] for i in live[:limit] if i in items_by_id],
             )
-            for role, ids in role_item_ids.items()
-            if any(i in items_by_id for i in ids)
+            for role, live in role_live_ids.items()
         ]
 
     @staticmethod

--- a/neodb/catalog/models/people.py
+++ b/neodb/catalog/models/people.py
@@ -262,9 +262,9 @@ class People(Item):
         # Cheap id-only pass (values_list skips polymorphic downcast) to drop
         # deleted/merged items before deciding what to count and render.
         live_ids = set(
-            Item.objects.filter(
-                pk__in=all_ids, is_deleted=False, merged_to_item__isnull=True
-            ).values_list("pk", flat=True)
+            Item.objects.non_polymorphic()
+            .filter(pk__in=all_ids, is_deleted=False, merged_to_item__isnull=True)
+            .values_list("pk", flat=True)
         )
         role_live_ids: OrderedDict[str, list[int]] = OrderedDict()
         display_ids: list[int] = []

--- a/neodb/catalog/templates/people.html
+++ b/neodb/catalog/templates/people.html
@@ -46,7 +46,7 @@
   </div>
 {% endblock %}
 {% block content %}
-  {% for role_value, role_label, items in item.related_items_by_role %}
+  {% for role_value, role_label, total_count, items in item.related_items_by_role %}
     <section class="entity-sort shelf">
       <span class="action">
         <span>
@@ -63,11 +63,11 @@
   <h5>
     {{ role_label }}
     <small>
-      (<a href="{% url 'catalog:people_works' item.url_path item.uuid role_value %}">{{ items|length }}</a>)
+      (<a href="{% url 'catalog:people_works' item.url_path item.uuid role_value %}">{{ total_count }}</a>)
     </small>
   </h5>
   <ul class="cards">
-    {% for work in items|slice:":10" %}
+    {% for work in items %}
       <li class="card">
         <a href="{{ work.url }}" title="{{ work.display_title }}">
           <img src="{{ work.cover|thumb:'normal' }}"

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -526,7 +526,18 @@ def similar(request, item_path, item_uuid):
     if items:
         Item.prefetch_parent_items(items)
         Item.prefetch_edition_works(items)
-        prefetch_related_objects(items, "external_resources")
+        # Card partials only read url/site_name/site_label (derived from
+        # id_type/id_value), so skip the large metadata/other_lookup_ids JSON
+        # columns that made this prefetch a slow query (EGGPLANT-1DX).
+        prefetch_related_objects(
+            items,
+            Prefetch(
+                "external_resources",
+                queryset=ExternalResource.objects.only(
+                    "id", "item_id", "id_type", "id_value", "url"
+                ),
+            ),
+        )
     return render(
         request,
         "_item_similar.html",

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied, RequestAborted
 from django.core.signing import b62_decode, b62_encode
 from django.db import models
-from django.db.models import CharField, Q
+from django.db.models import CharField, Prefetch, Q, prefetch_related_objects
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
@@ -23,6 +23,7 @@ from user_messages import api as messages
 
 from catalog.models import (
     AvailableItemCategory,
+    ExternalResource,
     Item,
     ItemCategory,
     item_categories,
@@ -964,6 +965,31 @@ def prefetch_pieces_for_posts(posts: list["Post"]) -> None:
             post.__dict__["item"] = item
         else:
             post.__dict__["item"] = None
+    # Batch-prefetch item-card related data so feed templates (item card,
+    # rating, tags, credits, external resources) don't fire per-item queries
+    # while rendering feed_events.html. Mirrors the list-view prefetch in
+    # journal.views.common.
+    items = list(items_by_id.values())
+    if items:
+        from journal.models import Rating, Tag
+
+        Item.prefetch_parent_items(items)
+        Item.prefetch_credits(items)
+        Rating.attach_to_items(items)
+        Tag.attach_to_items(items)
+        prefetch_related_objects(
+            items,
+            # Feed cards render with allow_embed=1, so Album.get_embed_link reads
+            # res.metadata (Bandcamp/YouTube ids). Keep metadata in the deferred
+            # set to avoid a per-resource deferred load; only the large
+            # other_lookup_ids column is skipped.
+            Prefetch(
+                "external_resources",
+                queryset=ExternalResource.objects.only(
+                    "id", "item_id", "id_type", "id_value", "url", "metadata"
+                ),
+            ),
+        )
 
 
 class PieceInteraction(models.Model):

--- a/neodb/tests/social/test_timeline_n_plus_one.py
+++ b/neodb/tests/social/test_timeline_n_plus_one.py
@@ -82,6 +82,73 @@ class TestTimelineDataNPlusOne:
             + "; ".join(q["sql"][:120] for q in individual_mentions)
         )
 
+    def test_no_per_item_card_data_queries(self):
+        """Item-card data must be batch-prefetched in prefetch_pieces_for_posts,
+        not queried once per feed item while rendering feed_events.html
+        (NEODB-SOCIAL-4QY, NEODB-SOCIAL-7MQ).
+
+        external_resources and credits are read only by the item-card partials,
+        so a single-item lookup (``"item_id" = ...`` rather than the batched
+        ``"item_id" IN (...)``) on those tables is an unambiguous N+1 signal.
+        """
+        from catalog.models import ExternalResource, IdType
+
+        for i, book in enumerate(self.books):
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.GoogleBooks,
+                id_value=f"npo-{i}",
+                url=f"https://books.google.com/books?id=npo-{i}",
+            )
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            response = self.client.get("/timeline/data")
+        assert response.status_code == 200
+
+        per_item_signals = {
+            "catalog_externalresource": '"catalog_externalresource"."item_id" =',
+            "catalog_itemcredit": '"catalog_itemcredit"."item_id" =',
+        }
+        for table, needle in per_item_signals.items():
+            offenders = [q for q in ctx.captured_queries if needle in q["sql"]]
+            assert len(offenders) == 0, (
+                f"Expected 0 per-item {table} queries, got {len(offenders)}: "
+                + "; ".join(q["sql"][:120] for q in offenders)
+            )
+
+    def test_no_deferred_external_resource_metadata_load(self):
+        """Album feed cards render with allow_embed=1, so Album.get_embed_link
+        reads ExternalResource.metadata. The feed prefetch must keep metadata in
+        the loaded column set; otherwise each Bandcamp resource triggers a
+        deferred ``WHERE "catalog_externalresource"."id" = ...`` load per card.
+        """
+        from catalog.models import Album, ExternalResource, IdType
+
+        album = Album.objects.create(title="TL Album")
+        ExternalResource.objects.create(
+            item=album,
+            id_type=IdType.Bandcamp,
+            id_value="bc-1",
+            url="https://artist.bandcamp.com/album/tl",
+            metadata={"bandcamp_album_id": "123456"},
+        )
+        Mark(self.user.identity, album).update(
+            ShelfType.COMPLETE, "great album", 9, visibility=0
+        )
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            response = self.client.get("/timeline/data")
+        assert response.status_code == 200
+        # A deferred metadata load fetches a single resource by primary key.
+        deferred = [
+            q
+            for q in ctx.captured_queries
+            if 'FROM "catalog_externalresource"' in q["sql"]
+            and '"catalog_externalresource"."id" =' in q["sql"]
+        ]
+        assert len(deferred) == 0, (
+            f"Expected 0 deferred ExternalResource loads, got {len(deferred)}: "
+            + "; ".join(q["sql"][:120] for q in deferred)
+        )
+
     def test_query_count_stable_with_more_items(self):
         """Adding more items should not proportionally increase query count.
 

--- a/takahe/core/models/config.py
+++ b/takahe/core/models/config.py
@@ -193,6 +193,11 @@ class Config(models.Model):
             cls.IdentityOptions,
             {"identity": identity, "user__isnull": True, "domain__isnull": True},
         )
+        # Drop any cached Identity.config_identity so a later read in the same
+        # request reflects the new value (e.g. update_credentials serializes the
+        # response right after changing default_post_visibility, and the request
+        # middleware has already populated the cached property).
+        identity.__dict__.pop("config_identity", None)
 
     @classmethod
     def set_domain(cls, domain, key, value):

--- a/takahe/tests/api/test_accounts.py
+++ b/takahe/tests/api/test_accounts.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -6,6 +8,20 @@ def test_verify_credentials(api_client, identity):
     response = api_client.get("/api/v1/accounts/verify_credentials").json()
     assert response["id"] == str(identity.pk)
     assert response["username"] == identity.username
+
+
+@pytest.mark.django_db
+def test_update_credentials_privacy_reflected_immediately(api_client, identity):
+    """The update_credentials response must echo the privacy just written, not a
+    stale value cached by ConfigLoadingMiddleware via the config_identity
+    cached_property (Config.set_identity invalidates that cache)."""
+    response = api_client.patch(
+        "/api/v1/accounts/update_credentials",
+        data=json.dumps({"source": {"privacy": "private"}}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200, response.content
+    assert response.json()["source"]["privacy"] == "private"
 
 
 @pytest.mark.django_db

--- a/takahe/users/models/identity.py
+++ b/takahe/users/models/identity.py
@@ -1264,7 +1264,7 @@ class Identity(StatorModel):
             "statuses_count": stats.get("statuses_count", 0),
             "followers_count": stats.get("followers_count", 0),
             "following_count": stats.get("following_count", 0),
-            "hide_collections": not Config.load_identity(self).visible_follows,
+            "hide_collections": not self.config_identity.visible_follows,
         }
         if source:
             privacy_map = {
@@ -1291,7 +1291,7 @@ class Identity(StatorModel):
                     else []
                 ),
                 "privacy": privacy_map[
-                    Config.load_identity(self).default_post_visibility
+                    self.config_identity.default_post_visibility
                 ],
                 "sensitive": False,
                 "language": "unk",


### PR DESCRIPTION
## Summary

Fixes the database performance issues reported in Sentry (both `neodb-social` and `eggplant` projects) across the timeline feed, item/people pages, catalog import matching, and the Mastodon API serializer. All fixes are application-level (query batching / restructuring); no production index migrations.

## Changes

- **Timeline & profile feed N+1** — `prefetch_pieces_for_posts` now batch-loads item-card data (`credits`, `ratings`, `tags`, `external_resources`) instead of firing per-item queries during `feed_events.html` render. One change fixes `/timeline/data` and the 3 profile post-list call sites that share the helper. The `external_resources` prefetch keeps `metadata` (album cards render embeds via `Album.get_embed_link`) and only defers the large `other_lookup_ids`.
  - Fixes NEODB-SOCIAL-4QY, NEODB-SOCIAL-7MQ, EGGPLANT-1AW
- **People page polymorphic resolution** — `related_items_by_role` derives per-role counts from ids and downcasts only the displayed slice, so a prolific person no longer polymorphically resolves hundreds of full item rows per render. Returns a 4-tuple `(role, label, count, items)`; `people.html` updated.
  - Fixes EGGPLANT-1DP
- **`similar()` slow query** — trims the `external_resources` prefetch with `.only(...)` so it stops loading the large `metadata`/`other_lookup_ids` JSON columns (this view doesn't render embeds).
  - Fixes EGGPLANT-1DX
- **`_find_sibling_person` slow query** — splits the `Q(credited_items…) | Q(item_relations…)` OR-across-two-join-tables into two index-driven branches; the OR plan had degraded into a ~1.4s scan + `DISTINCT` over `catalog_people`. Semantics ("exactly one unambiguous match", dedup across credit/relation) are preserved (verified by Codex review).
  - Fixes EGGPLANT-1CV
- **Takahe `core_config` N+1** — `Identity.to_mastodon_json` uses the cached `config_identity` property instead of reloading `Config` per status. `Config.set_identity` now drops that cached property so `update_credentials` still echoes the just-written privacy in its response.
  - Fixes NEODB-SOCIAL-7K2

## Out of scope (discussed, deferred)

- NEODB-SOCIAL-4DS (ExternalResource JSONB lookup) — last seen 2026-03-31, not recurred; already has a GIN index.
- NEODB-SOCIAL-4QR / -4N7 (Takahe `activities_post` aggregations) — would require index migrations on a large prod table; low frequency / low actionability.

## Testing

- Added timeline N+1 regression guards: per-item card queries (4QY/7MQ) and album-embed `metadata` deferral; each verified to fail without its fix.
- Added an `update_credentials` privacy round-trip test (fails without the cache invalidation: `'public' == 'private'`).
- A Codex review pass caught the two issues above (stale privacy + embed metadata deferral); both fixed and regression-tested.
- `neodb`: 235 passed (`tests/social/`, `test_n_plus_one`, `test_people`, `test_backfill_people`, `test_recommendation`, `test_performance`).
- `takahe`: 26 passed (`api/test_accounts`, `users/models/test_identity`, `activities/models/test_neodb_ap_object`, `users/views/settings/test_privacy`); pre-existing env-only `test_fetch_actor` failure (remote actor HTTP fetch) deselected — confirmed failing identically on unmodified `main`.
- `pre-commit` (ruff, ruff-format, djLint, ty) clean on all changed files.