### PR TITLE
feat(catalog): staff podcast verification + Discord audit logging

### DIFF
--- a/neodb/catalog/jobs/creator_verify.py
+++ b/neodb/catalog/jobs/creator_verify.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.utils import timezone
 from loguru import logger
 
+from common.utils import discord_send
 from common.validators import is_valid_url
 from journal.models.renderers import html_to_text
 from users.models import User
@@ -157,6 +158,15 @@ def _verify_claim(claim: VerifiedCreator, user: User, matched: str) -> None:
         # commit together
         item.log_action({"!creator_verified": ["", f"{verified.owner} ({matched})"]})
     logger.info(f"creator verification matched {matched} for {verified}")
+    # post the audit line only after the transaction commits, so a rolled-back
+    # verification never emits a (best-effort, non-transactional) Discord message
+    discord_send(
+        "audit",
+        f"{item.absolute_url}\nverified creator: @{identity.full_handle} ({matched})\n"
+        f"by [@{user.username}]({user.absolute_url})",
+        thread_name=f"[verify] {item.display_title}",
+        username=f"@{user.username}",
+    )
 
 
 def verify_creator_task(claim_id: int, user_id: int) -> None:

--- a/neodb/catalog/templates/catalog_verify.html
+++ b/neodb/catalog/templates/catalog_verify.html
@@ -75,7 +75,7 @@
               <li>
                 <a href="{{ claim.owner.url }}">{{ claim.owner.display_name }}</a>
                 <small>@{{ claim.owner.full_handle }}</small>
-                {% if request.user.is_superuser and claim.owner != request.user.identity %}
+                {% if can_moderate and claim.owner != request.user.identity %}
                   <form method="post"
                         style="display:inline"
                         action="{% url 'catalog:unverify_creator' item.url_path item.uuid %}"
@@ -90,7 +90,7 @@
           </ul>
         </section>
       {% endif %}
-      {% if request.user.is_superuser %}
+      {% if can_moderate %}
         <details>
           <summary>{% trans 'Manually verify a creator' %}</summary>
           <form method="post"

--- a/neodb/catalog/views/verify.py
+++ b/neodb/catalog/views/verify.py
@@ -8,11 +8,12 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
 from common.utils import (
+    discord_send,
     get_uuid_or_404,
     target_identity_required,
     user_identity_required,
 )
-from users.models import APIdentity
+from users.models import APIdentity, User
 
 from ..jobs.creator_verify import enqueue_creator_verification
 from ..models import (
@@ -24,6 +25,13 @@ from ..models import (
 )
 
 VERIFY_COOLDOWN_SECONDS = 60
+
+
+def _can_moderate_verification(user: User) -> bool:
+    # staff handle routine creator moderation (consistent with is_editable_by
+    # and the rest of catalog moderation); superusers retain access too, since
+    # is_staff and is_superuser are independent flags in this codebase
+    return bool(user.is_staff or user.is_superuser)
 
 
 def _get_verifiable_item(item_uuid) -> Item:
@@ -63,6 +71,7 @@ def _verify_context(request, item: Item) -> dict:
         "verified_creators": item.verified_creator_list,
         "candidates": candidates,
         "example_url": example_url,
+        "can_moderate": _can_moderate_verification(request.user),
     }
 
 
@@ -143,7 +152,7 @@ def verify_creator_start(request, item_path, item_uuid):
 @login_required
 @user_identity_required
 def verify_creator_manual(request, item_path, item_uuid):
-    if not request.user.is_superuser:
+    if not _can_moderate_verification(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     item = _get_verifiable_item(item_uuid)
     handle = request.POST.get("handle", "").strip()
@@ -164,6 +173,13 @@ def verify_creator_manual(request, item_path, item_uuid):
     item.log_action(
         {"!creator_verified": ["", f"{identity} (manual by @{request.user.username})"]}
     )
+    discord_send(
+        "audit",
+        f"{item.absolute_url}\nverified creator: @{identity.full_handle} (manual)\n"
+        f"by [@{request.user.username}]({request.user.absolute_url})",
+        thread_name=f"[verify] {item.display_title}",
+        username=f"@{request.user.username}",
+    )
     messages.add_message(request, messages.INFO, _("Creator verified."))
     return redirect(_verify_page_url(item))
 
@@ -181,12 +197,19 @@ def unverify_creator(request, item_path, item_uuid):
         pk=claim_id,
         item=item,
     )
