### PR TITLE
feat(catalog): connect verified podcast creators to their fediverse identity

### DIFF
--- a/neodb/catalog/jobs/creator_verify.py
+++ b/neodb/catalog/jobs/creator_verify.py
@@ -138,7 +138,10 @@ def _verify_claim(claim: VerifiedCreator, user: User, matched: str) -> None:
             verified = pending
         else:
             # attribute the work to the matched identity; the original pending
-            # row is dropped so the (item, owner) uniqueness still holds
+            # row is dropped so the (item, owner) uniqueness still holds.
+            # edited_time is set explicitly: update_or_create saves an existing
+            # row with update_fields limited to defaults, so the auto_now field
+            # would not refresh on the update branch otherwise.
             pending.delete()
             verified, _ = VerifiedCreator.objects.update_or_create(
                 item=item,
@@ -147,9 +150,12 @@ def _verify_claim(claim: VerifiedCreator, user: User, matched: str) -> None:
                     "state": VerifiedCreator.State.VERIFIED,
                     "matched": matched,
                     "failure_reason": "",
+                    "edited_time": timezone.now(),
                 },
             )
-    item.log_action({"!creator_verified": ["", f"{verified.owner} ({matched})"]})
+        # log inside the transaction so the state change and its audit entry
+        # commit together
+        item.log_action({"!creator_verified": ["", f"{verified.owner} ({matched})"]})
     logger.info(f"creator verification matched {matched} for {verified}")
 
 

--- a/neodb/catalog/jobs/creator_verify.py
+++ b/neodb/catalog/jobs/creator_verify.py
@@ -1,7 +1,11 @@
+from urllib.parse import urlparse
+
 import django_rq
+from django.db import transaction
 from django.utils import timezone
 from loguru import logger
 
+from common.validators import is_valid_url
 from journal.models.renderers import html_to_text
 from users.models import User
 
@@ -9,6 +13,7 @@ from ..models import (
     VerifiedCreator,
     creator_identity_candidates,
     match_creator_identity,
+    resolve_creator_identity,
 )
 
 
@@ -26,6 +31,124 @@ def _fail_claim(claim: VerifiedCreator, reason: str) -> None:
         failure_reason=reason,
         edited_time=timezone.now(),
     )
+
+
+def _has_audio_episode(feed: dict) -> bool:
+    """Whether the parsed feed has at least one playable audio episode.
+
+    Guards against verifying a feed that is not actually a podcast (no audio
+    enclosures). Enclosures without a declared mime type are accepted, since
+    many feeds omit it; clearly non-audio types (e.g. video) do not count.
+    """
+    for episode in feed.get("episodes") or []:
+        for enclosure in episode.get("enclosures") or []:
+            mime = (enclosure.get("mime_type") or "").lower()
+            if enclosure.get("url") and (mime.startswith("audio") or not mime):
+                return True
+    return False
+
+
+# rel="me" links on a page (rel is a space-separated, case-insensitive token list)
+_REL_ME_XPATH = (
+    "//a[contains(concat(' ', normalize-space(translate(@rel, 'ME', 'me')), ' '),"
+    " ' me ')]/@href"
+    " | //link[contains(concat(' ', normalize-space(translate(@rel, 'ME', 'me')), ' '),"
+    " ' me ')]/@href"
+)
+
+
+def _fetch_page_rel_me_urls(url: str) -> list[str]:
+    """rel="me" link targets declared by the page the feed's channel links to.
+
+    A creator's own site typically rel="me"-links to their fediverse and Bluesky
+    profiles, so matching these proves authorship across both networks. The page
+    URL itself is included too, so a feed whose channel link is the creator's
+    Bluesky (its handle is a domain) also counts. Best-effort: [] on any error.
+    """
+    from catalog.common.downloaders import BasicDownloader2
+
+    if not url or not is_valid_url(url):
+        return []
+    try:
+        content = BasicDownloader2(url).download().html()
+    except Exception:
+        logger.debug(f"verify_creator_task: unable to fetch page {url}")
+        return []
+    return [h.strip() for h in content.xpath(_REL_ME_XPATH) if h and h.strip()]
+
+
+def _channel_link_matches_bluesky(user: User, link: str) -> str | None:
+    """Proof when the feed's channel link is the user's Bluesky: a Bluesky handle
+    is itself a domain, so a channel link hosted on it (any path) counts."""
+    bluesky = getattr(user, "bluesky", None)
+    handle = getattr(bluesky, "handle", None) if bluesky else None
+    if not handle or not link:
+        return None
+    host = urlparse(link if "://" in link else f"https://{link}").hostname or ""
+    if host.lower().removeprefix("www.") == handle.lower().removeprefix("www."):
+        return f"@{handle}"
+    return None
+
+
+def _match_creator(user: User, feed: dict) -> str | None:
+    """Find proof of ownership in the feed.
+
+    A rel="me" link on the page the channel <link> points to (or the channel link
+    being the creator's own Bluesky) is preferred over a text match in the feed
+    description; all paths must still match one of the user's own candidates.
+    """
+    candidates = creator_identity_candidates(user)
+    link = feed.get("link") or ""
+    if link:
+        proofs = [link, *_fetch_page_rel_me_urls(link)]
+        matched = match_creator_identity(proofs, candidates)
+        if matched:
+            return matched
+        matched = _channel_link_matches_bluesky(user, link)
+        if matched:
+            return matched
+    description = feed.get("description") or ""
+    return match_creator_identity([description, html_to_text(description)], candidates)
+
+
+def _verify_claim(claim: VerifiedCreator, user: User, matched: str) -> None:
+    """Mark the pending claim VERIFIED, attributing it to the identity the
+    matched identifier represents (e.g. the user's linked Mastodon identity
+    rather than their local one)."""
+    identity = resolve_creator_identity(user, matched)
+    item = claim.item
+    with transaction.atomic():
+        pending = (
+            VerifiedCreator.objects.select_for_update()
+            .filter(pk=claim.pk, state=VerifiedCreator.State.PENDING)
+            .first()
+        )
+        if not pending:
+            return
+        if identity.pk == pending.owner_id:
+            pending.state = VerifiedCreator.State.VERIFIED
+            pending.matched = matched
+            pending.failure_reason = ""
+            pending.edited_time = timezone.now()
+            pending.save(
+                update_fields=["state", "matched", "failure_reason", "edited_time"]
+            )
+            verified = pending
+        else:
+            # attribute the work to the matched identity; the original pending
+            # row is dropped so the (item, owner) uniqueness still holds
+            pending.delete()
+            verified, _ = VerifiedCreator.objects.update_or_create(
+                item=item,
+                owner=identity,
+                defaults={
+                    "state": VerifiedCreator.State.VERIFIED,
+                    "matched": matched,
+                    "failure_reason": "",
+                },
+            )
+    item.log_action({"!creator_verified": ["", f"{verified.owner} ({matched})"]})
+    logger.info(f"creator verification matched {matched} for {verified}")
 
 
 def verify_creator_task(claim_id: int, user_id: int) -> None:
@@ -53,22 +176,11 @@ def verify_creator_task(claim_id: int, user_id: int) -> None:
     if status != 200 or feed is None:
         _fail_claim(claim, VerifiedCreator.FailureReason.FETCH_FAILED)
         return
-    description = feed.get("description") or ""
-    matched = match_creator_identity(
-        [description, html_to_text(description)],
-        creator_identity_candidates(user),
-    )
+    if not _has_audio_episode(feed):
+        _fail_claim(claim, VerifiedCreator.FailureReason.NO_AUDIO)
+        return
+    matched = _match_creator(user, feed)
     if matched:
-        verified = VerifiedCreator.objects.filter(
-            pk=claim.pk, state=VerifiedCreator.State.PENDING
-        ).update(
-            state=VerifiedCreator.State.VERIFIED,
-            matched=matched,
-            failure_reason="",
-            edited_time=timezone.now(),
-        )
-        if verified:
-            item.log_action({"!creator_verified": ["", f"{claim.owner} ({matched})"]})
-            logger.info(f"creator verification matched {matched} for {claim}")
+        _verify_claim(claim, user, matched)
     else:
         _fail_claim(claim, VerifiedCreator.FailureReason.NO_MATCH)

--- a/neodb/catalog/jobs/creator_verify.py
+++ b/neodb/catalog/jobs/creator_verify.py
@@ -74,6 +74,8 @@ def _fetch_page_rel_me_urls(url: str) -> list[str]:
     except Exception:
         logger.debug(f"verify_creator_task: unable to fetch page {url}")
         return []
+    if content is None:
+        return []
     return [h.strip() for h in content.xpath(_REL_ME_XPATH) if h and h.strip()]
 
 
@@ -179,8 +181,14 @@ def verify_creator_task(claim_id: int, user_id: int) -> None:
     if not _has_audio_episode(feed):
         _fail_claim(claim, VerifiedCreator.FailureReason.NO_AUDIO)
         return
-    matched = _match_creator(user, feed)
-    if matched:
-        _verify_claim(claim, user, matched)
-    else:
-        _fail_claim(claim, VerifiedCreator.FailureReason.NO_MATCH)
+    # never let an unexpected matching/resolution/db error leave the claim stuck
+    # in PENDING; fail it instead so the user can retry
+    try:
+        matched = _match_creator(user, feed)
+        if matched:
+            _verify_claim(claim, user, matched)
+        else:
+            _fail_claim(claim, VerifiedCreator.FailureReason.NO_MATCH)
+    except Exception:
+        logger.exception(f"verify_creator_task: error verifying claim {claim_id}")
+        _fail_claim(claim, VerifiedCreator.FailureReason.FETCH_FAILED)

