### PR TITLE
perf(journal): hide tags on some endpoints to increase performance

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -12,7 +12,7 @@ from ninja.pagination import paginate
 from common.api import PageNumberPagination, RedirectedResult, Result, api
 from journal.models.mark import Mark
 from journal.models.rating import Rating
-from journal.models.tag import Tag
+from journal.models.tag import TagManager
 
 from .common import SiteManager
 from .models import (
@@ -135,7 +135,8 @@ def search_item(
         Item.credits_prefetch(),
     )
     Rating.attach_to_items(items)
-    Tag.attach_to_items(items)
+    # Public tags already ride along from the search index (query_index); no
+    # per-request journal_tagmember aggregation here (NEODB-SOCIAL-7KW).
     if request.user.is_authenticated:
         Mark.attach_to_items(request.user.identity, items, request.user)
     return Status(200, {"data": items, "pages": num_pages, "count": count})
@@ -319,7 +320,6 @@ def trending_verified_podcasts(request, page: int = 1):
         Item.credits_prefetch(),
     )
     Rating.attach_to_items(podcasts)
-    Tag.attach_to_items(podcasts)
     return Status(
         200,
         {"data": podcasts, "pages": paginator.num_pages, "count": paginator.count},
@@ -340,6 +340,9 @@ def _get_item(cls, uuid, response):
     if item.__class__ != cls:
         response["Location"] = item.api_url
         return Status(302, {"message": "Item recasted", "url": item.api_url})
+    # Public tags are returned for single-item lookups; aggregate for this item
+    # only (list endpoints no longer attach tags -- NEODB-SOCIAL-7KW).
+    item.tags = TagManager.indexable_tags_for_item(item)
     return item
 
 
@@ -499,8 +502,9 @@ def _prepare_reco_items(request, items: list) -> None:
     """Hydrate items for ItemSchema serialization. Mirrors search_item.
 
     Without this the schema dereferences parents, credits, external resources,
-    ratings, tags and mark state per row -- a 60-item response would issue
-    hundreds of queries.
+    ratings and mark state per row -- a 60-item response would issue hundreds
+    of queries. Public tags are intentionally not attached (recommendations are
+    a list surface), so ItemSchema.tags serializes as null without a query.
     """
     if not items:
         return
@@ -511,7 +515,6 @@ def _prepare_reco_items(request, items: list) -> None:
         Item.credits_prefetch(),
     )
     Rating.attach_to_items(items)
-    Tag.attach_to_items(items)
     if request.user.is_authenticated:
         Mark.attach_to_items(request.user.identity, items, request.user)
 

--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -184,7 +184,6 @@ class DiscoverGenerator(BaseJob):
                 break
         episodes = episodes[:max_items]
         for e in episodes:
-            e.tags
             e.rating
             e.rating_count
             e.rating_distribution
@@ -232,7 +231,6 @@ class DiscoverGenerator(BaseJob):
                 }
             )
             for i in items:
-                i.tags
                 i.rating
                 i.rating_count
                 i.rating_distribution

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -239,6 +239,12 @@ class Item(PolymorphicModel):
     url_path = "item"  # subclass must specify this
     child_class = None  # subclass may specify this to allow link to parent item
     parent_class = None  # subclass may specify this to allow create child item
+    # Public tags (cross-user, cleaned, top-20) are NOT computed on read. They
+    # are attached explicitly only where shown -- the item detail view/API and
+    # search results (from the precomputed index). Left None on list/feed/
+    # discover surfaces so they neither render nor trigger the per-item tag
+    # aggregation that was the NEODB-SOCIAL-7KW slow query.
+    tags: list[str] | None = None
     uid = models.UUIDField(default=uuid.uuid4, editable=False, db_index=True)
     title = models.CharField(_("title"), max_length=1000, default="")
     brief = models.TextField(_("description"), blank=True, default="")
@@ -620,6 +626,8 @@ class Item(PolymorphicModel):
         return list(set(titles))
 
     def to_indexable_doc(self) -> dict[str, str | int | list[str] | list[int]]:
+        from journal.models import TagManager
+
         from .people import PeopleRole
 
         org_roles = PeopleRole.organization_roles()
@@ -636,7 +644,9 @@ class Item(PolymorphicModel):
             "item_id": [self.pk],
             "item_class": self.__class__.__name__,
             "title": self.to_indexable_titles(),
