### PR TITLE
fix(takahe): clamp PreviewCard fields to column limits on fetch

### DIFF
--- a/takahe/activities/models/preview_card.py
+++ b/takahe/activities/models/preview_card.py
@@ -159,11 +159,14 @@ class PreviewCardStates(StateGraph):
         instance.description = (
             meta.get("og:description") or meta.get("description") or ""
         )
-        # og:image comes from arbitrary remote HTML and can exceed the 2048-char
-        # column width; a truncated URL is useless, so drop it rather than store
-        # a broken value (avoids DataError on save).
+        # og:* values come from arbitrary remote HTML and can exceed the column
+        # widths they're stored in. A truncated URL is useless, so drop an
+        # oversized image_url (and its now-meaningless dimensions) rather than
+        # store a broken value; clamp the text fields to fit. max_length is read
+        # from the model so these stay in sync with the column definitions.
         instance.image_url = meta.get("og:image") or ""
-        if len(instance.image_url) > 2048:
+        image_url_max = instance._meta.get_field("image_url").max_length
+        if image_url_max and len(instance.image_url) > image_url_max:
             instance.image_url = ""
         try:
             instance.image_width = int(meta["og:image:width"])
@@ -173,9 +176,13 @@ class PreviewCardStates(StateGraph):
             instance.image_height = int(meta["og:image:height"])
         except KeyError, ValueError, TypeError:
             instance.image_height = None
