### PR TITLE
feat(journal): preview recent articles on profile shelf

### DIFF
--- a/neodb/common/static/scss/_gallery.scss
+++ b/neodb/common/static/scss/_gallery.scss
@@ -121,6 +121,50 @@
   }
 }
 
+.shelf {
+  // Compact, text-only preview of recent articles (articles have no cover
+  // image, so the cover-card row used by other shelves doesn't apply).
+  .article-preview {
+    list-style: none;
+    padding: var(--pico-nav-link-spacing-vertical) 0;
+
+    >li {
+      padding: calc(var(--pico-spacing) / 2) 0;
+      line-height: 1.4;
+
+      &+li {
+        border-top: 1px solid var(--pico-muted-border-color);
+      }
+    }
+
+    .title {
+      font-weight: bold;
+    }
+
+    .meta {
+      color: var(--pico-muted-color);
+      margin-left: 0.4em;
+      white-space: nowrap;
+    }
+
+    .excerpt {
+      margin: calc(var(--pico-spacing) / 4) 0 0;
+      color: var(--pico-muted-color);
+      font-size: 90%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+    }
+
+    .empty {
+      color: var(--pico-muted-color);
+      opacity: 0.7;
+    }
+  }
+}
+
 #sibling .cards{
   a>div {
     font-size: 80%;

--- a/neodb/journal/templates/profile.html
+++ b/neodb/journal/templates/profile.html
@@ -134,17 +134,26 @@
               {% endfor %}
             {% endfor %}
             <section class="entity-sort shelf" id="article_created">
-              <h5>
-                <a href="{% url 'journal:user_article_list' identity.handle %}">{% trans 'Articles' %}</a>
-                {% if request.user.identity == identity %}
-                  <small>
-                    <a href="{% url 'journal:article_compose' %}"
-                       title="{% trans 'Compose Article' %}">
-                      <i class="fa-solid fa-pen-to-square"></i>
-                    </a>
-                  </small>
-                {% endif %}
-              </h5>
+              <div hx-swap="outerHTML"
+                   hx-get="{% url 'journal:profile_articles' identity.handle %}"
+                   hx-trigger="intersect once queue:last">
+                <h5>
+                  <a href="{% url 'journal:user_article_list' identity.handle %}">{% trans 'Articles' %}</a>
+                  {% if request.user.identity == identity %}
+                    <small>
+                      <a href="{% url 'journal:article_compose' %}"
+                         title="{% trans 'Compose Article' %}">
+                        <i class="fa-solid fa-pen-to-square"></i>
+                      </a>
+                    </small>
+                  {% endif %}
+                </h5>
+                <ul class="article-preview">
+                  <li>
+                    <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+                  </li>
+                </ul>
+              </div>
             </section>
             <section class="entity-sort shelf" id="collection_created">
               <div hx-swap="outerHTML"

--- a/neodb/journal/templates/profile.html
+++ b/neodb/journal/templates/profile.html
@@ -139,7 +139,7 @@
                    hx-trigger="intersect once queue:last">
                 <h5>
                   <a href="{% url 'journal:user_article_list' identity.handle %}">{% trans 'Articles' %}</a>
-                  {% if request.user.identity == identity %}
+                  {% if request.user.is_authenticated and request.user.identity == identity %}
                     <small>
                       <a href="{% url 'journal:article_compose' %}"
                          title="{% trans 'Compose Article' %}">

--- a/neodb/journal/templates/profile_articles.html
+++ b/neodb/journal/templates/profile_articles.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+{% load l10n %}
+<h5>
+  <a href="{{ url }}">{{ title }}</a>
+  <small>
+    <a href="{{ url }}">{{ total }}</a>
+    {% if show_create_button %}
+      <a href="{% url 'journal:article_compose' %}"
+         title="{% trans 'Compose Article' %}">
+        <i class="fa-solid fa-pen-to-square"></i>
+      </a>
+    {% endif %}
+  </small>
+</h5>
+<ul class="article-preview">
+  {% for article in articles %}
+    <li>
+      <a href="{{ article.url }}" class="title">{{ article.title }}</a>
+      <small class="meta">{{ article.created_time|date }}</small>
+      {% if article.excerpt %}<p class="excerpt">{{ article.excerpt }}</p>{% endif %}
+    </li>
+  {% empty %}
+    {% if show_create_button %}
+      <li class="empty">{% trans "nothing so far." %}</li>
+    {% else %}
+      <li _="init hide closest .shelf">{% trans "nothing so far." %}</li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/neodb/journal/urls.py
+++ b/neodb/journal/urls.py
@@ -123,6 +123,11 @@ urlpatterns = [
         name="profile_liked_collections",
     ),
     path(
+        "users/<str:user_name>/profile/articles",
+        profile_articles,
+        name="profile_articles",
+    ),
+    path(
         "users/<str:user_name>/profile/<str:category>/<str:shelf_type>/items",
         profile_shelf_items,
         name="profile_shelf_items",

--- a/neodb/journal/views/__init__.py
+++ b/neodb/journal/views/__init__.py
@@ -47,6 +47,7 @@ from .post import (
 )
 from .profile import (
     profile,
+    profile_articles,
     profile_collection_items,
     profile_created_collections,
     profile_liked_collections,
@@ -114,6 +115,7 @@ __all__ = [
     "post_compose",
     "post_vote",
     "profile",
+    "profile_articles",
     "profile_collection_items",
     "profile_created_collections",
     "profile_liked_collections",

--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -431,6 +431,38 @@ def profile_liked_collections(request: AuthedHttpRequest, user_name):
     )
 
 
+# Number of recent articles shown inline in the profile shelf preview; the
+# full set is reachable via the "see all" link to ``user_article_list``.
+_ARTICLE_PREVIEW_COUNT = 5
+
+
+@require_http_methods(["GET", "HEAD"])
+@profile_identity_required
+def profile_articles(request: AuthedHttpRequest, user_name):
+    """
+    Display a compact preview of recent articles on a user profile page.
+    """
+    target = request.target_identity
+    if not request.user.is_authenticated and not target.anonymous_viewable:
+        return HttpResponse()
+
+    qv = q_owned_piece_visible_to_user(request.user, target)
+    articles = Article.objects.filter(owner=target).filter(qv).order_by("-created_time")
+    total = articles.count()
+
+    return render(
+        request,
+        "profile_articles.html",
+        {
+            "title": _("Articles"),
+            "url": f"{target.url}articles/",
+            "articles": list(articles[:_ARTICLE_PREVIEW_COUNT]),
+            "total": total,
+            "show_create_button": target.user == request.user,
+        },
+    )
+
+
 _FOLLOW_LIST_PAGE_SIZE = 20
 
 

--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -448,7 +448,13 @@ def profile_articles(request: AuthedHttpRequest, user_name):
 
     qv = q_owned_piece_visible_to_user(request.user, target)
     articles = Article.objects.filter(owner=target).filter(qv).order_by("-created_time")
-    total = articles.count()
+    # Fetch one past the preview limit so a short result set yields the exact
+    # total without a separate COUNT query; only count when the page is full.
+    preview = list(articles[: _ARTICLE_PREVIEW_COUNT + 1])
+    if len(preview) <= _ARTICLE_PREVIEW_COUNT:
+        total = len(preview)
+    else:
+        total = articles.count()
 
     return render(
         request,
@@ -456,7 +462,7 @@ def profile_articles(request: AuthedHttpRequest, user_name):
         {
             "title": _("Articles"),
             "url": f"{target.url}articles/",
-            "articles": list(articles[:_ARTICLE_PREVIEW_COUNT]),
+            "articles": preview[:_ARTICLE_PREVIEW_COUNT],
             "total": total,
             "show_create_button": target.user == request.user,
         },

--- a/neodb/tests/journal/test_pages.py
+++ b/neodb/tests/journal/test_pages.py
@@ -159,3 +159,20 @@ def test_profile_articles_shelf_empty_hidden_for_visitor():
     assert response.status_code == 200
     # With no articles, a visitor's shelf collapses itself.
     assert "hide closest .shelf" in response.content.decode()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_articles_shelf_hidden_from_anonymous_when_not_viewable():
+    owner = User.register(email="artprivate@example.com", username="artprivateuser")
+    identity = owner.identity
+    identity.anonymous_viewable = False
+    identity.save(update_fields=["anonymous_viewable"])
+    Article.update_local_article(
+        owner=identity, title="Hidden Article", body="secret", visibility=0
+    )
+
+    # An anonymous visitor gets an empty response (no article data leaked).
+    preview_url = reverse("journal:profile_articles", args=[identity.handle])
+    response = Client().get(preview_url)
+    assert response.status_code == 200
+    assert response.content == b""

--- a/neodb/tests/journal/test_pages.py
+++ b/neodb/tests/journal/test_pages.py
@@ -4,7 +4,7 @@ from django.test import Client
 from django.urls import reverse
 
 from catalog.models import Edition, Movie
-from journal.models import Collection, Mark, Review, ShelfType, Tag
+from journal.models import Article, Collection, Mark, Review, ShelfType, Tag
 from users.models import User
 
 
@@ -106,3 +106,56 @@ def test_tag_pages_category_filter():
     assert response.status_code == 200
     assert b"Tag Page Book" in response.content
     assert b"Tag Page Movie" not in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_articles_shelf_preview():
+    user = User.register(email="artshelf@example.com", username="artshelfuser")
+    identity = user.identity
+    Article.update_local_article(
+        owner=identity,
+        title="First Article",
+        body="Body of the first article with several words to excerpt.",
+        tags=["alpha"],
+        visibility=0,
+    )
+    Article.update_local_article(
+        owner=identity,
+        title="Second Article",
+        body="Another article body.",
+        visibility=0,
+    )
+
+    client = Client()
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    handle = identity.handle
+
+    # The shelf preview partial renders recent articles in a compact list.
+    preview_url = reverse("journal:profile_articles", args=[handle])
+    response = client.get(preview_url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "First Article" in content
+    assert "Second Article" in content
+    assert 'class="article-preview"' in content
+    # see-all count reflects the visible total
+    assert ">2</a>" in content
+
+    # The profile page lazy-loads the shelf via htmx rather than a bare link.
+    profile_response = client.get(identity.url)
+    assert profile_response.status_code == 200
+    assert preview_url in profile_response.content.decode()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_articles_shelf_empty_hidden_for_visitor():
+    owner = User.register(email="artempty@example.com", username="artemptyuser")
+    visitor = User.register(email="artvisitor@example.com", username="artvisitor")
+
+    client = Client()
+    client.force_login(visitor, backend="mastodon.auth.OAuth2Backend")
+    preview_url = reverse("journal:profile_articles", args=[owner.identity.handle])
+    response = client.get(preview_url)
+    assert response.status_code == 200
+    # With no articles, a visitor's shelf collapses itself.
+    assert "hide closest .shelf" in response.content.decode()


### PR DESCRIPTION
## Summary

The Articles shelf on the user profile page previously rendered only a bare link, unlike every sibling shelf (books, collections, people) which show a rich preview. This wires it up to lazy-load (HTMX, on scroll-into-view) a compact preview of the most recent articles.

Each entry shows a title link, publish date, and a one-line auto-truncated excerpt. The header links to the full article list with a count, keeps the compose button for the owner, and the shelf self-collapses for visitors when there are no articles.

## Changes

- `journal/views/profile.py` - new `profile_articles` view (mirrors `profile_created_collections`; visibility-filtered, latest 5 + total count)
- `journal/views/__init__.py` - export the view
- `journal/urls.py` - new `profile_articles` route
- `journal/templates/profile_articles.html` - new compact-preview partial
- `journal/templates/profile.html` - wire the shelf to HTMX-load the partial
- `common/static/scss/_gallery.scss` - `.article-preview` styling (reuses pico tokens)
- `tests/journal/test_pages.py` - 2 new tests

## Testing

- `pre-commit run -a` (ruff, ruff-format, djLint, ty) - green
- `pytest tests/journal/test_pages.py tests/journal/test_article.py` - 45 passed
- Verified live in the browser