-            "tag": self.tags,
+            # Aggregate public tags here (at index time, async) rather than on
+            # every page render; read paths reuse this indexed value.
+            "tag": TagManager.indexable_tags_for_item(self),
             "mark_count": self.mark_count,
             "language": getattr(self, "language", None) or [],
             "people": people,
@@ -1295,12 +1305,6 @@ class Item(PolymorphicModel):
     @cached_property
     def rating_distribution(self):
         return self.rating_info.get("distribution")
-
-    @cached_property
-    def tags(self):
-        from journal.models import TagManager
-
-        return TagManager.indexable_tags_for_item(self)
 
     def journal_exists(self):
         from journal.models import journal_exists_for_item

--- a/neodb/catalog/templates/_item_card_metadata_base.html
+++ b/neodb/catalog/templates/_item_card_metadata_base.html
@@ -47,7 +47,7 @@
       </div>
     {% endblock full %}
   </div>
-  {% if not mark and not mark.shelf %}
+  {% if item.tags and not mark %}
     <div class="tag-list solo-hidden">
       {% for tag in item.tags %}
         {% if forloop.counter <= 5 %}

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -28,7 +28,7 @@ from journal.models import (
     Review,
     ShelfManager,
     ShelfMember,
-    Tag,
+    TagManager,
     q_piece_in_home_feed_of_user,
     q_piece_visible_to_user,
 )
@@ -126,6 +126,9 @@ def retrieve(request, item_path, item_uuid):
         Item.credits_prefetch(),
     )
     Item.prefetch_parent_items([item])
+    # Public tags are shown on the item detail page; aggregate for this single
+    # item only (list pages no longer attach tags -- NEODB-SOCIAL-7KW).
+    item.tags = TagManager.indexable_tags_for_item(item)
     focus_item = None
     if request.GET.get("focus"):
         focus_item = get_object_or_404(
@@ -246,7 +249,6 @@ def people_works(request, item_path, item_uuid, role):
         )
         Item.prefetch_parent_items(works_items)
         Rating.attach_to_items(works_items)
-        Tag.attach_to_items(works_items)
     return render(
         request,
         "people_works.html",
@@ -722,7 +724,6 @@ def discover_original_podcasts(request):
             Item.credits_prefetch(),
         )
         Rating.attach_to_items(podcast_items)