-    if not user_controls_owner(request.user, claim.owner) and (
-        not request.user.is_superuser
-    ):
+    if not user_controls_owner(
+        request.user, claim.owner
+    ) and not _can_moderate_verification(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     item.log_action({"!creator_unverified": ["", str(claim.owner)]})
     claim.delete()
+    discord_send(
+        "audit",
+        f"{item.absolute_url}\nremoved creator: @{claim.owner.full_handle}\n"
+        f"by [@{request.user.username}]({request.user.absolute_url})",
+        thread_name=f"[unverify] {item.display_title}",
+        username=f"@{request.user.username}",
+    )
     messages.add_message(request, messages.INFO, _("Creator verification removed."))
     return redirect(item.url)
 

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -59,6 +59,14 @@ def _verified(item, identity, matched="@x@example.org") -> VerifiedCreator:
     )
 
 
+def _capture_discord(monkeypatch: pytest.MonkeyPatch, target: str) -> list:
+    """Replace the `discord_send` bound in `target`'s module with a stub that
+    records its calls, returning the list of (args, kwargs) tuples."""
+    calls: list = []
+    monkeypatch.setattr(target, lambda *a, **k: calls.append((a, k)) or True)
+    return calls
+
+
 def _restrict(identity, level=2) -> None:
     """Set the Takahe identity's moderation restriction (1=limited, 2=blocked)."""
     from takahe.models import Identity
@@ -271,6 +279,9 @@ class TestVerifyTask:
         return VerifiedCreator.objects.create(item=podcast, owner=user.identity)
 
     def test_verified_on_match(self, monkeypatch):
+        audits = _capture_discord(
+            monkeypatch, "catalog.jobs.creator_verify.discord_send"
+        )
         user = User.register(email="a@example.com", username="alice")
         podcast = _podcast()
         claim = self._claim(user, podcast)
@@ -289,6 +300,9 @@ class TestVerifyTask:
         claim.refresh_from_db()
         assert claim.state == VerifiedCreator.State.VERIFIED
         assert claim.matched == handle
+        # a successful self-service verification posts to the audit channel
+        assert len(audits) == 1
+        assert audits[0][0][0] == "audit"
 
     def test_failed_no_match(self, monkeypatch):
         user = User.register(email="a@example.com", username="alice")
@@ -491,42 +505,73 @@ class TestVerifyViews:
         ).exists()
         assert len(calls) == 1
 
-    def test_manual_verify_superuser_only(self):
+    def test_manual_verify_staff_only(self, monkeypatch):
+        audits = _capture_discord(monkeypatch, "catalog.views.verify.discord_send")
         user = User.register(email="a@example.com", username="alice")
-        admin = User.register(email="root@example.com", username="root")
+        staff = User.register(email="root@example.com", username="root")
         podcast = _podcast()
+        # a non-staff user cannot manually verify, and posts no audit
         response = _client(user).post(
             f"/podcast/{podcast.uuid}/verify/manual", {"handle": "@alice"}
         )
         assert response.status_code == 403
