### PR TITLE
fix(catalog): defer external_resource JSON columns on item detail page

### DIFF
--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -104,7 +104,16 @@ def retrieve(request, item_path, item_uuid):
     # Prefetch parent item, external resources, and credits to avoid N+1 in templates
     prefetch_related_objects(
         [item],
-        "external_resources",
+        # The detail page only reads url/site_name/site_label (derived from
+        # id_type/id_value) via item.display_resources, so skip the large
+        # metadata/other_lookup_ids JSON columns that made this prefetch a slow
+        # query (EGGPLANT-1DX).
+        Prefetch(
+            "external_resources",
+            queryset=ExternalResource.objects.only(
+                "id", "item_id", "id_type", "id_value", "url"
+            ),
+        ),
         Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
     )
     Item.prefetch_parent_items([item])

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -101,18 +101,21 @@ def retrieve(request, item_path, item_uuid):
         return JsonResponse(item.ap_object, content_type="application/activity+json")
     if request.method == "HEAD":
         return HttpResponse()
-    # Prefetch parent item, external resources, and credits to avoid N+1 in templates
+    # Prefetch parent item, external resources, and credits to avoid N+1 in templates.
+    # The detail page only reads url/site_name/site_label (derived from
+    # id_type/id_value) via item.display_resources, so skip the large
+    # metadata/other_lookup_ids JSON columns that made this prefetch a slow
+    # query (EGGPLANT-1DX). Albums are the exception: album.html renders an
+    # embed via Album.get_embed_link(), which reads res.metadata for Bandcamp
+    # resources, so keep metadata for them to avoid a per-resource deferred load.
+    extres_fields = ["id", "item_id", "id_type", "id_value", "url"]
+    if item.class_name == "album":
+        extres_fields.append("metadata")
     prefetch_related_objects(
         [item],
-        # The detail page only reads url/site_name/site_label (derived from
-        # id_type/id_value) via item.display_resources, so skip the large
-        # metadata/other_lookup_ids JSON columns that made this prefetch a slow
-        # query (EGGPLANT-1DX).
         Prefetch(
             "external_resources",
-            queryset=ExternalResource.objects.only(
-                "id", "item_id", "id_type", "id_value", "url"
-            ),
+            queryset=ExternalResource.objects.only(*extres_fields),
         ),
         Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
     )


### PR DESCRIPTION
## Problem

Sentry **EGGPLANT-1DX** (Slow DB Query, 79 occurrences / 71 users, still recurring) flags this query on the item detail page `/{item_path}/{item_uuid}`:

```sql
SELECT ... FROM catalog_externalresource WHERE item_id IN (%s)
```

`retrieve()` prefetched `external_resources` with **all** columns, including the large `metadata` JSON blob (full scraped payloads from external sites). The detail page only renders `url` / `site_name` / `site_label` (the latter two derived from `id_type` / `id_value`) via `item.display_resources`, so the heavy `metadata` / `other_lookup_ids` columns were fetched and deserialized for nothing.

## Fix

Use the same `.only("id", "item_id", "id_type", "id_value", "url")` `Prefetch` already applied to the works list and similar-items list elsewhere in this view (see `people_works` / `similar_items`, which carry the same `EGGPLANT-1DX` note). This keeps the detail page's external-link rendering intact while skipping the large JSON columns.

`Album.get_embed_link()` reads `res.metadata` only for Bandcamp resources (short-circuited `and`), so at most ~1 cheap extra query per album detail page that has a Bandcamp link — the same tradeoff the existing card-list code already accepts.

## Test

`tests/catalog/test_pages.py::test_catalog_item_pages` (renders the detail page for every item type, incl. Album and Podcast) passes. `pre-commit run -a` (ruff + ty) clean.

Note: the second slow-query issue **EGGPLANT-1EA** (`catalog_podcastepisode WHERE program_id = %s`, 1 occurrence, non-recurring) was reviewed — that code path (`Podcast.child_item_ids`) was already optimized for EGGPLANT-1BH and uses an indexed FK lookup; the single hit looks transient, so no change here.