### PR TITLE
feat(catalog): original podcasts page and trending API

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -285,6 +285,22 @@ def trending_original_episodes(request):
     return _get_trending("original_episodes")
 
 
+@api.get(
+    "/trending/podcast/verified/",
+    response={200: List[PodcastSchema]},
+    summary="Podcasts with a verified creator",
+    auth=None,
+    tags=["trending"],
+)
+@paginate(PageNumberPagination)
+def trending_verified_podcasts(request):
+    """Podcasts that have a verified creator, most recently verified first.
+
+    These are the shows behind the discover page's "original episodes".
+    """
+    return Podcast.verified_originals()
+
+
 def _get_item(cls, uuid, response):
     item = Item.get_by_url(uuid)
     if not item:

--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import List
 
 from django.core.cache import cache
+from django.core.paginator import Paginator
 from django.db.models import Prefetch, prefetch_related_objects
 from django.http import HttpResponse
 from django.utils import timezone
@@ -19,6 +20,7 @@ from .models import (
     AlbumSchema,
     Edition,
     EditionSchema,
+    ExternalResource,
     Game,
     GameSchema,
     Item,
@@ -67,6 +69,12 @@ class SearchResult(Schema):
 
 class EpisodeList(Schema):
     data: List[PodcastEpisodeSchema]
+    pages: int
+    count: int
+
+
+class PodcastList(Schema):
+    data: List[PodcastSchema]
     pages: int
     count: int
 
@@ -287,18 +295,36 @@ def trending_original_episodes(request):
 
 @api.get(
     "/trending/podcast/verified/",
-    response={200: List[PodcastSchema]},
+    response={200: PodcastList},
     summary="Podcasts with a verified creator",
     auth=None,
     tags=["trending"],
 )
-@paginate(PageNumberPagination)
-def trending_verified_podcasts(request):
+def trending_verified_podcasts(request, page: int = 1):
     """Podcasts that have a verified creator, most recently verified first.
 
     These are the shows behind the discover page's "original episodes".
     """
-    return Podcast.verified_originals()
+    paginator = Paginator(Podcast.verified_originals(), PAGE_SIZE)
+    podcasts = list(paginator.get_page(page).object_list)
+    # PodcastSchema serializes credits/external_resources/rating/tags, each of
+    # which queries per item; hydrate in bulk to avoid N+1 during serialization.
+    prefetch_related_objects(
+        podcasts,
+        Prefetch(
+            "external_resources",
+            queryset=ExternalResource.objects.only(
+                "id", "item_id", "id_type", "id_value", "url"
+            ),
+        ),
+        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+    )
+    Rating.attach_to_items(podcasts)
+    Tag.attach_to_items(podcasts)
+    return Status(
+        200,
+        {"data": podcasts, "pages": paginator.num_pages, "count": paginator.count},
+    )
 
 
 def _get_item(cls, uuid, response):

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -11,6 +11,7 @@ from .common import (
     LanguageListField,
     jsondata,
 )
+from .creator import VerifiedCreator
 from .item import (
     BaseSchema,
     IdType,
@@ -114,6 +115,31 @@ class Podcast(Item):
             IdType.RSS,
         ]
         return [(i.value, i.label) for i in id_types]
+
+    @classmethod
+    def verified_originals(cls) -> models.QuerySet["Podcast"]:
+        """Podcasts with a verified creator, most recently verified first.
+
+        These are the shows behind the discover page's "original episodes"
+        shelf. A show may carry several verified-creator claims, so it is
+        ranked by the newest of those claims and appears only once.
+        """
+        return (
+            cls.objects.filter(
+                is_deleted=False,
+                merged_to_item__isnull=True,
+            )
+            .annotate(
+                verified_at=models.Max(
+                    "verified_creators__created_time",
+                    filter=models.Q(
+                        verified_creators__state=VerifiedCreator.State.VERIFIED
+                    ),
+                )
+            )
+            .filter(verified_at__isnull=False)
+            .order_by("-verified_at", "-pk")
+        )
 
     @property
     def recent_episodes(self):

--- a/neodb/catalog/templates/discover.html
+++ b/neodb/catalog/templates/discover.html
@@ -84,7 +84,7 @@
               </span>
               <h5>
                 {% if gallery.name == "original_episodes" %}
-                  {% trans 'original episodes' %}
+                  <a href="{% url 'catalog:discover_original_podcasts' %}">{% trans 'original episodes' %}</a>
                 {% else %}
                   {{ gallery.category.label }}
                 {% endif %}

--- a/neodb/catalog/templates/discover_original_podcasts.html
+++ b/neodb/catalog/templates/discover_original_podcasts.html
@@ -1,0 +1,33 @@
+{% load static %}
+{% load i18n %}
+{% load thumb %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}" class="content-page">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans "original podcasts" %}</title>
+    {% include "common_libs.html" %}
+  </head>
+  <body>
+    {% include "_header.html" %}
+    <main>
+      <div class="grid__main">
+        <h5>
+          {% trans "original podcasts" %}
+          <small>({{ total }})</small>
+        </h5>
+        <div class="item-card-list">
+          {% for item in podcasts %}
+            {% include "_list_item.html" with item=item %}
+          {% empty %}
+            <div>{% trans 'nothing so far.' %}</div>
+          {% endfor %}
+        </div>
+        {% include "_pagination.html" %}
+      </div>
+    </main>
+    {% include "_footer.html" %}
+  </body>
+</html>

--- a/neodb/catalog/urls.py
+++ b/neodb/catalog/urls.py
@@ -284,6 +284,11 @@ urlpatterns = [
         discover_popular_posts,
         name="discover_popular_posts",
     ),
+    path(
+        "discover/original-podcasts/",
+        discover_original_podcasts,
+        name="discover_original_podcasts",
+    ),
     path("discover/", discover, name="discover"),
     # Debug views: DEBUG=True allows anyone, otherwise requires superuser
     path("debug/scraper/", scraper_debug_page, name="debug_scraper"),

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.db.models import Count, F, Prefetch, Window, prefetch_related_objects
+from django.db.models import Count, F, Prefetch, Q, Window, prefetch_related_objects
 from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -34,7 +34,14 @@ from journal.models import (
 )
 from takahe.utils import Takahe
 
-from ..models import ExternalResource, IdType, Item, ItemCredit, Podcast, TVEpisode
+from ..models import (
+    ExternalResource,
+    IdType,
+    Item,
+    ItemCredit,
+    Podcast,
+    TVEpisode,
+)
 from ..models.people import ItemPeopleRelation, People, PeopleRole
 from ..recommendation import blended_for_discover, can_show_reco, similar_items
 from ..sites import WikiData
@@ -326,7 +333,6 @@ def _prefetch_mark_list(members: list["ShelfMember"], user) -> None:
     prefetch_latest_posts(members)
     # Batch-fetch Comments for all (owner, item) pairs
     pairs = [(m.owner_id, m.item_id) for m in members]
-    from django.db.models import Q
 
     q = Q()
     for owner_id, item_id in pairs:
@@ -689,6 +695,44 @@ def discover(request):
             "layout": layout,
             "updated": updated,
             "reco_items": reco_items,
+        },
+    )
+
+
+def discover_original_podcasts(request):
+    """Paginated list of podcasts that have a verified creator.
+
+    These are the shows behind the discover page's "original episodes"
+    shelf; clicking the shelf heading lands here.
+    """
+    queryset = Podcast.verified_originals()
+    paginator = CustomPaginator(queryset, request)
+    page_number = request.GET.get("page", default=1)
+    podcasts = paginator.get_page(page_number)
+    pagination = PageLinksGenerator(page_number, paginator.num_pages, request.GET)
+    podcast_items = list(podcasts.object_list)
+    if podcast_items:
+        prefetch_related_objects(
+            podcast_items,
+            Prefetch(
+                "external_resources",
+                queryset=ExternalResource.objects.only(
+                    "id", "item_id", "id_type", "id_value", "url"
+                ),
+            ),
+            Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        )
+        Rating.attach_to_items(podcast_items)
+        Tag.attach_to_items(podcast_items)
+        if request.user.is_authenticated:
+            Mark.attach_to_items(request.user.identity, podcast_items, request.user)
+    return render(
+        request,
+        "discover_original_podcasts.html",
+        {
+            "podcasts": podcasts,
+            "pagination": pagination,
+            "total": paginator.count,
         },
     )
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-14 15:31-0400\n"
+"POT-Creation-Date: 2026-06-15 18:13+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -645,7 +645,7 @@ msgstr ""
 msgid "year of publication"
 msgstr ""
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:202
+#: catalog/models/game.py:135 catalog/models/podcast.py:228
 msgid "date of publication"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 
 #: catalog/models/game.py:159 catalog/models/movie.py:160
 #: catalog/models/people.py:158 catalog/models/performance.py:259