-        admin.is_superuser = True
-        admin.save(update_fields=["is_superuser"])
-        response = _client(admin).post(
+        assert audits == []
+        # staff (not superuser) can manually verify
+        staff.is_staff = True
+        staff.save(update_fields=["is_staff"])
+        response = _client(staff).post(
             f"/podcast/{podcast.uuid}/verify/manual", {"handle": "@alice"}
         )
         assert response.status_code == 302
         claim = VerifiedCreator.objects.get(item=podcast, owner=user.identity)
         assert claim.state == VerifiedCreator.State.VERIFIED
         assert claim.matched == "manual"
+        assert len(audits) == 1
+        assert audits[0][0][0] == "audit"
 
-    def test_unverify_permissions(self):
-        alice = User.register(email="a@example.com", username="alice")
-        bob = User.register(email="b@example.com", username="bob")
+    def test_manual_verify_superuser_still_allowed(self, monkeypatch):
+        # is_staff and is_superuser are independent flags here; broadening to
+        # staff must not drop access for a superuser who is not also staff
+        _capture_discord(monkeypatch, "catalog.views.verify.discord_send")
+        user = User.register(email="a@example.com", username="alice")
         admin = User.register(email="root@example.com", username="root")
         admin.is_superuser = True
         admin.save(update_fields=["is_superuser"])
+        assert not admin.is_staff
+        podcast = _podcast()
+        response = _client(admin).post(
+            f"/podcast/{podcast.uuid}/verify/manual", {"handle": "@alice"}
+        )
+        assert response.status_code == 302
+        claim = VerifiedCreator.objects.get(item=podcast, owner=user.identity)
+        assert claim.state == VerifiedCreator.State.VERIFIED
+
+    def test_unverify_permissions(self, monkeypatch):
+        audits = _capture_discord(monkeypatch, "catalog.views.verify.discord_send")
+        alice = User.register(email="a@example.com", username="alice")
+        bob = User.register(email="b@example.com", username="bob")
+        staff = User.register(email="root@example.com", username="root")
+        staff.is_staff = True
+        staff.save(update_fields=["is_staff"])
         podcast = _podcast()
         claim = _verified(podcast, alice.identity)
         url = f"/podcast/{podcast.uuid}/verify/remove"
+        # an unrelated non-staff user cannot remove, and posts no audit
         response = _client(bob).post(url, {"claim_id": claim.pk})
         assert response.status_code == 403
-        response = _client(admin).post(url, {"claim_id": claim.pk})
+        assert audits == []
+        # staff (not superuser) can remove anyone's claim
+        response = _client(staff).post(url, {"claim_id": claim.pk})
         assert response.status_code == 302
         assert not VerifiedCreator.objects.filter(pk=claim.pk).exists()
+        # the creator can still remove their own claim
         claim = _verified(podcast, alice.identity)
         response = _client(alice).post(url, {"claim_id": claim.pk})
         assert response.status_code == 302
         assert not VerifiedCreator.objects.filter(pk=claim.pk).exists()
+        # both successful removals posted to the audit channel
+        assert len(audits) == 2
+        assert all(c[0][0] == "audit" for c in audits)
 
     def test_unverify_invalid_claim_id(self):
         # a missing or non-numeric claim_id is a bad request, not a 500


### PR DESCRIPTION
## What

1. **Staff can verify/unverify podcasts.** Previously the manual-verify and remove-others'-claim operations were gated to `is_superuser`. They now use a `_can_moderate_verification(user)` helper (`is_staff or is_superuser`), consistent with how the rest of catalog moderation (`edit.py`, `Item.is_editable_by`) gates on `is_staff`.
2. **Audit to Discord.** Every verify/unverify now posts a line to the Discord `"audit"` channel via the existing `discord_send(...)` helper, matching the format used throughout `catalog/views/edit.py`:
   - self-service verification success (background job `_verify_claim`)
   - staff manual verification (`verify_creator_manual`)
   - unverification (`unverify_creator`)

## Notes / decisions

- **Superusers keep access.** `is_staff` and `is_superuser` are independent flags in this codebase (`create_superuser` sets only `is_superuser`; the `user` management command toggles them separately). So the permission change is additive (`is_staff or is_superuser`) rather than a swap, to avoid locking out existing non-staff superusers. A regression test covers this.
- **Template flag.** Django templates can't group `(a or b) and c` (no parentheses; `and` binds tighter than `or`), so the per-creator remove button and manual-verify form gate on a `can_moderate` context flag computed in `_verify_context`, not an inline boolean.
- **Self-service audit timing.** In the background job the audit is sent only after the DB transaction commits, so a rolled-back/early-return verification never emits a (best-effort, non-transactional) Discord message.
- **Merge cascade out of scope.** Automatic claim removal during item merge (`item.py`) is a system cascade, not an explicit user/staff action, so it does not post to Discord.
- **Enqueue not wrapped.** The synchronous `discord_send` enqueue is left unguarded to match the established `edit.py` audit pattern (webhook-missing and HTTP failures are already handled; a failing enqueue implies Redis is down).

## Tests

`tests/catalog/test_creator_verify.py`: updated the manual-verify and unverify permission tests to staff, added a non-staff-superuser regression test, and added assertions (via a monkeypatched `discord_send`) that an `"audit"` message fires on self-service verify, manual verify, and unverify.

## Verification

`uv run pre-commit run -a` passes (ruff, ruff format, djLint, ty).