### PR TITLE
Interleave original podcast episodes by podcast

### DIFF
--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -145,22 +145,43 @@ class DiscoverGenerator(BaseJob):
                     items.append(season.show)
         return items
 
-    def get_original_episodes(self, max_items: int = 20) -> list:
-        """Recent episodes of podcasts with a verified creator."""
+    def get_original_episodes(
+        self, max_items: int = 100, max_per_program: int = 10
+    ) -> list:
+        """Recent episodes of podcasts with a verified creator.
+
+        Episodes are interleaved round-robin across podcasts so every podcast
+        gets equal exposure: the newest episode of each podcast comes first,
+        then the second newest of each, and so on. Within each round newer
+        episodes are listed first. Capped at `max_per_program` per podcast and
+        `max_items` overall.
+        """
         verified_item_ids = VerifiedCreator.objects.filter(
             state=VerifiedCreator.State.VERIFIED
         ).values_list("item_id", flat=True)
-        episodes = list(
-            PodcastEpisode.objects.filter(
-                program_id__in=verified_item_ids,
-                is_deleted=False,
-                merged_to_item__isnull=True,
-                program__is_deleted=False,
-                program__merged_to_item__isnull=True,
+        base = PodcastEpisode.objects.filter(
+            is_deleted=False,
+            merged_to_item__isnull=True,
+            program__is_deleted=False,
+            program__merged_to_item__isnull=True,
+        ).select_related("program")
+        per_program = []
+        for program_id in verified_item_ids:
+            eps = list(
+                base.filter(program_id=program_id).order_by("-pub_date")[
+                    :max_per_program
+                ]
             )
-            .select_related("program")
-            .order_by("-pub_date")[:max_items]
-        )
+            if eps:
+                per_program.append(eps)
+        episodes = []
+        for rank in range(max_per_program):
+            row = [eps[rank] for eps in per_program if len(eps) > rank]
+            row.sort(key=lambda e: e.pub_date, reverse=True)
+            episodes.extend(row)
+            if len(episodes) >= max_items:
+                break
+        episodes = episodes[:max_items]
         for e in episodes:
             e.tags
             e.rating

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -576,6 +576,56 @@ class TestOriginalEpisodes:
         self._episodes(podcast)
         assert DiscoverGenerator().get_original_episodes() == []
 
+    def _episode(self, podcast, guid, days_ago):
+        return PodcastEpisode.objects.create(
+            program=podcast,
+            guid=guid,
+            title=guid,
+            pub_date=timezone.now() - timedelta(days=days_ago),
+            media_url="https://example.com/1.mp3",
+        )
+
+    def test_interleaved_so_each_podcast_gets_exposure(self):
+        # pod A has many recent episodes, pod B has a single older one;
+        # round-robin still surfaces B at the second slot.
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        pod_a = _podcast("A", "a.example.com/feed.rss")
+        pod_b = _podcast("B", "b.example.com/feed.rss")
+        _verified(pod_a, alice.identity)
+        _verified(pod_b, bob.identity)
+        for i in range(5):
+            self._episode(pod_a, f"a{i}", days_ago=i)
+        self._episode(pod_b, "b0", days_ago=100)
+        episodes = DiscoverGenerator().get_original_episodes()
+        programs = [e.program_id for e in episodes]
+        assert programs[:2] == [pod_a.pk, pod_b.pk]
+        assert len(episodes) == 6
+
+    def test_max_per_program(self):
+        alice = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        for i in range(15):
+            self._episode(podcast, f"e{i}", days_ago=i)
+        episodes = DiscoverGenerator().get_original_episodes()
+        assert len(episodes) == 10
+        # the 10 newest are kept, ordered newest first
+        assert [e.guid for e in episodes] == [f"e{i}" for i in range(10)]
+
+    def test_max_items_total(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        pod_a = _podcast("A", "a.example.com/feed.rss")
+        pod_b = _podcast("B", "b.example.com/feed.rss")
+        _verified(pod_a, alice.identity)
+        _verified(pod_b, bob.identity)
+        for i in range(3):
+            self._episode(pod_a, f"a{i}", days_ago=i)
+            self._episode(pod_b, f"b{i}", days_ago=i)
+        episodes = DiscoverGenerator().get_original_episodes(max_items=3)
+        assert len(episodes) == 3
+
     def test_discover_gated_by_test_enabled(self, monkeypatch):
         alice = User.register(email="a@example.com", username="alice")
         podcast = _podcast()


### PR DESCRIPTION
## What

Reworks `DiscoverGenerator.get_original_episodes()` (the cached "original episodes" shelf shown on `/discover/` and served by `GET /api/trending/podcast/original/`) so episodes from verified-creator podcasts are interleaved round-robin across podcasts.

## Why

Previously the shelf took the globally newest 20 episodes by `pub_date`, so a single prolific podcast could fill the entire shelf and crowd out everyone else.

## How

- **max 10 per podcast** — fetch each verified podcast's 10 newest episodes.
- **interleave for equal exposure** — round-robin: rank 0 is every podcast's newest episode, rank 1 every podcast's second newest, and so on, so each podcast's newest always surfaces near the top.
- **newer first** — earlier rounds come before later ones, and within each round episodes are sorted by `pub_date` descending.
- **max 100 total** — the assembled list is capped at 100 (was 20).

## Tests

Added tests for interleave fairness, the per-podcast cap (10), and the total cap. Full `TestOriginalEpisodes` group plus the API test pass. The existing `test_only_verified_podcasts_included` (asserts descending dates) still passes since a single podcast degenerates to plain newest-first order.