-#: catalog/models/performance.py:471 catalog/models/podcast.py:87
+#: catalog/models/performance.py:471 catalog/models/podcast.py:88
 #: catalog/models/tv.py:235 catalog/models/tv.py:478
 #: catalog/templates/game.html:34 catalog/templates/movie.html:58
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
@@ -712,7 +712,7 @@ msgstr ""
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/podcast.py:78
+#: catalog/models/item.py:125 catalog/models/podcast.py:79
 msgid "host"
 msgstr ""
 
@@ -1772,47 +1772,49 @@ msgstr ""
 msgid "original episodes"
 msgstr ""
 
-#: catalog/templates/discover.html:123
+#: catalog/templates/discover.html:135
 #: journal/templates/user_collection_list.html:18
 #: journal/templates/user_collection_list.html:32
 msgid "Collections"
 msgstr ""
 
-#: catalog/templates/discover.html:141 journal/templates/profile.html:235
+#: catalog/templates/discover.html:153 journal/templates/profile.html:244
 msgid "edit layout"
 msgstr ""
 
-#: catalog/templates/discover.html:144 journal/templates/profile.html:238
+#: catalog/templates/discover.html:156 journal/templates/profile.html:247
 msgid "save"
 msgstr ""
 
-#: catalog/templates/discover.html:155 journal/templates/profile.html:249
+#: catalog/templates/discover.html:167 journal/templates/profile.html:258
 msgid "cancel"
 msgstr ""
 
