### PR TITLE
feat(catalog): make original podcast episodes playable on discover page

### DIFF
--- a/neodb/catalog/templates/discover.html
+++ b/neodb/catalog/templates/discover.html
@@ -92,18 +92,30 @@
               <ul class="cards">
                 {% for item in gallery.items %}
                   <li class="card">
-                    <a href="{{ item.url }}" title="{{ item.display_title }}">
-                      {% if gallery.name == "original_episodes" %}
+                    {% if gallery.name == "original_episodes" %}
+                      <a href="{{ item.url }}"
+                         title="{{ item.display_title }}"
+                         class="episode"
+                         data-media="{{ item.media_url }}"
+                         data-cover="{{ item.cover_image_url }}"
+                         data-title="{{ item.display_title }}"
+                         data-album="{{ item.program.display_title }}"
+                         data-hosts="{{ item.program.host_names|join:' / ' }}"
+                         data-uuid="{{ item.uuid }}"
+                         {% if request.user.is_authenticated %}data-comment-href="{% url 'journal:comment' item.uuid %}"{% endif %}>
                         <img src="{{ item.cover_image_url }}"
                              alt="{{ item.display_title }}"
                              loading="lazy">
-                      {% else %}
+                        <div class="card-title">{{ item.display_title }}</div>
+                      </a>
+                    {% else %}
+                      <a href="{{ item.url }}" title="{{ item.display_title }}">
                         <img src="{{ item.cover|thumb:'normal' }}"
                              alt="{{ item.display_title }}"
                              loading="lazy">
-                      {% endif %}
-                      <div class="card-title">{{ item.display_title }}</div>
-                    </a>
+                        <div class="card-title">{{ item.display_title }}</div>
+                      </a>
+                    {% endif %}
                   </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
## Summary

The "original episodes" shelf on the discover / front page previously rendered each episode card as a plain link to the episode detail page. This makes those cards play the episode audio inline instead.

## Change

Template-only change in `neodb/catalog/templates/discover.html`. For the `original_episodes` gallery, each card's `<a>` now carries `class="episode"` plus the `data-*` attributes that `podcast.js`'s click handler already consumes:

- `data-media`, `data-cover`, `data-title`, `data-album`, `data-hosts`, `data-uuid`
- `data-comment-href` when the user is authenticated

Clicking a card now plays the audio inline via the Shikwasa player (the handler calls `preventDefault()`), mirroring the podcast detail page.

## Why no JS / view changes are needed

The discover page already loads the Shikwasa library, `podcast.js`, and (via `_footer.html`) the `<div class="player">` container. The same `.episode` click handler used by `podcast_episode_data.html` is already bound on this page. `item.program` is already `select_related`'d in `jobs/discover.py`, so no extra queries are introduced.

## Testing

- `pre-commit` (djLint formatting + linting, `ty`) passes on the changed file.
- Verified the data attributes match exactly what `podcast.js:podcast_init()` reads and that `{% url 'journal:comment' item.uuid %}` is the same URL used in the reference template.