### PR TITLE
feat(journal): add translate action for articles

### DIFF
--- a/neodb/journal/templates/article.html
+++ b/neodb/journal/templates/article.html
@@ -62,12 +62,12 @@
                 {% include "action_post_timestamp.html" with post=article.latest_post %}
                 {% include "action_like_post.html" with post=article.latest_post %}
                 {% include "action_boost_post.html" with post=article.latest_post %}
-                {% if article.classname == "review" and translate_enabled and request.user.is_authenticated %}
+                {% if translate_enabled and request.user.is_authenticated %}
                   <span>
                     <a title="{% trans "translate" %}"
-                       hx-post="{% url 'journal:review_translate' article.uuid %}"
+                       {% if article.classname == "review" %}hx-post="{% url 'journal:review_translate' article.uuid %}"{% else %}hx-post="{% url 'journal:article_translate' article.uuid %}"{% endif %}
                        hx-trigger="click once"
-                       hx-target="#review_{{ article.uuid }}_content">
+                       hx-target="#{{ article.classname }}_{{ article.uuid }}_content">
                       <i class="fa-solid fa-language"></i>
                     </a>
                   </span>

--- a/neodb/journal/urls.py
+++ b/neodb/journal/urls.py
@@ -57,6 +57,11 @@ urlpatterns = [
     path("article/compose", article_edit, name="article_compose"),
     path("article/edit/<str:article_uuid>", article_edit, name="article_edit"),
     path("article/delete/<str:piece_uuid>", piece_delete, name="article_delete"),
+    path(
+        "article/translate/<str:article_uuid>",
+        article_translate,
+        name="article_translate",
+    ),
     re_path(
         r"^article/(?P<article_uuid>[A-Za-z0-9]{21,22})$",
         article_retrieve,

--- a/neodb/journal/views/__init__.py
+++ b/neodb/journal/views/__init__.py
@@ -1,4 +1,10 @@
-from .article import ArticleFeed, article_edit, article_retrieve, user_article_list
+from .article import (
+    ArticleFeed,
+    article_edit,
+    article_retrieve,
+    article_translate,
+    user_article_list,
+)
 from .collection import (
     add_to_collection,
     collection_add_featured,
@@ -72,6 +78,7 @@ __all__ = [
     "ArticleFeed",
     "article_edit",
     "article_retrieve",
+    "article_translate",
     "user_article_list",
     "add_to_collection",
     "save_as_dynamic_collection",

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -5,9 +5,11 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.html import escape
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.models.lang import translate
 from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404, target_identity_required
 from takahe.utils import Takahe
@@ -128,6 +130,27 @@ def article_retrieve(request, article_uuid: str):
         request,
         "article.html",
         {"article": article, "quotes_count": post_quotes_count(article.latest_post)},
+    )
+
+
+@require_http_methods(["POST"])
+@login_required
+def article_translate(request, article_uuid: str):
+    article = get_object_or_404(Article, uid=get_uuid_or_404(article_uuid))
+    if not article.is_visible_to(request.user):
+        raise PermissionDenied(_("Insufficient permission"))
+    text = article.html_content
+    if article.latest_post:
+        lang = article.latest_post.language
+    elif article.owner.local:
+        lang = article.owner.user.language
+    else:
+        lang = None
+    target_lang = request.user.language or "en"
+    text = translate(text, target_lang, lang)
+    title = translate(article.title, target_lang, lang)
+    return HttpResponse(
+        f'<span hx-swap-oob="true" id="article_{article.uuid}_title">{escape(title)}</span><div>{text}</div>'
     )
 
 


### PR DESCRIPTION
## What

Adds a translate action for standalone articles, mirroring the existing translate feature for reviews, comments, and posts.

## Changes

- `journal/views/article.py`: new `article_translate` view (POST, login-required). Source language is taken from the article's federated post, else the local owner's user language; target language is the viewer's language (falling back to `"en"` when unset). Translates `html_content` into the content div and the title via an out-of-band swap, matching `review_translate`.
- `journal/views/__init__.py`: export `article_translate`.
- `journal/urls.py`: add `article/translate/<str:article_uuid>` -> `journal:article_translate`.
- `journal/templates/article.html`: generalize the previously review-only translate button so it also appears on articles, routing to the correct endpoint and targeting `#{{ article.classname }}_{{ article.uuid }}_content`.

## Notes

- Reuses the existing `translate()` backend (DeepL / LibreTranslate) and the existing `"translate"` i18n string; no new strings.
- The translate button shows only when the article has a federated post (the action bar's existing condition) and the viewer is authenticated, consistent with reviews.