-#: catalog/templates/discover.html:161 journal/templates/profile.html:255
+#: catalog/templates/discover.html:173 journal/templates/profile.html:264
 msgid "show"
 msgstr ""
 
-#: catalog/templates/discover.html:162 journal/templates/profile.html:256
+#: catalog/templates/discover.html:174 journal/templates/profile.html:265
 msgid "hide"
 msgstr ""
 
-#: catalog/templates/discover.html:194 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
 msgid "Unread Announcements"
 msgstr ""
 
-#: catalog/templates/discover.html:200 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr ""
 
-#: catalog/templates/discover.html:210
+#: catalog/templates/discover.html:222
 #: common/templates/_sidebar_anonymous.html:55
 msgid "Popular Tags"
 msgstr ""
 
-#: catalog/templates/discover.html:217 catalog/templates/item_base.html:281
+#: catalog/templates/discover.html:229
+#: catalog/templates/discover_original_podcasts.html:25
+#: catalog/templates/item_base.html:281
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1820,6 +1822,8 @@ msgstr ""
 #: common/templates/_sidebar.html:122
 #: common/templates/_sidebar_anonymous.html:46
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: journal/templates/profile_articles.html:24
+#: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_article_list.html:58
@@ -1833,8 +1837,13 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:227 common/templates/_sidebar.html:245
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:245
 msgid "Recent Posts"
+msgstr ""
+
+#: catalog/templates/discover_original_podcasts.html:10
+#: catalog/templates/discover_original_podcasts.html:18
+msgid "original podcasts"
 msgstr ""
 
 #: catalog/templates/edition.html:38
@@ -2099,7 +2108,7 @@ msgid "Logged in user may see search results from other sites."
 msgstr ""
 
 #: catalog/templates/search_results_people.html:12
-#: journal/templates/profile.html:187 journal/views/profile.py:540
+#: journal/templates/profile.html:196 journal/views/profile.py:578
 msgid "People"
 msgstr ""
 
