### PR TITLE
feat(journal): add REST API endpoints for articles

### DIFF
--- a/neodb/journal/apis/__init__.py
+++ b/neodb/journal/apis/__init__.py
@@ -1,3 +1,4 @@
+from .article import *  # noqa
 from .collection import *  # noqa
 from .note import *  # noqa
 from .review import *  # noqa

--- a/neodb/journal/apis/article.py
+++ b/neodb/journal/apis/article.py
@@ -97,11 +97,12 @@ def get_user_article(request, article_uuid: str):
     """
     Get an article owned by current user by its uuid
     """
-    a = Article.get_by_url(article_uuid)
+    # Owner-scoped lookup (returns 404, not 403, for someone else's article) so
+    # the endpoint cannot be used to probe the existence of other users'
+    # private articles, and to match update_article/delete_article.
+    a = Article.get_by_url_and_owner(article_uuid, request.user.identity.pk)
     if not a:
-        return Status(404, {"message": "Article not found"})
-    if a.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+        return NOT_FOUND
     return a
 
 

--- a/neodb/journal/apis/article.py
+++ b/neodb/journal/apis/article.py
@@ -1,0 +1,200 @@
+from datetime import datetime
+from typing import Any, List
+
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from ninja import Field, Schema, Status
+from ninja.pagination import paginate
+
+from common.api import (
+    NOT_FOUND,
+    OK,
+    OptionalOAuthAccessTokenAuth,
+    PageNumberPagination,
+    Result,
+    api,
+)
+from common.sentry import record_activity
+
+from ..models import Article
+from ..models.common import prefetch_latest_posts
+
+
+class ArticleSchema(Schema):
+    uuid: str
+    url: str
+    api_url: str
+    visibility: int = Field(ge=0, le=2)
+    post_id: int | None = Field(alias="latest_post_id")
+    created_time: datetime
+    title: str
+    body: str
+    summary: str
+    sensitive: bool = False
+    language: str = ""
+    tags: list[str] = []
+    html_content: str
+
+
+class ArticleInSchema(Schema):
+    # title/language are bounded to the model's CharField limits so over-long
+    # input returns a clean 422 instead of an uncaught DB DataError (500).
+    # body/summary are unbounded TextFields, so no cap here.
+    title: str = Field(max_length=500)
+    body: str
+    summary: str = ""
+    sensitive: bool = False
+    visibility: int = Field(ge=0, le=2)
+    language: str = Field("", max_length=8)
+    tags: list[str] = []
+    post_to_fediverse: bool = False
+
+
+class ArticlePageNumberPagination(PageNumberPagination):
+    """Pagination that batch-prefetches latest posts after slicing.
+
+    Plain ``PageNumberPagination`` serializes each Article one at a time, and
+    ``ArticleSchema.post_id`` (``latest_post_id``) would then trigger its own
+    ``PiecePost`` query per row (N+1). This hook resolves the whole page's
+    latest posts in one batched query.
+    """
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        if isinstance(val, tuple):
+            return val
+        data = val.get("data") if isinstance(val, dict) else None
+        if data:
+            prefetch_latest_posts(list(data))
+        return val
+
+
+@api.get(
+    "/me/article/",
+    response={200: List[ArticleSchema], 401: Result, 403: Result},
+    tags=["article"],
+)
+@paginate(ArticlePageNumberPagination)
+def list_articles(request):
+    """
+    Get articles by current user
+    """
+    return Article.objects.filter(owner=request.user.identity).order_by("-created_time")
+
+
+@api.get(
+    "/me/article/{article_uuid}",
+    response={200: ArticleSchema, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+)
+def get_user_article(request, article_uuid: str):
+    """
+    Get an article owned by current user by its uuid
+    """
+    a = Article.get_by_url(article_uuid)
+    if not a:
+        return Status(404, {"message": "Article not found"})
+    if a.owner != request.user.identity:
+        return Status(403, {"message": "Not owner"})
+    return a
+
+
+@api.post(
+    "/me/article/",
+    response={200: ArticleSchema, 401: Result, 403: Result},
+    tags=["article"],
+)
+def create_article(request, a_in: ArticleInSchema):
+    """
+    Create an article for current user.
+
+    `title` and `body` (markdown formatted) are required; `visibility` is
+    required (0: public, 1: followers only, 2: private). `language` defaults
+    to the user's preferred language when omitted.
+    """
+    article = Article.update_local_article(
+        owner=request.user.identity,
+        title=a_in.title,
+        body=a_in.body,
+        summary=a_in.summary,
+        sensitive=a_in.sensitive,
+        visibility=a_in.visibility,
+        language=a_in.language or request.user.language,
+        tags=a_in.tags,
+        share_to_mastodon=a_in.post_to_fediverse,
+        application_id=getattr(request, "application_id", None),
+    )
+    record_activity("article", "api")
+    return article
+
+
+@api.put(
+    "/me/article/{article_uuid}",
+    response={200: ArticleSchema, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+)
+def update_article(request, article_uuid: str, a_in: ArticleInSchema):
+    """
+    Update an article owned by current user.
+    """
+    article = Article.get_by_url_and_owner(article_uuid, request.user.identity.pk)
+    if not article:
+        return NOT_FOUND
+    article = Article.update_local_article(
+        owner=request.user.identity,
+        title=a_in.title,
+        body=a_in.body,
+        summary=a_in.summary,
+        sensitive=a_in.sensitive,
+        visibility=a_in.visibility,
+        language=a_in.language or request.user.language,
+        tags=a_in.tags,
+        article=article,
+        share_to_mastodon=a_in.post_to_fediverse,
+        application_id=getattr(request, "application_id", None),
+    )
+    record_activity("article", "api")
+    return article
+
+
+@api.delete(
+    "/me/article/{article_uuid}",
+    response={200: Result, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+)
+def delete_article(request, article_uuid: str):
+    """
+    Delete an article owned by current user.
+    """
+    article = Article.get_by_url_and_owner(article_uuid, request.user.identity.pk)
+    if not article:
+        return NOT_FOUND
+    article.delete()
+    return OK
+
+
+@api.get(
+    "/article/{article_uuid}",
+    response={200: ArticleSchema, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+    auth=OptionalOAuthAccessTokenAuth(),
+)
+def get_article(request, article_uuid: str):
+    """
+    Get an article by its uuid with permission checks.
+
+    Returns the article if it is visible to the requesting user based on its
+    visibility and the relationship to the owner; otherwise 403.
+    """
+    a = Article.get_by_url(article_uuid)
+    if not a:
+        return Status(404, {"message": "Article not found"})
+    if not a.is_visible_to(request.user):
+        return Status(403, {"message": "Permission denied"})
+    return a

--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -15,7 +15,7 @@ from users.models import APIdentity
 
 from .atproto import DOCUMENT_NSID, build_document
 from .common import Piece, VisibilityType
-from .renderers import render_md
+from .renderers import render_md, sanitize_md_images
 from .tag import Tag as TagModel
 
 _RE_SPOILER_TAG = re.compile(r'<(div|span)\sclass="spoiler">.*</(div|span)>')
@@ -348,7 +348,11 @@ class Article(Piece):
         if article is None:
             article = cls(owner=owner)
         article.title = title
-        article.body = body
+        # Validate/normalize markdown image srcs here (not in each caller) so
+        # every local-author entry point — web compose form and the REST API —
+        # is sanitized by default. Idempotent: already-normalized srcs are
+        # unchanged. Inbound federation uses update_by_ap_object, not this path.
+        article.body = sanitize_md_images(body)
         article.summary = summary or ""
         article.sensitive = bool(sensitive)
         article.visibility = int(visibility)

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -17,7 +17,7 @@ from users.models.apidentity import APIdentity
 from ..forms import ArticleForm
 from ..models import Article
 from ..models.common import prefetch_latest_posts, q_owned_piece_visible_to_user
-from ..models.renderers import convert_leading_space_in_md, sanitize_md_images
+from ..models.renderers import convert_leading_space_in_md
 from .common import conditional_get_for_anonymous, post_quotes_count
 
 
@@ -77,7 +77,8 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
     body = form.cleaned_data["body"]
     if form.cleaned_data.get("leading_space"):
         body = convert_leading_space_in_md(body)
-    body = sanitize_md_images(body)
+    # Image-src sanitization now lives in Article.update_local_article so all
+    # local-author entry points share it; no need to sanitize here.
     tags = _parse_tags(form.cleaned_data.get("tags", ""))
     article = Article.update_local_article(
         owner=request.user.identity,

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1002,12 +1002,13 @@ def test_article_api_visibility():
     response = Client().get(f"/api/article/{article.uuid}")
     assert response.status_code == 403
 
-    # another user cannot reach it via the owner-scoped endpoint
+    # another user cannot reach it via the owner-scoped endpoint; it returns
+    # 404 (not 403) so the endpoint can't be used to probe article existence
     response = Client().get(
         f"/api/me/article/{article.uuid}",
         HTTP_AUTHORIZATION=f"Bearer {viewer_token}",
     )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -7,7 +7,15 @@ from django.test import Client, override_settings
 from django.utils import timezone
 
 from catalog.models import Edition, Game, Movie
-from journal.models import Collection, FeaturedCollection, Mark, Note, Review, Tag
+from journal.models import (
+    Article,
+    Collection,
+    FeaturedCollection,
+    Mark,
+    Note,
+    Review,
+    Tag,
+)
 from journal.models.shelf import ShelfType
 from takahe.models import Post
 from takahe.utils import Takahe
@@ -858,6 +866,195 @@ def test_review_api_crud_and_public_fetch():
         HTTP_AUTHORIZATION=f"Bearer {token}",
     )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_api_crud_and_public_fetch():
+    user = User.register(email="articleuser@example.com", username="articleuser")
+
+    app = Takahe.get_or_create_app(
+        "Article API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    response = client.post(
+        "/api/me/article/",
+        data=json.dumps(
+            {
+                "title": "Article Title",
+                "body": "Article **body** in markdown",
+                "summary": "A short summary",
+                "visibility": 0,
+                "tags": ["Foo", "bar"],
+                "post_to_fediverse": False,
+            }
+        ),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+    created = response.json()
+    article_uuid = created["uuid"]
+    assert created["title"] == "Article Title"
+    assert created["body"] == "Article **body** in markdown"
+    assert created["summary"] == "A short summary"
+    assert created["tags"] == ["Foo", "bar"]
+    assert "<strong>body</strong>" in created["html_content"]
+
+    response = client.get(
+        "/api/me/article/",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["data"][0]["uuid"] == article_uuid
+
+    response = client.get(
+        f"/api/me/article/{article_uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+
+    response = client.put(
+        f"/api/me/article/{article_uuid}",
+        data=json.dumps(
+            {
+                "title": "Article Title Updated",
+                "body": "Updated body",
+                "visibility": 0,
+            }
+        ),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["title"] == "Article Title Updated"
+
+    response = Client().get(f"/api/article/{article_uuid}")
+
+    assert response.status_code == 200
+    assert response.json()["url"].endswith(article_uuid)
+
+    response = client.delete(
+        f"/api/me/article/{article_uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+    response = client.get(
+        f"/api/me/article/{article_uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_api_visibility():
+    owner = User.register(email="articleowner@example.com", username="articleowner")
+    viewer = User.register(email="articleviewer@example.com", username="articleviewer")
+
+    article = Article.update_local_article(
+        owner=owner.identity,
+        title="Private Article",
+        body="secret",
+        visibility=2,
+    )
+
+    owner_app = Takahe.get_or_create_app(
+        "Article Owner App",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=owner.identity.pk,
+    )
+    owner_token = Takahe.refresh_token(owner_app, owner.identity.pk, owner.pk)
+    viewer_app = Takahe.get_or_create_app(
+        "Article Viewer App",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=viewer.identity.pk,
+    )
+    viewer_token = Takahe.refresh_token(viewer_app, viewer.identity.pk, viewer.pk)
+
+    # owner can fetch their own private article via the public endpoint
+    response = Client().get(
+        f"/api/article/{article.uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {owner_token}",
+    )
+    assert response.status_code == 200
+
+    # another user cannot fetch a private article
+    response = Client().get(
+        f"/api/article/{article.uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {viewer_token}",
+    )
+    assert response.status_code == 403
+
+    # anonymous cannot fetch a private article
+    response = Client().get(f"/api/article/{article.uuid}")
+    assert response.status_code == 403
+
+    # another user cannot reach it via the owner-scoped endpoint
+    response = Client().get(
+        f"/api/me/article/{article.uuid}",
+        HTTP_AUTHORIZATION=f"Bearer {viewer_token}",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_api_sanitizes_body_and_validates_length():
+    user = User.register(email="articlesan@example.com", username="articlesan")
+    app = Takahe.get_or_create_app(
+        "Article Sanitize API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    # a markdown image with a relative (invalid) src is sanitized on the API
+    # path, just like the web compose form
+    response = client.post(
+        "/api/me/article/",
+        data=json.dumps(
+            {
+                "title": "Sanitized",
+                "body": "see ![pic](secret.png) here",
+                "visibility": 0,
+            }
+        ),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+    body = response.json()["body"]
+    assert "![pic](secret.png)" not in body
+    assert "==[invalid image: secret.png]==" in body
+
+    # an over-long title is rejected with a clean 422, not an uncaught DB 500
+    response = client.post(
+        "/api/me/article/",
+        data=json.dumps(
+            {
+                "title": "x" * 501,
+                "body": "ok",
+                "visibility": 0,
+            }
+        ),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Summary
Adds a django-ninja REST API for standalone Articles (the item-less, markdown ActivityPub article type), which previously had no API surface — only web compose forms.

### Endpoints (tag: `article`)
- `GET /api/me/article/` — list current user's articles (paginated)
- `POST /api/me/article/` — create
- `GET /api/me/article/{uuid}` — get own article
- `PUT /api/me/article/{uuid}` — update own article
- `DELETE /api/me/article/{uuid}` — delete own article
- `GET /api/article/{uuid}` — public fetch (visibility-checked, optional auth)

Create/update route through the existing `Article.update_local_article(...)`, so federation, indexing, and crossposting behave exactly as the web compose flow. `language` falls back to the user's preferred language when omitted.

### Hardening (from code review)
- **Centralized markdown image-src sanitization**: moved `sanitize_md_images` into `Article.update_local_article` so every local-author entry point (web form + API) sanitizes by default; removed the now-redundant call from the web view.
- **Input length validation**: `ArticleInSchema` bounds `title` (≤500) and `language` (≤8) to the model's column limits, so over-long input returns a clean 422 instead of an uncaught DB error.
- **List N+1 fix**: added a batching paginator that calls `prefetch_latest_posts` on each page (mirrors `CollectionPageNumberPagination`).

### Tests
- Article API CRUD + public fetch, visibility enforcement, and sanitize/length-validation tests.
- `tests/journal/test_api.py`: 27 passed; article web/model/federation suites: 104 passed; `pre-commit` (ruff, ruff format, ty) clean.

### Note
`PostTypes` in `apis/post.py` is intentionally unchanged — that set filters the item-scoped `/api/item/{uuid}/posts/` endpoint, and Articles are item-less, so they can never appear there.