### PR TITLE
fix(journal): delete articles when removing identity data

### DIFF
--- a/neodb/journal/models/utils.py
+++ b/neodb/journal/models/utils.py
@@ -7,6 +7,7 @@ from catalog.models import Item
 from journal.search import JournalIndex
 from users.models import APIdentity, User
 
+from .article import Article
 from .collection import Collection, CollectionMember, FeaturedCollection
 from .comment import Comment
 from .common import Content, Debris
@@ -37,6 +38,7 @@ def remove_data_by_identity(owner: APIdentity):
     CollectionMember.objects.filter(owner=owner).delete()
     Collection.objects.filter(owner=owner).delete()
     FeaturedCollection.objects.filter(owner=owner).delete()
+    Article.objects.filter(owner=owner).delete()
     index = JournalIndex.instance()
     index.delete_by_owner(owner.pk)
     logger.info(f"removed journal data by {owner}")

--- a/neodb/tests/journal/test_journal_utils.py
+++ b/neodb/tests/journal/test_journal_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from catalog.models import Edition
 from journal.models import (
+    Article,
     Collection,
     CollectionMember,
     Comment,
@@ -73,6 +74,7 @@ class TestRemoveDataByIdentity:
         Note.objects.create(
             owner=self.identity, item=self.book, content="note", visibility=0
         )
+        Article.update_local_article(self.identity, "Article Title", "Article body")
         assert ShelfMember.objects.filter(owner=self.identity).exists()
         assert Comment.objects.filter(owner=self.identity).exists()
         assert Rating.objects.filter(owner=self.identity).exists()
@@ -80,6 +82,7 @@ class TestRemoveDataByIdentity:
         assert TagMember.objects.filter(owner=self.identity).exists()
         assert Note.objects.filter(owner=self.identity).exists()
         assert CollectionMember.objects.filter(owner=self.identity).exists()
+        assert Article.objects.filter(owner=self.identity).exists()
         remove_data_by_identity(self.identity)
         assert not ShelfMember.objects.filter(owner=self.identity).exists()
         assert not ShelfLogEntry.objects.filter(owner=self.identity).exists()
@@ -91,6 +94,7 @@ class TestRemoveDataByIdentity:
         assert not Note.objects.filter(owner=self.identity).exists()
         assert not CollectionMember.objects.filter(owner=self.identity).exists()
         assert not Collection.objects.filter(owner=self.identity).exists()
+        assert not Article.objects.filter(owner=self.identity).exists()
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Problem

When a user account is deleted, `remove_data_by_identity()` (`neodb/journal/models/utils.py`) is responsible for clearing that identity's journal content. It deletes marks (`ShelfMember`/`ShelfLogEntry`), comments, ratings, reviews, tags, notes, and collections — but it **omits `Article`**.

As a result, standalone articles authored by the user are left orphaned in the `journal_article` table, with `owner` pointing at an identity that has been soft-deleted (the identity row is kept but flagged via `deleted`). Because `Article.owner` uses `on_delete=PROTECT` and the identity is only soft-deleted, nothing else cleans these up.

## Fix

Add `Article.objects.filter(owner=owner).delete()` to `remove_data_by_identity()`, matching how every other journal content type is removed. The associated Takahe posts are already removed by the identity deletion on the Takahe side.

## Test

Extended `test_remove_data_clears_all_journal_entries` to create an `Article` and assert it is removed alongside the other content types.

```
6 passed in 7.07s  (tests/journal/test_journal_utils.py)
```