@@ -2135,20 +2144,20 @@ msgstr ""
 #: catalog/views/edit.py:218 catalog/views/edit.py:272
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:147
-#: catalog/views/verify.py:187 journal/views/article.py:37
-#: journal/views/article.py:119 journal/views/collection.py:238
-#: journal/views/collection.py:299 journal/views/collection.py:318
-#: journal/views/collection.py:342 journal/views/collection.py:415
-#: journal/views/collection.py:451 journal/views/collection.py:489
-#: journal/views/collection.py:501 journal/views/collection.py:526
-#: journal/views/collection.py:529 journal/views/collection.py:570
-#: journal/views/common.py:268 journal/views/mark.py:245
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:165 journal/views/post.py:194
-#: journal/views/post.py:267 journal/views/post.py:282
-#: journal/views/post.py:389 journal/views/post.py:541
-#: journal/views/review.py:52 journal/views/review.py:69
-#: journal/views/review.py:94
+#: catalog/views/verify.py:187 journal/views/article.py:39
+#: journal/views/article.py:121 journal/views/article.py:141
+#: journal/views/collection.py:238 journal/views/collection.py:299
+#: journal/views/collection.py:318 journal/views/collection.py:342
+#: journal/views/collection.py:415 journal/views/collection.py:451
+#: journal/views/collection.py:489 journal/views/collection.py:501
+#: journal/views/collection.py:526 journal/views/collection.py:529
+#: journal/views/collection.py:570 journal/views/common.py:268
+#: journal/views/mark.py:245 journal/views/post.py:58 journal/views/post.py:78
+#: journal/views/post.py:100 journal/views/post.py:165
+#: journal/views/post.py:194 journal/views/post.py:267
+#: journal/views/post.py:282 journal/views/post.py:389
+#: journal/views/post.py:541 journal/views/review.py:52
+#: journal/views/review.py:69 journal/views/review.py:94
 msgid "Insufficient permission"
 msgstr ""
 
@@ -2238,7 +2247,7 @@ msgid "Please wait a moment before trying again."
 msgstr ""
 
 #: catalog/views/verify.py:153 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:151 journal/views/review.py:170
+#: journal/views/article.py:174 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr ""
@@ -2251,15 +2260,15 @@ msgstr ""
 msgid "Creator verification removed."
 msgstr ""
 
-#: catalog/views/view.py:66 catalog/views/view.py:91
+#: catalog/views/view.py:73 catalog/views/view.py:98
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:70 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:106
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:167
+#: catalog/views/view.py:186
 msgid "Invalid role"
 msgstr ""
 
@@ -3865,12 +3874,12 @@ msgid "User no longer exists"
 msgstr ""
 
 #: common/utils.py:120 common/utils.py:122 common/utils.py:125
-#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:445
+#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:483
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:169
-#: journal/views/profile.py:486 journal/views/review.py:188
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:192
+#: journal/views/profile.py:524 journal/views/review.py:188
 msgid "Login required"
 msgstr ""
 
@@ -4642,7 +4651,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:153 journal/views/article.py:183
+#: journal/models/article.py:153 journal/views/article.py:206
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -5506,7 +5515,8 @@ msgstr ""
 msgid "Edit Article"
 msgstr ""
 
-#: journal/templates/article_edit.html:15 journal/templates/profile.html:142
+#: journal/templates/article_edit.html:15 journal/templates/profile.html:145
+#: journal/templates/profile_articles.html:9
 msgid "Compose Article"
 msgstr ""
 
@@ -5755,22 +5765,22 @@ msgstr ""
 msgid "annual summary"
 msgstr ""
 
-#: journal/templates/profile.html:138
+#: journal/templates/profile.html:141
 #: journal/templates/user_article_list.html:14
-#: journal/templates/user_article_list.html:38
+#: journal/templates/user_article_list.html:38 journal/views/profile.py:463
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:153 journal/views/collection.py:385
+#: journal/templates/profile.html:162 journal/views/collection.py:385
 #: journal/views/profile.py:385
 msgid "collection"
 msgstr ""
 
-#: journal/templates/profile.html:170 journal/views/profile.py:426
+#: journal/templates/profile.html:179 journal/views/profile.py:426
 msgid "liked collection"
 msgstr ""
 
-#: journal/templates/profile.html:204 journal/views/profile.py:542
+#: journal/templates/profile.html:213 journal/views/profile.py:580
 msgid "Organizations"
 msgstr ""
 
@@ -5811,17 +5821,17 @@ msgstr ""
 msgid "Liked Collections"
 msgstr ""
 
-#: journal/templates/user_follow_list.html:23 journal/views/profile.py:453
+#: journal/templates/user_follow_list.html:23 journal/views/profile.py:491
 #: users/templates/users/account.html:452
 msgid "Following"
 msgstr ""
 
