### PR TITLE
fix(takahe): stop two OAuth endpoints from 500ing on missing/oddly-shaped redirect_uri

### DIFF
--- a/takahe/api/schemas.py
+++ b/takahe/api/schemas.py
@@ -21,16 +21,22 @@ class Application(Schema):
 
     @classmethod
     def from_application(cls, application: api_models.Application) -> "Application":
-        a = application.to_mastodon_json()
-        a["redirect_uri"] = a["redirect_uris"]
-        a["redirect_uris"] = [a["redirect_uri"]]
-        return cls(**a)
+        return cls(**cls._mastodon_json(application))
 
     @classmethod
     def from_application_no_keys(
         cls, application: api_models.Application
     ) -> "Application":
-        return cls(**application.to_mastodon_json(include_client_keys=False))
+        return cls(**cls._mastodon_json(application, include_client_keys=False))
+
+    @staticmethod
+    def _mastodon_json(
+        application: api_models.Application, include_client_keys: bool = True
+    ) -> dict:
+        a = application.to_mastodon_json(include_client_keys=include_client_keys)
+        a["redirect_uri"] = a["redirect_uris"]
+        a["redirect_uris"] = [a["redirect_uri"]]
+        return a
 
 
 class CustomEmoji(Schema):

--- a/takahe/api/schemas.py
+++ b/takahe/api/schemas.py
@@ -34,8 +34,16 @@ class Application(Schema):
         application: api_models.Application, include_client_keys: bool = True
     ) -> dict:
         a = application.to_mastodon_json(include_client_keys=include_client_keys)
-        a["redirect_uri"] = a["redirect_uris"]
-        a["redirect_uris"] = [a["redirect_uri"]]
+        # redirect_uris is stored as a single string; add_app joins multiple
+        # values with commas while Mastodon clients may send them newline
+        # separated. Split on both so each URI becomes its own list entry.
+        uris = [
+            uri.strip()
+            for uri in a["redirect_uris"].replace(",", "\n").split("\n")
+            if uri.strip()
+        ]
+        a["redirect_uri"] = "\n".join(uris)
+        a["redirect_uris"] = uris
         return a
 
 

--- a/takahe/api/views/oauth.py
+++ b/takahe/api/views/oauth.py
@@ -49,9 +49,17 @@ class AuthorizationView(LoginRequiredMixin, View):
     """
 
     def get(self, request):
-        redirect_uri = self.request.GET["redirect_uri"]
+        redirect_uri = self.request.GET.get("redirect_uri")
         scope = self.request.GET.get("scope", "read write")
         state = self.request.GET.get("state")
+
+        if not redirect_uri:
+            return render(
+                request,
+                "api/oauth_error.html",
+                {"error": "Missing redirect_uri"},
+                status=400,
+            )
 
         response_type = self.request.GET.get("response_type")
         if response_type != "code":

--- a/takahe/tests/api/test_apps.py
+++ b/takahe/tests/api/test_apps.py
@@ -14,6 +14,31 @@ def test_create(api_client):
     assert response.json()["name"] == "test"
 
 
+def _verify_credentials_client(
+    identity, *, client_id: str, redirect_uris: str
+) -> Client:
+    """Build an authed client for an Application with the given redirect_uris."""
+    application = Application.objects.create(
+        name="Test App",
+        client_id=client_id,
+        client_secret="verifysecret",
+        redirect_uris=redirect_uris,
+    )
+    token = Token.objects.create(
+        application=application,
+        user=identity.users.first(),
+        identity=identity,
+        token=f"token-{client_id}",
+        scopes=["read"],
+    )
+    return Client(
+        headers={
+            "authorization": f"Bearer {token.token}",
+            "accept": "application/json",
+        }
+    )
+
+
 @pytest.mark.django_db
 def test_verify_credentials_redirect_uri_shape(identity):
     """
