### PR TITLE
perf(catalog,journal): fix Sentry-flagged slow and N+1 DB queries

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -3,7 +3,7 @@ from typing import List
 
 from django.core.cache import cache
 from django.core.paginator import Paginator
-from django.db.models import Prefetch, prefetch_related_objects
+from django.db.models import prefetch_related_objects
 from django.http import HttpResponse
 from django.utils import timezone
 from ninja import Schema, Status
@@ -20,7 +20,6 @@ from .models import (
     AlbumSchema,
     Edition,
     EditionSchema,
-    ExternalResource,
     Game,
     GameSchema,
     Item,
@@ -311,12 +310,7 @@ def trending_verified_podcasts(request, page: int = 1):
     # which queries per item; hydrate in bulk to avoid N+1 during serialization.
     prefetch_related_objects(
         podcasts,
-        Prefetch(
-            "external_resources",
-            queryset=ExternalResource.objects.only(
-                "id", "item_id", "id_type", "id_value", "url"
-            ),
-        ),
+        Item.external_resources_prefetch(),
         Item.credits_prefetch(),
     )
     Rating.attach_to_items(podcasts)

--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -187,7 +187,7 @@ class DiscoverGenerator(BaseJob):
             e.rating
             e.rating_count
             e.rating_distribution
-        prefetch_related_objects(episodes, "external_resources")
+        prefetch_related_objects(episodes, Item.external_resources_prefetch())
         return episodes
 
     def run(self):
@@ -234,7 +234,13 @@ class DiscoverGenerator(BaseJob):
                 i.rating
                 i.rating_count
                 i.rating_distribution
-            prefetch_related_objects(items, "external_resources")
+            # Cache credits + slim external_resources so the trending API skips
+            # the per-item credits join (EGGPLANT-1EK) and metadata (EGGPLANT-1DX).
+            prefetch_related_objects(
+                items,
+                Item.external_resources_prefetch(),
+                Item.credits_prefetch(),
+            )
             editions = [i for i in items if isinstance(i, Edition)]
             if editions:
                 prefetch_related_objects(editions, "works")

--- a/neodb/catalog/migrations/0025_podcastepisode_covering_index.py
+++ b/neodb/catalog/migrations/0025_podcastepisode_covering_index.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("catalog", "0024_verifiedcreator"),
+    ]
+
+    operations = [
+        # Add item_ptr as a covering column so child_item_ids reads episode ids
+        # via an index-only scan (EGGPLANT-1EA).
+        migrations.RemoveIndex(
+            model_name="podcastepisode",
+            name="catalog_pod_program_2e4327_idx",
+        ),
+        migrations.AddIndex(
+            model_name="podcastepisode",
+            index=models.Index(
+                fields=["program", "pub_date"],
+                include=("item_ptr",),
+                name="podcast_ep_prog_pubdate_cov",
+            ),
+        ),
+    ]

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -830,6 +830,21 @@ class Item(PolymorphicModel):
         )
 
     @staticmethod
