### PR TITLE
perf(takahe): index Post(author, -id) for per-author post list

### DIFF
--- a/takahe/activities/migrations/0032_post_author_id_idx.py
+++ b/takahe/activities/migrations/0032_post_author_id_idx.py
@@ -1,0 +1,17 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("activities", "0031_quoteauthorization"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="post",
+            index=models.Index(fields=["author", "-id"], name="ix_post_author_id"),
+        ),
+    ]

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -534,6 +534,11 @@ class Post(StatorModel):
                 name="ix_post_local_public_created",
             ),
             models.Index(fields=["url"], name="activities_post_url_idx"),
+            # Per-author post listing (NeoDB journal.user_post_list) filters by
+            # author and paginates with ORDER BY id DESC; without this composite
+            # index Postgres can scan the primary-key index backwards filtering
+            # author_id and time out the worker (NeoDB EGGPLANT-1E7).
+            models.Index(fields=["author", "-id"], name="ix_post_author_id"),
         ]
 
     class urls(urlman.Urls):


### PR DESCRIPTION
## What

`journal.user_post_list` paginates a user's posts with `WHERE author_id = %s ORDER BY id DESC LIMIT %s`. With only the implicit `author_id` FK index, Postgres can scan the primary-key index backwards filtering by `author_id`, which exceeds the gunicorn 60s worker timeout for accounts whose newest post is far from the global max id -- surfacing as `SystemExit: 1` worker aborts (EGGPLANT-1E7).

Adds a composite `(author, -id)` index on the Takahe `Post` model so the query is satisfied directly. Built with `CREATE INDEX CONCURRENTLY` (`atomic = False`) because `activities_post` is large.

## Note
This is a schema migration in the Takahe project (`takahe/activities/migrations/0032_post_author_id_idx.py`); apply via `takahe-manage migrate activities`. Verified locally:
`CREATE INDEX ix_post_author_id ON public.activities_post USING btree (author_id, id DESC)`.

## Sentry issue resolved
EGGPLANT-1E7

Generated with Claude Code.
