### PR TITLE
fix(catalog): resolve people merge on works URLs instead of 404

### DIFF
--- a/neodb/catalog/urls.py
+++ b/neodb/catalog/urls.py
@@ -56,6 +56,13 @@ urlpatterns = [
         people_works,
         name="people_works",
     ),
+    re_path(
+        r"^(?P<item_path>"
+        + _get_all_url_paths()
+        + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/works/?$",
+        people_works_root,
+        name="people_works_root",
+    ),
     path("podcast/<str:item_uuid>/episodes", episode_data, name="episode_data"),
     path("catalog/search_people", search_people, name="search_people"),
     path("catalog/create/<str:item_model>", create, name="create"),

--- a/neodb/catalog/urls.py
+++ b/neodb/catalog/urls.py
@@ -56,13 +56,6 @@ urlpatterns = [
         people_works,
         name="people_works",
     ),
-    re_path(
-        r"^(?P<item_path>"
-        + _get_all_url_paths()
-        + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/works/?$",
-        people_works_root,
-        name="people_works_root",
-    ),
     path("podcast/<str:item_uuid>/episodes", episode_data, name="episode_data"),
     path("catalog/search_people", search_people, name="search_people"),
     path("catalog/create/<str:item_model>", create, name="create"),

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -176,17 +176,6 @@ def retrieve(request, item_path, item_uuid):
 
 
 @require_http_methods(["GET"])
-def people_works_root(request, item_path, item_uuid):
-    # A role-less works URL has no page of its own; resolve merges and send
-    # the visitor to the people page instead of a bare 404.
-    item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
-    final = item.final_item
-    if final.is_deleted:
-        raise Http404(_("Item no longer exists"))
-    return redirect(final.url)
-
-
-@require_http_methods(["GET"])
 def people_works(request, item_path, item_uuid, role):
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
     if role not in PeopleRole.values:

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -176,8 +176,20 @@ def retrieve(request, item_path, item_uuid):
 
 
 @require_http_methods(["GET"])
+def people_works_root(request, item_path, item_uuid):
+    # A role-less works URL has no page of its own; resolve merges and send
+    # the visitor to the people page instead of a bare 404.
+    item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
+    return redirect((item.merged_to_item or item).url)
+
+
+@require_http_methods(["GET"])
 def people_works(request, item_path, item_uuid, role):
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
+    if item.merged_to_item:
+        return redirect(f"{item.merged_to_item.url}/works/{role}")
+    if item.is_deleted:
+        raise Http404(_("Item no longer exists"))
     if role not in PeopleRole.values:
         raise Http404(_("Invalid role"))
     role_label = PeopleRole(role).label

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -189,13 +189,13 @@ def people_works_root(request, item_path, item_uuid):
 @require_http_methods(["GET"])
 def people_works(request, item_path, item_uuid, role):
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
+    if role not in PeopleRole.values:
+        raise Http404(_("Invalid role"))
     final = item.final_item
     if final.is_deleted:
         raise Http404(_("Item no longer exists"))
     if final is not item:
         return redirect(f"{final.url}/works/{role}")
-    if role not in PeopleRole.values:
-        raise Http404(_("Invalid role"))
     role_label = PeopleRole(role).label
 
     # All roles this person has, for the role filter dropdown

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -180,14 +180,18 @@ def people_works_root(request, item_path, item_uuid):
     # A role-less works URL has no page of its own; resolve merges and send
     # the visitor to the people page instead of a bare 404.
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
-    return redirect((item.merged_to_item or item).url)
+    if item.merged_to_item:
+        return redirect(item.final_item.url)
+    if item.is_deleted:
+        raise Http404(_("Item no longer exists"))
+    return redirect(item.url)
 
 
 @require_http_methods(["GET"])
 def people_works(request, item_path, item_uuid, role):
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
     if item.merged_to_item:
-        return redirect(f"{item.merged_to_item.url}/works/{role}")
+        return redirect(f"{item.final_item.url}/works/{role}")
     if item.is_deleted:
         raise Http404(_("Item no longer exists"))
     if role not in PeopleRole.values:

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -180,20 +180,20 @@ def people_works_root(request, item_path, item_uuid):
     # A role-less works URL has no page of its own; resolve merges and send
     # the visitor to the people page instead of a bare 404.
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
-    if item.merged_to_item:
-        return redirect(item.final_item.url)
-    if item.is_deleted:
+    final = item.final_item
+    if final.is_deleted:
         raise Http404(_("Item no longer exists"))
-    return redirect(item.url)
+    return redirect(final.url)
 
 
 @require_http_methods(["GET"])
 def people_works(request, item_path, item_uuid, role):
     item = get_object_or_404(People, uid=get_uuid_or_404(item_uuid))
-    if item.merged_to_item:
-        return redirect(f"{item.final_item.url}/works/{role}")
-    if item.is_deleted:
+    final = item.final_item
+    if final.is_deleted:
         raise Http404(_("Item no longer exists"))
+    if final is not item:
+        return redirect(f"{final.url}/works/{role}")
     if role not in PeopleRole.values:
         raise Http404(_("Invalid role"))
     role_label = PeopleRole(role).label

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -189,10 +189,6 @@ class TestPeopleWorksMergedAndDeleted:
             f"{person3.url}/works/{PeopleRole.AUTHOR.value}"
         )
 
-        response = Client().get(f"{person1.url}/works/")
-        assert response.status_code == 302
-        assert response.headers["Location"] == person3.url
-
     def test_deleted_people_works_returns_404(self):
         person = _author()
         person.delete(soft=True)
@@ -209,41 +205,10 @@ class TestPeopleWorksMergedAndDeleted:
         response = Client().get(f"{person1.url}/works/{PeopleRole.AUTHOR.value}")
         assert response.status_code == 404
 
-        response = Client().get(f"{person1.url}/works/")
-        assert response.status_code == 404
-
-    def test_works_root_on_deleted_people_returns_404(self):
-        person = _author()
-        person.delete(soft=True)
-
-        response = Client().get(f"{person.url}/works/")
-        assert response.status_code == 404
-
-    def test_works_root_redirects_to_people_page(self):
-        person = _author()
-
-        for suffix in ("/works/", "/works"):
-            response = Client().get(f"{person.url}{suffix}")
-            assert response.status_code == 302
-            assert response.headers["Location"] == person.url
-
-    def test_works_root_on_merged_people_redirects_to_target(self):
-        person1 = _author("Dan Simmons")
-        person2 = _author("Daniel Simmons")
-        person1.merge_to(person2)
-
-        response = Client().get(f"{person1.url}/works/")
-        assert response.status_code == 302
-        assert response.headers["Location"] == person2.url
-
     def test_invalid_role_on_merged_people_returns_404_without_redirect(self):
         person1 = _author("Dan Simmons")
         person2 = _author("Daniel Simmons")
         person1.merge_to(person2)
 
         response = Client().get(f"{person1.url}/works/not_a_role")
-        assert response.status_code == 404
-
-    def test_works_root_unknown_uuid_returns_404(self):
-        response = Client().get("/people/zzzzzzzzzzzzzzzzzzzzzz/works/")
         assert response.status_code == 404

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -236,6 +236,14 @@ class TestPeopleWorksMergedAndDeleted:
         assert response.status_code == 302
         assert response.headers["Location"] == person2.url
 
+    def test_invalid_role_on_merged_people_returns_404_without_redirect(self):
+        person1 = _author("Dan Simmons")
+        person2 = _author("Daniel Simmons")
+        person1.merge_to(person2)
+
+        response = Client().get(f"{person1.url}/works/not_a_role")
+        assert response.status_code == 404
+
     def test_works_root_unknown_uuid_returns_404(self):
         response = Client().get("/people/zzzzzzzzzzzzzzzzzzzzzz/works/")
         assert response.status_code == 404

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -200,6 +200,18 @@ class TestPeopleWorksMergedAndDeleted:
         response = Client().get(f"{person.url}/works/{PeopleRole.AUTHOR.value}")
         assert response.status_code == 404
 
