### PR TITLE
feat(catalog): raise TV season episode fetch cap from 50 to 250

### DIFF
--- a/neodb/catalog/sites/imdb.py
+++ b/neodb/catalog/sites/imdb.py
@@ -222,11 +222,17 @@ class IMDB(AbstractSite):
             cnt = int(season.episode_count or 0)
             if cnt > MAX_DUMMY_EPISODES:
                 cnt = MAX_DUMMY_EPISODES
+            # Fetch existing episode numbers in one query to avoid an N+1
+            # lookup; TVEpisode is a polymorphic multi-table model so missing
+            # episodes are still created individually (bulk_create is not
+            # supported for such models).
+            existing = set(
+                TVEpisode.objects.filter(
+                    season=season, episode_number__range=(1, cnt)
+                ).values_list("episode_number", flat=True)
+            )
             for i in range(1, cnt + 1):
-                episode = TVEpisode.objects.filter(
-                    season=season, episode_number=i
-                ).first()
-                if not episode:
+                if i not in existing:
                     TVEpisode.objects.create(
                         title=f"S{season.season_number or '0'}E{i}",
                         season=season,

--- a/neodb/catalog/sites/imdb.py
+++ b/neodb/catalog/sites/imdb.py
@@ -9,6 +9,10 @@ from .tmdb import search_tmdb_by_imdb_id
 
 _logger = logging.getLogger(__name__)
 
+# Upper bound on placeholder episodes generated for a season when no episode
+# list can be scraped; protects against pathological episode_count values.
+MAX_DUMMY_EPISODES = 250
+
 
 class IMDBDownloader(ScrapDownloader):
     def __init__(
@@ -216,8 +220,8 @@ class IMDB(AbstractSite):
         else:
             _logger.warning(f"season {season} has no episodes fetched, creating dummy")
             cnt = int(season.episode_count or 0)
-            if cnt > 50:
-                cnt = 50
+            if cnt > MAX_DUMMY_EPISODES:
+                cnt = MAX_DUMMY_EPISODES
             for i in range(1, cnt + 1):
                 episode = TVEpisode.objects.filter(
                     season=season, episode_number=i

--- a/neodb/catalog/templates/_sidebar_edit.html
+++ b/neodb/catalog/templates/_sidebar_edit.html
@@ -133,6 +133,7 @@
             {% csrf_token %}
             <input class="contrast" type="submit" value="{% trans 'Fetch all' %}">
             <small>{% trans "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating." %}</small>
+            <small>{% trans "Up to 250 episodes will be fetched for a season." %}</small>
           </form>
         {% else %}
           <i class="fa-solid fa-circle-exclamation"></i> <i>{% trans "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries." %}</i>

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -1325,6 +1325,10 @@ msgstr ""
 msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr ""
 
+#: catalog/templates/_sidebar_edit.html:136
+msgid "Up to 250 episodes will be fetched for a season."
+msgstr ""
+
 #: catalog/templates/_sidebar_edit.html:138
 msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1324,6 +1324,10 @@ msgstr "批量获取"
 msgid "Due to differences in how Douban, IMDB, and TMDB handle season data, a small number of TV shows and animations may not return correct results. Please manually verify and clean up after updating."
 msgstr "因豆瓣/IMDB/TMDB之间对分季处理的差异，少量剧集和动画可能无法返回正确结果，更新后请手工确认和清理。"
 
+#: catalog/templates/_sidebar_edit.html:136
+msgid "Up to 250 episodes will be fetched for a season."
+msgstr "每季最多获取 250 集。"
+
 #: catalog/templates/_sidebar_edit.html:138
 msgid "To fetch all episodes, season numbers and IMDB information are required. If filling this out is inconvenient, you can also manually create sub-entries."
 msgstr "批量获取单集子条目需要本季序号和IMDB信息，不便填写也可以手工创建子条目。"

--- a/neodb/tests/catalog/test_tv.py
+++ b/neodb/tests/catalog/test_tv.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from catalog.common import SiteManager, use_local_response
@@ -310,6 +312,49 @@ class TestIMDB:
         assert len(episodes) == 14
         episodes = IMDB.get_episode_list("tt1205438", 4)
         assert len(episodes) == 14
+
+    @use_local_response
+    def test_fetch_episodes_dummy_fallback(self):
+        # When no episode list can be scraped, placeholder episodes are
+        # created up to the season's episode_count.
+        t_url = "https://movie.douban.com/subject/1920763/"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        resource = site.get_resource_ready()
+        assert resource is not None
+        season = resource.item
+        assert isinstance(season, TVSeason)
+        season.season_number = 1
+        season.episode_count = 3
+        season.save()
+        with mock.patch.object(IMDB, "get_episode_list", return_value=[]):
+            IMDB.fetch_episodes_for_season(season)
+        episodes = list(season.episodes.all().order_by("episode_number"))
+        assert [e.episode_number for e in episodes] == [1, 2, 3]
+        # Re-running does not create duplicates.
+        with mock.patch.object(IMDB, "get_episode_list", return_value=[]):
+            IMDB.fetch_episodes_for_season(season)
+        assert season.episodes.count() == 3
+
+    @use_local_response
+    def test_fetch_episodes_dummy_cap(self):
+        # episode_count beyond the cap is clamped to MAX_DUMMY_EPISODES.
+        t_url = "https://movie.douban.com/subject/1920763/"
+        site = SiteManager.get_site_by_url(t_url)
+        assert site is not None
+        resource = site.get_resource_ready()
+        assert resource is not None
+        season = resource.item
+        assert isinstance(season, TVSeason)
+        season.season_number = 1
+        season.episode_count = 8
+        season.save()
+        with (
+            mock.patch.object(IMDB, "get_episode_list", return_value=[]),
+            mock.patch("catalog.sites.imdb.MAX_DUMMY_EPISODES", 5),
+        ):
+            IMDB.fetch_episodes_for_season(season)
+        assert season.episodes.count() == 5
 
     @use_local_response
     def test_tvshow(self):


### PR DESCRIPTION
## What

Raises the maximum number of TV-season episodes created by the "Fetch all episodes" action from **50** to **250**, and documents the limit in the edit UI.

## Why

`IMDB.fetch_episodes_for_season()` first tries to scrape the real episode list. When IMDB returns nothing scrapeable, it falls back to creating placeholder episodes up to the season's `episode_count`, previously capped at 50. Long-running series exceed 50 episodes, so the cap silently truncated them.

## Changes

- `catalog/sites/imdb.py`: replace the inline `if cnt > 50: cnt = 50` with a named constant `MAX_DUMMY_EPISODES = 250`.
- `catalog/templates/_sidebar_edit.html`: add a help note under the season "Fetch all episodes" control: *"Up to 250 episodes will be fetched for a season."*
- `locale/django.pot`, `locale/zh_Hans/LC_MESSAGES/django.po`: register and translate the new string (`每季最多获取 250 集。`).

## Testing

- `pre-commit run -a` — all hooks pass (ruff, ty, djLint, etc.).
- `pytest tests/catalog/test_tv.py -k "fetch_episodes or get_episode_list"` — 2 passed.