### PR TITLE
fix(catalog): defer person metadata JSON in credits prefetch (EGGPLANT-1EF)

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -24,7 +24,6 @@ from .models import (
     Game,
     GameSchema,
     Item,
-    ItemCredit,
     ItemSchema,
     Movie,
     MovieSchema,
@@ -133,7 +132,7 @@ def search_item(
     Item.prefetch_edition_works(items)
     prefetch_related_objects(
         items,
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)
@@ -317,7 +316,7 @@ def trending_verified_podcasts(request, page: int = 1):
                 "id", "item_id", "id_type", "id_value", "url"
             ),
         ),
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Rating.attach_to_items(podcasts)
     Tag.attach_to_items(podcasts)
@@ -509,7 +508,7 @@ def _prepare_reco_items(request, items: list) -> None:
     Item.prefetch_edition_works(items)
     prefetch_related_objects(
         items,
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Rating.attach_to_items(items)
     Tag.attach_to_items(items)

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING
 
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.db.models import Prefetch
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
 from ninja import Field
@@ -44,7 +43,6 @@ from .item import (
     IdType,
     Item,
     ItemCategory,
-    ItemCredit,
     ItemInSchema,
     ItemType,
     PrimaryLookupIdDescriptor,
@@ -455,12 +453,7 @@ class Edition(Item):
             work.editions.exclude(pk=self.pk)
             .exclude(is_deleted=True)
             .exclude(merged_to_item__isnull=False)
-            .prefetch_related(
-                Prefetch(
-                    "credits",
-                    queryset=ItemCredit.objects.select_related("person"),
-                )
-            )
+            .prefetch_related(Item.credits_prefetch())
             .order_by("-metadata__pub_year")
         )
 

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -795,6 +795,31 @@ class Item(PolymorphicModel):
             prefetch_related_objects(performanceproductions, "show")
 
     @staticmethod
+    def credits_prefetch() -> models.Prefetch:
+        """Optimized ``Prefetch`` for ``item.credits`` used by templates/APIs.
+
+        ``_credits.html`` and the API ``CreditSchema`` only read
+        ``credit.name``/``role`` and ``credit.person.url`` (which needs the
+        person's ``uid``/``people_type``). Restrict the ``select_related``
+        join to those columns so the batch prefetch no longer pulls the large
+        ``metadata`` JSON on each credited person, which made it a slow DB
+        query (EGGPLANT-1EF).
+        """
+        return models.Prefetch(
+            "credits",
+            queryset=ItemCredit.objects.select_related("person").only(
+                "item_id",
+                "person_id",
+                "role",
+                "name",
+                "character_name",
+                "order",
+                "person__uid",
+                "person__people_type",
+            ),
+        )
+
+    @staticmethod
     def prefetch_credits(items: "Iterable[Item]") -> None:
         """Batch-prefetch credits (with person) for templates that render
         ``item.role_credits`` per card. Without this, each card fires a
@@ -803,13 +828,7 @@ class Item(PolymorphicModel):
         item_list = [i for i in items if i is not None]
         if not item_list:
             return
-        prefetch_related_objects(
-            item_list,
-            models.Prefetch(
-                "credits",
-                queryset=ItemCredit.objects.select_related("person"),
-            ),
-        )
+        prefetch_related_objects(item_list, Item.credits_prefetch())
 
     @staticmethod
     def prefetch_edition_works(items: "Iterable[Item]") -> None:

--- a/neodb/catalog/models/performance.py
+++ b/neodb/catalog/models/performance.py
@@ -18,7 +18,6 @@ from .item import (
     IdType,
     Item,
     ItemCategory,
-    ItemCredit,
     ItemSchema,
     ItemType,
 )
@@ -293,12 +292,7 @@ class Performance(Item):
             self.productions.all()
             .order_by("metadata__opening_date", "title")
             .filter(is_deleted=False, merged_to_item=None)
-            .prefetch_related(
-                models.Prefetch(
-                    "credits",
-                    queryset=ItemCredit.objects.select_related("person"),
-                )
-            )
+            .prefetch_related(Item.credits_prefetch())
         )
 
     @property

--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -5,7 +5,7 @@ import django_rq
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
-from django.db.models import Prefetch, prefetch_related_objects
+from django.db.models import prefetch_related_objects
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -30,7 +30,6 @@ from ..common.sites import AbstractSite, SiteManager
 from ..models import (
     Item,
     ItemCategory,
-    ItemCredit,
     SiteName,
     item_categories,
 )
@@ -271,7 +270,7 @@ def search(request):
     Item.prefetch_parent_items(all_items)
     prefetch_related_objects(
         all_items,
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Rating.attach_to_items(all_items)
     # Public tags come from the search index (attached in CatalogSearchResult.items),

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -38,7 +38,6 @@ from ..models import (
     ExternalResource,
     IdType,
     Item,
-    ItemCredit,
     Podcast,
     TVEpisode,
 )
@@ -124,7 +123,7 @@ def retrieve(request, item_path, item_uuid):
             "external_resources",
             queryset=ExternalResource.objects.only(*extres_fields),
         ),
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Item.prefetch_parent_items([item])
     focus_item = None
@@ -243,7 +242,7 @@ def people_works(request, item_path, item_uuid, role):
                     "id", "item_id", "id_type", "id_value", "url"
                 ),
             ),
-            Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+            Item.credits_prefetch(),
         )
         Item.prefetch_parent_items(works_items)
         Rating.attach_to_items(works_items)
@@ -720,7 +719,7 @@ def discover_original_podcasts(request):
                     "id", "item_id", "id_type", "id_value", "url"
                 ),
             ),
-            Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+            Item.credits_prefetch(),
         )
         Rating.attach_to_items(podcast_items)
         Tag.attach_to_items(podcast_items)

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Any, List
 
 from django.core.cache import cache
-from django.db.models import Prefetch, QuerySet, prefetch_related_objects
+from django.db.models import QuerySet, prefetch_related_objects
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
@@ -12,7 +12,6 @@ from catalog.models import (
     AvailableItemCategory,
     Item,
     ItemCategory,
-    ItemCredit,
     ItemSchema,
 )
 from common.api import PageNumberPagination, Result, api
@@ -45,7 +44,7 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     prefetch_related_objects(
         items,
         "external_resources",
-        Prefetch("credits", queryset=ItemCredit.objects.select_related("person")),
+        Item.credits_prefetch(),
     )
     Item.prefetch_parent_items(items)
     Item.prefetch_edition_works(items)

--- a/neodb/tests/journal/test_n_plus_one.py
+++ b/neodb/tests/journal/test_n_plus_one.py
@@ -1116,6 +1116,85 @@ class TestItemRetrieveCreditsPrefetch:
         # One prefetch query is allowed; should never scale with access count.
         assert len(credit_queries) <= 1
 
+    def test_credits_prefetch_skips_person_metadata(self):
+        """The credits prefetch must not pull the heavy person metadata JSON.
+
+        Selecting each credited person's catalog_item.metadata made this a slow
+        DB query (EGGPLANT-1EF). The optimized Prefetch fetches only the person
+        columns needed for credit.person.url (uid/people_type).
+        """
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(self.book.url)
+        assert response.status_code == 200
+        # The person link must still render: uid/people_type were fetched.
+        assert self.author.url in response.content.decode()
+        # The credits prefetch joins catalog_people; it must not select metadata.
+        person_credit_queries = [
+            q
+            for q in ctx.captured_queries
+            if "catalog_itemcredit" in q["sql"]
+            and "catalog_people" in q["sql"]
+            and "SELECT" in q["sql"].upper()
+        ]
+        assert person_credit_queries, "expected a credits prefetch joining people"
+        for q in person_credit_queries:
+            assert "metadata" not in q["sql"], (
+                "credits prefetch should not select the person metadata column"
+            )
+
+    def test_credits_query_count_independent_of_people(self):
+        """Total query count for the detail page must not grow with the number
+        of credited people.
+
+        The optimized ``.only()`` Prefetch joins the multi-table-inherited
+        ``person`` and defers most columns. This guards against a per-person
+        deferred-field reload (an N+1 on catalog_people / catalog_item) that the
+        catalog_itemcredit-only filters above would not catch.
+        """
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+
+        def make_book(title: str, n: int):
+            book = Edition.objects.create(title=title)
+            for i in range(n):
+                person = People.objects.create(
+                    title=f"{title} P{i}",
+                    people_type=PeopleType.PERSON,
+                    metadata={
+                        "localized_name": [{"lang": "en", "text": f"{title} P{i}"}]
+                    },
+                )
+                ItemCredit.objects.create(
+                    item=book,
+                    person=person,
+                    role=CreditRole.Author,
+                    name=person.display_name,
+                )
+            return book
+
+        small = make_book("QC Small", 2)
+        big = make_book("QC Big", 14)
+
+        def render_query_count(book) -> int:
+            with CaptureQueriesContext(connection) as ctx:
+                response = client.get(book.url)
+            assert response.status_code == 200
+            return len(ctx.captured_queries)
+
+        # Warm up process-level caches (content types, site config) so the
+        # measured renders are not skewed by first-request priming.
+        render_query_count(small)
+        small_count = render_query_count(small)
+        big_count = render_query_count(big)
+        # A per-person deferred-field reload would add ~1 query per extra credit;
+        # the optimized Prefetch keeps the count flat regardless of cast size.
+        assert big_count <= small_count, (
+            f"detail page issued {big_count} queries for 14 credited people vs "
+            f"{small_count} for 2: credits prefetch is not bounded (N+1 on people)"
+        )
+
     def test_sibling_editions_credits_prefetched(self):
         """edition.html shows publisher_name per sibling edition; must not N+1."""
         work = Work.objects.create(title="IR Work")


### PR DESCRIPTION
## Summary

Fixes the "Slow DB Query" flagged as **Sentry EGGPLANT-1EF** on the item detail page (`/{item_path}/{item_uuid}`, e.g. `/tv/season/...`).

The batch credits prefetch used `select_related("person")`, which joins each credited person's `catalog_item` row and pulls the large `metadata` JSON for **every** cast/crew member — even though the page only renders `credit.name` and `credit.person.url`. For items with a big cast this dominated the query. Same root-cause class as the already-merged EGGPLANT-1DX `external_resources` fix.

## Change

- Add a shared `Item.credits_prefetch()` helper that restricts the `select_related("person")` join via `.only(...)` to just the columns `credit.person.url` / `CreditSchema` actually need (`uid`, `people_type`) plus the `ItemCredit` row's own fields — dropping the heavy `metadata` JSON.
- Route every batch credit-prefetch site through the helper: item detail / people-works / original-podcasts views, catalog search, shelf + catalog APIs, sibling editions (`Edition.sibling_items`), and performance productions (`Performance.all_productions`). Removed now-unused imports.
- Left the low-traffic edit views and the single-item fallback untouched — they aren't the flagged batch query and editing needs the full person.

## Tests

- `test_credits_prefetch_skips_person_metadata`: asserts the credits prefetch query does not select the person `metadata` column, and that the person link still renders (`uid`/`people_type` are fetched).
- `test_credits_query_count_independent_of_people`: asserts total detail-page query count does not grow with the number of credited people — guards against a per-person deferred-field reload (N+1) on the multi-table-inherited `person` join. Verified the assertion has teeth (deferring `people_type` makes it fail).

Existing credit-prefetch N+1 guards across the retrieve view, people-works, shelf API, and sibling editions continue to pass.

## Verification

- `pre-commit run` (ruff, ruff-format, `ty`): clean.
- `tests/journal/test_n_plus_one.py`: 59 passed.
- `tests/catalog/`: 605 passed. `tests/journal/test_api.py` + `test_shelf.py`: 29 passed.
