### PR TITLE
perf(catalog,journal): prefetch external_resources on reco and collection item APIs

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -507,6 +507,11 @@ def _prepare_reco_items(request, items: list) -> None:
     prefetch_related_objects(
         items,
         Item.credits_prefetch(),
+        # Reco items come from similar_items()/blended_for_discover(), which
+        # (unlike query_index) don't pre-hydrate external_resources; without
+        # this ItemSchema.external_resources fires one query per item
+        # (EGGPLANT-1FN /similar, EGGPLANT-1FP /me/recommendations).
+        Item.external_resources_prefetch(),
     )
     Rating.attach_to_items(items)
     if request.user.is_authenticated:

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from django.core.cache import cache
 from django.core.signing import b62_encode
-from django.db.models import Count, QuerySet
+from django.db.models import Count, QuerySet, prefetch_related_objects
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
@@ -23,7 +23,7 @@ from common.api import (
 from common.sentry import record_activity
 from journal.models.common import q_piece_visible_to_user
 
-from ..models import Collection, FeaturedCollection, ShelfMember, ShelfType
+from ..models import Collection, FeaturedCollection, Rating, ShelfMember, ShelfType
 
 
 class CollectionPageNumberPagination(PageNumberPagination):
@@ -77,6 +77,63 @@ class CollectionInSchema(Schema):
 class CollectionItemSchema(Schema):
     item: ItemSchema
     note: str
+
+
+def _prefetch_collection_member_items(data: list) -> None:
+    """Batch-hydrate items for ``CollectionItemSchema`` (``item: ItemSchema``).
+
+    Without this, each member serializes its item's ``external_resources`` and
+    ``credits`` one row at a time. Dynamic collections carry the item in a
+    dict; static members reference it through a polymorphic FK that can't be
+    ``select_related`` (django-polymorphic), so resolve those in a single query
+    and assign back, mirroring ``Collection.get_members_by_page``.
+    """
+    if not data:
+        return
+    members = [m for m in data if not isinstance(m, dict)]
+    item_ids = [m.item_id for m in members if m.item_id]
+    if item_ids:
+        items_map = {it.pk: it for it in Item.objects.filter(pk__in=item_ids)}
+        for m in members:
+            # Assign only when resolved. The FK is PROTECTed so a miss is not
+            # expected; dereferencing m.item for a missing id would defeat the
+            # batch with a lazy load (and assigning None would break the schema).
+            resolved = items_map.get(m.item_id)
+            if resolved is not None:
+                m.item = resolved
+    items = [(m["item"] if isinstance(m, dict) else m.item) for m in data]
+    items = [i for i in items if i is not None]
+    if not items:
+        return
+    # external_resources skips the metadata JSON (EGGPLANT-1DX).
+    prefetch_related_objects(
+        items,
+        Item.external_resources_prefetch(),
+        Item.credits_prefetch(),
+    )
+    Item.prefetch_parent_items(items)
+    Item.prefetch_edition_works(items)
+    Rating.attach_to_items(items)
+
+
+class CollectionItemPageNumberPagination(PageNumberPagination):
+    """Hydrate the page's items so ``CollectionItemSchema`` serialization does
+    not fire per-item ``external_resources``/``credits`` queries (N+1)."""
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        if isinstance(val, tuple):
+            return val
+        data = val.get("data") if isinstance(val, dict) else None
+        if data:
+            _prefetch_collection_member_items(list(data))
+        return val
 
 
 class CollectionItemInSchema(Schema):
@@ -151,7 +208,7 @@ def get_collection(request, collection_uuid: str):
     tags=["collection"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
-@paginate(PageNumberPagination)
+@paginate(CollectionItemPageNumberPagination)
 def collection_list_items(request, collection_uuid: str):
     """
     Get items in a collection collections
@@ -245,7 +302,7 @@ def delete_collection(request, collection_uuid: str):
     response={200: List[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
 )
-@paginate(PageNumberPagination)
+@paginate(CollectionItemPageNumberPagination)
 def user_collection_list_items(request, collection_uuid: str):
     """
     Get items in a collection collections

--- a/neodb/tests/catalog/test_recommendation.py
+++ b/neodb/tests/catalog/test_recommendation.py
@@ -1,8 +1,17 @@
-import pytest
+from types import SimpleNamespace
 
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from catalog.apis import _prepare_reco_items
 from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommendations
 from catalog.models import (
     Edition,
+    ExternalResource,
+    IdType,
+    Item,
     ItemSimilarity,
     Performance,
     PerformanceProduction,
@@ -471,3 +480,51 @@ class TestSiblingEditionExclusion:
         _public_mark(watcher.identity, self.e1)
         ids = {i.pk for i in similar_items(self.src, viewer=watcher, limit=10)}
         assert self.e2.pk in ids
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRecoItemsExternalResourcesNoNPlusOne:
+    """EGGPLANT-1FN (/similar) and EGGPLANT-1FP (/me/recommendations).
+
+    Reco items come from similar_items()/blended_for_discover(), which -- unlike
+    the search path's query_index -- do not pre-hydrate external_resources, so
+    ItemSchema serialization fired one ``catalog_externalresource WHERE
+    item_id = %s`` query per item. ``_prepare_reco_items`` must batch-prefetch
+    them.
+    """
+
+    def _items_with_external_resources(self, n: int = 3) -> list:
+        created = []
+        for i in range(n):
+            book = Edition.objects.create(title=f"Reco {i}")
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.RSS,
+                id_value=f"reco-{i}",
+                url=f"https://example.com/reco-{i}",
+            )
+            created.append(book)
+        # Fresh polymorphic instances with an empty prefetch cache, mirroring
+        # what similar_items()/blended_for_discover() hand back.
+        return list(Item.objects.filter(pk__in=[b.pk for b in created]))
+
+    def test_external_resources_prefetched(self):
+        items = self._items_with_external_resources()
+        request = SimpleNamespace(user=AnonymousUser())
+        _prepare_reco_items(request, items)
+        # Reading external_resources (as ItemSchema does) must now be served
+        # from the prefetch cache without per-item queries.
+        with CaptureQueriesContext(connection) as ctx:
+            for it in items:
+                for res in it.external_resources.all():
+                    _ = res.url
+        offending = [
+            q
+            for q in ctx.captured_queries
+            if 'FROM "catalog_externalresource"' in q["sql"]
+        ]
+        assert offending == [], (
+            f"reading reco items' external_resources fired {len(offending)} "
+            "query(ies); expected 0 (prefetched). First offending SQL: "
+            f"{offending[0]['sql'] if offending else 'n/a'}"
+        )

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -1,6 +1,9 @@
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
-from catalog.models import Edition, Movie
+from catalog.models import Edition, ExternalResource, IdType, ItemCredit, Movie
+from journal.apis.collection import _prefetch_collection_member_items
 from journal.models.collection import Collection
 from users.models import User
 
@@ -273,4 +276,62 @@ class TestCollectionEditItemsNPlusOne:
         assert len(credit_queries) <= 1, (
             f"edit_items fired {len(credit_queries)} catalog_itemcredit queries "
             f"for {len(movies)} members; expected <=1 (batched)."
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionItemsApiPrefetch:
+    """The ``/collection/{uuid}/item/`` and ``/me/collection/{uuid}/item/``
+    APIs serialize each member's item via ``ItemSchema``; without batch
+    prefetch each item fired a per-row ``catalog_externalresource`` query.
+    ``CollectionItemPageNumberPagination`` hydrates the page post-slice
+    (mirrors the shelf API).
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="colpf@test.com", username="colpf")
+        self.collection = Collection(
+            owner=self.user.identity, title="Pf Collection", brief=""
+        )
+        self.collection.save()
+        for i in range(3):
+            book = Edition.objects.create(title=f"Pf Book {i}")
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.RSS,
+                id_value=f"colpf-{i}",
+                url=f"https://example.com/colpf-{i}",
+            )
+            ItemCredit.objects.create(item=book, role="author", name=f"Author {i}")
+            self.collection.append_item(book)
+
+    def test_member_items_external_resources_and_credits_prefetched(self):
+        # Fresh member instances, as the paginator receives them post-slice.
+        members = list(self.collection.ordered_members)
+        _prefetch_collection_member_items(members)
+        # Reading external_resources and credits (as ItemSchema does) must now
+        # be served from the prefetch cache without per-item queries.
+        with CaptureQueriesContext(connection) as ctx:
+            for m in members:
+                for res in m.item.external_resources.all():
+                    _ = res.url
+                list(m.item.credits.all())
+        extres = [
+            q
+            for q in ctx.captured_queries
+            if 'FROM "catalog_externalresource"' in q["sql"]
+        ]
+        credits = [
+            q for q in ctx.captured_queries if 'FROM "catalog_itemcredit"' in q["sql"]
+        ]
+        assert extres == [], (
+            f"reading collection member items' external_resources fired "
+            f"{len(extres)} query(ies); expected 0 (prefetched). First: "
+            f"{extres[0]['sql'] if extres else 'n/a'}"
+        )
+        assert credits == [], (
+            f"reading collection member items' credits fired {len(credits)} "
+            f"query(ies); expected 0 (prefetched). First: "
+            f"{credits[0]['sql'] if credits else 'n/a'}"
         )


### PR DESCRIPTION
## Summary

Fixes two N+1 query patterns flagged by Sentry where item-list endpoints serialize `ItemSchema` without pre-hydrating the `external_resources` relation.

### 1. Recommendation APIs — `EGGPLANT-1FN`, `EGGPLANT-1FP`
`_prepare_reco_items` (powering `/catalog/item/{uuid}/similar` and `/me/recommendations`) prefetched `credits` but **not** `external_resources`. Unlike the search path, these items come from `similar_items()` / `blended_for_discover()` rather than `query_index`, so they aren't pre-hydrated — `ItemSchema.external_resources` then fired one `catalog_externalresource WHERE item_id = %s` query per item. Added `Item.external_resources_prefetch()` to the batch.

### 2. Collection item APIs (latent)
`/collection/{uuid}/item/` and `/me/collection/{uuid}/item/` returned `ordered_members` (static) or `[{"item": ...}]` (dynamic) and serialized each member's `ItemSchema` with no batch prefetch. Added `CollectionItemPageNumberPagination`, which hydrates the current page **post-slice** (external_resources + credits + parent items + edition works + ratings), mirroring the existing `ShelfPageNumberPagination`. Handles both the static `CollectionMember` and dynamic dict shapes; static members' polymorphic items are resolved in one query (django-polymorphic can't `select_related` them) and assigned back, mirroring `Collection.get_members_by_page`.

## Tests
- `tests/catalog/test_recommendation.py::TestRecoItemsExternalResourcesNoNPlusOne` — asserts reco items' `external_resources` reads hit 0 queries after `_prepare_reco_items`.
- `tests/journal/test_collection.py::TestCollectionItemsApiPrefetch` — asserts collection member items' `external_resources` and `credits` reads hit 0 queries after the paginator hydration.
- Full affected + N+1 regression suites pass (147 tests); `pre-commit run -a` clean.

These reuse the existing `Item.external_resources_prefetch()` / `Item.credits_prefetch()` helpers (`.only(...)` to skip the heavy `metadata` JSON, per `EGGPLANT-1DX`/`-1EF`).