### PR TITLE
fix(journal): order user post list by published, not pk

### DIFF
--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -230,10 +230,10 @@ def profile_posts_data(request: AuthedHttpRequest, user_name):
             qs = qs.filter(boost_pk__lt=last_pk)
         posts = list(qs[:20])
     else:
-        qs = Takahe.get_recent_posts(target.pk, viewer_pk, days=None)
-        if last_pk:
-            qs = qs.filter(pk__lt=last_pk)
-        posts = list(qs.order_by("-pk")[:20])
+        qs = Takahe.get_recent_posts(
+            target.pk, viewer_pk, days=None, before_pk=last_pk or None
+        )
+        posts = list(qs[:20])
     prefetch_pieces_for_posts(posts)
     return render(
         request,
@@ -283,10 +283,10 @@ def user_post_list(request: AuthedHttpRequest, user_name):
                 qs = qs.filter(boost_pk__lt=last_pk)
             posts = list(qs[:_USER_POST_LIST_PAGE_SIZE])
         else:
-            qs = Takahe.get_recent_posts(target.pk, viewer_pk, days=days)
-            if last_pk:
-                qs = qs.filter(pk__lt=last_pk)
-            posts = list(qs.order_by("-pk")[:_USER_POST_LIST_PAGE_SIZE])
+            qs = Takahe.get_recent_posts(
+                target.pk, viewer_pk, days=days, before_pk=last_pk or None
+            )
+            posts = list(qs[:_USER_POST_LIST_PAGE_SIZE])
         prefetch_pieces_for_posts(posts)
     context = {
         "posts": posts,

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -1151,6 +1151,7 @@ class Takahe:
         author_pk: int,
         viewer_pk: int | None = None,
         days: int | None = 90,
+        before_pk: int | None = None,
     ):
         qs = Post.objects.exclude(state__in=["deleted", "deleted_fanned_out"]).filter(
             author_id=author_pk
@@ -1158,7 +1159,27 @@ class Takahe:
         if days is not None:
             since = timezone.now() - timedelta(days=days)
             qs = qs.filter(published__gte=since)
-        qs = qs.order_by("-published")
+        if before_pk:
+            # Keyset pagination ordered by (-published, -pk). published is not
+            # unique, so fall back to pk as a stable tiebreaker. The cursor is
+            # still just a post pk (so callers/templates pass one value); we
+            # look up its published time to seed the boundary. Ordering by
+            # published (not pk) also keeps the planner off the pathological
+            # backward primary-key scan that an author-filtered ORDER BY id
+            # DESC LIMIT triggers (EGGPLANT-1E7).
+            boundary = (
+                Post.objects.filter(pk=before_pk)
+                .values_list("published", flat=True)
+                .first()
+            )
+            if boundary is not None:
+                qs = qs.filter(
+                    models.Q(published__lt=boundary)
+                    | models.Q(published=boundary, pk__lt=before_pk)
+                )
+            else:
+                qs = qs.filter(pk__lt=before_pk)
+        qs = qs.order_by("-published", "-pk")
         if viewer_pk and Takahe.get_is_following(viewer_pk, author_pk):
             qs = qs.exclude(visibility=3)
         else:

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -1160,13 +1160,10 @@ class Takahe:
             since = timezone.now() - timedelta(days=days)
             qs = qs.filter(published__gte=since)
         if before_pk:
-            # Keyset pagination ordered by (-published, -pk). published is not
-            # unique, so fall back to pk as a stable tiebreaker. The cursor is
-            # still just a post pk (so callers/templates pass one value); we
-            # look up its published time to seed the boundary. Ordering by
-            # published (not pk) also keeps the planner off the pathological
-            # backward primary-key scan that an author-filtered ORDER BY id
-            # DESC LIMIT triggers (EGGPLANT-1E7).
+            # Keyset on (-published, -pk): resolve the cursor pk to its
+            # published time and compare the tuple, so paging holds when pk
+            # order != published order. Sorting by published (not pk) also
+            # avoids the ORDER BY id pathology (EGGPLANT-1E7).
             boundary = (
                 Post.objects.filter(pk=before_pk)
                 .values_list("published", flat=True)

--- a/neodb/tests/journal/test_user_post_list.py
+++ b/neodb/tests/journal/test_user_post_list.py
@@ -137,13 +137,8 @@ def test_user_post_list_follower_sees_all(alice_with_posts):
 
 @pytest.mark.django_db(databases="__all__", transaction=True)
 def test_get_recent_posts_keyset_follows_published_not_pk():
-    """Pagination orders by (-published, -pk) but the cursor token is a pk.
-    The pk is resolved back to its published time and filtered as the
-    (published, pk) tuple, so paging must stay correct even when pk order
-    disagrees with published order (federated posts) and when two posts
-    share a published time. Regression for the EGGPLANT-1E7 published-keyset
-    fix.
-    """
+    """Keyset paging stays correct when pk order != published order and when
+    two posts share a published time (EGGPLANT-1E7 published-keyset fix)."""
     alice = User.register(email="alice_keyset@example.com", username="alicekeyset")
     posts = []
     for i in range(4):

--- a/neodb/tests/journal/test_user_post_list.py
+++ b/neodb/tests/journal/test_user_post_list.py
@@ -136,6 +136,45 @@ def test_user_post_list_follower_sees_all(alice_with_posts):
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)
+def test_get_recent_posts_keyset_follows_published_not_pk():
+    """Pagination orders by (-published, -pk) but the cursor token is a pk.
+    The pk is resolved back to its published time and filtered as the
+    (published, pk) tuple, so paging must stay correct even when pk order
+    disagrees with published order (federated posts) and when two posts
+    share a published time. Regression for the EGGPLANT-1E7 published-keyset
+    fix.
+    """
+    alice = User.register(email="alice_keyset@example.com", username="alicekeyset")
+    posts = []
+    for i in range(4):
+        book = Edition.objects.create(title=f"Keyset Book {i}")
+        Mark(alice.identity, book).update(ShelfType.WISHLIST, "x", None, [], 0)
+        shelfmember = Mark(alice.identity, book).shelfmember
+        assert shelfmember is not None and shelfmember.latest_post is not None
+        posts.append(shelfmember.latest_post)
+    p0, p1, p2, p3 = posts  # pk strictly ascending (Snowflake creation order)
+    now = timezone.now()
+    # Published order deliberately mismatches pk order: p3 and p0 share the
+    # newest time (p3 has the larger pk, so wins the -pk tiebreak), then p1,
+    # then p2. Expected (-published, -pk) order: [p3, p0, p1, p2].
+    Post.objects.filter(pk=p0.pk).update(published=now)
+    Post.objects.filter(pk=p3.pk).update(published=now)
+    Post.objects.filter(pk=p1.pk).update(published=now - timedelta(days=1))
+    Post.objects.filter(pk=p2.pk).update(published=now - timedelta(days=2))
+
+    viewer_pk = alice.identity.pk
+    page1 = list(Takahe.get_recent_posts(alice.identity.pk, viewer_pk, days=None)[:2])
+    assert [p.pk for p in page1] == [p3.pk, p0.pk]
+    page2 = list(
+        Takahe.get_recent_posts(
+            alice.identity.pk, viewer_pk, days=None, before_pk=page1[-1].pk
+        )[:2]
+    )
+    # No skip and no duplicate of the same-published p3/p0 already shown.
+    assert [p.pk for p in page2] == [p1.pk, p2.pk]
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
 def test_user_post_list_self_sees_all(alice_with_posts):
     alice, old_pk = alice_with_posts
     _set_locked(alice.identity, True)


### PR DESCRIPTION
## What
`user_post_list` (and the identical `profile_posts_data`) paginated a user's posts with `WHERE author_id = %s ORDER BY id DESC LIMIT %s`. With only the implicit `author_id` FK index, Postgres can scan the primary-key index backwards filtering by `author_id`, exceeding the gunicorn 60s worker timeout for accounts whose newest post is far from the global max id — surfacing as `SystemExit: 1` worker aborts (EGGPLANT-1E7).

This **supersedes #1630** (which added a `(author, -id)` index). Instead of new schema, it changes the sort to `(-published, -pk)`. The planner can no longer pick the pathological backward primary-key scan, so it uses the existing `author_id` index and sorts the small per-author result set. It also matches `get_recent_posts`' declared `-published` ordering and shows federated posts in authored-time order — better UX.

## Pagination correctness
The cursor token stays a single post pk (no template change). `get_recent_posts(before_pk=...)` resolves that pk to its `published` time and filters on the full `(published, pk)` tuple:

```
published < boundary OR (published = boundary AND pk < before_pk)
```

which is exactly lexicographic-descending `(published, pk)`. So keyset paging is correct even when pk order disagrees with published order (federated posts) or two posts share a published time. If the cursor post was deleted between requests it falls back to `pk__lt` (forward progress guaranteed; self-corrects on reload).

## Test
New `test_get_recent_posts_keyset_follows_published_not_pk` proves the pk-order ≠ published-order case plus the same-timestamp pk tiebreak. Full `test_user_post_list.py` (9) and `test_n_plus_one.py` (65) pass, verified with the index **absent**.

## Sentry issue resolved
EGGPLANT-1E7

Supersedes #1630.

Generated with Claude Code.