+    def test_merged_to_deleted_target_returns_404_without_redirect(self):
+        person1 = _author("Dan Simmons")
+        person2 = _author("Daniel Simmons")
+        person1.merge_to(person2)
+        person2.delete(soft=True)
+
+        response = Client().get(f"{person1.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 404
+
+        response = Client().get(f"{person1.url}/works/")
+        assert response.status_code == 404
+
     def test_works_root_on_deleted_people_returns_404(self):
         person = _author()
         person.delete(soft=True)

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -176,11 +176,35 @@ class TestPeopleWorksMergedAndDeleted:
             f"{person2.url}/works/{PeopleRole.AUTHOR.value}"
         )
 
+    def test_chained_merge_redirects_to_final_target_in_one_hop(self):
+        person1 = _author("Dan Simmons")
+        person2 = _author("Daniel Simmons")
+        person3 = _author("D. Simmons")
+        person1.merge_to(person2)
+        person2.merge_to(person3)
+
+        response = Client().get(f"{person1.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 302
+        assert response.headers["Location"] == (
+            f"{person3.url}/works/{PeopleRole.AUTHOR.value}"
+        )
+
+        response = Client().get(f"{person1.url}/works/")
+        assert response.status_code == 302
+        assert response.headers["Location"] == person3.url
+
     def test_deleted_people_works_returns_404(self):
         person = _author()
         person.delete(soft=True)
 
         response = Client().get(f"{person.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 404
+
+    def test_works_root_on_deleted_people_returns_404(self):
+        person = _author()
+        person.delete(soft=True)
+
+        response = Client().get(f"{person.url}/works/")
         assert response.status_code == 404
 
     def test_works_root_redirects_to_people_page(self):

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -161,3 +161,45 @@ class TestPeopleWorksHidesChildren:
         ids = {w.pk for w in response.context["works"].object_list}
         assert edition.pk in ids
         assert work.pk not in ids
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPeopleWorksMergedAndDeleted:
+    def test_merged_people_works_redirects_to_target(self):
+        person1 = _author("Dan Simmons")
+        person2 = _author("Daniel Simmons")
+        person1.merge_to(person2)
+
+        response = Client().get(f"{person1.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 302
+        assert response.headers["Location"] == (
+            f"{person2.url}/works/{PeopleRole.AUTHOR.value}"
+        )
+
+    def test_deleted_people_works_returns_404(self):
+        person = _author()
+        person.delete(soft=True)
+
+        response = Client().get(f"{person.url}/works/{PeopleRole.AUTHOR.value}")
+        assert response.status_code == 404
+
+    def test_works_root_redirects_to_people_page(self):
+        person = _author()
+
+        for suffix in ("/works/", "/works"):
+            response = Client().get(f"{person.url}{suffix}")
+            assert response.status_code == 302
+            assert response.headers["Location"] == person.url
+
+    def test_works_root_on_merged_people_redirects_to_target(self):
+        person1 = _author("Dan Simmons")
+        person2 = _author("Daniel Simmons")
+        person1.merge_to(person2)
+
+        response = Client().get(f"{person1.url}/works/")
+        assert response.status_code == 302
+        assert response.headers["Location"] == person2.url
+
+    def test_works_root_unknown_uuid_returns_404(self):
+        response = Client().get("/people/zzzzzzzzzzzzzzzzzzzzzz/works/")
+        assert response.status_code == 404


### PR DESCRIPTION
## Problem

`/people/<uid>/works/<role>` for a merged people rendered an empty works list (the person's relations had moved to the merge target) instead of resolving the merge.

## Change

`people_works` now mirrors the item `retrieve` view: it validates the role first, resolves `final_item` so multi-level merge chains redirect in one hop, returns 404 when the people or its final merge target is soft-deleted, and otherwise redirects to the merge target's works page with the same role.

## Tests

New tests in `tests/catalog/test_people_works_view.py` covering merged redirect, chained merge, soft-deleted people, merged-to-deleted target, and invalid role on a merged people.