### PR TITLE
fix(catalog): hide restricted creators' podcasts from discover

### DIFF
--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -156,9 +156,10 @@ class DiscoverGenerator(BaseJob):
         episodes are listed first. Capped at `max_per_program` per podcast and
         `max_items` overall.
         """
-        verified_item_ids = VerifiedCreator.objects.filter(
-            state=VerifiedCreator.State.VERIFIED
-        ).values_list("item_id", flat=True)
+        # verified_originals() is the single source of truth for which shows
+        # count as "originals": it is deduped and already drops shows whose
+        # verified creator is a restricted identity.
+        verified_item_ids = Podcast.verified_originals().values_list("pk", flat=True)
         base = PodcastEpisode.objects.filter(
             is_deleted=False,
             merged_to_item__isnull=True,

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -123,8 +123,21 @@ class Podcast(Item):
         These are the shows behind the discover page's "original episodes"
         shelf. A show may carry several verified-creator claims, so it is
         ranked by the newest of those claims and appears only once.
+
+        A show is hidden entirely if any of its verified creators is a
+        restricted (limited or blocked) identity, so moderated creators do
+        not surface on discover.
         """
-        return (
+        from takahe.models import Identity
+
+        # Restriction lives on the Takahe identity (separate db, shared pk),
+        # so materialize the restricted ids rather than joining across dbs.
+        restricted_ids = list(
+            Identity.objects.filter(
+                restriction__gt=Identity.Restriction.none
+            ).values_list("pk", flat=True)
+        )
+        qs = (
             cls.objects.filter(
                 is_deleted=False,
                 merged_to_item__isnull=True,
@@ -138,8 +151,13 @@ class Podcast(Item):
                 )
             )
             .filter(verified_at__isnull=False)
-            .order_by("-verified_at", "-pk")
         )
+        if restricted_ids:
+            qs = qs.exclude(
+                verified_creators__state=VerifiedCreator.State.VERIFIED,
+                verified_creators__owner_id__in=restricted_ids,
+            )
+        return qs.order_by("-verified_at", "-pk")
 
     @property
     def recent_episodes(self):

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -130,11 +130,19 @@ class Podcast(Item):
         """
         from takahe.models import Identity
 
-        # Restriction lives on the Takahe identity (separate db, shared pk),
-        # so materialize the restricted ids rather than joining across dbs.
+        # Restriction lives on the Takahe identity (separate db, shared pk), so
+        # look up only the identities that are actually verified creators (a
+        # small, curated set) and materialize the restricted ids, rather than
+        # scanning every restricted identity on the instance or joining dbs.
+        verified_owner_ids = list(
+            VerifiedCreator.objects.filter(state=VerifiedCreator.State.VERIFIED)
+            .values_list("owner_id", flat=True)
+            .distinct()
+        )
         restricted_ids = list(
             Identity.objects.filter(
-                restriction__gt=Identity.Restriction.none
+                pk__in=verified_owner_ids,
+                restriction__gt=Identity.Restriction.none,
             ).values_list("pk", flat=True)
         )
         qs = (

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -56,6 +56,13 @@ def _verified(item, identity, matched="@x@example.org") -> VerifiedCreator:
     )
 
 
+def _restrict(identity, level=2) -> None:
+    """Set the Takahe identity's moderation restriction (1=limited, 2=blocked)."""
+    from takahe.models import Identity
+
+    Identity.objects.filter(pk=identity.pk).update(restriction=level)
+
+
 def _make_remote_identity(username="alice", domain_name="mast.example"):
     """Create a remote APIdentity (and its Takahe Identity) for tests that
     attribute a verified work to a linked Mastodon account."""
@@ -717,6 +724,22 @@ class TestOriginalEpisodes:
         self._episodes(podcast)
         assert DiscoverGenerator().get_original_episodes() == []
 
