### PR TITLE
fix(users): auto-redirect after passkey creation in register wizard

### DIFF
--- a/neodb/users/templates/users/welcome.html
+++ b/neodb/users/templates/users/welcome.html
@@ -74,6 +74,7 @@
               btn.removeAttribute('aria-busy');
               btn.disabled = true;
               btn.textContent = '{% trans "Passkey created" %}';
+              location = document.getElementById('accept-btn').dataset.redirectUrl;
             },
             function(err) {
               btn.removeAttribute('aria-busy');

--- a/neodb/users/templates/users/welcome.html
+++ b/neodb/users/templates/users/welcome.html
@@ -74,7 +74,7 @@
               btn.removeAttribute('aria-busy');
               btn.disabled = true;
               btn.textContent = '{% trans "Passkey created" %}';
-              location = document.getElementById('accept-btn').dataset.redirectUrl;
+              window.location.href = document.getElementById('accept-btn')?.dataset?.redirectUrl || '/';
             },
             function(err) {
               btn.removeAttribute('aria-busy');


### PR DESCRIPTION
## Problem

When a new user registers and creates a passkey on the welcome (wizard) page, the page does not auto-redirect. The user is left stranded on the welcome page and has to manually click "Continue" / "Maybe later".

## Root cause

In `users/templates/users/welcome.html`, the passkey-creation `onSuccess` callback only relabeled the button and never navigated:

```js
function() {
  btn.removeAttribute('aria-busy');
  btn.disabled = true;
  btn.textContent = 'Passkey created';
}
```

By contrast, the login passkey flow (`login.html`) redirects on success via `location.href = result.redirect || '/'`. The register verify endpoint returns only `{"ok": true}` (no redirect field), so the welcome page never navigated.

## Fix

Redirect after a successful passkey creation to the same destination the "Continue" button already uses — the `data-redirect-url` on `#accept-btn`, which is `{{ request.session.next_url|safe_next_url:'/' }}`:

```js
location = document.getElementById('accept-btn').dataset.redirectUrl;
```

Frontend-only, single-line change. No backend change needed since the destination is already rendered into the page (and goes through the `safe_next_url` filter).

## Testing

- `pre-commit run --files neodb/users/templates/users/welcome.html` passes (djLint, ty, etc.).
- `#accept-btn` remains in the DOM when passkeys are supported (only `display` is hidden), so its `dataset.redirectUrl` is readable from the callback.