### PR TITLE
fix(catalog): exclude trending articles from authors with no shelf items

### DIFF
--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models import Count, F, Q
+from django.db.models import Count, Exists, F, OuterRef, Q
 from django.db.models.query import prefetch_related_objects
 from django.utils import timezone
 from loguru import logger
@@ -325,6 +325,15 @@ class DiscoverGenerator(BaseJob):
                 | set(self._top_post_ids(self.get_popular_posts(1, 0, local), 3))
                 | set(reviews.values_list("posts", flat=True)[:5])
                 | set(articles.values_list("posts", flat=True)[:5])
+            )
+            # An article must not trend if its author has no items on a shelf,
+            # regardless of which path above surfaced its post.
+            post_ids -= set(
+                Article.objects.filter(posts__in=post_ids)
+                .filter(
+                    ~Exists(ShelfMember.objects.filter(owner_id=OuterRef("owner_id")))
+                )
+                .values_list("posts", flat=True)
             )
         else:
             post_ids = []

--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -326,15 +326,21 @@ class DiscoverGenerator(BaseJob):
                 | set(reviews.values_list("posts", flat=True)[:5])
                 | set(articles.values_list("posts", flat=True)[:5])
             )
+            # ``posts`` is a M2M, so values_list() yields None for any piece
+            # without an associated post; drop it before querying or caching.
+            post_ids.discard(None)
             # An article must not trend if its author has no items on a shelf,
             # regardless of which path above surfaced its post.
-            post_ids -= set(
-                Article.objects.filter(posts__in=post_ids)
-                .filter(
-                    ~Exists(ShelfMember.objects.filter(owner_id=OuterRef("owner_id")))
+            if post_ids:
+                post_ids -= set(
+                    Article.objects.filter(posts__in=post_ids)
+                    .filter(
+                        ~Exists(
+                            ShelfMember.objects.filter(owner_id=OuterRef("owner_id"))
+                        )
+                    )
+                    .values_list("posts", flat=True)
                 )
-                .values_list("posts", flat=True)
-            )
         else:
             post_ids = []
         cache.set("public_gallery", gallery_list, timeout=None)

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from catalog.jobs.creator_verify import _has_audio_episode, verify_creator_task
 from catalog.jobs.discover import DiscoverGenerator
 from catalog.models import (
+    Edition,
     IdType,
     Podcast,
     PodcastEpisode,
@@ -20,6 +21,8 @@ from catalog.models import (
     user_owned_claims_q,
 )
 from catalog.sites.rss import RSS
+from common.models import SiteConfig
+from journal.models import Article, Mark, ShelfType
 from mastodon.models.bluesky import BlueskyAccount
 from mastodon.models.mastodon import MastodonAccount
 from users.models import User
@@ -1126,3 +1129,50 @@ class TestItemPageMeta:
         assert remote.profile_uri == "https://mast.example/@alice"
         assert 'rel="me"' in content
         assert remote.profile_uri in content
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTrendingArticles:
+    def _article_post_ids(self, article) -> set:
+        # read post ids from the journal side (the through table), mirroring the
+        # discover job; ``article.posts`` would force a cross-database join.
+        return {
+            pk
+            for pk in Article.objects.filter(pk=article.pk).values_list(
+                "posts", flat=True
+            )
+            if pk is not None
+        }
+
+    def test_article_only_trends_when_author_has_shelf_items(self, monkeypatch):
+        # an author's article is eligible for trending only if the author has
+        # at least one item on a shelf; otherwise it is excluded.
+        monkeypatch.setattr(SiteConfig.system, "discover_show_popular_posts", True)
+
+        with_shelf = User.register(email="ws@example.com", username="hasshelf")
+        without_shelf = User.register(email="ns@example.com", username="noshelf")
+
+        book = Edition.objects.create(title="Shelf Book")
+        Mark(with_shelf.identity, book).update(ShelfType.WISHLIST)
+        kept = Article.update_local_article(
+            owner=with_shelf.identity,
+            title="Kept Article",
+            body="Body of the kept article.",
+            visibility=0,
+        )
+        dropped = Article.update_local_article(
+            owner=without_shelf.identity,
+            title="Dropped Article",
+            body="Body of the dropped article.",
+            visibility=0,
+        )
+
+        kept_posts = self._article_post_ids(kept)
+        dropped_posts = self._article_post_ids(dropped)
+        assert kept_posts and dropped_posts  # both articles created posts
+
+        DiscoverGenerator().run()
+        popular = set(cache.get("popular_posts") or [])
+
+        assert kept_posts & popular  # author with a shelf item trends
+        assert not (dropped_posts & popular)  # author without one does not


### PR DESCRIPTION
## What

Articles by authors who have no items on any shelf are no longer surfaced in trending posts.

## Why

An article should not trend when its author has not engaged with the catalog (no items on any shelf). Previously such articles could appear in trending either through the explicit "recent articles" path or the general recent-posts path in the discover job.

## How

In `DiscoverGenerator.run()`, after `post_ids` is assembled, subtract any post belonging to an article whose owner has no `ShelfMember`. Applying the rule to the final set means it holds regardless of which collection path surfaced the post.

- Scoped to articles only (reviews / marks / other posts untouched)
- Bounded by the current `post_ids` set (no unbounded query)
- Stays on the journal DB (no cross-DB join to Takahe)

## Test

Adds `TestTrendingArticles`: an author with a shelf item has their article trend; an author with no shelf items does not. Full `test_creator_verify.py` (72 tests) and pre-commit pass.