### PR TITLE
fix(catalog): stop logging transient external failures as errors

### DIFF
--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -21,6 +21,8 @@ from loguru import logger
 
 from common.models import SiteConfig
 from common.models.misc import uniq
+from common.sentry import count as sentry_count
+from common.sentry import url_domain
 from common.validators import is_valid_url
 
 from ..models import ExternalResource, IdType, Item, SiteName
@@ -557,9 +559,8 @@ class SiteManager:
                     # the fetch; that's expected noise, not a NeoDB bug, so log
                     # it as a warning to keep it out of Sentry issues. Anything
                     # else is unexpected and stays at error level.
-                    log = (
-                        logger.warning if isinstance(e, DownloadError) else logger.error
-                    )
+                    is_download = isinstance(e, DownloadError)
+                    log = logger.warning if is_download else logger.error
                     log(
                         f"error fetching from {linked_site.ID_TYPE}",
                         extra={
@@ -567,6 +568,15 @@ class SiteManager:
                             "linked_resource": linked_resource,
                             "linked_site": linked_site,
                             "exception": e,
+                        },
+                    )
+                    # Warnings don't surface as Sentry issues, so emit a metric
+                    # to keep these external-fetch failures trackable by site.
+                    sentry_count(
+                        "catalog.linked_resource.failure",
+                        attributes={
+                            "site": str(linked_site.ID_TYPE),
+                            "reason": "download" if is_download else "error",
                         },
                     )
                     continue
@@ -622,6 +632,16 @@ class SiteManager:
                     extra={
                         "resource": resource,
                         "linked_resource": linked_resource,
+                    },
+                )
+                # Tracked as a metric (not an error issue) so the volume of
+                # unresolvable linked resources stays visible by source.
+                sentry_count(
+                    "catalog.linked_resource.failure",
+                    attributes={
+                        "site": linked_resource.get("id_type")
+                        or url_domain(linked_resource.get("url")),
+                        "reason": "no_site",
                     },
                 )
         if resource.item and processed:

--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -555,10 +555,8 @@ class SiteManager:
                         preloaded_content=linked_resource.get("content"),
                     )
                 except Exception as e:
-                    # DownloadError means the third-party site failed/blocked
-                    # the fetch; that's expected noise, not a NeoDB bug, so log
-                    # it as a warning to keep it out of Sentry issues. Anything
-                    # else is unexpected and stays at error level.
+                    # DownloadError = expected third-party failure -> warn (no
+                    # Sentry issue); anything else is a real error.
                     is_download = isinstance(e, DownloadError)
                     log = logger.warning if is_download else logger.error
                     log(
@@ -570,8 +568,7 @@ class SiteManager:
                             "exception": e,
                         },
                     )