+    def test_restricted_creator_episodes_excluded(self):
+        # episodes of a show whose verified creator is restricted must not
+        # surface in the discover "original episodes" shelf
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        kept_pod = _podcast("Kept", "k.example.com/feed.rss")
+        hidden_pod = _podcast("Hidden", "h.example.com/feed.rss")
+        _verified(kept_pod, alice.identity)
+        _verified(hidden_pod, bob.identity)
+        self._episodes(kept_pod)
+        self._episodes(hidden_pod)
+        _restrict(bob.identity, level=2)
+        episodes = DiscoverGenerator().get_original_episodes()
+        assert episodes
+        assert {e.program_id for e in episodes} == {kept_pod.pk}
+
     def _episode(self, podcast, guid, days_ago):
         return PodcastEpisode.objects.create(
             program=podcast,
@@ -841,6 +864,43 @@ class TestVerifiedOriginals:
         _verified(podcast, alice.identity)
         _verified(podcast, bob.identity)
         assert list(Podcast.verified_originals()) == [podcast]
+
+    def test_blocked_creator_excluded(self):
+        alice = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        _restrict(alice.identity, level=2)
+        assert list(Podcast.verified_originals()) == []
+
+    def test_limited_creator_excluded(self):
+        # the discover convention hides limited identities too, not just blocked
+        alice = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        _restrict(alice.identity, level=1)
+        assert list(Podcast.verified_originals()) == []
+
+    def test_any_restricted_creator_hides_show(self):
+        # a show co-hosted by a restricted creator is hidden entirely, even
+        # though it still has an unrestricted verified creator
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        _verified(podcast, bob.identity)
+        _restrict(bob.identity, level=2)
+        assert list(Podcast.verified_originals()) == []
+
+    def test_unrestricted_creator_kept(self):
+        # restricting an unrelated creator must not drop other shows
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        alice_pod = _podcast("Alice", "a.example.com/feed.rss")
+        bob_pod = _podcast("Bob", "b.example.com/feed.rss")
+        _verified(alice_pod, alice.identity)
+        _verified(bob_pod, bob.identity)
+        _restrict(bob.identity, level=2)
+        assert list(Podcast.verified_originals()) == [alice_pod]
 
     def test_ordered_by_most_recently_verified(self):
         alice = User.register(email="a@example.com", username="alice")


### PR DESCRIPTION
## Problem

A podcast whose verified creator's fediverse identity is restricted (Takahe `restriction` = limited or blocked, i.e. an admin moderation action) still surfaced on the discover page. Moderated creators should not be promoted there.

## Change

Filter restricted creators out in `Podcast.verified_originals()`, which is the single source of truth backing all three discover surfaces:

- `/trending/podcast/verified/` API
- the `/discover/original-podcasts/` page
- the `original_episodes` shelf cache (also feeds `/trending/podcast/original/`)

Restriction lives on the Takahe identity (separate DB, shared pk), so the restricted ids are materialized rather than joined across databases — matching the existing pattern in the discover job. A show is hidden entirely if **any** of its verified creators is restricted. Levels limited (1) and blocked (2) are both excluded, consistent with the discover page's existing post convention (`get_popular_posts` requires `restriction=0`).

`get_original_episodes()` now derives its show list from `Podcast.verified_originals()` instead of its own `VerifiedCreator` query, so the episodes shelf inherits the same filter (and gains dedup for shows with multiple verified creators).

## Scope: discovery only

Verification is unaffected — a restricted creator can still verify and manage their show:

- the verify flow (`catalog/views/verify.py`, `catalog/jobs/creator_verify.py`) never checks restriction
- edit rights (`Item.is_editable_by` / `verified_creator_list`) read `VerifiedCreator` directly
- the creator's own `/users/<handle>/verified_works` page and the item page's `fediverse:creator` meta still show the podcast

## Tests

Added to `tests/catalog/test_creator_verify.py`: blocked creator excluded, limited creator excluded, any restricted co-host hides the show, unrelated restriction does not drop other shows, and restricted-creator episodes excluded from the shelf. Full file: 76 passed. pre-commit clean.