-#: journal/templates/user_follow_list.html:28 journal/views/profile.py:457
+#: journal/templates/user_follow_list.html:28 journal/views/profile.py:495
 #: users/templates/users/account.html:461
 msgid "Followers"
 msgstr ""
 
-#: journal/templates/user_follow_list.html:32 journal/views/profile.py:461
+#: journal/templates/user_follow_list.html:32 journal/views/profile.py:499
 msgid "Mutuals"
 msgstr ""
 
@@ -5850,16 +5860,16 @@ msgstr ""
 msgid "#%(year)s_report"
 msgstr ""
 
-#: journal/views/article.py:149 journal/views/review.py:168
+#: journal/views/article.py:172 journal/views/review.py:168
 msgid "User not local"
 msgstr ""
 
-#: journal/views/article.py:157 journal/views/article.py:171
+#: journal/views/article.py:180 journal/views/article.py:194
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr ""
 
-#: journal/views/article.py:159 journal/views/article.py:167
+#: journal/views/article.py:182 journal/views/article.py:190
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-14 15:31-0400\n"
+"POT-Creation-Date: 2026-06-15 18:13+0800\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -644,7 +644,7 @@ msgstr "开发者"
 msgid "year of publication"
 msgstr "发行年份"
 
-#: catalog/models/game.py:135 catalog/models/podcast.py:202
+#: catalog/models/game.py:135 catalog/models/podcast.py:228
 msgid "date of publication"
 msgstr "发行日期"
 
@@ -663,7 +663,7 @@ msgstr "平台"
 
 #: catalog/models/game.py:159 catalog/models/movie.py:160
 #: catalog/models/people.py:158 catalog/models/performance.py:259
-#: catalog/models/performance.py:471 catalog/models/podcast.py:87
+#: catalog/models/performance.py:471 catalog/models/podcast.py:88
 #: catalog/models/tv.py:235 catalog/models/tv.py:478
 #: catalog/templates/game.html:34 catalog/templates/movie.html:58
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
@@ -711,7 +711,7 @@ msgstr "编舞"
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:125 catalog/models/podcast.py:78
+#: catalog/models/item.py:125 catalog/models/podcast.py:79
 msgid "host"
 msgstr "主播"
 
@@ -1771,47 +1771,49 @@ msgstr "为你推荐"
 msgid "original episodes"
 msgstr "原创单集"
 
-#: catalog/templates/discover.html:123
+#: catalog/templates/discover.html:135
 #: journal/templates/user_collection_list.html:18
 #: journal/templates/user_collection_list.html:32
 msgid "Collections"
 msgstr "收藏单"
 
-#: catalog/templates/discover.html:141 journal/templates/profile.html:235
+#: catalog/templates/discover.html:153 journal/templates/profile.html:244
 msgid "edit layout"
 msgstr "编辑布局"
 
-#: catalog/templates/discover.html:144 journal/templates/profile.html:238
+#: catalog/templates/discover.html:156 journal/templates/profile.html:247
 msgid "save"
 msgstr "保存"
 
-#: catalog/templates/discover.html:155 journal/templates/profile.html:249
+#: catalog/templates/discover.html:167 journal/templates/profile.html:258
 msgid "cancel"
 msgstr "取消"
 
-#: catalog/templates/discover.html:161 journal/templates/profile.html:255
+#: catalog/templates/discover.html:173 journal/templates/profile.html:264
 msgid "show"
 msgstr "显示"
 
-#: catalog/templates/discover.html:162 journal/templates/profile.html:256
+#: catalog/templates/discover.html:174 journal/templates/profile.html:265
 msgid "hide"
 msgstr "隐藏"
 
-#: catalog/templates/discover.html:194 common/templates/_sidebar.html:14
+#: catalog/templates/discover.html:206 common/templates/_sidebar.html:14
 msgid "Unread Announcements"
 msgstr "未读公告"
 
-#: catalog/templates/discover.html:200 common/templates/_sidebar.html:20
+#: catalog/templates/discover.html:212 common/templates/_sidebar.html:20
 #: social/templates/notification.html:67
 msgid "mark all as read"
 msgstr "全部标为已读"
 
-#: catalog/templates/discover.html:210
+#: catalog/templates/discover.html:222
 #: common/templates/_sidebar_anonymous.html:55
 msgid "Popular Tags"
 msgstr "热门标签"
 
