### PR TITLE
fix(catalog): order people_works queryset to avoid unordered pagination warning

### DIFF
--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -201,9 +201,11 @@ def people_works(request, item_path, item_uuid, role):
     if hidden_ids:
         works_qs = works_qs.exclude(pk__in=hidden_ids)
 
+    # hidden_ids is a subset of visible_ids by construction, so derive the
+    # total in-memory instead of issuing another COUNT query.
+    total = len(visible_ids) - len(hidden_ids)
     # Order explicitly so pagination yields stable, consistent results.
     works_qs = works_qs.order_by("-pk")
-    total = works_qs.count()
     paginator = CustomPaginator(works_qs, request)
     page_number = request.GET.get("page", default=1)
     works_page = paginator.get_page(page_number)

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -201,6 +201,8 @@ def people_works(request, item_path, item_uuid, role):
     if hidden_ids:
         works_qs = works_qs.exclude(pk__in=hidden_ids)
 
+    # Order explicitly so pagination yields stable, consistent results.
+    works_qs = works_qs.order_by("-pk")
     total = works_qs.count()
     paginator = CustomPaginator(works_qs, request)
     page_number = request.GET.get("page", default=1)


### PR DESCRIPTION
## What

`people_works` paginated an `Item` PolymorphicQuerySet (`works_qs`) that had no explicit ordering, triggering Django's `UnorderedObjectListWarning`:

```
common/utils.py:191: UnorderedObjectListWarning: Pagination may yield inconsistent
results with an unordered object_list: <class 'catalog.models.item.Item'> PolymorphicQuerySet.
```

The warning surfaces at `CustomPaginator.__init__`, but the root cause is the caller passing an unordered queryset. `Item` has no `Meta.ordering`, and the other `CustomPaginator` callers (`mark_list`, `review_list`, journal `render_list`) already order their querysets.

## Change

Add `works_qs.order_by("-pk")` before pagination. This gives a deterministic order using the primary-key index (no extra sort node), over an already small per-person filtered result set, so there is no performance impact.