### PR TITLE
perf(catalog): make podcast covering-index migration non-blocking

### DIFF
--- a/neodb/catalog/migrations/0025_podcastepisode_covering_index.py
+++ b/neodb/catalog/migrations/0025_podcastepisode_covering_index.py
@@ -1,24 +1,39 @@
+from django.contrib.postgres.operations import (
+    AddIndexConcurrently,
+    RemoveIndexConcurrently,
+)
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+    """Swap the PodcastEpisode (program, pub_date) index for a covering one.
+
+    item_ptr as an INCLUDE column lets child_item_ids read episode ids via
+    an index-only scan (EGGPLANT-1EA). The covering index is created before
+    the old one is dropped so (program, pub_date) is never left without an
+    index during the migration.
+
+    Both ops use CREATE/DROP INDEX CONCURRENTLY, which must run outside a
+    transaction (atomic = False) so the table is never blocked.
+    """
+
+    atomic = False
+
     dependencies = [
         ("catalog", "0024_verifiedcreator"),
     ]
 
     operations = [
-        # Add item_ptr as a covering column so child_item_ids reads episode ids
-        # via an index-only scan (EGGPLANT-1EA).
-        migrations.RemoveIndex(
-            model_name="podcastepisode",
-            name="catalog_pod_program_2e4327_idx",
-        ),
-        migrations.AddIndex(
+        AddIndexConcurrently(
             model_name="podcastepisode",
             index=models.Index(
                 fields=["program", "pub_date"],
                 include=("item_ptr",),
                 name="podcast_ep_prog_pubdate_cov",
             ),
+        ),
+        RemoveIndexConcurrently(
+            model_name="podcastepisode",
+            name="catalog_pod_program_2e4327_idx",
         ),
     ]


### PR DESCRIPTION
## What

Migration `0025_podcastepisode_covering_index` swaps the `PodcastEpisode (program, pub_date)` index for a covering one that includes `item_ptr` (so `child_item_ids` can use an index-only scan).

This changes the migration to perform the swap **without blocking the table**:

- Use `AddIndexConcurrently` / `RemoveIndexConcurrently` (`CREATE`/`DROP INDEX CONCURRENTLY`) with `atomic = False`.
- Create the new covering index **before** dropping the old one, so `(program, pub_date)` is never left without an index mid-migration.

## Why

The original migration used blocking `RemoveIndex` + `AddIndex`, which takes table locks during the index build and leaves the column pair unindexed in between. On a live `podcastepisode` table this stalls writes. The end-state schema is identical (same index name and definition), so this is purely an apply-time improvement.

Follows the existing concurrent-index pattern already used in `catalog/0002` and `journal/0009`.

## Verification

- `pre-commit run` passes (ruff, ruff format, ty).
- Imports resolve; migration compiles.
- End-state index is byte-identical to before, so `makemigrations` detects no drift.