-#: catalog/templates/discover.html:217 catalog/templates/item_base.html:281
+#: catalog/templates/discover.html:229
+#: catalog/templates/discover_original_podcasts.html:25
+#: catalog/templates/item_base.html:281
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1819,6 +1821,8 @@ msgstr "热门标签"
 #: common/templates/_sidebar.html:122
 #: common/templates/_sidebar_anonymous.html:46
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
+#: journal/templates/profile_articles.html:24
+#: journal/templates/profile_articles.html:26
 #: journal/templates/profile_items.html:34
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_article_list.html:58
@@ -1832,9 +1836,14 @@ msgstr "热门标签"
 msgid "nothing so far."
 msgstr "暂无内容。"
 
-#: catalog/templates/discover.html:227 common/templates/_sidebar.html:245
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:245
 msgid "Recent Posts"
 msgstr "近期帖文"
+
+#: catalog/templates/discover_original_podcasts.html:10
+#: catalog/templates/discover_original_podcasts.html:18
+msgid "original podcasts"
+msgstr "原创播客"
 
 #: catalog/templates/edition.html:38
 msgid "publication date"
@@ -2098,7 +2107,7 @@ msgid "Logged in user may see search results from other sites."
 msgstr "登录用户可看到来自其它网站的搜索结果。"
 
 #: catalog/templates/search_results_people.html:12
-#: journal/templates/profile.html:187 journal/views/profile.py:540
+#: journal/templates/profile.html:196 journal/views/profile.py:578
 msgid "People"
 msgstr "人物"
 
@@ -2134,20 +2143,20 @@ msgstr "条目不可被删除。"
 #: catalog/views/edit.py:218 catalog/views/edit.py:272
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:147
-#: catalog/views/verify.py:187 journal/views/article.py:37
-#: journal/views/article.py:119 journal/views/collection.py:238
-#: journal/views/collection.py:299 journal/views/collection.py:318
-#: journal/views/collection.py:342 journal/views/collection.py:415
-#: journal/views/collection.py:451 journal/views/collection.py:489
-#: journal/views/collection.py:501 journal/views/collection.py:526
-#: journal/views/collection.py:529 journal/views/collection.py:570
-#: journal/views/common.py:268 journal/views/mark.py:245
-#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
-#: journal/views/post.py:165 journal/views/post.py:194
-#: journal/views/post.py:267 journal/views/post.py:282
-#: journal/views/post.py:389 journal/views/post.py:541
-#: journal/views/review.py:52 journal/views/review.py:69
-#: journal/views/review.py:94
+#: catalog/views/verify.py:187 journal/views/article.py:39
+#: journal/views/article.py:121 journal/views/article.py:141
+#: journal/views/collection.py:238 journal/views/collection.py:299
+#: journal/views/collection.py:318 journal/views/collection.py:342
+#: journal/views/collection.py:415 journal/views/collection.py:451
+#: journal/views/collection.py:489 journal/views/collection.py:501
+#: journal/views/collection.py:526 journal/views/collection.py:529
+#: journal/views/collection.py:570 journal/views/common.py:268
+#: journal/views/mark.py:245 journal/views/post.py:58 journal/views/post.py:78
+#: journal/views/post.py:100 journal/views/post.py:165
+#: journal/views/post.py:194 journal/views/post.py:267
+#: journal/views/post.py:282 journal/views/post.py:389
+#: journal/views/post.py:541 journal/views/review.py:52
+#: journal/views/review.py:69 journal/views/review.py:94
 msgid "Insufficient permission"
 msgstr "权限不足"
 
@@ -2237,7 +2246,7 @@ msgid "Please wait a moment before trying again."
 msgstr ""
 
 #: catalog/views/verify.py:153 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:151 journal/views/review.py:170
+#: journal/views/article.py:174 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr "用户不存在"
@@ -2250,15 +2259,15 @@ msgstr "创作者已验证。"
 msgid "Creator verification removed."
 msgstr "创作者验证已移除。"
 
-#: catalog/views/view.py:66 catalog/views/view.py:91
+#: catalog/views/view.py:73 catalog/views/view.py:98
 msgid "Item not found"
 msgstr "条目不存在"
 
