### PR TITLE
fix(users): refuse createsuperuser when email login is not configured

### DIFF
--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -29,6 +29,8 @@ A step-by-step admin account creation. If you already have an account and want t
 docker compose --profile production run --rm shell neodb-manage createsuperuser
 ```
 
+NeoDB has no password login: the account created this way logs in with a verification code sent to its email address, so `NEODB_EMAIL_URL` must be configured in `.env` first — the command will refuse to run without it. Any password entered at the prompt is not used.
+
 Alternatively, set `NEODB_ADMIN_HANDLES` in `.env` to auto-promote users to superuser when they register with a matching handle:
 ```
 NEODB_ADMIN_HANDLES=mastodon:user@mastodon.social,email:admin@example.com

--- a/neodb/tests/users/test_createsuperuser.py
+++ b/neodb/tests/users/test_createsuperuser.py
@@ -1,0 +1,38 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
+
+from mastodon.models import EmailAccount
+from takahe.models import User as TakaheUser
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCreateSuperuser:
+    @override_settings(ENABLE_LOGIN_EMAIL=False)
+    def test_refuses_when_email_login_disabled(self):
+        with pytest.raises(CommandError, match="NEODB_EMAIL_URL"):
+            call_command(
+                "createsuperuser",
+                interactive=False,
+                username="rootadmin",
+                email="root@example.org",
+            )
+        assert not User.objects.filter(username="rootadmin").exists()
+
+    @override_settings(ENABLE_LOGIN_EMAIL=True)
+    def test_creates_superuser_when_email_login_enabled(self):
+        call_command(
+            "createsuperuser",
+            interactive=False,
+            username="rootadmin",
+            email="root@example.org",
+        )
+        user = User.objects.get(username="rootadmin")
+        assert user.is_superuser
+        assert not user.has_usable_password()
+        assert TakaheUser.objects.get(pk=user.pk).admin
+        assert EmailAccount.objects.filter(
+            user=user, handle="root@example.org"
+        ).exists()

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -91,9 +91,27 @@ class UserManager(BaseUserManager):
         return user
 
     def create_superuser(self, username, email, password=None):
+        from django.core.management.base import CommandError
+
         from mastodon.models import Email
         from takahe.models import User as TakaheUser
 
+        # NeoDB has no password login: this account can only log in with a
+        # verification code sent to its email, which requires a working
+        # email backend. Fail early instead of creating an unreachable
+        # account (see https://github.com/neodb-social/neodb/issues/1666).
+        if not settings.ENABLE_LOGIN_EMAIL:
+            raise CommandError(
+                "Refusing to create a superuser that would not be able to"
+                " log in: NeoDB does not support password login, and email"
+                " login is disabled because NEODB_EMAIL_URL is not"
+                " configured.\n"
+                "Either set NEODB_EMAIL_URL in .env and retry, or set"
+                " NEODB_ADMIN_HANDLES to auto-promote a Fediverse login,"
+                " or promote an existing user with"
+                " `neodb-manage user --super <username>`"
+                " (see docs/accounts.md)."
+            )
         Takahe.get_domain()  # ensure configuration is complete
         user = User.register(username=username, is_superuser=True)
         e = Email.new_account(email)
@@ -104,6 +122,10 @@ class UserManager(BaseUserManager):
         tu = TakaheUser.objects.get(pk=user.pk, email="@" + username)
         tu.admin = True
         tu.save()
+        logger.warning(
+            f"Any password entered is not used: log in as {username} with a"
+            f" verification code sent to {email} instead."
+        )
         return user
 
 

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -91,26 +91,17 @@ class UserManager(BaseUserManager):
         return user
 
     def create_superuser(self, username, email, password=None):
-        from django.core.management.base import CommandError
-
         from mastodon.models import Email
         from takahe.models import User as TakaheUser
 
-        # NeoDB has no password login: this account can only log in with a
-        # verification code sent to its email, which requires a working
-        # email backend. Fail early instead of creating an unreachable
-        # account (see https://github.com/neodb-social/neodb/issues/1666).
+        # this account can only log in by emailed verification code (no
+        # password login), so refuse to create it unreachable (#1666)
         if not settings.ENABLE_LOGIN_EMAIL:
-            raise CommandError(
-                "Refusing to create a superuser that would not be able to"
-                " log in: NeoDB does not support password login, and email"
-                " login is disabled because NEODB_EMAIL_URL is not"
-                " configured.\n"
-                "Either set NEODB_EMAIL_URL in .env and retry, or set"
-                " NEODB_ADMIN_HANDLES to auto-promote a Fediverse login,"
-                " or promote an existing user with"
-                " `neodb-manage user --super <username>`"
-                " (see docs/accounts.md)."
+            raise ValidationError(
+                "This account could not log in: NeoDB has no password login"
+                " and NEODB_EMAIL_URL is not configured. Set NEODB_EMAIL_URL,"
+                " or use NEODB_ADMIN_HANDLES or `neodb-manage user --super`"
+                " instead (see docs/accounts.md)."
             )
         Takahe.get_domain()  # ensure configuration is complete
         user = User.register(username=username, is_superuser=True)
@@ -123,8 +114,8 @@ class UserManager(BaseUserManager):
         tu.admin = True
         tu.save()
         logger.warning(
-            f"Any password entered is not used: log in as {username} with a"
-            f" verification code sent to {email} instead."
+            f"Password is not used for login; {username} logs in with a"
+            f" verification code sent to {email}."
         )
         return user
 


### PR DESCRIPTION
## Problem

NeoDB has no password login: the account created by `createsuperuser` can only log in with a verification code sent to its email address. When `NEODB_EMAIL_URL` is not configured, the command reported success while creating an account that has no way to log in — see #1666, where a fresh install ended up with an unreachable admin account and no clear error.

## Changes

- `UserManager.create_superuser` now fails early with an actionable `CommandError` when `ENABLE_LOGIN_EMAIL` is off, pointing to `NEODB_EMAIL_URL`, `NEODB_ADMIN_HANDLES`, and `neodb-manage user --super` as ways forward. (The check lives in the manager because a same-name command override in the `users` app would lose to `django.contrib.auth` in `INSTALLED_APPS` order.)
- On success, log a warning that any password entered at the prompt is not used and login happens via email code.
- Document the email prerequisite in `docs/accounts.md`.

## Tests

- New `tests/users/test_createsuperuser.py` covering both the refusal (no user created) and the success path (superuser + takahe admin flag + linked email account).
- Full `tests/users/` suite passes (75 passed).
- Verified end-to-end in a dev compose cluster without `NEODB_EMAIL_URL`: the command now exits with the clean error instead of creating an unreachable account.