-        # Clamp remote-sourced text fields to their column widths.
-        instance.author_name = (meta.get("og:article:author") or "")[:500]
-        instance.provider_name = (parsed.hostname or "")[:500]
+        if not instance.image_url:
+            instance.image_width = None
+            instance.image_height = None
+        author_name_max = instance._meta.get_field("author_name").max_length
+        instance.author_name = (meta.get("og:article:author") or "")[:author_name_max]
+        provider_name_max = instance._meta.get_field("provider_name").max_length
+        instance.provider_name = (parsed.hostname or "")[:provider_name_max]
         instance.provider_url = f"{parsed.scheme}://{parsed.netloc}"
         instance.fetched_at = timezone.now()
         instance.save(

--- a/takahe/activities/models/preview_card.py
+++ b/takahe/activities/models/preview_card.py
@@ -159,7 +159,12 @@ class PreviewCardStates(StateGraph):
         instance.description = (
             meta.get("og:description") or meta.get("description") or ""
         )
+        # og:image comes from arbitrary remote HTML and can exceed the 2048-char
+        # column width; a truncated URL is useless, so drop it rather than store
+        # a broken value (avoids DataError on save).
         instance.image_url = meta.get("og:image") or ""
+        if len(instance.image_url) > 2048:
+            instance.image_url = ""
         try:
             instance.image_width = int(meta["og:image:width"])
         except KeyError, ValueError, TypeError:
@@ -168,8 +173,9 @@ class PreviewCardStates(StateGraph):
             instance.image_height = int(meta["og:image:height"])
         except KeyError, ValueError, TypeError:
             instance.image_height = None
-        instance.author_name = meta.get("og:article:author") or ""
-        instance.provider_name = parsed.hostname or ""
+        # Clamp remote-sourced text fields to their column widths.
+        instance.author_name = (meta.get("og:article:author") or "")[:500]
+        instance.provider_name = (parsed.hostname or "")[:500]
         instance.provider_url = f"{parsed.scheme}://{parsed.netloc}"
         instance.fetched_at = timezone.now()
         instance.save(

--- a/takahe/tests/activities/models/test_preview_card.py
+++ b/takahe/tests/activities/models/test_preview_card.py
@@ -283,11 +283,13 @@ def test_handle_needs_fetch_ssrf_blocked(httpx_mock, config_system):
     assert_all_requests_were_expected=False, can_send_already_matched_responses=True
 )
 def test_handle_needs_fetch_drops_oversized_image_url(httpx_mock, config_system):
-    """An og:image longer than the column limit is dropped, not stored truncated."""
+    """An oversized og:image is dropped along with its now-meaningless dimensions."""
     long_image = "https://example.com/" + ("a" * 3000) + ".jpg"
     html = (
         "<html><head><title>T</title>"
         f'<meta property="og:image" content="{long_image}" />'
+        '<meta property="og:image:width" content="1200" />'
+        '<meta property="og:image:height" content="630" />'
         "</head></html>"
     )
     httpx_mock.add_response(
@@ -303,6 +305,9 @@ def test_handle_needs_fetch_drops_oversized_image_url(httpx_mock, config_system)
     card.refresh_from_db()
     assert result == PreviewCardStates.fetched
     assert card.image_url == ""
+    # Dimensions must not linger without an image (avoids inconsistent API output).
+    assert card.image_width is None
+    assert card.image_height is None
 
 
 @pytest.mark.django_db

--- a/takahe/tests/activities/models/test_preview_card.py
+++ b/takahe/tests/activities/models/test_preview_card.py
@@ -278,6 +278,60 @@ def test_handle_needs_fetch_ssrf_blocked(httpx_mock, config_system):
     assert result == PreviewCardStates.fetch_failed
 
 
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(
+    assert_all_requests_were_expected=False, can_send_already_matched_responses=True
+)
+def test_handle_needs_fetch_drops_oversized_image_url(httpx_mock, config_system):
+    """An og:image longer than the column limit is dropped, not stored truncated."""
+    long_image = "https://example.com/" + ("a" * 3000) + ".jpg"
+    html = (
+        "<html><head><title>T</title>"
+        f'<meta property="og:image" content="{long_image}" />'
+        "</head></html>"
+    )
+    httpx_mock.add_response(
+        url="https://example.com/big-image",
+        headers={"Content-Type": "text/html"},
+        text=html,
+    )
+    card = PreviewCard.objects.create(url="https://example.com/big-image")
+    with patch(
+        "socket.getaddrinfo", return_value=[(2, 1, 0, "", ("93.184.216.34", 443))]
+    ):
+        result = PreviewCardStates.handle_needs_fetch(card)
+    card.refresh_from_db()
+    assert result == PreviewCardStates.fetched
+    assert card.image_url == ""
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(
+    assert_all_requests_were_expected=False, can_send_already_matched_responses=True
+)
+def test_handle_needs_fetch_truncates_long_author(httpx_mock, config_system):
+    """An og:article:author longer than the column limit is truncated to fit."""
+    long_author = "X" * 600
+    html = (
+        "<html><head><title>T</title>"
+        f'<meta property="og:article:author" content="{long_author}" />'
+        "</head></html>"
+    )
+    httpx_mock.add_response(
+        url="https://example.com/long-author",
+        headers={"Content-Type": "text/html"},
+        text=html,
+    )
+    card = PreviewCard.objects.create(url="https://example.com/long-author")
+    with patch(
+        "socket.getaddrinfo", return_value=[(2, 1, 0, "", ("93.184.216.34", 443))]
+    ):
+        result = PreviewCardStates.handle_needs_fetch(card)
+    card.refresh_from_db()
+    assert result == PreviewCardStates.fetched
+    assert card.author_name == "X" * 500
+
+
 # ---------------------------------------------------------------------------
 # to_mastodon_json
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`PreviewCardStates.handle_needs_fetch` populates `PreviewCard` CharFields directly from arbitrary remote Open Graph metadata with no length clamping. A remote `og:image` URL longer than the 2048-char `image_url` column (e.g. a long signed CDN URL or a data URI) raises a Postgres `DataError: value too long for type character varying(2048)` and crashes the stator task on `save()`. `og:article:author` could overflow the 500-char `author_name` column the same way.

Reported via Sentry: **EGGPLANT-1FR** (`stator.task_transition:activities.previewcard ... from needs_fetch`).

## Fix

- `image_url`: drop the value (store `""`) when it exceeds 2048 chars — a truncated URL would be a broken link, so no image is the correct graceful degradation.
- `author_name` / `provider_name`: slice-truncate to their 500-char column widths, matching the existing inline-truncation idiom used elsewhere (e.g. `Emoji.by_ap_tag`).
- `title`/`description` are `TextField` (unbounded) and `provider_url` is `scheme://netloc` (bounded by the already-stored `url`), so both are left unchanged.

## Testing

- Added two regression tests covering an oversized `og:image` (dropped) and an oversized `og:article:author` (truncated), both asserting `save()` no longer raises.
- `tests/activities/models/test_preview_card.py`: 47 passed.
- `pre-commit` clean (ruff, ruff-format, ty).

Fixes EGGPLANT-1FR