--- a/neodb/catalog/models/__init__.py
+++ b/neodb/catalog/models/__init__.py
@@ -13,6 +13,9 @@ from .creator import (
     VerifiedCreator,
     creator_identity_candidates,
     match_creator_identity,
+    resolve_creator_identity,
+    user_controls_owner,
+    user_owned_claims_q,
 )
 from .game import Game, GameInSchema, GameSchema
 from .item import (
@@ -171,4 +174,7 @@ __all__ = [
     "VerifiedCreator",
     "creator_identity_candidates",
     "match_creator_identity",
+    "resolve_creator_identity",
+    "user_controls_owner",
+    "user_owned_claims_q",
 ]

--- a/neodb/catalog/models/creator.py
+++ b/neodb/catalog/models/creator.py
@@ -3,11 +3,14 @@ from typing import TYPE_CHECKING, Iterable
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from loguru import logger
 
 from .item import Item
 
 if TYPE_CHECKING:
-    from users.models import User
+    from django.contrib.auth.models import AnonymousUser
+
+    from users.models import APIdentity, User
 
 
 class VerifiedCreator(models.Model):
@@ -25,7 +28,11 @@ class VerifiedCreator(models.Model):
     class FailureReason(models.TextChoices):
         NO_FEED = "no_feed", _("no feed url available for this item")
         FETCH_FAILED = "fetch_failed", _("unable to fetch or parse the feed")
-        NO_MATCH = "no_match", _("no matching identity found in the feed description")
+        NO_AUDIO = "no_audio", _("no audio episode found in the feed")
+        NO_MATCH = (
+            "no_match",
+            _("no matching identity found in the feed or its linked website"),
+        )
 
     if TYPE_CHECKING:
         item_id: int
@@ -79,6 +86,104 @@ def creator_identity_candidates(user: "User") -> list[str]:
         if user.bluesky.url:
             candidates.append(user.bluesky.url)
     return candidates
+
+
+def _mastodon_handle_parts(user: "User | AnonymousUser") -> tuple[str, str] | None:
+    """(username, domain) of the user's linked Mastodon handle, lowercased."""
+    mastodon = getattr(user, "mastodon", None)
+    handle = getattr(mastodon, "handle", None) if mastodon else None
+    if not handle:
+        return None
+    username, _, domain = handle.partition("@")
+    if not username or not domain:
+        return None
+    return username.lower(), domain.lower()
+
+
+def user_owned_claims_q(user: "User") -> models.Q:
+    """Q matching VerifiedCreator rows controlled by ``user``.
+
+    A claim is controlled by the user when its owner is the user's local
+    identity, or when the owner is the remote identity of the user's linked
+    Mastodon account (matched by the owner's stored username/domain, so no
+    remote-actor resolution happens on the request path).
+    """
+    q = models.Q(owner_id=user.identity.pk)
+    parts = _mastodon_handle_parts(user)
+    if parts:
+        username, domain = parts
+        q |= models.Q(
+            owner__username__iexact=username, owner__domain_name__iexact=domain
+        )
+    return q
+
+
+def user_controls_owner(user: "User | AnonymousUser", owner: "APIdentity") -> bool:
+    """Whether ``user`` controls a claim with this (already-loaded) ``owner``.
+
+    Mirrors :func:`user_owned_claims_q` for in-memory checks; compares only
+    fields already loaded on ``owner`` (no query, no remote-actor resolution).
+    """
+    identity = getattr(user, "identity", None)
+    if identity is None:
+        return False
+    if owner.pk == identity.pk:
+        return True
+    parts = _mastodon_handle_parts(user)
+    if parts and owner.username and owner.domain_name:
+        username, domain = parts
+        return owner.username.lower() == username and (
+            owner.domain_name.lower() == domain
+        )
+    return False
+
+
+def resolve_creator_identity(user: "User", matched: str) -> "APIdentity":
+    """Map a matched candidate string to the fediverse identity it represents.
+
+    A match against the user's linked Mastodon handle/url resolves to that
+    remote Mastodon identity (so the verified work is attributed to it); every
+    other match (local NeoDB handle/uri, Bluesky) stays the local identity.
+
+    This performs remote-actor resolution (DB lookup, then webfinger fetch) and
+    MUST only be called from the background verification task, never on the web
+    request path.
+    """
+    m = matched.strip().lower()
+    mastodon = getattr(user, "mastodon", None)
+    if mastodon and m:
+        mastodon_candidates = {f"@{mastodon.handle}".lower()}
+        if mastodon.url:
+            mastodon_candidates.add(mastodon.url.lower())
+        if m in mastodon_candidates:
+            identity = _resolve_remote_identity(mastodon.handle)
+            if identity:
+                return identity
+    return user.identity
+
+
+def _resolve_remote_identity(handle: str) -> "APIdentity | None":
+    """Resolve a ``user@domain`` handle to a remote APIdentity, fetching it via
+    webfinger when it is not already known. Returns None on failure."""
+    from users.models import APIdentity
+
+    username, _, domain = handle.partition("@")
+    if not username or not domain:
+        return None
+    identity = APIdentity.get_remote(username, domain)
+    if identity:
+        return identity
+    from takahe.models import Identity
+    from takahe.utils import Takahe
+
+    try:
+        takahe_identity = Identity.by_username_and_domain(username, domain, fetch=True)
+    except Exception:
+        logger.exception(f"failed to resolve remote identity {handle}")
+        return None
+    if takahe_identity:
+        return Takahe.get_or_create_remote_apidentity(takahe_identity)
+    return None
 
 
 def match_creator_identity(

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -1209,8 +1209,11 @@ class Item(PolymorphicModel):
         if parent:
             creators += parent.verified_creator_list
         if creators:
-            identity = getattr(user, "identity", None)
-            if not identity or not any(c.owner_id == identity.pk for c in creators):
+            from .creator import user_controls_owner
+
+            # a claim may be attributed to the user's linked Mastodon identity,
+            # not their local one, but they still control it
+            if not any(user_controls_owner(user, c.owner) for c in creators):
                 return False
         return True
 

--- a/neodb/catalog/templates/_verify_status.html
+++ b/neodb/catalog/templates/_verify_status.html
@@ -33,13 +33,29 @@
     <form method="post"
           action="{% url 'catalog:verify_creator_start' item.url_path item.uuid %}">
       {% csrf_token %}
-      <input type="submit" value="{% trans 'Try again' %}">
+      <label>
+        <input type="checkbox"
+               onchange="document.getElementById('verify-submit').disabled = !this.checked">
+        {% trans "I have updated my feed's description or website as described above." %}
+      </label>
+      <input id="verify-submit"
+             type="submit"
+             value="{% trans 'Try again' %}"
+             disabled>
     </form>
   {% else %}
     <form method="post"
           action="{% url 'catalog:verify_creator_start' item.url_path item.uuid %}">
       {% csrf_token %}
-      <input type="submit" value="{% trans 'Start verification' %}">
+      <label>
+        <input type="checkbox"
+               onchange="document.getElementById('verify-submit').disabled = !this.checked">
+        {% trans "I have updated my feed's description or website as described above." %}
+      </label>
+      <input id="verify-submit"
+             type="submit"
+             value="{% trans 'Start verification' %}"
+             disabled>
     </form>
   {% endif %}
 </section>

--- a/neodb/catalog/templates/catalog_verify.html
+++ b/neodb/catalog/templates/catalog_verify.html
@@ -21,16 +21,50 @@
           {% trans "If you are a creator of this podcast, you may verify the ownership, so that only you (and other verified creators) can edit its metadata on this site." %}
           {% trans "Your recent episodes may also occasionally be featured in discovery." %}
         </p>
-        <p>
-          {% trans "To verify, add one of the following identifiers of your account to the description of the podcast feed, then start verification. The identifier may be removed from the description once verified, but we recommend you keep it so that your audience can discover and connect with you in distributed social media." %}
-        </p>
+        <p>{% trans "To verify, prove you control one of the following identifiers of your account (click to copy):" %}</p>
         <ul>
           {% for candidate in candidates %}
             <li>
-              <code>{{ candidate }}</code>
+              <code style="cursor:copy"
+                    onmouseleave="$(this).removeAttr('data-tooltip')"
+                    onclick="navigator.clipboard.writeText(this.innerText);$(this).attr('data-tooltip','{% trans 'copied' %}');">{{ candidate }}</code>
             </li>
           {% endfor %}
         </ul>
+        <p>
+          {% blocktrans trimmed %}
+            You can prove this in a few ways, then start verification: add one of the
+            identifiers above to the podcast feed's description; add a <code>rel="me"</code>
+            link back to one of them on the web page your feed links to (the link
+            verification Mastodon uses); or point your feed's website at your Bluesky
+            handle's own domain.
+          {% endblocktrans %}
+        </p>
+        {% if example_url %}
+          <p>{% trans "For example, add this rel=me link to the web page your feed links to (click to copy):" %}</p>
+          <p>
+            <code style="cursor:copy"
+                  onmouseleave="$(this).removeAttr('data-tooltip')"
+                  onclick="navigator.clipboard.writeText(this.innerText);$(this).attr('data-tooltip','{% trans 'copied' %}');">&lt;a rel="me" href="{{ example_url }}"&gt;{{ site_name }}&lt;/a&gt;</code>
+          </p>
+          <p>{% trans "or, in the page's head:" %}</p>
+          <p>
+            <code style="cursor:copy"
+                  onmouseleave="$(this).removeAttr('data-tooltip')"
+                  onclick="navigator.clipboard.writeText(this.innerText);$(this).attr('data-tooltip','{% trans 'copied' %}');">&lt;link rel="me" href="{{ example_url }}"&gt;</code>
+          </p>
+          <p>
+            {% trans "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):" %}
+          </p>
+          <p>
+            <code style="cursor:copy"
+                  onmouseleave="$(this).removeAttr('data-tooltip')"
+                  onclick="navigator.clipboard.writeText(this.innerText);$(this).attr('data-tooltip','{% trans 'copied' %}');">{% trans "Welcome to follow me on the Fediverse:" %} {{ example_url }}</code>
+          </p>
+        {% endif %}
+        <p>
+          {% trans "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media." %}
+        </p>
       </section>
       {% include "_verify_status.html" %}
       {% if verified_creators %}

--- a/neodb/catalog/templates/item_base.html
+++ b/neodb/catalog/templates/item_base.html
@@ -23,6 +23,10 @@
           content="{{ site_name }} {% trans item.category.label %}">
     <meta property="og:description"
           content="{{ item.brief_description|slice:':300' }}">
+    {% for claim in item.verified_creator_list %}
+      <meta name="fediverse:creator" content="@{{ claim.owner.full_handle }}">
+      {% if claim.owner.profile_uri %}<link rel="me" href="{{ claim.owner.profile_uri }}">{% endif %}
+    {% endfor %}
     <meta rel="canonical" content="{{ item.absolute_url }}">
     {% all_languages as languages %}
     {% for lang in languages %}

--- a/neodb/catalog/views/verify.py
+++ b/neodb/catalog/views/verify.py
@@ -15,7 +15,13 @@ from common.utils import (
 from users.models import APIdentity
 
 from ..jobs.creator_verify import enqueue_creator_verification
-from ..models import Item, VerifiedCreator, creator_identity_candidates
+from ..models import (
+    Item,
+    VerifiedCreator,
+    creator_identity_candidates,
+    user_controls_owner,
+    user_owned_claims_q,
+)
 
 VERIFY_COOLDOWN_SECONDS = 60
 
@@ -34,11 +40,29 @@ def _verify_page_url(item: Item) -> str:
 
 
 def _verify_context(request, item: Item) -> dict:
+    # a verified claim may be attributed to the user's linked Mastodon identity,
+    # so look it up by any identity the user controls, not just the local one
+    my_claim = (
+        item.verified_creators.filter(user_owned_claims_q(request.user))
+        .select_related("owner")
+        .order_by("-edited_time")
+        .first()
+    )
+    # show only link/url identifiers; bare @handles still verify but are
+    # discouraged in the UI in favor of rel="me" links
+    candidates = [c for c in creator_identity_candidates(request.user) if "://" in c]
+    # a url to show in the copyable rel="me" example, preferring the linked
+    # Mastodon profile when available
+    mastodon = request.user.mastodon
+    example_url = (mastodon.url if mastodon and mastodon.url else "") or (
+        candidates[0] if candidates else ""
+    )
     return {
         "item": item,
-        "my_claim": item.verified_creators.filter(owner=request.user.identity).first(),
+        "my_claim": my_claim,
         "verified_creators": item.verified_creator_list,
-        "candidates": creator_identity_candidates(request.user),
+        "candidates": candidates,
+        "example_url": example_url,
     }
 
 
@@ -75,14 +99,22 @@ def verify_creator_start(request, item_path, item_uuid):
             request, messages.ERROR, _("No feed url available for this item.")
         )
         return redirect(_verify_page_url(item))
-    existing = VerifiedCreator.objects.filter(
-        item=item, owner=request.user.identity
-    ).first()
-    if existing and existing.state == VerifiedCreator.State.VERIFIED:
+    # a prior verification may have re-homed the claim onto a linked identity,
+    # so check every identity the user controls for an existing verified claim
+    if VerifiedCreator.objects.filter(
+        user_owned_claims_q(request.user),
+        item=item,
+        state=VerifiedCreator.State.VERIFIED,
+    ).exists():
         messages.add_message(
             request, messages.INFO, _("You are already a verified creator.")
         )
         return redirect(_verify_page_url(item))
+    # a pending claim is always owned by the local identity (attribution is
+    # only resolved once verification succeeds)
+    existing = VerifiedCreator.objects.filter(
+        item=item, owner=request.user.identity
+    ).first()
     if existing and existing.state == VerifiedCreator.State.PENDING:
         messages.add_message(
             request, messages.INFO, _("Verification is already in progress.")
@@ -142,9 +174,13 @@ def verify_creator_manual(request, item_path, item_uuid):
 def unverify_creator(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     claim = get_object_or_404(
-        VerifiedCreator, pk=request.POST.get("claim_id"), item=item
+        VerifiedCreator.objects.select_related("owner"),
+        pk=request.POST.get("claim_id"),
+        item=item,
     )
-    if claim.owner_id != request.user.identity.pk and not request.user.is_superuser:
+    if not user_controls_owner(request.user, claim.owner) and (
+        not request.user.is_superuser
+    ):
         raise PermissionDenied(_("Insufficient permission"))
     item.log_action({"!creator_unverified": ["", str(claim.owner)]})
     claim.delete()

--- a/neodb/catalog/views/verify.py
+++ b/neodb/catalog/views/verify.py
@@ -173,9 +173,12 @@ def verify_creator_manual(request, item_path, item_uuid):
 @user_identity_required
 def unverify_creator(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
+    claim_id = request.POST.get("claim_id", "")
+    if not claim_id.isdigit():
+        raise BadRequest(_("Invalid parameter"))
     claim = get_object_or_404(
         VerifiedCreator.objects.select_related("owner"),
-        pk=request.POST.get("claim_id"),
+        pk=claim_id,
         item=item,
     )
     if not user_controls_owner(request.user, claim.owner) and (

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 08:25-0400\n"
+"POT-Creation-Date: 2026-06-14 15:21-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -564,32 +564,36 @@ msgid "genre"
 msgstr ""
 
 #: catalog/models/common.py:284 catalog/templates/_language_list.html:5
-#: users/models/user.py:128
+#: users/models/user.py:129
 msgid "language"
 msgstr ""
 
-#: catalog/models/creator.py:21
+#: catalog/models/creator.py:24
 msgid "pending"
 msgstr ""
 
-#: catalog/models/creator.py:22
+#: catalog/models/creator.py:25
 msgid "verified"
 msgstr ""
 
-#: catalog/models/creator.py:23
+#: catalog/models/creator.py:26
 msgid "failed"
 msgstr ""
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:29
 msgid "no feed url available for this item"
 msgstr ""
 
-#: catalog/models/creator.py:27
+#: catalog/models/creator.py:30
 msgid "unable to fetch or parse the feed"
 msgstr ""
 
-#: catalog/models/creator.py:28
-msgid "no matching identity found in the feed description"
+#: catalog/models/creator.py:31
+msgid "no audio episode found in the feed"
+msgstr ""
+
+#: catalog/models/creator.py:34
+msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
 #: catalog/models/game.py:25
@@ -641,7 +645,7 @@ msgstr ""
 msgid "year of publication"
 msgstr ""
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:200
+#: catalog/models/game.py:135 catalog/models/podcast.py:202
 msgid "date of publication"
 msgstr ""
 
@@ -743,7 +747,7 @@ msgstr ""
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:150 catalog/models/people.py:449
+#: catalog/models/item.py:150 catalog/models/people.py:477
 #: catalog/models/performance.py:116 catalog/models/performance.py:135
 msgid "role"
 msgstr ""
@@ -768,7 +772,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:255 catalog/models/people.py:457
+#: catalog/models/item.py:255 catalog/models/people.py:485
 msgid "metadata"
 msgstr ""
 
@@ -776,27 +780,27 @@ msgstr ""
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1322
+#: catalog/models/item.py:1325
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1324
+#: catalog/models/item.py:1327
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1326
+#: catalog/models/item.py:1329
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1342
+#: catalog/models/item.py:1345
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1348
+#: catalog/models/item.py:1351
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1351
+#: catalog/models/item.py:1354
 msgid "url to the resource"
 msgstr ""
 
@@ -979,11 +983,11 @@ msgstr ""
 msgid "date of death"
 msgstr ""
 
-#: catalog/models/people.py:451
+#: catalog/models/people.py:479
 msgid "character"
 msgstr ""
 
-#: catalog/models/people.py:455
+#: catalog/models/people.py:483
 msgid "Character name for actor roles"
 msgstr ""
 
@@ -1063,12 +1067,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:196
+#: catalog/templates/item_base.html:200
 msgid "ratings"
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:251
+#: catalog/templates/item_base.html:255
 msgid "part of"
 msgstr ""
 
@@ -1093,7 +1097,7 @@ msgstr ""
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:279
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:283
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1132,7 +1136,7 @@ msgid "Remove this credit?"
 msgstr ""
 
 #: catalog/templates/_item_credits_list.html:146
-#: catalog/templates/catalog_verify.html:51
+#: catalog/templates/catalog_verify.html:85
 msgid "remove"
 msgstr ""
 
@@ -1222,14 +1226,14 @@ msgid "revision history"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:15
-#: catalog/templates/catalog_verify.html:86
+#: catalog/templates/catalog_verify.html:120
 msgid "back to item"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:19
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:177
+#: catalog/templates/item_base.html:181
 msgid "Creator verification"
 msgstr ""
 
@@ -1237,15 +1241,15 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:173
-#: catalog/views/edit.py:81 catalog/views/edit.py:139 catalog/views/edit.py:189
-#: catalog/views/edit.py:227 catalog/views/edit.py:293
-#: catalog/views/edit.py:297 catalog/views/edit.py:315
-#: catalog/views/edit.py:362 catalog/views/edit.py:386
-#: catalog/views/edit.py:401 catalog/views/edit.py:439
-#: catalog/views/edit.py:449 catalog/views/edit.py:475
-#: catalog/views/edit.py:538 catalog/views/edit.py:592
-#: catalog/views/edit.py:613 catalog/views/search.py:366
+#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:177
+#: catalog/views/edit.py:81 catalog/views/edit.py:141 catalog/views/edit.py:191
+#: catalog/views/edit.py:229 catalog/views/edit.py:295
+#: catalog/views/edit.py:299 catalog/views/edit.py:317
+#: catalog/views/edit.py:364 catalog/views/edit.py:388
+#: catalog/views/edit.py:403 catalog/views/edit.py:441
+#: catalog/views/edit.py:451 catalog/views/edit.py:477
+#: catalog/views/edit.py:540 catalog/views/edit.py:594
+#: catalog/views/edit.py:615 catalog/views/search.py:366
 msgid "Editing this item is restricted."
 msgstr ""
 
@@ -1452,7 +1456,7 @@ msgid "To suggest merging or association, please include the URL of the target i
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:320
-#: catalog/templates/catalog_verify.html:82
+#: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
@@ -1566,11 +1570,16 @@ msgstr ""
 msgid "Verification failed"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:36
+#: catalog/templates/_verify_status.html:39
+#: catalog/templates/_verify_status.html:53
+msgid "I have updated my feed's description or website as described above."
+msgstr ""
+
+#: catalog/templates/_verify_status.html:43
 msgid "Try again"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:42
+#: catalog/templates/_verify_status.html:57
 msgid "Start verification"
 msgstr ""
 
@@ -1687,35 +1696,66 @@ msgstr ""
 msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:25
-msgid "To verify, add one of the following identifiers of your account to the description of the podcast feed, then start verification. The identifier may be removed from the description once verified, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
+#: catalog/templates/catalog_verify.html:24
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:38
+#: catalog/templates/catalog_verify.html:30
+#: catalog/templates/catalog_verify.html:48
+#: catalog/templates/catalog_verify.html:54
+#: catalog/templates/catalog_verify.html:62
+msgid "copied"
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:35
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:44
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:50
+msgid "or, in the page's head:"
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:57
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:62
+msgid "Welcome to follow me on the Fediverse:"
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:66
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
+msgstr ""
+
+#: catalog/templates/catalog_verify.html:72
 msgid "Verified creators"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:48
+#: catalog/templates/catalog_verify.html:82
 msgid "Sure to remove this creator verification?"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:61
+#: catalog/templates/catalog_verify.html:95
 msgid "Manually verify a creator"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:68
+#: catalog/templates/catalog_verify.html:102
 msgid "user handle, e.g. @user or @user@instance"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:69
+#: catalog/templates/catalog_verify.html:103
 msgid "verify"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:74
+#: catalog/templates/catalog_verify.html:108
 msgid "Send feedback"
 msgstr ""
 
-#: catalog/templates/catalog_verify.html:81
+#: catalog/templates/catalog_verify.html:115
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
@@ -1772,7 +1812,7 @@ msgstr ""
 msgid "Popular Tags"
 msgstr ""
 
-#: catalog/templates/discover.html:217 catalog/templates/item_base.html:277
+#: catalog/templates/discover.html:217 catalog/templates/item_base.html:281
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1835,67 +1875,67 @@ msgstr ""
 msgid "release year"
 msgstr ""
 
-#: catalog/templates/item_base.html:90
+#: catalog/templates/item_base.html:94
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:124
+#: catalog/templates/item_base.html:128
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:137
+#: catalog/templates/item_base.html:141
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:146
+#: catalog/templates/item_base.html:150
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:161
+#: catalog/templates/item_base.html:165
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:171
+#: catalog/templates/item_base.html:175
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:186
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:225
+#: catalog/templates/item_base.html:229
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:269
+#: catalog/templates/item_base.html:273
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:300
+#: catalog/templates/item_base.html:304
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:303
+#: catalog/templates/item_base.html:307
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:304
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:318
+#: catalog/templates/item_base.html:322
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:328
+#: catalog/templates/item_base.html:332
 msgid "notes"
 msgstr ""
 
@@ -2084,19 +2124,19 @@ msgstr ""
 msgid "Editions"
 msgstr ""
 
-#: catalog/views/edit.py:191
+#: catalog/views/edit.py:193
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:193
+#: catalog/views/edit.py:195
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:216 catalog/views/edit.py:270
-#: catalog/views/edit.py:388 catalog/views/edit.py:477
-#: catalog/views/edit.py:509 catalog/views/verify.py:96
-#: catalog/views/verify.py:129 journal/views/article.py:37
-#: journal/views/article.py:118 journal/views/collection.py:238
+#: catalog/views/edit.py:218 catalog/views/edit.py:272
+#: catalog/views/edit.py:390 catalog/views/edit.py:479
+#: catalog/views/edit.py:511 catalog/views/verify.py:147
+#: catalog/views/verify.py:184 journal/views/article.py:37
+#: journal/views/article.py:119 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
 #: journal/views/collection.py:451 journal/views/collection.py:489
@@ -2112,7 +2152,7 @@ msgstr ""
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:273 catalog/views/edit.py:276
+#: catalog/views/edit.py:275 catalog/views/edit.py:278
 #: journal/views/collection.py:75 journal/views/collection.py:100
 #: journal/views/collection.py:506 journal/views/collection.py:601
 #: journal/views/common.py:196 journal/views/mark.py:171
@@ -2124,43 +2164,43 @@ msgstr ""
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:337
+#: catalog/views/edit.py:339
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:342
+#: catalog/views/edit.py:344
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:367
+#: catalog/views/edit.py:369
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:373
+#: catalog/views/edit.py:375
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:377
+#: catalog/views/edit.py:379
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:399
+#: catalog/views/edit.py:401
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:404
+#: catalog/views/edit.py:406
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:408
+#: catalog/views/edit.py:410
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:449
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:451
+#: catalog/views/edit.py:453
 msgid "Cannot link items other than editions"
 msgstr ""
 
@@ -2176,29 +2216,37 @@ msgstr ""
 msgid "Unsupported URL"
 msgstr ""
 
-#: catalog/views/verify.py:24
+#: catalog/views/verify.py:33
 msgid "Creator verification is only available for podcasts for now."
 msgstr ""
 
-#: catalog/views/verify.py:72
+#: catalog/views/verify.py:99
 msgid "No feed url available for this item."
 msgstr ""
 
-#: catalog/views/verify.py:80
+#: catalog/views/verify.py:110
 msgid "You are already a verified creator."
 msgstr ""
 
-#: catalog/views/verify.py:102 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:150 journal/views/review.py:170
+#: catalog/views/verify.py:120
+msgid "Verification is already in progress."
+msgstr ""
+
+#: catalog/views/verify.py:128
+msgid "Please wait a moment before trying again."
+msgstr ""
+
+#: catalog/views/verify.py:153 common/utils.py:109 common/utils.py:150
+#: journal/views/article.py:151 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr ""
 
-#: catalog/views/verify.py:116
+#: catalog/views/verify.py:167
 msgid "Creator verified."
 msgstr ""
 
-#: catalog/views/verify.py:132
+#: catalog/views/verify.py:187
 msgid "Creator verification removed."
 msgstr ""
 
@@ -3820,7 +3868,7 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:168
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:169
 #: journal/views/profile.py:486 journal/views/review.py:188
 msgid "Login required"
 msgstr ""
@@ -4593,7 +4641,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:153 journal/views/article.py:182
+#: journal/models/article.py:153 journal/views/article.py:183
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -4665,7 +4713,7 @@ msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
+#: journal/models/common.py:51 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/comment.html:35
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
@@ -4679,7 +4727,7 @@ msgstr[1] ""
 msgid "Public"
 msgstr ""
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
+#: journal/models/common.py:52 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
@@ -4692,7 +4740,7 @@ msgstr ""
 msgid "Followers Only"
 msgstr ""
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
+#: journal/models/common.py:53 journal/templates/collection_share.html:57
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
@@ -4705,27 +4753,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:638
+#: journal/models/common.py:639
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:743
+#: journal/models/common.py:744
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:776
+#: journal/models/common.py:777
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:786
+#: journal/models/common.py:787
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:800
+#: journal/models/common.py:801
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:809
+#: journal/models/common.py:810
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5801,16 +5849,16 @@ msgstr ""
 msgid "#%(year)s_report"
 msgstr ""
 
-#: journal/views/article.py:148 journal/views/review.py:168
+#: journal/views/article.py:149 journal/views/review.py:168
 msgid "User not local"
 msgstr ""
 
-#: journal/views/article.py:156 journal/views/article.py:170
+#: journal/views/article.py:157 journal/views/article.py:171
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr ""
 
-#: journal/views/article.py:158 journal/views/article.py:166
+#: journal/views/article.py:159 journal/views/article.py:167
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr ""
@@ -5954,20 +6002,20 @@ msgstr ""
 msgid "Summary posted to timeline."
 msgstr ""
 
-#: mastodon/models/common.py:12 users/templates/users/account.html:45
+#: mastodon/models/common.py:28 users/templates/users/account.html:45
 #: users/templates/users/account.html:55 users/templates/users/login.html:67
 msgid "Email"
 msgstr ""
 
-#: mastodon/models/common.py:13
+#: mastodon/models/common.py:29
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:14 users/templates/users/login.html:101
+#: mastodon/models/common.py:30 users/templates/users/login.html:101
 msgid "Threads"
 msgstr ""
 
-#: mastodon/models/common.py:15
+#: mastodon/models/common.py:31
 msgid "Bluesky"
 msgstr ""
 
@@ -6489,23 +6537,23 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: users/models/user.py:68
+#: users/models/user.py:69
 msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr ""
 
-#: users/models/user.py:116
+#: users/models/user.py:117
 msgid "username"
 msgstr ""
 
-#: users/models/user.py:121
+#: users/models/user.py:122
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr ""
 
-#: users/models/user.py:124
+#: users/models/user.py:125
 msgid "A user with that username already exists."
 msgstr ""
 
-#: users/models/user.py:347
+#: users/models/user.py:368
 msgid "This username is already taken."
 msgstr ""
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-14 15:21-0400\n"
+"POT-Creation-Date: 2026-06-14 15:31-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2135,7 +2135,7 @@ msgstr ""
 #: catalog/views/edit.py:218 catalog/views/edit.py:272
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:147
-#: catalog/views/verify.py:184 journal/views/article.py:37
+#: catalog/views/verify.py:187 journal/views/article.py:37
 #: journal/views/article.py:119 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
@@ -2153,14 +2153,15 @@ msgid "Insufficient permission"
 msgstr ""
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
-#: journal/views/collection.py:75 journal/views/collection.py:100
-#: journal/views/collection.py:506 journal/views/collection.py:601
-#: journal/views/common.py:196 journal/views/mark.py:171
-#: journal/views/post.py:112 journal/views/post.py:114
-#: journal/views/post.py:161 journal/views/post.py:180
-#: journal/views/post.py:182 journal/views/post.py:223
-#: journal/views/post.py:236 journal/views/review.py:142
-#: journal/views/review.py:146 users/views/actions.py:171
+#: catalog/views/verify.py:178 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:506
+#: journal/views/collection.py:601 journal/views/common.py:196
+#: journal/views/mark.py:171 journal/views/post.py:112
+#: journal/views/post.py:114 journal/views/post.py:161
+#: journal/views/post.py:180 journal/views/post.py:182
+#: journal/views/post.py:223 journal/views/post.py:236
+#: journal/views/review.py:142 journal/views/review.py:146
+#: users/views/actions.py:171
 msgid "Invalid parameter"
 msgstr ""
 
@@ -2246,7 +2247,7 @@ msgstr ""
 msgid "Creator verified."
 msgstr ""
 
-#: catalog/views/verify.py:187
+#: catalog/views/verify.py:190
 msgid "Creator verification removed."
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-14 15:21-0400\n"
+"POT-Creation-Date: 2026-06-14 15:31-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -2134,7 +2134,7 @@ msgstr "条目不可被删除。"
 #: catalog/views/edit.py:218 catalog/views/edit.py:272
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:147
-#: catalog/views/verify.py:184 journal/views/article.py:37
+#: catalog/views/verify.py:187 journal/views/article.py:37
 #: journal/views/article.py:119 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
@@ -2152,14 +2152,15 @@ msgid "Insufficient permission"
 msgstr "权限不足"
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
-#: journal/views/collection.py:75 journal/views/collection.py:100
-#: journal/views/collection.py:506 journal/views/collection.py:601
-#: journal/views/common.py:196 journal/views/mark.py:171
-#: journal/views/post.py:112 journal/views/post.py:114
-#: journal/views/post.py:161 journal/views/post.py:180
-#: journal/views/post.py:182 journal/views/post.py:223
-#: journal/views/post.py:236 journal/views/review.py:142
-#: journal/views/review.py:146 users/views/actions.py:171
+#: catalog/views/verify.py:178 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:506
+#: journal/views/collection.py:601 journal/views/common.py:196
+#: journal/views/mark.py:171 journal/views/post.py:112
+#: journal/views/post.py:114 journal/views/post.py:161
+#: journal/views/post.py:180 journal/views/post.py:182
+#: journal/views/post.py:223 journal/views/post.py:236
+#: journal/views/review.py:142 journal/views/review.py:146
+#: users/views/actions.py:171
 msgid "Invalid parameter"
 msgstr "无效参数"
 
@@ -2245,7 +2246,7 @@ msgstr "用户不存在"
 msgid "Creator verified."
 msgstr "创作者已验证。"
 
-#: catalog/views/verify.py:187
+#: catalog/views/verify.py:190
 msgid "Creator verification removed."
 msgstr "创作者验证已移除。"
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 08:25-0400\n"
+"POT-Creation-Date: 2026-06-14 15:21-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -563,33 +563,37 @@ msgid "genre"
 msgstr "类型"
 
 #: catalog/models/common.py:284 catalog/templates/_language_list.html:5
-#: users/models/user.py:128
+#: users/models/user.py:129
 msgid "language"
 msgstr "语言"
 
-#: catalog/models/creator.py:21
+#: catalog/models/creator.py:24
 msgid "pending"
 msgstr "等待中"
 
-#: catalog/models/creator.py:22
+#: catalog/models/creator.py:25
 msgid "verified"
 msgstr "已验证"
 
-#: catalog/models/creator.py:23
+#: catalog/models/creator.py:26
 msgid "failed"
 msgstr "失败"
 
-#: catalog/models/creator.py:26
+#: catalog/models/creator.py:29
 msgid "no feed url available for this item"
 msgstr "此条目没有可用的订阅源地址"
 
-#: catalog/models/creator.py:27
+#: catalog/models/creator.py:30
 msgid "unable to fetch or parse the feed"
 msgstr "无法获取或解析订阅源"
 
-#: catalog/models/creator.py:28
-msgid "no matching identity found in the feed description"
-msgstr "未在订阅源简介中找到匹配的身份标识"
+#: catalog/models/creator.py:31
+msgid "no audio episode found in the feed"
+msgstr "订阅源中没有找到任何音频单集"
+
+#: catalog/models/creator.py:34
+msgid "no matching identity found in the feed or its linked website"
+msgstr "未在订阅源或其关联网站中找到匹配的身份标识"
 
 #: catalog/models/game.py:25
 msgid "Main Game"
@@ -640,7 +644,7 @@ msgstr "开发者"
 msgid "year of publication"
 msgstr "发行年份"
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:200
+#: catalog/models/game.py:135 catalog/models/podcast.py:202
 msgid "date of publication"
 msgstr "发行日期"
 
@@ -742,7 +746,7 @@ msgstr "工作室"
 msgid "troupe"
 msgstr "剧团"
 
-#: catalog/models/item.py:150 catalog/models/people.py:449
+#: catalog/models/item.py:150 catalog/models/people.py:477
 #: catalog/models/performance.py:116 catalog/models/performance.py:135
 msgid "role"
 msgstr "角色"
@@ -767,7 +771,7 @@ msgstr "标题"
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:255 catalog/models/people.py:457
+#: catalog/models/item.py:255 catalog/models/people.py:485
 msgid "metadata"
 msgstr "元数据"
 
@@ -775,27 +779,27 @@ msgstr "元数据"
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1322
+#: catalog/models/item.py:1325
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:1324
+#: catalog/models/item.py:1327
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:1326
+#: catalog/models/item.py:1329
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1342
+#: catalog/models/item.py:1345
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1348
+#: catalog/models/item.py:1351
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1351
+#: catalog/models/item.py:1354
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
@@ -978,11 +982,11 @@ msgstr "出生日期"
 msgid "date of death"
 msgstr "死亡日期"
 
-#: catalog/models/people.py:451
+#: catalog/models/people.py:479
 msgid "character"
 msgstr "角色"
 
-#: catalog/models/people.py:455
+#: catalog/models/people.py:483
 msgid "Character name for actor roles"
 msgstr "演员饰演的角色名称"
 
@@ -1062,12 +1066,12 @@ msgstr "无法加载条目，请确认链接正确。部分网站可能删除条
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:196
+#: catalog/templates/item_base.html:200
 msgid "ratings"
 msgstr "个评分"
 
 #: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:251
+#: catalog/templates/item_base.html:255
 msgid "part of"
 msgstr "所属"
 
@@ -1092,7 +1096,7 @@ msgstr "翻译"
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:279
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:283
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "显示更多"
@@ -1131,7 +1135,7 @@ msgid "Remove this credit?"
 msgstr "移除此演职员？"
 
 #: catalog/templates/_item_credits_list.html:146
-#: catalog/templates/catalog_verify.html:51
+#: catalog/templates/catalog_verify.html:85
 msgid "remove"
 msgstr "移除"
 
@@ -1221,14 +1225,14 @@ msgid "revision history"
 msgstr "编辑历史"
 
 #: catalog/templates/_sidebar_edit.html:15
-#: catalog/templates/catalog_verify.html:86
+#: catalog/templates/catalog_verify.html:120
 msgid "back to item"
 msgstr "回到条目"
 
 #: catalog/templates/_sidebar_edit.html:19
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:177
+#: catalog/templates/item_base.html:181
 msgid "Creator verification"
 msgstr "创作者验证"
 
@@ -1236,15 +1240,15 @@ msgstr "创作者验证"
 msgid "Edit Options"
 msgstr "编辑选项"
 
-#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:173
-#: catalog/views/edit.py:81 catalog/views/edit.py:139 catalog/views/edit.py:189
-#: catalog/views/edit.py:227 catalog/views/edit.py:293
-#: catalog/views/edit.py:297 catalog/views/edit.py:315
-#: catalog/views/edit.py:362 catalog/views/edit.py:386
-#: catalog/views/edit.py:401 catalog/views/edit.py:439
-#: catalog/views/edit.py:449 catalog/views/edit.py:475
-#: catalog/views/edit.py:538 catalog/views/edit.py:592
-#: catalog/views/edit.py:613 catalog/views/search.py:366
+#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:177
+#: catalog/views/edit.py:81 catalog/views/edit.py:141 catalog/views/edit.py:191
+#: catalog/views/edit.py:229 catalog/views/edit.py:295
+#: catalog/views/edit.py:299 catalog/views/edit.py:317
+#: catalog/views/edit.py:364 catalog/views/edit.py:388
+#: catalog/views/edit.py:403 catalog/views/edit.py:441
+#: catalog/views/edit.py:451 catalog/views/edit.py:477
+#: catalog/views/edit.py:540 catalog/views/edit.py:594
+#: catalog/views/edit.py:615 catalog/views/search.py:366
 msgid "Editing this item is restricted."
 msgstr "这个条目仅管理员可编辑。"
 
@@ -1451,7 +1455,7 @@ msgid "To suggest merging or association, please include the URL of the target i
 msgstr "建议详情。如提议合并或关联，请包含目标条目网址"
 
 #: catalog/templates/_sidebar_edit.html:320
-#: catalog/templates/catalog_verify.html:82
+#: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "提交"
 
@@ -1565,11 +1569,16 @@ msgstr "移除我的验证"
 msgid "Verification failed"
 msgstr "验证失败"
 
-#: catalog/templates/_verify_status.html:36
+#: catalog/templates/_verify_status.html:39
+#: catalog/templates/_verify_status.html:53
+msgid "I have updated my feed's description or website as described above."
+msgstr "我已按上述说明更新了订阅源的简介或网站。"
+
+#: catalog/templates/_verify_status.html:43
 msgid "Try again"
 msgstr "重试"
 
-#: catalog/templates/_verify_status.html:42
+#: catalog/templates/_verify_status.html:57
 msgid "Start verification"
 msgstr "开始验证"
 
@@ -1686,35 +1695,66 @@ msgstr "如果你是此播客的创作者，可以验证所有权；验证后只
 msgid "Your recent episodes may also occasionally be featured in discovery."
 msgstr "你最近的单集有时也可能在发现页中获得推荐。"
 
-#: catalog/templates/catalog_verify.html:25
-msgid "To verify, add one of the following identifiers of your account to the description of the podcast feed, then start verification. The identifier may be removed from the description once verified, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
-msgstr "验证方法：将以下任一账号标识添加到播客订阅源的简介中，然后开始验证。验证完成后可以从简介中移除该标识，但我们建议保留它，以便你的听众能在分布式社交媒体上发现并关注你。"
+#: catalog/templates/catalog_verify.html:24
+msgid "To verify, prove you control one of the following identifiers of your account (click to copy):"
+msgstr "要进行验证，请证明你拥有以下任一账号标识（点击可复制）："
 
-#: catalog/templates/catalog_verify.html:38
+#: catalog/templates/catalog_verify.html:30
+#: catalog/templates/catalog_verify.html:48
+#: catalog/templates/catalog_verify.html:54
+#: catalog/templates/catalog_verify.html:62
+msgid "copied"
+msgstr "已复制"
+
+#: catalog/templates/catalog_verify.html:35
+msgid "You can prove this in a few ways, then start verification: add one of the identifiers above to the podcast feed's description; add a <code>rel=\"me\"</code> link back to one of them on the web page your feed links to (the link verification Mastodon uses); or point your feed's website at your Bluesky handle's own domain."
+msgstr "你可以通过以下几种方式来证明，然后开始验证：将上述任一标识添加到播客订阅源的简介中；在订阅源所指向的网页上，添加一个指回上述任一标识的 <code>rel=\"me\"</code> 链接（与 Mastodon 所用的链接验证方式相同）；或让订阅源的网站使用你的 Bluesky handle 所在的域名。"
+
+#: catalog/templates/catalog_verify.html:44
+msgid "For example, add this rel=me link to the web page your feed links to (click to copy):"
+msgstr "例如，在订阅源所指向的网页中添加如下 rel=me 链接（点击可复制）："
+
+#: catalog/templates/catalog_verify.html:50
+msgid "or, in the page's head:"
+msgstr "或者，放在网页的 head 中："
+
+#: catalog/templates/catalog_verify.html:57
+msgid "Can't edit the website? Just add a line like this to your feed's description instead (click to copy):"
+msgstr "改不了网站？也可以直接在订阅源的简介里加上这样一句（点击可复制）："
+
+#: catalog/templates/catalog_verify.html:62
+msgid "Welcome to follow me on the Fediverse:"
+msgstr "欢迎在联邦宇宙关注我："
+
+#: catalog/templates/catalog_verify.html:66
+msgid "NeoDB does not re-check this periodically at the moment, but we recommend you keep it so that your audience can discover and connect with you in distributed social media."
+msgstr "NeoDB 目前不会定期重新检查，但我们建议保留它，以便你的听众能在分布式社交媒体上发现并关注你。"
+
+#: catalog/templates/catalog_verify.html:72
 msgid "Verified creators"
 msgstr "已验证创作者"
 
-#: catalog/templates/catalog_verify.html:48
+#: catalog/templates/catalog_verify.html:82
 msgid "Sure to remove this creator verification?"
 msgstr "确定移除此创作者验证吗？"
 
-#: catalog/templates/catalog_verify.html:61
+#: catalog/templates/catalog_verify.html:95
 msgid "Manually verify a creator"
 msgstr "手动验证创作者"
 
-#: catalog/templates/catalog_verify.html:68
+#: catalog/templates/catalog_verify.html:102
 msgid "user handle, e.g. @user or @user@instance"
 msgstr "用户标识，如 @user 或 @user@instance"
 
-#: catalog/templates/catalog_verify.html:69
+#: catalog/templates/catalog_verify.html:103
 msgid "verify"
 msgstr "验证"
 
-#: catalog/templates/catalog_verify.html:74
+#: catalog/templates/catalog_verify.html:108
 msgid "Send feedback"
 msgstr "发送反馈"
 
-#: catalog/templates/catalog_verify.html:81
+#: catalog/templates/catalog_verify.html:115
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr "对创作者验证有疑问或遇到问题？请告知站点管理员。"
 
@@ -1771,7 +1811,7 @@ msgstr "全部标为已读"
 msgid "Popular Tags"
 msgstr "热门标签"
 
-#: catalog/templates/discover.html:217 catalog/templates/item_base.html:277
+#: catalog/templates/discover.html:217 catalog/templates/item_base.html:281
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1834,67 +1874,67 @@ msgstr "系统繁忙，请稍等几秒钟再搜索。"
 msgid "release year"
 msgstr "发行年份"
 
-#: catalog/templates/item_base.html:90
+#: catalog/templates/item_base.html:94
 msgid "select one of the seasons to comment"
 msgstr "这是全剧条目，以下是可标记的单季"
 
-#: catalog/templates/item_base.html:124
+#: catalog/templates/item_base.html:128
 msgid "mark, comment and collect"
 msgstr "标签 · 短评 · 评论 · 收藏"
 
-#: catalog/templates/item_base.html:137
+#: catalog/templates/item_base.html:141
 msgid "Login or register to review or add this item to your collection."
 msgstr "登录后可管理标记收藏。"
 
-#: catalog/templates/item_base.html:146
+#: catalog/templates/item_base.html:150
 msgid "Related Collections"
 msgstr "相关收藏单"
 
-#: catalog/templates/item_base.html:161
+#: catalog/templates/item_base.html:165
 msgid "Unsupported item type."
 msgstr "此类数据尚未支持。"
 
-#: catalog/templates/item_base.html:171
+#: catalog/templates/item_base.html:175
 msgid "Edit this item"
 msgstr "编辑这个条目"
 
-#: catalog/templates/item_base.html:182
+#: catalog/templates/item_base.html:186
 msgid "Last edited"
 msgstr "最近编辑"
 
-#: catalog/templates/item_base.html:225
+#: catalog/templates/item_base.html:229
 msgid "No enough ratings"
 msgstr "评分人数不足"
 
-#: catalog/templates/item_base.html:269
+#: catalog/templates/item_base.html:273
 msgid "overview"
 msgstr "简介"
 
-#: catalog/templates/item_base.html:300
+#: catalog/templates/item_base.html:304
 msgid "comments"
 msgstr "短评"
 
-#: catalog/templates/item_base.html:303
+#: catalog/templates/item_base.html:307
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "标记"
 
-#: catalog/templates/item_base.html:304
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "好友标记"
 
-#: catalog/templates/item_base.html:318
+#: catalog/templates/item_base.html:322
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "评论"
 
-#: catalog/templates/item_base.html:328
+#: catalog/templates/item_base.html:332
 msgid "notes"
 msgstr "笔记"
 
@@ -2083,19 +2123,19 @@ msgstr "已验证作品"
 msgid "Editions"
 msgstr "版本"
 
-#: catalog/views/edit.py:191
+#: catalog/views/edit.py:193
 msgid "Item in use."
 msgstr "条目已被引用或标记。"
 
-#: catalog/views/edit.py:193
+#: catalog/views/edit.py:195
 msgid "Item cannot be deleted."
 msgstr "条目不可被删除。"
 
-#: catalog/views/edit.py:216 catalog/views/edit.py:270
-#: catalog/views/edit.py:388 catalog/views/edit.py:477
-#: catalog/views/edit.py:509 catalog/views/verify.py:96
-#: catalog/views/verify.py:129 journal/views/article.py:37
-#: journal/views/article.py:118 journal/views/collection.py:238
+#: catalog/views/edit.py:218 catalog/views/edit.py:272
+#: catalog/views/edit.py:390 catalog/views/edit.py:479
+#: catalog/views/edit.py:511 catalog/views/verify.py:147
+#: catalog/views/verify.py:184 journal/views/article.py:37
+#: journal/views/article.py:119 journal/views/collection.py:238
 #: journal/views/collection.py:299 journal/views/collection.py:318
 #: journal/views/collection.py:342 journal/views/collection.py:415
 #: journal/views/collection.py:451 journal/views/collection.py:489
@@ -2111,7 +2151,7 @@ msgstr "条目不可被删除。"
 msgid "Insufficient permission"
 msgstr "权限不足"
 
-#: catalog/views/edit.py:273 catalog/views/edit.py:276
+#: catalog/views/edit.py:275 catalog/views/edit.py:278
 #: journal/views/collection.py:75 journal/views/collection.py:100
 #: journal/views/collection.py:506 journal/views/collection.py:601
 #: journal/views/common.py:196 journal/views/mark.py:171
@@ -2123,43 +2163,43 @@ msgstr "权限不足"
 msgid "Invalid parameter"
 msgstr "无效参数"
 
-#: catalog/views/edit.py:337
+#: catalog/views/edit.py:339
 msgid "TV Season with IMDB id and season number required."
 msgstr "必须是电视剧分季，且包含IMDB id和分季序号。"
 
-#: catalog/views/edit.py:342
+#: catalog/views/edit.py:344
 msgid "Updating episodes"
 msgstr "正在更新单集列表"
 
-#: catalog/views/edit.py:367
+#: catalog/views/edit.py:369
 msgid "This person has no supported source to fetch works from."
 msgstr "此人没有可供获取作品的数据源。"
 
-#: catalog/views/edit.py:373
+#: catalog/views/edit.py:375
 msgid "Already pulling works for this person, try again later."
 msgstr "已在获取此人的作品，请稍后再试。"
 
-#: catalog/views/edit.py:377
+#: catalog/views/edit.py:379
 msgid "Pulling works in background."
 msgstr "正在后台获取作品。"
 
-#: catalog/views/edit.py:399
+#: catalog/views/edit.py:401
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "无法合并到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:404
+#: catalog/views/edit.py:406
 msgid "Cannot merge items in different categories"
 msgstr "无法合并不同类型的条目"
 
-#: catalog/views/edit.py:408
+#: catalog/views/edit.py:410
 msgid "Cannot merge an item to itself"
 msgstr "无法合并条目和它自己"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:449
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "无法关联到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:451
+#: catalog/views/edit.py:453
 msgid "Cannot link items other than editions"
 msgstr "无法关联到非图书类的条目"
 
@@ -2175,29 +2215,37 @@ msgstr "无效网址"
 msgid "Unsupported URL"
 msgstr "尚未支持的网址"
 
-#: catalog/views/verify.py:24
+#: catalog/views/verify.py:33
 msgid "Creator verification is only available for podcasts for now."
 msgstr "创作者验证目前仅支持播客。"
 
-#: catalog/views/verify.py:72
+#: catalog/views/verify.py:99
 msgid "No feed url available for this item."
 msgstr "此条目没有可用的订阅源地址。"
 
-#: catalog/views/verify.py:80
+#: catalog/views/verify.py:110
 msgid "You are already a verified creator."
 msgstr "你已是已验证创作者。"
 
-#: catalog/views/verify.py:102 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:150 journal/views/review.py:170
+#: catalog/views/verify.py:120
+msgid "Verification is already in progress."
+msgstr "验证已在进行中。"
+
+#: catalog/views/verify.py:128
+msgid "Please wait a moment before trying again."
+msgstr ""
+
+#: catalog/views/verify.py:153 common/utils.py:109 common/utils.py:150
+#: journal/views/article.py:151 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr "用户不存在"
 
-#: catalog/views/verify.py:116
+#: catalog/views/verify.py:167
 msgid "Creator verified."
 msgstr "创作者已验证。"
 
-#: catalog/views/verify.py:132
+#: catalog/views/verify.py:187
 msgid "Creator verification removed."
 msgstr "创作者验证已移除。"
 
@@ -3840,7 +3888,7 @@ msgstr "用户不存在了"
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:168
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:169
 #: journal/views/profile.py:486 journal/views/review.py:188
 msgid "Login required"
 msgstr "登录后访问"
@@ -4613,7 +4661,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:153 journal/views/article.py:182
+#: journal/models/article.py:153 journal/views/article.py:183
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -4685,7 +4733,7 @@ msgid_plural "%(count)d items"
 msgstr[0] "%(count)d 个条目"
 msgstr[1] "%(count)d 个条目"
 
-#: journal/models/common.py:50 journal/templates/action_open_post.html:15
+#: journal/models/common.py:51 journal/templates/action_open_post.html:15
 #: journal/templates/collection_share.html:35 journal/templates/comment.html:35
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
@@ -4699,7 +4747,7 @@ msgstr[1] "%(count)d 个条目"
 msgid "Public"
 msgstr "公开"
 
-#: journal/models/common.py:51 journal/templates/action_open_post.html:9
+#: journal/models/common.py:52 journal/templates/action_open_post.html:9
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
@@ -4712,7 +4760,7 @@ msgstr "公开"
 msgid "Followers Only"
 msgstr "仅关注者"
 
-#: journal/models/common.py:52 journal/templates/collection_share.html:57
+#: journal/models/common.py:53 journal/templates/collection_share.html:57
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
@@ -4725,27 +4773,27 @@ msgstr "仅关注者"
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
-#: journal/models/common.py:638
+#: journal/models/common.py:639
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "帖文未能发布到Bluesky，请重新使用ATProto验证登录。"
 
-#: journal/models/common.py:743
+#: journal/models/common.py:744
 msgid "A recent post was not posted to Threads."
 msgstr "帖文未能发布到Threads。"
 
-#: journal/models/common.py:776
+#: journal/models/common.py:777
 msgid "A recent post was not boosted on Mastodon."
 msgstr "帖文未能在联邦实例转播。"
 
-#: journal/models/common.py:786
+#: journal/models/common.py:787
 msgid "Original post no longer exists."
 msgstr "原帖文已不存在。"
 
-#: journal/models/common.py:800
+#: journal/models/common.py:801
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "帖文未能发布到联邦实例，请重新验证登录。"
 
-#: journal/models/common.py:809
+#: journal/models/common.py:810
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能发布到联邦实例。"
 
@@ -5866,16 +5914,16 @@ msgstr "分享年度小结"
 msgid "#%(year)s_report"
 msgstr "#我的#%(year)s书影音"
 
-#: journal/views/article.py:148 journal/views/review.py:168
+#: journal/views/article.py:149 journal/views/review.py:168
 msgid "User not local"
 msgstr "用户不在本站"
 
-#: journal/views/article.py:156 journal/views/article.py:170
+#: journal/views/article.py:157 journal/views/article.py:171
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr "{0} 的文章"
 
-#: journal/views/article.py:158 journal/views/article.py:166
+#: journal/views/article.py:159 journal/views/article.py:167
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr "链接无效"
@@ -6019,20 +6067,20 @@ msgstr "标签已更新"
 msgid "Summary posted to timeline."
 msgstr "总结已发布到时间轴"
 
-#: mastodon/models/common.py:12 users/templates/users/account.html:45
+#: mastodon/models/common.py:28 users/templates/users/account.html:45
 #: users/templates/users/account.html:55 users/templates/users/login.html:67
 msgid "Email"
 msgstr "电子邮件"
 
-#: mastodon/models/common.py:13
+#: mastodon/models/common.py:29
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:14 users/templates/users/login.html:101
+#: mastodon/models/common.py:30 users/templates/users/login.html:101
 msgid "Threads"
 msgstr "Threads"
 
-#: mastodon/models/common.py:15
+#: mastodon/models/common.py:31
 msgid "Bluesky"
 msgstr "Bluesky"
 
@@ -6613,23 +6661,23 @@ msgstr "已开始"
 msgid "Complete"
 msgstr "完成"
 
-#: users/models/user.py:68
+#: users/models/user.py:69
 msgid "Enter a valid username. This value may contain only unaccented lowercase a-z and uppercase A-Z letters, numbers, and _ characters."
 msgstr "输入用户名，限英文字母数字下划线，最多30个字符。"
 
-#: users/models/user.py:116
+#: users/models/user.py:117
 msgid "username"
 msgstr "用户名"
 
-#: users/models/user.py:121
+#: users/models/user.py:122
 msgid "Required. 50 characters or fewer. Letters, digits and _ only."
 msgstr "必填，限英文字母数字下划线，最多30个字符。"
 
-#: users/models/user.py:124
+#: users/models/user.py:125
 msgid "A user with that username already exists."
 msgstr "使用该用户名的用户已存在。"
 
-#: users/models/user.py:347
+#: users/models/user.py:368
 msgid "This username is already taken."
 msgstr "用户名已被使用"
 

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -835,6 +835,35 @@ class TestMastodonAttribution:
         assert rehomed.state == VerifiedCreator.State.VERIFIED
         assert rehomed.matched == handle
 
+    def test_rehome_onto_existing_claim_refreshes_edited_time(self, monkeypatch):
+        # re-homing onto an already-existing mastodon-owned claim must refresh
+        # edited_time (the page orders "my claim" by -edited_time)
+        user = User.register(email="a@example.com", username="alice")
+        _link_mastodon(user)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        existing = _verified(podcast, remote, matched="@alice@mast.example")
+        old = timezone.now() - timedelta(days=3)
+        VerifiedCreator.objects.filter(pk=existing.pk).update(edited_time=old)
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        monkeypatch.setattr(
+            RSS,
+            "fetch_feed_with_metadata",
+            lambda url, etag="", last_modified="": (
+                {
+                    "description": "by @alice@mast.example",
+                    "episodes": _AUDIO_EPISODES,
+                },
+                "",
+                "",
+                200,
+            ),
+        )
+        verify_creator_task(claim.pk, user.pk)
+        existing.refresh_from_db()
+        assert existing.state == VerifiedCreator.State.VERIFIED
+        assert existing.edited_time > old
+
     def test_unverify_mastodon_owned_claim(self):
         alice = User.register(email="a@example.com", username="alice")
         bob = User.register(email="b@example.com", username="bob")

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.test import Client
 from django.utils import timezone
 
-from catalog.jobs.creator_verify import verify_creator_task
+from catalog.jobs.creator_verify import _has_audio_episode, verify_creator_task
 from catalog.jobs.discover import DiscoverGenerator
 from catalog.models import (
     IdType,
@@ -191,6 +191,33 @@ class TestMatcher:
         assert match_creator_identity([""], ["@alice@example.org"]) is None
 
 
+class TestAudioEpisode:
+    def test_audio_enclosure_counts(self):
+        assert _has_audio_episode(
+            {
+                "episodes": [
+                    {"enclosures": [{"url": "x.mp3", "mime_type": "audio/mpeg"}]}
+                ]
+            }
+        )
+
+    def test_missing_mime_is_accepted(self):
+        assert _has_audio_episode({"episodes": [{"enclosures": [{"url": "x.mp3"}]}]})
+
+    def test_no_episodes_or_enclosures(self):
+        assert not _has_audio_episode({})
+        assert not _has_audio_episode({"episodes": []})
+        assert not _has_audio_episode({"episodes": [{"enclosures": []}]})
+
+    def test_non_audio_and_urlless_do_not_count(self):
+        assert not _has_audio_episode(
+            {"episodes": [{"enclosures": [{"url": "v.mp4", "mime_type": "video/mp4"}]}]}
+        )
+        assert not _has_audio_episode(
+            {"episodes": [{"enclosures": [{"mime_type": "audio/mpeg"}]}]}
+        )
+
+
 @pytest.mark.django_db(databases="__all__")
 class TestCandidates:
     def test_local_identity(self):
@@ -293,6 +320,31 @@ class TestVerifyTask:
         claim.refresh_from_db()
         assert claim.state == VerifiedCreator.State.FAILED
         assert claim.failure_reason == VerifiedCreator.FailureReason.NO_AUDIO
+
+    def test_unexpected_error_fails_claim(self, monkeypatch):
+        # a crash while matching must fail the claim, not leave it PENDING
+        user = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        claim = self._claim(user, podcast)
+        monkeypatch.setattr(
+            RSS,
+            "fetch_feed_with_metadata",
+            lambda url, etag="", last_modified="": (
+                {"description": "x", "episodes": _AUDIO_EPISODES},
+                "",
+                "",
+                200,
+            ),
+        )
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("catalog.jobs.creator_verify._match_creator", boom)
+        verify_creator_task(claim.pk, user.pk)
+        claim.refresh_from_db()
+        assert claim.state == VerifiedCreator.State.FAILED
+        assert claim.failure_reason == VerifiedCreator.FailureReason.FETCH_FAILED
 
     def test_failed_fetch_error(self, monkeypatch):
         user = User.register(email="a@example.com", username="alice")
@@ -465,6 +517,14 @@ class TestVerifyViews:
         response = _client(alice).post(url, {"claim_id": claim.pk})
         assert response.status_code == 302
         assert not VerifiedCreator.objects.filter(pk=claim.pk).exists()
+
+    def test_unverify_invalid_claim_id(self):
+        # a missing or non-numeric claim_id is a bad request, not a 500
+        user = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        url = f"/podcast/{podcast.uuid}/verify/remove"
+        assert _client(user).post(url, {"claim_id": "abc"}).status_code == 400
+        assert _client(user).post(url, {}).status_code == 400
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -15,11 +15,22 @@ from catalog.models import (
     VerifiedCreator,
     creator_identity_candidates,
     match_creator_identity,
+    resolve_creator_identity,
+    user_controls_owner,
+    user_owned_claims_q,
 )
 from catalog.sites.rss import RSS
+from mastodon.models.bluesky import BlueskyAccount
+from mastodon.models.mastodon import MastodonAccount
 from users.models import User
 
 _BACKEND = "mastodon.auth.OAuth2Backend"
+
+# a parsed-feed episode list with one audio enclosure, so a feed passes the
+# "has an audio episode" guard during verification
+_AUDIO_EPISODES = [
+    {"enclosures": [{"url": "https://ex.example/1.mp3", "mime_type": "audio/mpeg"}]}
+]
 
 
 def _podcast(title="Test Pod", feed="podcast.example.com/feed.rss") -> Podcast:
@@ -42,6 +53,50 @@ def _verified(item, identity, matched="@x@example.org") -> VerifiedCreator:
         owner=identity,
         state=VerifiedCreator.State.VERIFIED,
         matched=matched,
+    )
+
+
+def _make_remote_identity(username="alice", domain_name="mast.example"):
+    """Create a remote APIdentity (and its Takahe Identity) for tests that
+    attribute a verified work to a linked Mastodon account."""
+    from takahe.models import Domain, Identity
+    from takahe.utils import Takahe
+
+    domain, _ = Domain.objects.get_or_create(
+        domain=domain_name, defaults={"local": False}
+    )
+    identity = Identity.objects.create(
+        actor_uri=f"https://{domain_name}/users/{username}/",
+        profile_uri=f"https://{domain_name}/@{username}",
+        local=False,
+        username=username,
+        domain=domain,
+    )
+    return Takahe.get_or_create_remote_apidentity(identity)
+
+
+def _link_mastodon(
+    user, handle="alice@mast.example", url="https://mast.example/@alice"
+):
+    """Link a Mastodon account to ``user`` so ``user.mastodon`` resolves it."""
+    username, domain = handle.split("@")
+    return MastodonAccount.objects.create(
+        user=user,
+        domain=domain,
+        uid=f"uid-{handle}",
+        handle=handle,
+        account_data={"url": url, "username": username},
+    )
+
+
+def _link_bluesky(user, handle="alice.bsky.social"):
+    """Link a Bluesky account to ``user`` (handle is a domain; url == https://handle)."""
+    return BlueskyAccount.objects.create(
+        user=user,
+        domain="bsky.app",
+        uid=f"did:plc:{handle}",
+        handle=handle,
+        account_data={},
     )
 
 
@@ -187,7 +242,7 @@ class TestVerifyTask:
             RSS,
             "fetch_feed_with_metadata",
             lambda url, etag="", last_modified="": (
-                {"description": f"a podcast by {handle}"},
+                {"description": f"a podcast by {handle}", "episodes": _AUDIO_EPISODES},
                 "",
                 "",
                 200,
@@ -206,7 +261,7 @@ class TestVerifyTask:
             RSS,
             "fetch_feed_with_metadata",
             lambda url, etag="", last_modified="": (
-                {"description": "no identity here"},
+                {"description": "no identity here", "episodes": _AUDIO_EPISODES},
                 "",
                 "",
                 200,
@@ -216,6 +271,28 @@ class TestVerifyTask:
         claim.refresh_from_db()
         assert claim.state == VerifiedCreator.State.FAILED
         assert claim.failure_reason == VerifiedCreator.FailureReason.NO_MATCH
+
+    def test_failed_no_audio_episode(self, monkeypatch):
+        # a feed with no audio episode is not a podcast and must not verify,
+        # even when the identity matches
+        user = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        claim = self._claim(user, podcast)
+        handle = f"@{user.identity.full_handle}"
+        monkeypatch.setattr(
+            RSS,
+            "fetch_feed_with_metadata",
+            lambda url, etag="", last_modified="": (
+                {"description": f"by {handle}", "episodes": []},
+                "",
+                "",
+                200,
+            ),
+        )
+        verify_creator_task(claim.pk, user.pk)
+        claim.refresh_from_db()
+        assert claim.state == VerifiedCreator.State.FAILED
+        assert claim.failure_reason == VerifiedCreator.FailureReason.NO_AUDIO
 
     def test_failed_fetch_error(self, monkeypatch):
         user = User.register(email="a@example.com", username="alice")
@@ -277,7 +354,11 @@ class TestVerifyViews:
         podcast = _podcast()
         response = _client(user).get(f"/podcast/{podcast.uuid}/verify")
         assert response.status_code == 200
-        assert f"@{user.identity.full_handle}" in response.content.decode()
+        content = response.content.decode()
+        # only link/url identifiers are listed (bare @handles are discouraged)
+        url_candidates = [c for c in creator_identity_candidates(user) if "://" in c]
+        assert url_candidates
+        assert all(c in content for c in url_candidates)
 
     def test_start_flow(self, monkeypatch):
         user = User.register(email="a@example.com", username="alice")
@@ -287,7 +368,7 @@ class TestVerifyViews:
             RSS,
             "fetch_feed_with_metadata",
             lambda url, etag="", last_modified="": (
-                {"description": f"by {handle}"},
+                {"description": f"by {handle}", "episodes": _AUDIO_EPISODES},
                 "",
                 "",
                 200,
@@ -619,3 +700,217 @@ def test_original_episodes_api(live_server):
     payload = response.json()
     assert len(payload) == 1
     assert payload[0]["uuid"] == episode.uuid
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMastodonAttribution:
+    def test_resolve_identity_local(self):
+        user = User.register(email="a@example.com", username="alice")
+        local = f"@{user.identity.full_handle}"
+        assert resolve_creator_identity(user, local) == user.identity
+
+    def test_resolve_identity_mastodon(self):
+        user = User.register(email="a@example.com", username="alice")
+        _link_mastodon(user)
+        remote = _make_remote_identity("alice", "mast.example")
+        # a match against the linked Mastodon handle/url resolves to its
+        # remote identity; the local handle stays the local identity
+        assert resolve_creator_identity(user, "@alice@mast.example") == remote
+        assert resolve_creator_identity(user, "https://mast.example/@alice") == remote
+        assert resolve_creator_identity(user, f"@{user.identity.full_handle}") == (
+            user.identity
+        )
+
+    def test_user_controls_owner(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        _link_mastodon(alice)
+        remote = _make_remote_identity("alice", "mast.example")
+        # local identity and the linked Mastodon identity are both controlled
+        assert user_controls_owner(alice, alice.identity)
+        assert user_controls_owner(alice, remote)
+        # someone else's identities are not
+        assert not user_controls_owner(bob, remote)
+        assert not user_controls_owner(bob, alice.identity)
+
+    def test_user_owned_claims_q(self):
+        alice = User.register(email="a@example.com", username="alice")
+        _link_mastodon(alice)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        local_claim = _verified(podcast, alice.identity)
+        other = _podcast("Other", "other.example.com/feed.rss")
+        remote_claim = _verified(other, remote, matched="@alice@mast.example")
+        owned = set(
+            VerifiedCreator.objects.filter(user_owned_claims_q(alice)).values_list(
+                "pk", flat=True
+            )
+        )
+        assert owned == {local_claim.pk, remote_claim.pk}
+
+    def test_verify_rehomes_to_mastodon(self, monkeypatch):
+        user = User.register(email="a@example.com", username="alice")
+        _link_mastodon(user)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        handle = "@alice@mast.example"
+        monkeypatch.setattr(
+            RSS,
+            "fetch_feed_with_metadata",
+            lambda url, etag="", last_modified="": (
+                {"description": f"hosted by {handle}", "episodes": _AUDIO_EPISODES},
+                "",
+                "",
+                200,
+            ),
+        )
+        verify_creator_task(claim.pk, user.pk)
+        # the pending local claim is re-homed onto the linked Mastodon identity
+        assert not VerifiedCreator.objects.filter(pk=claim.pk).exists()
+        assert not VerifiedCreator.objects.filter(
+            item=podcast, owner=user.identity
+        ).exists()
+        rehomed = VerifiedCreator.objects.get(item=podcast, owner=remote)
+        assert rehomed.state == VerifiedCreator.State.VERIFIED
+        assert rehomed.matched == handle
+
+    def test_unverify_mastodon_owned_claim(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        _link_mastodon(alice)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        claim = _verified(podcast, remote, matched="@alice@mast.example")
+        url = f"/podcast/{podcast.uuid}/verify/remove"
+        # bob does not control the Mastodon identity
+        assert _client(bob).post(url, {"claim_id": claim.pk}).status_code == 403
+        # alice does, via her linked Mastodon account
+        assert _client(alice).post(url, {"claim_id": claim.pk}).status_code == 302
+        assert not VerifiedCreator.objects.filter(pk=claim.pk).exists()
+
+    def test_edit_allowed_for_mastodon_attributed_creator(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        _link_mastodon(alice)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        _verified(podcast, remote, matched="@alice@mast.example")
+        url = f"/podcast/{podcast.uuid}/edit"
+        assert _client(bob).get(url).status_code == 403
+        assert _client(alice).get(url).status_code == 200
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestFeedLinkCreator:
+    def _feed(self, monkeypatch, description, link="https://pod.example/"):
+        monkeypatch.setattr(
+            RSS,
+            "fetch_feed_with_metadata",
+            lambda url, etag="", last_modified="": (
+                {"description": description, "link": link, "episodes": _AUDIO_EPISODES},
+                "",
+                "",
+                200,
+            ),
+        )
+
+    def _rel_me(self, monkeypatch, urls):
+        monkeypatch.setattr(
+            "catalog.jobs.creator_verify._fetch_page_rel_me_urls",
+            lambda url: urls,
+        )
+
+    def test_page_rel_me_preferred_over_description(self, monkeypatch):
+        # a rel="me" to the linked Mastodon wins over a description match and
+        # attributes the work to that Mastodon identity
+        user = User.register(email="a@example.com", username="alice")
+        _link_mastodon(user)
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast()
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        self._feed(monkeypatch, f"by @{user.identity.full_handle}")
+        self._rel_me(monkeypatch, ["https://mast.example/@alice"])
+        verify_creator_task(claim.pk, user.pk)
+        rehomed = VerifiedCreator.objects.get(item=podcast, owner=remote)
+        assert rehomed.matched == "https://mast.example/@alice"
+
+    def test_page_rel_me_matches_bluesky(self, monkeypatch):
+        # a rel="me" to the user's Bluesky also verifies (stays local identity)
+        user = User.register(email="a@example.com", username="alice")
+        _link_bluesky(user, "alice.bsky.social")
+        podcast = _podcast()
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        self._feed(monkeypatch, "no identity in here")
+        self._rel_me(monkeypatch, ["https://alice.bsky.social"])
+        verify_creator_task(claim.pk, user.pk)
+        claim.refresh_from_db()
+        assert claim.state == VerifiedCreator.State.VERIFIED
+        assert claim.matched == "https://alice.bsky.social"
+        assert claim.owner_id == user.identity.pk
+
+    def test_channel_link_is_bluesky_handle(self, monkeypatch):
+        # the channel link being on the user's Bluesky handle (a domain) passes
+        # even with no rel="me" on the page
+        user = User.register(email="a@example.com", username="alice")
+        _link_bluesky(user, "alice.bsky.social")
+        podcast = _podcast()
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        self._feed(monkeypatch, "nothing here", link="https://alice.bsky.social/show")
+        self._rel_me(monkeypatch, [])
+        verify_creator_task(claim.pk, user.pk)
+        claim.refresh_from_db()
+        assert claim.state == VerifiedCreator.State.VERIFIED
+        assert claim.matched == "@alice.bsky.social"
+        assert claim.owner_id == user.identity.pk
+
+    def test_unrelated_rel_me_falls_back_to_description(self, monkeypatch):
+        # rel="me" links that aren't the user's are ignored; we fall back to the
+        # description match against the user's own candidates
+        user = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        claim = VerifiedCreator.objects.create(item=podcast, owner=user.identity)
+        local_handle = f"@{user.identity.full_handle}"
+        self._feed(monkeypatch, f"by {local_handle}")
+        self._rel_me(monkeypatch, ["https://stranger.example/@bob"])
+        verify_creator_task(claim.pk, user.pk)
+        claim.refresh_from_db()
+        assert claim.state == VerifiedCreator.State.VERIFIED
+        assert claim.matched == local_handle
+        assert claim.owner_id == user.identity.pk
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestItemPageMeta:
+    def test_fediverse_creator_meta_on_item_page(self):
+        alice = User.register(email="a@example.com", username="alice")
+        podcast = _podcast("Meta Show")
+        _verified(podcast, alice.identity)
+        response = Client().get(podcast.url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'name="fediverse:creator"' in content
+        assert f"@{alice.identity.full_handle}" in content
+
+    def test_meta_emitted_for_each_verified_creator(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        podcast = _podcast("Co-hosted Show")
+        _verified(podcast, alice.identity)
+        _verified(podcast, bob.identity)
+        content = Client().get(podcast.url).content.decode()
+        # one fediverse:creator meta per verified creator
+        assert content.count('name="fediverse:creator"') == 2
+        assert f"@{alice.identity.full_handle}" in content
+        assert f"@{bob.identity.full_handle}" in content
+
+    def test_rel_me_link_points_to_creator_profile(self):
+        # a rel="me" link back to the creator's profile lets Mastodon show its
+        # green "verified link" check when the creator lists this page
+        remote = _make_remote_identity("alice", "mast.example")
+        podcast = _podcast("Rel Me Show")
+        _verified(podcast, remote, matched="@alice@mast.example")
+        content = Client().get(podcast.url).content.decode()
+        assert remote.profile_uri == "https://mast.example/@alice"
+        assert 'rel="me"' in content
+        assert remote.profile_uri in content


### PR DESCRIPTION
## What

Builds on podcast creator verification so a verified creator is connected to their **open fediverse identity**, not just a local row.

### Verification
- Checks the page the feed's channel `<link>` points to for a `rel="me"` link back to one of the user's identities (the same link verification Mastodon uses) — this covers both fediverse and Bluesky profile links. A channel link hosted on the user's Bluesky handle (a Bluesky handle is itself a domain) also counts. This is preferred over a feed-description text match, which remains as a fallback.
- The feed must contain at least one **audio episode**; feeds without audio no longer verify (new `NO_AUDIO` failure reason).
- When the matched identifier is the user's **linked Mastodon**, the verified record is attributed to that Mastodon identity. The NeoDB user keeps edit + unverify control via a controlled-identity check that compares the linked handle against the owner's stored username/domain — so no remote-actor resolution happens on the request path (it runs only in the background worker).

### Item page
- Verified creators are advertised in `<head>` via `fediverse:creator` (Mastodon author byline on link previews) and `rel="me"` (verified-link / green check), one tag per creator.

### Verify page UX
- Lists link/URL identifiers only (bare `@handle`s are de-emphasized to encourage links; the matcher still accepts them leniently).
- Click-to-copy identifiers, plus copyable `rel="me"` and feed-description examples (including a "can't edit your site? add this line to the description" fallback).
- A confirmation checkbox gates the Start verification button.

## Notes
- No migration: the `FailureReason` change is choices-only (no schema change), consistent with how this repo already handles choices drift.
- zh_Hans translations updated.

## Testing
- `tests/catalog/test_creator_verify.py` extended: `rel="me"`/Bluesky matching, Mastodon attribution + controlled-identity permissions, the audio-episode guard, item-page `fediverse:creator`/`rel="me"`, and the copyable UI. Full `tests/catalog/` suite passes locally.