-                    # Warnings don't surface as Sentry issues, so emit a metric
-                    # to keep these external-fetch failures trackable by site.
+                    # Warnings aren't Sentry issues; metric keeps them trackable.
                     sentry_count(
                         "catalog.linked_resource.failure",
                         attributes={
@@ -624,9 +621,8 @@ class SiteManager:
                         case _:
                             logger.error(f"unknown link type {link_type}")
             else:
-                # Many linked resources (e.g. a Douban author page) have no
-                # registered site that can resolve them; this is expected and
-                # not actionable, so warn instead of erroring into Sentry.
+                # No registered site for this link (e.g. a Douban author);
+                # expected, so warn rather than error.
                 logger.warning(
                     "unable to get site for linked resource",
                     extra={
@@ -634,8 +630,7 @@ class SiteManager:
                         "linked_resource": linked_resource,
                     },
                 )
-                # Tracked as a metric (not an error issue) so the volume of
-                # unresolvable linked resources stays visible by source.
+                # Track as a metric so the volume stays visible.
                 sentry_count(
                     "catalog.linked_resource.failure",
                     attributes={

--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -24,6 +24,7 @@ from common.models.misc import uniq
 from common.validators import is_valid_url
 
 from ..models import ExternalResource, IdType, Item, SiteName
+from .downloaders import DownloadError
 
 
 @dataclass
@@ -552,7 +553,14 @@ class SiteManager:
                         preloaded_content=linked_resource.get("content"),
                     )
                 except Exception as e:
-                    logger.error(
+                    # DownloadError means the third-party site failed/blocked
+                    # the fetch; that's expected noise, not a NeoDB bug, so log
+                    # it as a warning to keep it out of Sentry issues. Anything
+                    # else is unexpected and stays at error level.
+                    log = (
+                        logger.warning if isinstance(e, DownloadError) else logger.error
+                    )
+                    log(
                         f"error fetching from {linked_site.ID_TYPE}",
                         extra={
                             "resource": resource,
@@ -606,7 +614,10 @@ class SiteManager:
                         case _:
                             logger.error(f"unknown link type {link_type}")
             else:
-                logger.error(
+                # Many linked resources (e.g. a Douban author page) have no
+                # registered site that can resolve them; this is expected and
+                # not actionable, so warn instead of erroring into Sentry.
+                logger.warning(
                     "unable to get site for linked resource",
                     extra={
                         "resource": resource,

--- a/neodb/catalog/search/utils.py
+++ b/neodb/catalog/search/utils.py
@@ -191,9 +191,8 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
                 logger.error(f"fetch {url} failed")
                 _record_fetch_failure(url)
         except DownloadError as e:
-            # External download/network/invalid-response failures are expected
-            # noise, not NeoDB bugs; warn (kept out of Sentry issues) rather
-            # than error. Censored responses are already silently skipped.
+            # Expected external failure -> warn, not a Sentry error. Censored
+            # responses are already skipped.
             if e.response_type != RESPONSE_CENSORSHIP:
                 logger.warning(f"fetch {url} error", extra={"exception": e})
             _record_fetch_failure(url)

--- a/neodb/catalog/search/utils.py
+++ b/neodb/catalog/search/utils.py
@@ -191,8 +191,11 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
                 logger.error(f"fetch {url} failed")
                 _record_fetch_failure(url)
         except DownloadError as e:
+            # External download/network/invalid-response failures are expected
+            # noise, not NeoDB bugs; warn (kept out of Sentry issues) rather
+            # than error. Censored responses are already silently skipped.
             if e.response_type != RESPONSE_CENSORSHIP:
-                logger.error(f"fetch {url} error", extra={"exception": e})
+                logger.warning(f"fetch {url} error", extra={"exception": e})
             _record_fetch_failure(url)
         except Exception as e:
             logger.error(f"parse {url} error {e}", extra={"exception": e})

--- a/neodb/catalog/sites/bandcamp.py
+++ b/neodb/catalog/sites/bandcamp.py
@@ -34,10 +34,8 @@ class Bandcamp(AbstractSite):
 
     @classmethod
     def url_to_id(cls, url: str):
-        # Standard *.bandcamp.com album URLs match URL_PATTERNS, but custom
-        # domains (CNAME'd to Bandcamp, accepted via validate_url_fallback) do
-        # not, so fall back to URL_PATTERN_FALLBACK. Without this the site is
-        # built with url=None and scrape() raises AssertionError.
+        # Custom domains match only URL_PATTERN_FALLBACK; without this fallback
+        # url_to_id returns None and scrape() asserts on self.url.
         id_value = super().url_to_id(url)
         if id_value:
             return id_value

--- a/neodb/catalog/sites/bandcamp.py
+++ b/neodb/catalog/sites/bandcamp.py
@@ -33,6 +33,18 @@ class Bandcamp(AbstractSite):
         return f"https://{id_value}"
 
     @classmethod
+    def url_to_id(cls, url: str):
+        # Standard *.bandcamp.com album URLs match URL_PATTERNS, but custom
+        # domains (CNAME'd to Bandcamp, accepted via validate_url_fallback) do
+        # not, so fall back to URL_PATTERN_FALLBACK. Without this the site is
+        # built with url=None and scrape() raises AssertionError.
+        id_value = super().url_to_id(url)
+        if id_value:
+            return id_value
+        m = re.match(cls.URL_PATTERN_FALLBACK, url)
+        return m[1] if m else None
+
+    @classmethod
     def validate_url_fallback(cls, url):
         if re.match(cls.URL_PATTERN_FALLBACK, url) is None:
             return False

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -609,6 +609,15 @@ class MusicBrainzRelease(AbstractSite):
             except httpx.TimeoutException:
                 logger.warning("MusicBrainz release search timeout", extra={"query": q})
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
+            except httpx.HTTPError as e:
+                # MusicBrainz frequently returns 503 under load; that and other
+                # transport errors are transient upstream failures, not NeoDB
+                # bugs, so warn rather than error into Sentry.
+                logger.warning(
+                    "MusicBrainz release search error",
+                    extra={"query": q, "exception": e},
+                )
+                record_search_failure(SiteName.MusicBrainz.value, "error")
             except Exception as e:
                 logger.error(
                     "MusicBrainz release search error",
@@ -897,6 +906,16 @@ class MusicBrainzArtist(AbstractSite):
             except httpx.TimeoutException:
                 logger.warning("MusicBrainz artist search timeout", extra={"query": q})
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
+                return results
+            except httpx.HTTPError as e:
+                # MusicBrainz frequently returns 503 under load; that and other
+                # transport errors are transient upstream failures, not NeoDB
+                # bugs, so warn rather than error into Sentry.
+                logger.warning(
+                    "MusicBrainz artist search error",
+                    extra={"query": q, "exception": e},
+                )
+                record_search_failure(SiteName.MusicBrainz.value, "error")
                 return results
             except Exception as e:
                 logger.error(

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -610,9 +610,7 @@ class MusicBrainzRelease(AbstractSite):
                 logger.warning("MusicBrainz release search timeout", extra={"query": q})
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
             except httpx.HTTPError as e:
-                # MusicBrainz frequently returns 503 under load; that and other
-                # transport errors are transient upstream failures, not NeoDB
-                # bugs, so warn rather than error into Sentry.
+                # MusicBrainz 503s and transport errors are transient -> warn.
                 logger.warning(
                     "MusicBrainz release search error",
                     extra={"query": q, "exception": e},
@@ -908,9 +906,7 @@ class MusicBrainzArtist(AbstractSite):
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
                 return results
             except httpx.HTTPError as e:
-                # MusicBrainz frequently returns 503 under load; that and other
-                # transport errors are transient upstream failures, not NeoDB
-                # bugs, so warn rather than error into Sentry.
+                # MusicBrainz 503s and transport errors are transient -> warn.
                 logger.warning(
                     "MusicBrainz artist search error",
                     extra={"query": q, "exception": e},

--- a/neodb/catalog/sites/openlibrary.py
+++ b/neodb/catalog/sites/openlibrary.py
@@ -228,9 +228,17 @@ class OpenLibrary(AbstractSite):
                             )
                         )
 
-            except httpx.ReadTimeout:
+            except httpx.TimeoutException:
                 logger.warning("OpenLibrary search timeout", extra={"query": q})
                 record_search_failure(cls.SITE_NAME.value, "timeout")
+            except httpx.HTTPError as e:
+                # Connect errors, transport errors and bad upstream statuses are
+                # transient third-party failures, not NeoDB bugs; warn so they
+                # stay out of Sentry issues.
+                logger.warning(
+                    "OpenLibrary search error", extra={"query": q, "exception": e}
+                )
+                record_search_failure(cls.SITE_NAME.value, "error")
             except Exception as e:
                 logger.error(
                     "OpenLibrary search error", extra={"query": q, "exception": e}

--- a/neodb/catalog/sites/openlibrary.py
+++ b/neodb/catalog/sites/openlibrary.py
@@ -232,9 +232,7 @@ class OpenLibrary(AbstractSite):
                 logger.warning("OpenLibrary search timeout", extra={"query": q})
                 record_search_failure(cls.SITE_NAME.value, "timeout")
             except httpx.HTTPError as e:
-                # Connect errors, transport errors and bad upstream statuses are
-                # transient third-party failures, not NeoDB bugs; warn so they
-                # stay out of Sentry issues.
+                # Transient third-party failure (timeout/connect/bad status) -> warn.
                 logger.warning(
                     "OpenLibrary search error", extra={"query": q, "exception": e}
                 )

--- a/neodb/tests/catalog/test_music.py
+++ b/neodb/tests/catalog/test_music.py
@@ -150,6 +150,24 @@ class TestBandcamp:
         assert site.url == t_url2
         assert site.id_value == t_id_value
 
+    def test_custom_domain_url_to_id(self):
+        # Regression for NEODB-SOCIAL-4MW: custom Bandcamp domains (CNAME'd to
+        # Bandcamp, accepted via validate_url_fallback) only match
+        # URL_PATTERN_FALLBACK, so url_to_id must resolve them. Otherwise the
+        # site is built with url=None and scrape() raises AssertionError.
+        from catalog.sites.bandcamp import Bandcamp
+
+        custom_url = "https://music.example.com/album/some-album"
+        assert Bandcamp.url_to_id(custom_url) == "music.example.com/album/some-album"
+        site = Bandcamp(url=custom_url)
+        assert site.url == custom_url
+        assert site.id_value == "music.example.com/album/some-album"
+        # standard *.bandcamp.com URLs still resolve via URL_PATTERNS
+        assert (
+            Bandcamp.url_to_id("https://intlanthem.bandcamp.com/album/in-these-times")
+            == "intlanthem.bandcamp.com/album/in-these-times"
+        )
+
     @use_local_response
     def test_scrape(self):
         t_url = "https://intlanthem.bandcamp.com/album/in-these-times?from=hpbcw"

--- a/neodb/tests/catalog/test_music.py
+++ b/neodb/tests/catalog/test_music.py
@@ -151,10 +151,8 @@ class TestBandcamp:
         assert site.id_value == t_id_value
 
     def test_custom_domain_url_to_id(self):
-        # Regression for NEODB-SOCIAL-4MW: custom Bandcamp domains (CNAME'd to
-        # Bandcamp, accepted via validate_url_fallback) only match
-        # URL_PATTERN_FALLBACK, so url_to_id must resolve them. Otherwise the
-        # site is built with url=None and scrape() raises AssertionError.
+        # Regression for NEODB-SOCIAL-4MW: custom Bandcamp domains must resolve
+        # via URL_PATTERN_FALLBACK, else scrape() asserts on a None url.
         from catalog.sites.bandcamp import Bandcamp
 
         custom_url = "https://music.example.com/album/some-album"


### PR DESCRIPTION
## What

External catalog site fetch/search failures (timeouts, 503s, downstream blocking, invalid responses) were logged at `error` level and captured as Sentry issues, even though they are not NeoDB bugs. Sentry's loguru integration only turns `error`+ into issues, so this PR downgrades expected/transient external failures to `warning`, matching the existing treatment of timeouts.

It also fixes a real bug: Bandcamp custom domains (matched via `validate_url_fallback`) only matched `URL_PATTERN_FALLBACK`, so `url_to_id` returned `None`, leaving `self.url = None` and making `scrape()` raise `AssertionError`. `url_to_id` now falls back to `URL_PATTERN_FALLBACK`.

## Changes
- `sites/openlibrary.py`, `sites/musicbrainz.py`: treat `httpx.HTTPError` (incl. 503 and connect timeouts) as warnings; keep unexpected exceptions at `error`
- `search/utils.py`: `DownloadError` -> warning
- `common/sites.py`: `DownloadError` in `fetch_linked_resources` -> warning; "unable to get site for linked resource" -> warning
- `sites/bandcamp.py`: `url_to_id` fallback + regression test

## Still trackable (not lost from observability)
Downgrading to `warning` removes the Sentry **error issues** but the failures stay visible as **metrics** (queryable in the metrics dataset), so trends/alerts can replace the error-issue tracking:
- search failures (openlibrary, musicbrainz): `catalog.search.failure` `{site, reason}`
- `_fetch_task` failures (goodreads, etc.): `catalog.fetch.failure` `{domain}`
- `fetch_linked_resources` failures + unresolvable links: **new** `catalog.linked_resource.failure` `{site, reason=download|error|no_site}` (added here, since those two paths previously had no metric)

## Sentry issues resolved
NEODB-SOCIAL-4JA, 40E, 40D, 4MW, 4JD, 3T6; EGGPLANT-VF, VG, SS, 1DZ, 10D, V6, V3, SY

## Test
`pytest tests/catalog/test_music.py -k Bandcamp` -> 5 passed (incl. new `test_custom_domain_url_to_id`). `manage.py check` clean. `pre-commit run -a` clean.

Generated with Claude Code.
