### PR TITLE
perf(catalog,journal): fix Sentry-flagged search/discover/collection N+1s

### DIFF
--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -188,6 +188,10 @@ class DiscoverGenerator(BaseJob):
             e.rating_count
             e.rating_distribution
         prefetch_related_objects(episodes, Item.external_resources_prefetch())
+        # Episode cards render ``item.program.host_names``; batch the per-program
+        # credits join to avoid one catalog_itemcredit query per episode
+        # (Sentry: NEODB-SOCIAL-7NC).
+        Item.prefetch_credits([e.program for e in episodes])
         return episodes
 
     def run(self):

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -754,9 +754,11 @@ class Item(PolymorphicModel):
     def get_by_ids(cls, ids: list[int]):
         select = {f"id_{i}": f"id={i}" for i in ids}
         order = [f"-id_{i}" for i in ids]
+        # Result cards only read url/site_name/site_label, so skip the large
+        # metadata/other_lookup_ids JSON columns (Sentry: EGGPLANT-1DX).
         items = (
             cls.objects.filter(pk__in=ids, is_deleted=False)
-            .prefetch_related("external_resources")
+            .prefetch_related(cls.external_resources_prefetch())
             .extra(select=select, order_by=order)
         )
         return items

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -752,6 +752,8 @@ class Item(PolymorphicModel):
 
     @classmethod
     def get_by_ids(cls, ids: list[int]):
+        if not ids:
+            return cls.objects.none()
         select = {f"id_{i}": f"id={i}" for i in ids}
         order = [f"-id_{i}" for i in ids]
         # Result cards only read url/site_name/site_label, so skip the large

--- a/neodb/catalog/search/utils.py
+++ b/neodb/catalog/search/utils.py
@@ -18,7 +18,7 @@ from common.sentry import url_domain
 from takahe.search import search_by_ap_url
 from users.models import User
 
-from ..models import Edition, TVSeason
+from ..models import Edition, Item, TVSeason
 from .index import CatalogIndex, CatalogQueryParser
 
 
@@ -53,7 +53,10 @@ def query_index(
     items = []
     urls = []
     search_items = r.items
-    prefetch_related_objects(search_items, "external_resources")
+    # Result cards only read url/site_name/site_label, so skip the large
+    # metadata/other_lookup_ids JSON columns that made this a slow query
+    # (Sentry: EGGPLANT-1DX).
+    prefetch_related_objects(search_items, Item.external_resources_prefetch())
     editions = [item for item in search_items if isinstance(item, Edition)]
     if editions:
         prefetch_related_objects(editions, "works")

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -238,7 +238,8 @@ class JournalSearchResult(SearchResult):
                 [],
             )
         )
-        items = Item.get_by_ids(ids).prefetch_related("external_resources")
+        # get_by_ids already prefetches external_resources (slim; EGGPLANT-1DX).
+        items = Item.get_by_ids(ids)
         return Item.get_final_items(items)
 
     @cached_property

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -431,6 +431,11 @@ def collection_edit_items(request: AuthedHttpRequest, collection_uuid):
                 Item.external_resources_prefetch()
             )
         )
+        # Batch credits + rating to avoid a per-item catalog_itemcredit join and
+        # journal_rating GROUP BY (Sentry: EGGPLANT-1EM).
+        Item.prefetch_parent_items(items)
+        Item.prefetch_credits(items)
+        Rating.attach_to_items(items)
         items_map = {i.pk: i for i in items}
         for member in members:
             member.item = items_map.get(member.item_id)

--- a/neodb/tests/catalog/test_creator_verify.py
+++ b/neodb/tests/catalog/test_creator_verify.py
@@ -3,7 +3,9 @@ from types import SimpleNamespace
 
 import pytest
 from django.core.cache import cache
