### PR TITLE
feat(catalog): exclude sibling editions from recommendations

### DIFF
--- a/neodb/catalog/recommendation.py
+++ b/neodb/catalog/recommendation.py
@@ -28,6 +28,7 @@ from .models import (
     TVEpisode,
     TVShow,
     UserRecommendation,
+    Work,
     item_content_types,
 )
 
@@ -133,6 +134,23 @@ def _user_shelved_item_ids(identity_pk: int) -> set[int]:
     )
 
 
+def _sibling_edition_ids(item_ids: set[int]) -> set[int]:
+    """Edition ids sharing a Work with any Edition in ``item_ids``.
+
+    Non-edition ids don't match the Work.editions through table, so the whole
+    shelved set can be passed in. Single query via a work-id subquery.
+    """
+    if not item_ids:
+        return set()
+    through = Work.editions.through
+    work_ids = through.objects.filter(edition_id__in=item_ids).values("work_id")
+    return set(
+        through.objects.filter(work_id__in=work_ids).values_list(
+            "edition_id", flat=True
+        )
+    )
+
+
 def similar_items(item: Item, viewer=None, limit: int = 10) -> list[Item]:
     """Return up to ``limit`` items similar to ``item``.
 
@@ -195,7 +213,10 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
         seeds.append(mapped)
         if len(seeds) >= seed_cap:
             break
+    # Exclude shelved items plus their sibling editions (same Work). Precompute
+    # only; a sibling marked later may dupe until the next refresh.
     shelved = _user_shelved_item_ids(identity_pk)
+    excluded = shelved | _sibling_edition_ids(shelved)
     seed_set = set(seeds)
 
     scores: dict[int, float] = defaultdict(float)
@@ -204,7 +225,7 @@ def compute_for_user(user_pk: int, identity_pk: int) -> list[UserRecommendation]
         "source_id", "target_id", "score"
     )
     for src, tgt, score in sim_rows:
-        if tgt in shelved or tgt in seed_set:
+        if tgt in excluded or tgt in seed_set:
             continue
         scores[tgt] += score
         if len(seeds_by_target[tgt]) < 3:

--- a/neodb/tests/catalog/test_recommendation.py
+++ b/neodb/tests/catalog/test_recommendation.py
@@ -8,6 +8,7 @@ from catalog.models import (
     PerformanceProduction,
     TVShow,
     UserRecommendation,
+    Work,
 )
 from catalog.recommendation import (
     blended_for_discover,
@@ -413,3 +414,69 @@ class TestExcludedTargetClasses:
             ItemSimilarity.objects.values_list("target_id", flat=True).distinct()
         )
         assert self.show.pk not in target_ids
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSiblingEditionExclusion:
+    """Precompute drops sibling editions of shelved items; request path allows dupes."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(
+            enable_recommendations=True,
+            reco_min_source_marks=2,
+            reco_min_target_marks=2,
+            reco_similarity_top_k=10,
+            reco_user_top_n=10,
+            reco_per_user_seed_cap=50,
+            reco_user_mark_cap=100,
+            reco_user_active_days=30,
+            reco_user_idf_dampen=False,
+            reco_lazy_ttl_days=7,
+        )
+        self.strangers = [
+            User.register(email=f"sib{i}@t.com", username=f"sib{i}").identity
+            for i in range(2)
+        ]
+        self.src = Edition.objects.create(title="Src")
+        # A Work with two sibling editions.
+        self.work = Work.objects.create(title="The Work")
+        self.e1 = Edition.objects.create(title="Edition One")
+        self.e2 = Edition.objects.create(title="Edition Two")
+        self.work.editions.add(self.e1, self.e2)
+        # A standalone target with no siblings, as a control.
+        self.other = Edition.objects.create(title="Other")
+        # Strangers co-shelve src with e2 and with other -> similarity built so
+        # both e2 and other are valid recommendation targets for src.
+        for ident in self.strangers:
+            _public_mark(ident, self.src)
+            _public_mark(ident, self.e2)
+            _public_mark(ident, self.other)
+        BuildItemSimilarity().run()
+
+    def test_compute_for_user_excludes_sibling_edition(self):
+        target = User.register(email="sibt@t.com", username="sibt")
+        # Seed with src so similarity surfaces e2 and other, and mark e1.
+        _public_mark(target.identity, self.src)
+        _public_mark(target.identity, self.e1)
+        ids = {r.item_id for r in compute_for_user(target.pk, target.identity.pk)}
+        assert self.e2.pk not in ids  # sibling of marked e1 -> excluded
+        assert self.other.pk in ids  # unrelated target still recommended
+
+    def test_batch_job_excludes_sibling_edition(self):
+        target = User.register(email="sibb@t.com", username="sibb")
+        _public_mark(target.identity, self.src)
+        _public_mark(target.identity, self.e1)
+        BuildUserRecommendations().run()
+        rows = UserRecommendation.objects.filter(user=target)
+        item_ids = {r.item_id for r in rows}
+        assert self.e2.pk not in item_ids  # sibling excluded by the precompute
+        assert self.other.pk in item_ids
+
+    def test_request_path_allows_sibling_dupe(self):
+        # similar_items is request-time and deliberately does NOT do sibling
+        # suppression; marking e1 still lets its sibling e2 surface as a dupe.
+        watcher = User.register(email="sibw@t.com", username="sibw")
+        _public_mark(watcher.identity, self.e1)
+        ids = {i.pk for i in similar_items(self.src, viewer=watcher, limit=10)}
+        assert self.e2.pk in ids


### PR DESCRIPTION
## What

The recommendation precompute already excludes items the viewer has shelved, but the exclusion is keyed on exact item id. Because a book is an `Edition` grouped under a `Work` (`Work.editions` M2M), a *different* edition of the same work could still be recommended after the user marked one of its siblings.

This expands the exclusion to also drop the sibling editions of any edition the user has shelved.

## Where

The suppression lives **only in the precompute** (`compute_for_user`, run by the nightly `BuildUserRecommendations` job) — off the request path. The sibling lookup is a single subquery over the `Work.editions` through-table. Request-time surfaces (`similar_items`, `for_you` serving filter, `from_your_circles`) are unchanged, so a sibling marked *after* the precompute runs may still surface as a dupe until the next refresh — an accepted trade-off to keep request handling cheap.

## Tests

`TestSiblingEditionExclusion` covers:
- `compute_for_user` drops the sibling edition while keeping an unrelated control target.
- the full `BuildUserRecommendations` batch job produces rows without the sibling.
- the request path (`similar_items`) deliberately still allows the sibling dupe (documents the trade-off).

Rebased on latest `upstream/main`. Full `tests/catalog/test_recommendation.py`: 22 passed.