-        Tag.attach_to_items(podcast_items)
         if request.user.is_authenticated:
             Mark.attach_to_items(request.user.identity, podcast_items, request.user)
     return render(

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -24,7 +24,6 @@ from journal.models.common import (
 )
 from journal.models.rating import Rating
 from journal.models.shelf import ShelfMember
-from journal.models.tag import Tag
 from users.models.apidentity import APIdentity
 
 from ..models import (
@@ -49,7 +48,9 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     Item.prefetch_parent_items(items)
     Item.prefetch_edition_works(items)
     Rating.attach_to_items(items)
-    Tag.attach_to_items(items)
+    # Public item tags are not returned on the shelf; only the owner's own tags
+    # (MarkSchema.tags, fetched below). ItemSchema.tags serializes as null
+    # without a per-item aggregation (NEODB-SOCIAL-7KW).
     # Batch-fetch latest_post_id for all members to avoid N+1 queries
     # when MarkSchema accesses latest_post_id
     prefetch_latest_posts(members)

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -185,7 +185,6 @@ class Collection(List):
         from .common import q_owned_piece_visible_to_user
         from .mark import Mark
         from .rating import Rating
-        from .tag import Tag
 
         if self.is_dynamic:
             # Dynamic collections: use existing search-based pagination
@@ -199,7 +198,6 @@ class Collection(List):
                 Item.prefetch_parent_items(items)
                 Item.prefetch_credits(items)
                 Rating.attach_to_items(items)
-                Tag.attach_to_items(items)
                 if viewer:
                     Mark.attach_to_items(viewer, items, viewer.user)
                 members = [{"item": i, "parent": self} for i in items]
@@ -238,7 +236,6 @@ class Collection(List):
                 Item.prefetch_parent_items(items)
                 Item.prefetch_credits(items)
                 Rating.attach_to_items(items)
-                Tag.attach_to_items(items)
                 if viewer:
                     Mark.attach_to_items(viewer, items, viewer.user)
         return members, pages

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -974,17 +974,17 @@ def prefetch_pieces_for_posts(posts: list["Post"]) -> None:
         else:
             post.__dict__["item"] = None
     # Batch-prefetch item-card related data so feed templates (item card,
-    # rating, tags, credits, external resources) don't fire per-item queries
-    # while rendering feed_events.html. Mirrors the list-view prefetch in
-    # journal.views.common.
+    # rating, credits, external resources) don't fire per-item queries while
+    # rendering feed_events.html. Mirrors the list-view prefetch in
+    # journal.views.common. Public tags are not shown on feed cards, so they
+    # are intentionally not attached (NEODB-SOCIAL-7KW).
     items = list(items_by_id.values())
     if items:
-        from journal.models import Rating, Tag
+        from journal.models import Rating
 
         Item.prefetch_parent_items(items)
         Item.prefetch_credits(items)
         Rating.attach_to_items(items)
-        Tag.attach_to_items(items)
         prefetch_related_objects(
             items,
             # Feed cards render with allow_embed=1, so Album.get_embed_link reads

--- a/neodb/journal/models/tag.py
+++ b/neodb/journal/models/tag.py
@@ -1,7 +1,7 @@
 import re
 from datetime import timedelta
 from functools import cached_property
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from django.core.cache import cache
 from django.core.validators import RegexValidator
@@ -99,35 +99,6 @@ class Tag(List):
 
     def to_indexable_doc(self):
         return {}
-
-    @classmethod
-    def attach_to_items(cls, items: Sequence[Item]) -> Sequence[Item]:
-        item_ids = [item.pk for item in items if item.pk]
-        tags_by_item: dict[int, list[str]] = {item_id: [] for item_id in item_ids}
-        if item_ids:
-            rows = (
-                TagMember.objects.filter(item_id__in=item_ids, parent__visibility=0)
-                .values("item_id", "parent__title")
-                .annotate(frequency=Count("parent__owner"))
-                .order_by("item_id", "-frequency")
-            )
-            for row in rows:
-                item_id = row["item_id"]
-                tag_list = tags_by_item.get(item_id)
-                if tag_list is None or len(tag_list) >= 20:
-                    continue
-                tag_list.append(row["parent__title"])
-        for item in items:
-            titles = tags_by_item.get(item.pk, [])
-            cleaned = sorted(
-                [
-                    t
-                    for t in set(Tag.deep_cleanup_title(title) for title in titles)
-                    if t and t != "_"
-                ]
-            )
-            item.tags = cleaned
-        return items
 
 
 class TagManager:

--- a/neodb/tests/journal/test_tag.py
+++ b/neodb/tests/journal/test_tag.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from catalog.models import Edition, ItemCategory, Movie
 from journal.models import Tag, TagManager
@@ -9,7 +11,10 @@ from users.models import User
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_attach_to_items_sets_public_tags():
+def test_indexable_tags_for_item_aggregates_public_tags():
+    """Public tags are aggregated across users, cleaned and de-duplicated;
+    private (visibility != 0) tags are excluded. This single-item primitive
+    feeds the search index and the item detail page/API."""
     owner = User.register(email="tagger@example.com", username="tagger")
     other = User.register(email="tagger2@example.com", username="tagger2")
     tagged = Edition.objects.create(title="Tagged Book")
@@ -22,10 +27,44 @@ def test_attach_to_items_sets_public_tags():
     dup.append_item(tagged)
     hidden.append_item(tagged)
 
-    Tag.attach_to_items([tagged, untagged])
+    # "Sci-Fi" and "sci fi" both clean to "sci fi"; "Hidden" is private.
+    assert TagManager.indexable_tags_for_item(tagged) == ["sci fi"]
+    assert TagManager.indexable_tags_for_item(untagged) == []
 
-    assert tagged.tags == ["sci fi"]
-    assert untagged.tags == []
+
+@pytest.mark.django_db(databases="__all__")
+def test_item_tags_not_aggregated_on_read():
+    """Item.tags must not auto-aggregate on read (NEODB-SOCIAL-7KW): a freshly
+    loaded item exposes tags as None and touches no journal_tagmember row, so
+    list/feed surfaces that never attach tags cannot trigger the slow query."""
+    owner = User.register(email="noagg@example.com", username="noagg")
+    book = Edition.objects.create(title="No-Aggregation Book")
+    Tag.objects.create(owner=owner.identity, title="public", visibility=0).append_item(
+        book
+    )
+
+    fresh = Edition.objects.get(pk=book.pk)
+    with CaptureQueriesContext(connection) as ctx:
+        tags = fresh.tags
+    assert tags is None
+    assert [q for q in ctx.captured_queries if "journal_tagmember" in q["sql"]] == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_to_indexable_doc_includes_public_tags():
+    """The public-tag aggregation runs at index time so read paths can reuse the
+    indexed value; to_indexable_doc must carry the cleaned, public-only tags."""
+    owner = User.register(email="idxtag@example.com", username="idxtag")
+    book = Edition.objects.create(title="Indexed Tag Book")
+    Tag.objects.create(owner=owner.identity, title="Sci-Fi", visibility=0).append_item(
+        book
+    )
+    Tag.objects.create(owner=owner.identity, title="secret", visibility=1).append_item(
+        book
+    )
+
+    doc = Edition.objects.get(pk=book.pk).to_indexable_doc()
+    assert doc["tag"] == ["sci fi"]
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_tag_coverage.py
+++ b/neodb/tests/journal/test_tag_coverage.py
@@ -55,7 +55,7 @@ class TestTagMemberTitle:
 
 
 @pytest.mark.django_db(databases="__all__")
-class TestTagAttachToItems:
+class TestIndexableTagsForItem:
     @pytest.fixture(autouse=True)
     def setup_data(self):
         self.user1 = User.register(email="ati1@test.com", username="atiuser1")
@@ -63,24 +63,18 @@ class TestTagAttachToItems:
         self.book1 = Edition.objects.create(title="ATI Book1")
         self.book2 = Edition.objects.create(title="ATI Book2")
 
-    def test_attach_tags_to_items(self):
+    def test_aggregates_public_tags_across_users(self):
         TagManager.tag_item_for_owner(
             self.user1.identity, self.book1, ["sci-fi", "space"]
         )
         TagManager.tag_item_for_owner(
             self.user2.identity, self.book1, ["sci-fi", "adventure"]
         )
-        items = [self.book1, self.book2]
-        Tag.attach_to_items(items)
-        # book1 should have tags, book2 should have empty list
-        assert hasattr(self.book1, "tags")
-        assert len(self.book1.tags) > 0
-        assert hasattr(self.book2, "tags")
-        assert self.book2.tags == []
-
-    def test_attach_tags_empty_items(self):
-        result = Tag.attach_to_items([])
-        assert result == []
+        tags = TagManager.indexable_tags_for_item(self.book1)
+        # Aggregated across both users, cleaned and de-duplicated.
+        assert "sci fi" in tags
+        assert len(tags) > 0
+        assert TagManager.indexable_tags_for_item(self.book2) == []
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Problem

Sentry **NEODB-SOCIAL-7KW** ("Slow DB Query", 54 users) fires on the creator
works page. `Tag.attach_to_items()` aggregated public tag frequency across **all
users** for every item on a list page — a `GROUP BY`/`COUNT` over
`journal_tagmember` that ran **1.3–10.8s** for popular items. `Item.tags` was an
auto-aggregating `cached_property`, so even serializing or rendering a list
re-ran it per row. ~8 list/API endpoints were affected.

## Change

Compute public tags only where they're shown, never on a list render.
`Item.tags` is now a plain attribute (default `None`); the cross-user
aggregation runs **only at index time** (`to_indexable_doc`), and read paths
reuse the indexed value or attach explicitly for a single item.

| Surface | Tags shown |
|---|---|
| Item detail page + item API | public tags (single-item aggregation) |
| Search page + API | public tags (reused from the search index) |
| Shelf view + API | owner's own tags only (visibility-filtered) |
| Works page, podcasts/discover, collections, home feed, trending/reco API | none |

`Tag.attach_to_items` is removed (no callers left). **No Redis cache.**

**API note:** `ItemSchema.tags` now serializes `null` on the trending-podcasts
and recommendations endpoints and for items embedded in the shelf response
(single-item and search endpoints still populate it).

## Testing

- Full local `catalog/` + `journal/` suites: **1206 passed**; `pre-commit`
  (ruff, ruff-format, ty, djlint) passes.
- Added: `Item.tags` does not aggregate on read (no `journal_tagmember` query on
  a fresh load); `to_indexable_doc` carries cleaned, public-only tags.
- Replaced the old `attach_to_items` tests with `indexable_tags_for_item`
  coverage; existing search index-reuse tests still pass.