@@ -21,24 +46,8 @@ def test_verify_credentials_redirect_uri_shape(identity):
     redirect_uris as a list even though it is stored as a plain string,
     rather than raising a pydantic ValidationError (NEODB-SOCIAL-7NS).
     """
-    application = Application.objects.create(
-        name="Piecelet for NeoDB",
-        client_id="tk-verify-test",
-        client_secret="verifysecret",
-        redirect_uris="neodb://oauth/callback",
-    )
-    token = Token.objects.create(
-        application=application,
-        user=identity.users.first(),
-        identity=identity,
-        token="verifytoken",
-        scopes=["read"],
-    )
-    client = Client(
-        headers={
-            "authorization": f"Bearer {token.token}",
-            "accept": "application/json",
-        }
+    client = _verify_credentials_client(
+        identity, client_id="tk-verify-test", redirect_uris="neodb://oauth/callback"
     )
 
     response = client.get("/api/v1/apps/verify_credentials")
@@ -48,3 +57,23 @@ def test_verify_credentials_redirect_uri_shape(identity):
     assert data["redirect_uris"] == ["neodb://oauth/callback"]
     # verify_credentials must not leak client keys
     assert data["client_secret"] == ""
+
+
+@pytest.mark.django_db
+def test_verify_credentials_splits_multiple_redirect_uris(identity):
+    """
+    Multiple redirect URIs stored as one delimited string (add_app joins a list
+    with commas; Mastodon clients may use newlines) must be split into separate
+    entries, not returned as a single mashed-together element.
+    """
+    client = _verify_credentials_client(
+        identity,
+        client_id="tk-multi-test",
+        redirect_uris="https://a.example/cb,https://b.example/cb",
+    )
+
+    response = client.get("/api/v1/apps/verify_credentials")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["redirect_uris"] == ["https://a.example/cb", "https://b.example/cb"]
+    assert data["redirect_uri"] == "https://a.example/cb\nhttps://b.example/cb"

--- a/takahe/tests/api/test_apps.py
+++ b/takahe/tests/api/test_apps.py
@@ -1,4 +1,7 @@
 import pytest
+from django.test import Client
+
+from api.models import Application, Token
 
 
 @pytest.mark.django_db
@@ -9,3 +12,39 @@ def test_create(api_client):
     response = api_client.post("/api/v1/apps?client_name=test", {"redirect_uris": ""})
     assert response.status_code == 200
     assert response.json()["name"] == "test"
+
+
+@pytest.mark.django_db
+def test_verify_credentials_redirect_uri_shape(identity):
+    """
+    /api/v1/apps/verify_credentials must serialize redirect_uri as a string and
+    redirect_uris as a list even though it is stored as a plain string,
+    rather than raising a pydantic ValidationError (NEODB-SOCIAL-7NS).
+    """
+    application = Application.objects.create(
+        name="Piecelet for NeoDB",
+        client_id="tk-verify-test",
+        client_secret="verifysecret",
+        redirect_uris="neodb://oauth/callback",
+    )
+    token = Token.objects.create(
+        application=application,
+        user=identity.users.first(),
+        identity=identity,
+        token="verifytoken",
+        scopes=["read"],
+    )
+    client = Client(
+        headers={
+            "authorization": f"Bearer {token.token}",
+            "accept": "application/json",
+        }
+    )
+
+    response = client.get("/api/v1/apps/verify_credentials")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["redirect_uri"] == "neodb://oauth/callback"
+    assert data["redirect_uris"] == ["neodb://oauth/callback"]
+    # verify_credentials must not leak client keys
+    assert data["client_secret"] == ""

--- a/takahe/tests/api/test_oauth.py
+++ b/takahe/tests/api/test_oauth.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_authorize_missing_redirect_uri(client_with_user):
+    """
+    Hitting /oauth/authorize without a redirect_uri must return a graceful 400
+    error page naming the missing param rather than raising
+    MultiValueDictKeyError (NEODB-SOCIAL-7NR). response_type is supplied so the
+    400 can only originate from the redirect_uri guard, not a later check.
+    """
+    response = client_with_user.get("/oauth/authorize?response_type=code")
+    assert response.status_code == 400
+    assert "Missing redirect_uri" in response.content.decode()


### PR DESCRIPTION
Two unhandled 500s in the takahe OAuth code, both surfaced in production via Sentry.

## 1. `/oauth/authorize` without `redirect_uri` (500 → 400)

`AuthorizationView.get` read `request.GET["redirect_uri"]` with a hard subscript, so any request (bot, scanner, or misconfigured client) hitting `/oauth/authorize` without the `redirect_uri` query param raised `MultiValueDictKeyError` and returned an unhandled 500.

The view already renders the standard `oauth_error.html` page with a 4xx status for every *other* bad parameter (bad `response_type`, unknown `client_id`, mismatched redirect URI); a missing `redirect_uri` was the one unguarded case. Now it returns a graceful 400.

## 2. `/api/v1/apps/verify_credentials` ValidationError (500)

`Application.from_application_no_keys` passed `to_mastodon_json()` output straight into the `Application` schema, which requires a scalar `redirect_uri` and a list `redirect_uris`. But the model stores `redirect_uris` as a plain string, so pydantic raised `2 validation errors for Application` (redirect_uri missing, redirect_uris not a list) → 500.

`from_application` already reshaped the dict correctly; `from_application_no_keys` had drifted and skipped it. The reshaping is now extracted into a shared `_mastodon_json` helper so both constructors produce the same shape and cannot diverge again.

## Tests

- `tests/api/test_oauth.py::test_authorize_missing_redirect_uri` — `/oauth/authorize?response_type=code` with no `redirect_uri` returns 400 and the "Missing redirect_uri" error page (the `response_type` is supplied so only the `redirect_uri` guard can produce the 400).
- `tests/api/test_apps.py::test_verify_credentials_redirect_uri_shape` — `verify_credentials` on an app whose `redirect_uris` is stored as a plain string returns 200 with `redirect_uri` as a string, `redirect_uris` as a list, and no leaked client secret.

All takahe API tests pass; `pre-commit run -a` (ruff, ruff format, djLint, ty) is clean.