### PR TITLE
perf(takahe): safe DB/query fixes (case-insensitive handle indexes, bulk fan-out, stator skip_locked)

### DIFF
--- a/neodb/users/migrations/0014_apidentity_local_username_ci_index.py
+++ b/neodb/users/migrations/0014_apidentity_local_username_ci_index.py
@@ -1,0 +1,22 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+from django.db.models.functions import Upper
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("users", "0013_preference_auto_note_on_reply"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="apidentity",
+            index=models.Index(
+                Upper("username"),
+                condition=models.Q(local=True, deleted__isnull=True),
+                name="ix_apidentity_local_uname_ci",
+            ),
+        ),
+    ]

--- a/neodb/users/models/apidentity.py
+++ b/neodb/users/models/apidentity.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Self
 
 from django.conf import settings
 from django.db import models
+from django.db.models.functions import Upper
 from django.utils import timezone
 from loguru import logger
 
@@ -40,6 +41,12 @@ class APIdentity(models.Model):
         indexes = [
             models.Index(fields=["local", "username"]),
             models.Index(fields=["domain_name", "username"]),
+            # Backs the case-insensitive local handle lookup in get_by_handle().
+            models.Index(
+                Upper("username"),
+                condition=models.Q(local=True, deleted__isnull=True),
+                name="ix_apidentity_local_uname_ci",
+            ),
         ]
 
     def __str__(self):

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -123,13 +123,15 @@ class PostStates(StateGraph):
 
     @classmethod
     def targets_fan_out(cls, post: "Post", type_: str) -> None:
-        # Fan out to each target
-        for follow in post.get_targets():
-            FanOut.objects.create(
-                identity=follow,
-                type=type_,
-                subject_post=post,
-            )
+        # Fan out to each target in bulk to avoid one INSERT round-trip per
+        # follower (state/created defaults are applied the same as create()).
+        FanOut.objects.bulk_create(
+            (
+                FanOut(identity=follow, type=type_, subject_post=post)
+                for follow in post.get_targets()
+            ),
+            batch_size=500,
+        )
         cls.fan_out_to_relay(post, type_)
 
     @classmethod

--- a/takahe/stator/models.py
+++ b/takahe/stator/models.py
@@ -130,7 +130,7 @@ class StatorModel(models.Model):
                     | models.Q(state_next_attempt__lte=timezone.now()),
                     state__in=cls.state_graph.automatic_states,
                     state_locked_until__isnull=True,
-                )[:number].select_for_update()
+                )[:number].select_for_update(skip_locked=True)
             )
             cls.objects.filter(pk__in=[i.pk for i in selected]).update(
                 state_locked_until=lock_expiry

--- a/takahe/users/migrations/0033_identity_local_username_ci_index.py
+++ b/takahe/users/migrations/0033_identity_local_username_ci_index.py
@@ -1,0 +1,23 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+from django.db.models.functions import Upper
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("users", "0032_add_account_note"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="identity",
+            index=models.Index(
+                Upper("username"),
+                models.F("domain"),
+                condition=models.Q(local=True),
+                name="ix_identity_local_uname_ci",
+            ),
+        ),
+    ]

--- a/takahe/users/models/identity.py
+++ b/takahe/users/models/identity.py
@@ -31,6 +31,7 @@ from core.uris import (
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models, transaction
+from django.db.models.functions import Upper
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -326,7 +327,17 @@ class Identity(StatorModel):
     class Meta:
         verbose_name_plural = "identities"
         unique_together = [("username", "domain")]
-        indexes: list = []  # We need this so Stator can add its own
+        # Non-empty so Stator can append its own state index (see
+        # stator.models.add_stator_indexes). Functional partial index backs the
+        # case-insensitive local handle lookup in by_username_and_domain().
+        indexes: list = [
+            models.Index(
+                Upper("username"),
+                models.F("domain"),
+                condition=models.Q(local=True),
+                name="ix_identity_local_uname_ci",
+            ),
+        ]
 
     class urls(urlman.Urls):
         view = "/@{self.username}@{self.domain_id}/"


### PR DESCRIPTION
Low-risk performance fixes found by reviewing takahe DB/query code against production Sentry span data. All three are additive or behavior-preserving; no query results change.

## Changes

### 1. Case-insensitive functional indexes for local handle lookups
`Identity.by_username_and_domain` and (in the neodb app) `APIdentity.get_by_handle` filter on `username__iexact`, producing `UPPER(username)=UPPER(%s)`. The only supporting indexes were case-sensitive, so local handle resolution degraded to scanning all local identities as the local user count grows.

Added partial functional indexes matching each query's exact predicate:
- takahe `users_identity`: `UPPER(username), domain_id WHERE local`
- neodb `users_apidentity`: `UPPER(username) WHERE deleted IS NULL AND local`

Both use `AddIndexConcurrently` (`atomic = False`) so the tables are never write-blocked, matching the repo's existing concurrent-index migrations.

### 2. Bulk fan-out creation
`Post.targets_fan_out` issued one `FanOut.objects.create()` per follower (one INSERT round-trip each). Switched to `bulk_create(batch_size=500)`. `FanOut` has no save-time signals and its `state`/`created(auto_now_add)` defaults are applied identically by `bulk_create`, so the rows produced are unchanged and the stator still discovers them by polling.

### 3. Stator `skip_locked=True`
`transition_get_with_lock` used `SELECT ... FOR UPDATE` without `SKIP LOCKED`, so concurrent stator workers could block on each other's in-flight rows. Added `skip_locked=True`; it pairs with the existing `state_locked_until` application-level lock. Behavior-preserving.

## Validation
- `pre-commit run -a` clean (ruff, ruff-format, djLint, `ty`).
- `makemigrations --check` clean for both `users` apps (no model/migration state drift).
- Applied both migrations against Postgres 16; verified the created indexes:
  - `ix_identity_local_uname_ci btree (upper(username::text), domain_id) WHERE local`
  - `ix_apidentity_local_uname_ci btree (upper(username::text)) WHERE deleted IS NULL AND local`
- takahe tests pass across post/fan-out (via the stator fixture), replies, follow, statuses, identity, and domain suites.

## Deploy note
`AddIndexConcurrently` builds `CONCURRENTLY`; if an index build is interrupted on a large table, Postgres leaves an INVALID index that must be dropped before re-running the migration (standard for concurrent index migrations).