-#: catalog/views/view.py:70 catalog/views/view.py:99
+#: catalog/views/view.py:77 catalog/views/view.py:106
 msgid "Item no longer exists"
 msgstr "条目已不存在"
 
-#: catalog/views/view.py:167
+#: catalog/views/view.py:186
 msgid "Invalid role"
 msgstr "无效职务或角色。"
 
@@ -3885,12 +3894,12 @@ msgid "User no longer exists"
 msgstr "用户不存在了"
 
 #: common/utils.py:120 common/utils.py:122 common/utils.py:125
-#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:445
+#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:483
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:169
-#: journal/views/profile.py:486 journal/views/review.py:188
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:192
+#: journal/views/profile.py:524 journal/views/review.py:188
 msgid "Login required"
 msgstr "登录后访问"
 
@@ -4662,7 +4671,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:153 journal/views/article.py:183
+#: journal/models/article.py:153 journal/views/article.py:206
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -5526,7 +5535,8 @@ msgstr "作者已设置仅限已登录用户查看。"
 msgid "Edit Article"
 msgstr "编辑文章"
 
-#: journal/templates/article_edit.html:15 journal/templates/profile.html:142
+#: journal/templates/article_edit.html:15 journal/templates/profile.html:145
+#: journal/templates/profile_articles.html:9
 msgid "Compose Article"
 msgstr "撰写文章"
 
@@ -5820,22 +5830,22 @@ msgstr "日历"
 msgid "annual summary"
 msgstr "年度小结"
 
-#: journal/templates/profile.html:138
+#: journal/templates/profile.html:141
 #: journal/templates/user_article_list.html:14
-#: journal/templates/user_article_list.html:38
+#: journal/templates/user_article_list.html:38 journal/views/profile.py:463
 msgid "Articles"
 msgstr "文章"
 
-#: journal/templates/profile.html:153 journal/views/collection.py:385
+#: journal/templates/profile.html:162 journal/views/collection.py:385
 #: journal/views/profile.py:385
 msgid "collection"
 msgstr "收藏单"
 
-#: journal/templates/profile.html:170 journal/views/profile.py:426
+#: journal/templates/profile.html:179 journal/views/profile.py:426
 msgid "liked collection"
 msgstr "喜欢的收藏单"
 
-#: journal/templates/profile.html:204 journal/views/profile.py:542
+#: journal/templates/profile.html:213 journal/views/profile.py:580
 msgid "Organizations"
 msgstr "团体"
 
@@ -5876,17 +5886,17 @@ msgstr "撰写新文章"
 msgid "Liked Collections"
 msgstr "喜欢的收藏单"
 
-#: journal/templates/user_follow_list.html:23 journal/views/profile.py:453
+#: journal/templates/user_follow_list.html:23 journal/views/profile.py:491
 #: users/templates/users/account.html:452
 msgid "Following"
 msgstr "正在关注"
 
-#: journal/templates/user_follow_list.html:28 journal/views/profile.py:457
+#: journal/templates/user_follow_list.html:28 journal/views/profile.py:495
 #: users/templates/users/account.html:461
 msgid "Followers"
 msgstr "关注者"
 
-#: journal/templates/user_follow_list.html:32 journal/views/profile.py:461
+#: journal/templates/user_follow_list.html:32 journal/views/profile.py:499
 msgid "Mutuals"
 msgstr "互相关注"
 
@@ -5915,16 +5925,16 @@ msgstr "分享年度小结"
 msgid "#%(year)s_report"
 msgstr "#我的#%(year)s书影音"
 
-#: journal/views/article.py:149 journal/views/review.py:168
+#: journal/views/article.py:172 journal/views/review.py:168
 msgid "User not local"
 msgstr "用户不在本站"
 
-#: journal/views/article.py:157 journal/views/article.py:171
+#: journal/views/article.py:180 journal/views/article.py:194
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr "{0} 的文章"
 
-#: journal/views/article.py:159 journal/views/article.py:167
+#: journal/views/article.py:182 journal/views/article.py:190
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr "链接无效"

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -813,6 +813,78 @@ def test_original_episodes_api(live_server):
 
 
 @pytest.mark.django_db(databases="__all__")