+from django.db import connection
 from django.test import Client
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from catalog.jobs.creator_verify import _has_audio_episode, verify_creator_task
@@ -11,6 +13,7 @@ from catalog.jobs.discover import DiscoverGenerator
 from catalog.models import (
     Edition,
     IdType,
+    ItemCredit,
     Podcast,
     PodcastEpisode,
     VerifiedCreator,
@@ -764,6 +767,31 @@ class TestOriginalEpisodes:
         assert {e.program_id for e in episodes} == {verified_pod.pk}
         dates = [e.pub_date for e in episodes]
         assert dates == sorted(dates, reverse=True)
+
+    def test_program_host_credits_prefetched_no_n_plus_one(self):
+        """NEODB-SOCIAL-7NC: discover episode cards read
+        ``item.program.host_names`` (host credits), so ``get_original_episodes``
+        must prefetch each program's credits; reading them across N episodes
+        must not fire one ``catalog_itemcredit`` query per episode.
+        """
+        alice = User.register(email="a@example.com", username="alice")
+        podcast = _podcast()
+        _verified(podcast, alice.identity)
+        ItemCredit.objects.create(item=podcast, role="host", name="Alice Host")
+        self._episodes(podcast, n=3)
+        episodes = DiscoverGenerator().get_original_episodes()
+        assert len(episodes) == 3
+        with CaptureQueriesContext(connection) as ctx:
+            names = [e.program.host_names for e in episodes]
+        assert names == [["Alice Host"]] * 3
+        offending = [
+            q for q in ctx.captured_queries if "catalog_itemcredit" in q["sql"]
+        ]
+        assert offending == [], (
+            f"reading program.host_names fired {len(offending)} catalog_itemcredit "
+            f"query(ies); program credits should be prefetched. First: "
+            f"{offending[0]['sql'] if offending else 'n/a'}"
+        )
 
     def test_no_duplicate_episodes_with_multiple_verified_creators(self):
         # a show with several verified creators must surface each episode once,

--- a/neodb/tests/catalog/test_search_n_plus_one.py
+++ b/neodb/tests/catalog/test_search_n_plus_one.py
@@ -7,7 +7,7 @@ import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
-from catalog.models import Edition, TVSeason, TVShow
+from catalog.models import Edition, ExternalResource, IdType, TVSeason, TVShow
 from catalog.search.index import CatalogIndex, CatalogSearchResult
 from catalog.search.utils import query_index
 
@@ -174,3 +174,53 @@ class TestSearchReusesIndexedTags:
         assert tags == []
         offending = [q for q in ctx.captured_queries if "journal_tagmember" in q["sql"]]
         assert offending == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSearchExternalResourcesSlim:
+    """EGGPLANT-1DX: search loaded the full ``catalog_externalresource`` row
+    (including the large ``metadata``/``other_lookup_ids`` JSON) for every
+    result. Cards only read url/site_name/site_label, so the prefetch must skip
+    those heavy columns.
+    """
+
+    def _run(self, items_in_index):
+        response = {
+            "hits": [{"document": {"id": str(it.pk)}} for it in items_in_index],
+            "found": len(items_in_index),
+            "page": 1,
+            "request_params": {"per_page": 20, "q": "book"},
+        }
+        with patch.object(CatalogIndex, "instance") as mock_instance:
+            mock_index = MagicMock(spec=CatalogIndex)
+            mock_instance.return_value = mock_index
+            result = CatalogSearchResult(mock_index, cast(Any, response))
+            mock_index.search.return_value = result
+            with CaptureQueriesContext(connection) as ctx:
+                query_index("book", page=1, prepare_external=False)
+        return ctx.captured_queries
+
+    def test_external_resources_prefetch_skips_heavy_json(self):
+        book = Edition.objects.create(title="ExtRes Book")
+        ExternalResource.objects.create(
+            item=book,
+            id_type=IdType.RSS,
+            id_value="extres-1",
+            url="https://example.com/extres-1",
+            metadata={"big": "x" * 1000},
+            other_lookup_ids={"isbn": "123"},
+        )
+        extres = [
+            q
+            for q in self._run([book])
+            if 'FROM "catalog_externalresource"' in q["sql"]
+        ]
+        assert extres, "expected an external_resources prefetch query"
+        for q in extres:
+            assert '"metadata"' not in q["sql"], (
+                f"search external_resources prefetch still selects metadata: {q['sql']}"
+            )
+            assert '"other_lookup_ids"' not in q["sql"], (
+                "search external_resources prefetch still selects "
+                f"other_lookup_ids: {q['sql']}"
+            )

--- a/neodb/tests/catalog/test_search_n_plus_one.py
+++ b/neodb/tests/catalog/test_search_n_plus_one.py
@@ -7,7 +7,7 @@ import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
-from catalog.models import Edition, ExternalResource, IdType, TVSeason, TVShow
+from catalog.models import Edition, ExternalResource, IdType, Item, TVSeason, TVShow
 from catalog.search.index import CatalogIndex, CatalogSearchResult
 from catalog.search.utils import query_index
 
@@ -199,6 +199,13 @@ class TestSearchExternalResourcesSlim:
             with CaptureQueriesContext(connection) as ctx:
                 query_index("book", page=1, prepare_external=False)
         return ctx.captured_queries
+
+    def test_get_by_ids_empty_fires_no_query(self):
+        # get_by_ids short-circuits on an empty id list instead of building an
+        # empty .extra() query.
+        with CaptureQueriesContext(connection) as ctx:
+            assert list(Item.get_by_ids([])) == []
+        assert ctx.captured_queries == []
 
     def test_external_resources_prefetch_skips_heavy_json(self):
         book = Edition.objects.create(title="ExtRes Book")

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -235,3 +235,42 @@ class TestCollectionListOperations:
     def test_collection_member_note_html_empty(self):
         member, _ = self.collection.append_item(self.book1)
         assert member.note_html == ""
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionEditItemsNPlusOne:
+    """EGGPLANT-1EM: /collection/<uuid>/edit_items rendered per-item credits
+    and rating distribution, firing a catalog_itemcredit join for every member.
+    Credits must be batch-prefetched instead.
+    """
+
+    def test_no_per_member_credit_query(self):
+        from django.db import connection
+        from django.test import Client
+        from django.test.utils import CaptureQueriesContext
+        from django.urls import reverse
+
+        from catalog.models import ItemCredit
+
+        user = User.register(email="curator@test.com", username="curator")
+        collection = Collection(owner=user.identity, title="C", brief="b")
+        collection.save()
+        movies = [Movie.objects.create(title=f"Edit Movie {i}") for i in range(4)]
+        for m in movies:
+            ItemCredit.objects.create(item=m, role="director", name="A Director")
+            collection.append_item(m)
+
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        url = reverse("journal:collection_edit_items", args=[collection.uuid])
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(url)
+        assert response.status_code == 200
+        credit_queries = [
+            q for q in ctx.captured_queries if "catalog_itemcredit" in q["sql"]
+        ]
+        # Credits are batch-prefetched once for all members, not per member.
+        assert len(credit_queries) <= 1, (
+            f"edit_items fired {len(credit_queries)} catalog_itemcredit queries "
+            f"for {len(movies)} members; expected <=1 (batched)."
+        )


### PR DESCRIPTION
Fixes three Sentry-flagged DB performance issues that still reproduce on current `main`.

## Fixes

### NEODB-SOCIAL-7NC — N+1 on `/discover/`
The "fediverse originals" episode cards render `item.program.host_names`, which reads the program's credits. `DiscoverGenerator.get_original_episodes()` prefetched `external_resources` but not the programs' credits, so each episode fired a `catalog_itemcredit` join during template render. Now batches the per-program credits prefetch (the cached episodes carry it, same pattern as the trending gallery items).

### EGGPLANT-1EM — N+1 on `/collection/{uuid}/edit_items`
The view only prefetched `external_resources`; member cards render per-item credits and rating distribution, firing a `catalog_itemcredit` join and a `journal_rating` GROUP BY per member. Now also calls `prefetch_parent_items` + `prefetch_credits` + `Rating.attach_to_items`, mirroring `render_list`.

### EGGPLANT-1DX — slow query on `/search`
Search loaded the full `catalog_externalresource` row (incl. the large `metadata` / `other_lookup_ids` JSON) for every result. The source is `Item.get_by_ids` (used by catalog and journal search hydration), not the view-level prefetch. Routed it through the existing slim `Item.external_resources_prefetch()` and dropped the now-redundant full re-prefetch in journal search. Result cards only read `url`/`site_name`/`site_label`.

## Tests
Added N+1 regression tests (matching the existing `test_search_n_plus_one.py` convention):
- discover: reading `program.host_names` across episodes fires no per-episode `catalog_itemcredit` query
- search: the `external_resources` prefetch no longer selects `metadata`/`other_lookup_ids`
- collection edit_items: at most one batched `catalog_itemcredit` query regardless of member count

All affected + adjacent suites pass (`pre-commit` clean: ruff, ruff-format, ty).
