### PR TITLE
fix(activities): recalculate parent reply count when a reply is deleted

### DIFF
--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -236,6 +236,8 @@ class PostStates(StateGraph):
                 )
                 conv.last_post = next_post
                 conv.save(update_fields=["last_post", "updated"])
+        # Keep the parent's replies_count accurate after a soft delete.
+        instance.recalculate_parent_stats()
         return cls.deleted_fanned_out
 
     @classmethod
@@ -856,6 +858,12 @@ class Post(StatorModel):
         }
         if save:
             self.save()
+
+    def recalculate_parent_stats(self) -> None:
+        """If this is a reply, refresh the parent's cached stats (replies_count)."""
+        parent = self.in_reply_to_post()
+        if parent:
+            parent.calculate_stats()
 
     def calculate_type_data(self, save=True):
         """
@@ -1917,6 +1925,10 @@ def post_created(sender, instance: Post, created, **kwargs):
 
 def post_deleted(sender, instance: Post, **kwargs):
     instance.author.calculate_stats()
+    # Hard deletes (incoming AP Delete, prune, admin) bypass handle_deleted;
+    # skip soft-deleted posts whose parent was already recalculated there.
+    if instance.state != PostStates.deleted_fanned_out:
+        instance.recalculate_parent_stats()
 
 
 post_save.connect(post_created, sender=Post, dispatch_uid="activities.post.created")

--- a/takahe/tests/activities/models/test_post_replies.py
+++ b/takahe/tests/activities/models/test_post_replies.py
@@ -1,7 +1,62 @@
 import pytest
 
-from activities.models import Post
+from activities.models import Post, PostStates
+from activities.services import PostService
 from users.models import InboxMessage
+
+
+@pytest.mark.django_db
+def test_reply_count_recalculated_after_reply_deleted(identity, stator):
+    """Regression for #1648: deleting a reply must decrease the parent's
+    replies_count instead of leaving it inflated indefinitely."""
+    parent = Post.create_local(
+        author=identity,
+        content="Parent post",
+        visibility=Post.Visibilities.public,
+    )
+    reply = Post.create_local(
+        author=identity,
+        content="A reply",
+        visibility=Post.Visibilities.public,
+        reply_to=parent,
+    )
+    # create_local() recalculates the parent's stats when a reply is created.
+    parent.refresh_from_db()
+    assert parent.stats["replies"] == 1
+
+    # Delete the reply and let the deleted-state handler run, as stator would.
+    PostService(reply).delete()
+    reply.refresh_from_db()
+    assert reply.state == str(PostStates.deleted)
+    stator.run_single_cycle()
+
+    parent.refresh_from_db()
+    assert parent.stats["replies"] == 0
+
+
+@pytest.mark.django_db
+def test_reply_count_recalculated_after_reply_hard_deleted(identity, config_system):
+    """Hard deletes (incoming AP Delete, prune, admin) bypass handle_deleted,
+    so the post_delete signal must also refresh the parent's replies_count."""
+    parent = Post.create_local(
+        author=identity,
+        content="Parent post",
+        visibility=Post.Visibilities.public,
+    )
+    reply = Post.create_local(
+        author=identity,
+        content="A reply",
+        visibility=Post.Visibilities.public,
+        reply_to=parent,
+    )
+    parent.refresh_from_db()
+    assert parent.stats["replies"] == 1
+
+    # Hard delete the row directly, firing the post_delete signal.
+    reply.delete()
+
+    parent.refresh_from_db()
+    assert parent.stats["replies"] == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

Fixes #1648.

A post's `stats["replies"]` (the Mastodon API `replies_count` and the AP `replies` Collection's `totalItems`) never decreases after one of its replies is deleted — it stays at the pre-deletion value indefinitely, even though `GET /api/v1/statuses/{id}/context` immediately stops listing the deleted reply.

Root cause: `Post.create_local()` calls `reply_to.calculate_stats()` when a reply is created (the only place that updates the parent's `stats["replies"]`), but no deletion path recalculates the parent.

## Fix

Recalculate the parent's stats on **both** deletion paths, via a shared `Post.recalculate_parent_stats()` helper (a no-op for non-replies):

- **`PostStates.handle_deleted`** — soft deletes (local API/UI `PostService.delete()`), so the count updates promptly rather than waiting for the eventual hard delete.
- **the `post_delete` signal** — hard deletes that bypass `handle_deleted` entirely: incoming ActivityPub `Delete` (`handle_delete_ap` → `post.delete()`), remote prune, and admin deletion. This mirrors the `instance.author.calculate_stats()` already done there.

`calculate_stats()` counts only `not_hidden()` replies, so the deleted child is correctly excluded.

## Tests

Added two regression tests in `tests/activities/models/test_post_replies.py`:

- `test_reply_count_recalculated_after_reply_deleted` — soft delete via `PostService.delete()` + a stator cycle.
- `test_reply_count_recalculated_after_reply_hard_deleted` — hard delete via the `post_delete` signal.

Both were confirmed to fail without their respective fix (`assert 1 == 0`) and pass with it. The broader related suites (post, replies, services, API statuses, conversations) pass, and `pre-commit` (ruff / ruff format / ty) is clean.