+class TestVerifiedOriginals:
+    def test_only_verified_podcasts(self):
+        alice = User.register(email="a@example.com", username="alice")
+        verified_pod = _podcast("Verified", "v.example.com/feed.rss")
+        pending_pod = _podcast("Pending", "p.example.com/feed.rss")
+        plain_pod = _podcast("Plain", "x.example.com/feed.rss")
+        _verified(verified_pod, alice.identity)
+        VerifiedCreator.objects.create(item=pending_pod, owner=alice.identity)
+        assert list(Podcast.verified_originals()) == [verified_pod]
+        assert plain_pod not in Podcast.verified_originals()
+
+    def test_deleted_or_merged_excluded(self):
+        alice = User.register(email="a@example.com", username="alice")
+        deleted_pod = _podcast("Deleted", "d.example.com/feed.rss")
+        live_pod = _podcast("Live", "l.example.com/feed.rss")
+        _verified(deleted_pod, alice.identity)
+        _verified(live_pod, alice.identity)
+        deleted_pod.is_deleted = True
+        deleted_pod.save()
+        assert list(Podcast.verified_originals()) == [live_pod]
+
+    def test_distinct_with_multiple_claims(self):
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        _verified(podcast, bob.identity)
+        assert list(Podcast.verified_originals()) == [podcast]
+
+    def test_ordered_by_most_recently_verified(self):
+        alice = User.register(email="a@example.com", username="alice")
+        pod_old = _podcast("Old", "old.example.com/feed.rss")
+        pod_new = _podcast("New", "new.example.com/feed.rss")
+        claim_old = _verified(pod_old, alice.identity)
+        claim_new = _verified(pod_new, alice.identity)
+        now = timezone.now()
+        VerifiedCreator.objects.filter(pk=claim_old.pk).update(
+            created_time=now - timedelta(days=2)
+        )
+        VerifiedCreator.objects.filter(pk=claim_new.pk).update(created_time=now)
+        assert list(Podcast.verified_originals()) == [pod_new, pod_old]
+
+    def test_page_lists_verified_podcasts(self):
+        alice = User.register(email="a@example.com", username="alice")
+        verified_pod = _podcast("My Verified Show", "v.example.com/feed.rss")
+        _podcast("Just A Show", "x.example.com/feed.rss")
+        _verified(verified_pod, alice.identity)
+        response = Client().get("/discover/original-podcasts/")
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "My Verified Show" in body
+        assert "Just A Show" not in body
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_verified_podcasts_api(live_server):
+    import requests
+
+    alice = User.register(email="a@example.com", username="alice")
+    podcast = _podcast("Api Show")
+    _verified(podcast, alice.identity)
+    response = requests.get(
+        f"{live_server.url}/api/trending/podcast/verified/", timeout=5
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["uuid"] == podcast.uuid
+
+
+@pytest.mark.django_db(databases="__all__")
 class TestMastodonAttribution:
     def test_resolve_identity_local(self):
         user = User.register(email="a@example.com", username="alice")

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -880,6 +880,7 @@ def test_verified_podcasts_api(live_server):
     assert response.status_code == 200
     payload = response.json()
     assert payload["count"] == 1
+    assert payload["pages"] == 1
     assert len(payload["data"]) == 1
     assert payload["data"][0]["uuid"] == podcast.uuid
 


### PR DESCRIPTION
## What

Clicking the **original episodes** heading on the discover page now opens a new paginated page listing the *original podcasts* (the verified shows themselves, not their episodes). The same list is exposed as a trending API endpoint.

## Changes

- `Podcast.verified_originals()` — shared queryset of podcasts that have a `VERIFIED` `VerifiedCreator`, deduped to one row per show, excluding deleted/merged, ordered most-recently-verified first.
- New view + route `discover/original-podcasts/` → paginated page (`CustomPaginator` / `PageLinksGenerator`, rendered via `_list_item.html` + `_pagination.html`).
- Discover `original episodes` shelf heading is now a link to the new page. The link inherits the existing `test_enabled` gating of the shelf; the page and API themselves are public, consistent with the existing `/trending/podcast/original/` episodes API.
- New public API `GET /api/trending/podcast/verified/` → paginated `list[PodcastSchema]`.
- i18n: added `original podcasts` (`原创播客`) for `zh_Hans`.

## Tests

Added query, page, and live-server API tests in `tests/catalog/test_creator_verify.py`. Full file passes (71/71); `pre-commit run` (ruff, format, djLint, ty) is clean.