+    def external_resources_prefetch(
+        *, lookup: str = "external_resources", with_metadata: bool = False
+    ) -> models.Prefetch:
+        """``Prefetch`` for external_resources that drops the large metadata /
+        other_lookup_ids JSON (Sentry: EGGPLANT-1DX); cards and the API only
+        read url/site_name/site_label. Pass ``with_metadata=True`` for embed
+        surfaces (item detail, feed cards) where ``Album.get_embed_link`` reads
+        ``res.metadata``; ``lookup`` sets the relation path for nested prefetch.
+        """
+        fields = ["id", "item_id", "id_type", "id_value", "url"]
+        if with_metadata:
+            fields.append("metadata")
+        return models.Prefetch(lookup, queryset=ExternalResource.objects.only(*fields))
+
+    @staticmethod
     def prefetch_credits(items: "Iterable[Item]") -> None:
         """Batch-prefetch credits (with person) for templates that render
         ``item.role_credits`` per card. Without this, each card fires a

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -192,9 +192,10 @@ class Podcast(Item):
         # JOIN with catalog_item to filter on is_deleted / merged_to_item_id;
         # for podcasts with many episodes this becomes a slow query
         # (Sentry: EGGPLANT-1BH). Split into two simple index lookups so the
-        # FK scan and the PK-bounded filter happen independently. The id lookup
-        # is index-only thanks to the covering index below (EGGPLANT-1EA).
-        raw_ids = list(self.episodes.values_list("id", flat=True))
+        # FK scan and the PK-bounded filter happen independently. ``pk`` reads
+        # the local item_ptr_id column, served index-only by the covering index
+        # below (EGGPLANT-1EA).
+        raw_ids = list(self.episodes.values_list("pk", flat=True))
         if not raw_ids:
             return []
         return list(

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -192,7 +192,8 @@ class Podcast(Item):
         # JOIN with catalog_item to filter on is_deleted / merged_to_item_id;
         # for podcasts with many episodes this becomes a slow query
         # (Sentry: EGGPLANT-1BH). Split into two simple index lookups so the
-        # FK scan and the PK-bounded filter happen independently.
+        # FK scan and the PK-bounded filter happen independently. The id lookup
+        # is index-only thanks to the covering index below (EGGPLANT-1EA).
         raw_ids = list(self.episodes.values_list("id", flat=True))
         if not raw_ids:
             return []
@@ -330,5 +331,13 @@ class PodcastEpisode(Item):
         return []
 
     class Meta:
-        indexes = [models.Index(fields=["program", "pub_date"])]
+        indexes = [
+            # Covering index: item_ptr lets child_item_ids read episode ids via
+            # an index-only scan (EGGPLANT-1EA).
+            models.Index(
+                fields=["program", "pub_date"],
+                include=["item_ptr"],
+                name="podcast_ep_prog_pubdate_cov",
+            ),
+        ]
         unique_together = [["program", "guid"]]

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.db.models import Count, F, Prefetch, Q, Window, prefetch_related_objects
+from django.db.models import Count, F, Q, Window, prefetch_related_objects
 from django.db.models.functions import RowNumber
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -114,15 +114,9 @@ def retrieve(request, item_path, item_uuid):
     # query (EGGPLANT-1DX). Albums are the exception: album.html renders an
     # embed via Album.get_embed_link(), which reads res.metadata for Bandcamp
     # resources, so keep metadata for them to avoid a per-resource deferred load.
-    extres_fields = ["id", "item_id", "id_type", "id_value", "url"]
-    if item.class_name == "album":
-        extres_fields.append("metadata")
     prefetch_related_objects(
         [item],
-        Prefetch(
-            "external_resources",
-            queryset=ExternalResource.objects.only(*extres_fields),
-        ),
+        Item.external_resources_prefetch(with_metadata=item.class_name == "album"),
         Item.credits_prefetch(),
     )
     Item.prefetch_parent_items([item])
@@ -234,17 +228,12 @@ def people_works(request, item_path, item_uuid, role):
     # Batch-prefetch per-item data used by _item_card_* partials to avoid N+1
     works_items = list(works_page.object_list)
     if works_items:
+        # Card partials only read url/site_name/site_label (derived from
+        # id_type/id_value), so skip the large metadata/other_lookup_ids JSON
+        # columns that made this prefetch a slow query (EGGPLANT-1DX).
         prefetch_related_objects(
             works_items,
-            # Card partials only read url/site_name/site_label (derived from
-            # id_type/id_value), so skip the large metadata/other_lookup_ids
-            # JSON columns that made this prefetch a slow query (EGGPLANT-1DX).
-            Prefetch(
-                "external_resources",
-                queryset=ExternalResource.objects.only(
-                    "id", "item_id", "id_type", "id_value", "url"
-                ),
-            ),
+            Item.external_resources_prefetch(),
             Item.credits_prefetch(),
         )
         Item.prefetch_parent_items(works_items)
@@ -553,15 +542,7 @@ def similar(request, item_path, item_uuid):
         # Card partials only read url/site_name/site_label (derived from
         # id_type/id_value), so skip the large metadata/other_lookup_ids JSON
         # columns that made this prefetch a slow query (EGGPLANT-1DX).
-        prefetch_related_objects(
-            items,
-            Prefetch(
-                "external_resources",
-                queryset=ExternalResource.objects.only(
-                    "id", "item_id", "id_type", "id_value", "url"
-                ),
-            ),
-        )
+        prefetch_related_objects(items, Item.external_resources_prefetch())
     return render(
         request,
         "_item_similar.html",
@@ -674,7 +655,8 @@ def discover(request):
         else:
             Item.prefetch_parent_items(reco_items)
             Item.prefetch_edition_works(reco_items)
-            prefetch_related_objects(reco_items, "external_resources")
+            # Discover cards skip the metadata JSON (EGGPLANT-1DX).
+            prefetch_related_objects(reco_items, Item.external_resources_prefetch())
             cat_order = {
                 cat: i
                 for i, cat in enumerate(
@@ -715,12 +697,7 @@ def discover_original_podcasts(request):
     if podcast_items:
         prefetch_related_objects(
             podcast_items,
-            Prefetch(
-                "external_resources",
-                queryset=ExternalResource.objects.only(
-                    "id", "item_id", "id_type", "id_value", "url"
-                ),
-            ),
+            Item.external_resources_prefetch(),
             Item.credits_prefetch(),
         )
         Rating.attach_to_items(podcast_items)

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -39,10 +39,10 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     if not members:
         return
     items = [m.item for m in members]
-    # Batch-fetch parent items and item-level data to avoid N+1 queries
+    # Batch-fetch to avoid N+1; external_resources skips metadata (EGGPLANT-1DX).
     prefetch_related_objects(
         items,
-        "external_resources",
+        Item.external_resources_prefetch(),
         Item.credits_prefetch(),
     )
     Item.prefetch_parent_items(items)

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -219,9 +219,10 @@ class Collection(List):
             members = p.get_page(page_number)
             pages = p.num_pages
             item_ids = [m.item_id for m in members]
+            # Member cards skip the metadata JSON (EGGPLANT-1DX).
             items = list(
                 Item.objects.filter(pk__in=item_ids).prefetch_related(
-                    "external_resources"
+                    Item.external_resources_prefetch()
                 )
             )
             # All members share this Collection as their parent. Setting it on

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied, RequestAborted
 from django.core.signing import b62_decode, b62_encode
 from django.db import models
-from django.db.models import CharField, Prefetch, Q, prefetch_related_objects
+from django.db.models import CharField, Q, prefetch_related_objects
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
@@ -23,7 +23,6 @@ from user_messages import api as messages
 
 from catalog.models import (
     AvailableItemCategory,
-    ExternalResource,
     Item,
     ItemCategory,
     item_categories,
@@ -985,18 +984,13 @@ def prefetch_pieces_for_posts(posts: list["Post"]) -> None:
         Item.prefetch_parent_items(items)
         Item.prefetch_credits(items)
         Rating.attach_to_items(items)
+        # Feed cards render with allow_embed=1, so Album.get_embed_link reads
+        # res.metadata (Bandcamp/YouTube ids). Keep metadata in the deferred set
+        # to avoid a per-resource deferred load; only the large other_lookup_ids
+        # column is skipped.
         prefetch_related_objects(
             items,
-            # Feed cards render with allow_embed=1, so Album.get_embed_link reads
-            # res.metadata (Bandcamp/YouTube ids). Keep metadata in the deferred
-            # set to avoid a per-resource deferred load; only the large
-            # other_lookup_ids column is skipped.
-            Prefetch(
-                "external_resources",
-                queryset=ExternalResource.objects.only(
-                    "id", "item_id", "id_type", "id_value", "url", "metadata"
-                ),
-            ),
+            Item.external_resources_prefetch(with_metadata=True),
         )
 
 

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -424,10 +424,12 @@ def collection_edit_items(request: AuthedHttpRequest, collection_uuid):
                 id=last_member
             )
         members = list(members_qs[:20])
-        # Batch-fetch items with external_resources to avoid N+1
+        # Member cards skip the metadata JSON (EGGPLANT-1DX).
         item_ids = [m.item_id for m in members]
         items = list(
-            Item.objects.filter(pk__in=item_ids).prefetch_related("external_resources")
+            Item.objects.filter(pk__in=item_ids).prefetch_related(
+                Item.external_resources_prefetch()
+            )
         )
         items_map = {i.pk: i for i in items}
         for member in members:

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -217,7 +217,10 @@ def render_list(
     people_type = request.GET.get("people_type") or ""
     if people_type in PeopleType.values and item_category == ItemCategory.People:
         queryset = queryset.filter(item__people__people_type=people_type)
-    queryset = queryset.prefetch_related("item", "item__external_resources")
+    # Slim external_resources prefetch: cards skip the metadata JSON (EGGPLANT-1DX).
+    queryset = queryset.prefetch_related(
+        "item", Item.external_resources_prefetch(lookup="item__external_resources")
+    )
     paginator = CustomPaginator(queryset, request)
     page_number = int_(request.GET.get("page", default=1))
     members = paginator.get_page(page_number)

--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -555,7 +555,11 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
             Review.objects.filter(q_item_in_category(item_category))
             .filter(qv)
             .order_by("-created_time")
-            .prefetch_related("item", "item__external_resources")
+            # Cards skip the metadata JSON (EGGPLANT-1DX).
+            .prefetch_related(
+                "item",
+                Item.external_resources_prefetch(lookup="item__external_resources"),
+            )
         )
         items = [review.item for review in items_queryset[:20]]
         total = items_queryset.count()
@@ -568,7 +572,11 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
         members_queryset = (
             target.shelf_manager.get_latest_members(shelf_type_enum, item_category)
             .filter(qv)
-            .prefetch_related("item", "item__external_resources")
+            # Cards skip the metadata JSON (EGGPLANT-1DX).
+            .prefetch_related(
+                "item",
+                Item.external_resources_prefetch(lookup="item__external_resources"),
+            )
         )
         if people_type:
             members_queryset = members_queryset.filter(


### PR DESCRIPTION
Fixes three performance issues flagged by Sentry in the `eggplant` project.

## EGGPLANT-1EA — slow podcast episode-id lookup
`Podcast.child_item_ids` runs `SELECT item_ptr_id FROM catalog_podcastepisode WHERE program_id = ?` (used by the show's reviews/comments/notes pages and rating/mark aggregation). The existing `(program, pub_date)` index didn't cover `item_ptr_id`, so podcasts with many episodes paid a per-row heap fetch. Made it a **covering index** (`INCLUDE (item_ptr)`) so the lookup is an index-only scan. Migration `0025`. The `INCLUDE` is additive — the `(program, pub_date)` key still serves the pub_date-ordered episode listing.

## EGGPLANT-1EK — N+1 credits on `/api/trending/book/`
The trending cache prefetched `external_resources` but not credits, so `ItemSchema.credits` fired one `catalog_itemcredit` join per item on every request. Added `Item.credits_prefetch()` to the trending cache build in `discover.py`.

## EGGPLANT-1DX — slow `external_resources` load on `/collection/{uuid}` (and elsewhere)
Card/list/API surfaces only read `url`/`site_name`/`site_label`, but the prefetch pulled the large `metadata`/`other_lookup_ids` JSON. Introduced a shared `Item.external_resources_prefetch(lookup=…, with_metadata=…)` helper (mirroring `credits_prefetch()`) that slims the columns, and routed **every** card/list/API prefetch through it — collection (model + edit view), discover (trending + episodes + reco), shelf API, trending-verified-podcasts API, journal list/profile views, similar, and item detail. This also consolidated five copy-pasted inline `.only(...)` prefetches and fixed several pre-existing full-column prefetches that were latent versions of the same slow query. `metadata` is kept only for the two real embed surfaces (album detail page, feed cards via `allow_embed`).

## Testing
- `tests/catalog` + `tests/journal`: **1207 passed**.
- `pre-commit` (ruff, ruff-format, ty) clean.
- Migration applies on Postgres; covering index verified in `pg_indexes`.

## Not included (follow-up)
Limiting `child_item_ids` to comments-only on the reviews/notes pages: episodes have no review/note UI, so aggregating them there is wasted work — but these views are generic, and `child_item_ids` also covers TVShow→season and Performance→production, which *are* reviewable. Left out pending a product decision on those types.
