### PR TITLE
fix(catalog): handle RSS feeds without channel description

### DIFF
--- a/neodb/catalog/sites/rss.py
+++ b/neodb/catalog/sites/rss.py
@@ -129,7 +129,7 @@ class RSS(AbstractSite):
         title = feed["title"].strip()
         if not title:
             raise ParseError(self, "title")
-        desc = html_to_text(feed["description"])
+        desc = html_to_text(feed.get("description") or "")
         lang = detect_language(title + " " + desc)
         pd = ResourceContent(
             metadata={


### PR DESCRIPTION
## Problem

`RSS.scrape()` raised `KeyError('description')` when parsing podcast feeds that have no channel-level description (e.g. `https://audio.pepemoss.com/api/v1/channels/tnd/rss`).

`podcastparser` only guarantees the `title` and `episodes` keys in the channel dict; `description` is added only when the feed contains a `<description>`, `<itunes:summary>` (RSS), or `<atom:subtitle>` (Atom) element. Accessing `feed["description"]` directly crashed the fetch task.

## Fix

Use `feed.get("description") or ""`, which handles both a missing key and a present-but-empty/None value. `html_to_text("")` returns `""` safely, and the downstream `localized_description` already guards on empty desc.

Fixes EGGPLANT-1EG