### PR TITLE
fix(journal): serialize null collection member note as empty string in API

### DIFF
--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -23,7 +23,14 @@ from common.api import (
 from common.sentry import record_activity
 from journal.models.common import q_piece_visible_to_user
 
-from ..models import Collection, FeaturedCollection, Rating, ShelfMember, ShelfType
+from ..models import (
+    Collection,
+    CollectionMember,
+    FeaturedCollection,
+    Rating,
+    ShelfMember,
+    ShelfType,
+)
 
 
 class CollectionPageNumberPagination(PageNumberPagination):
@@ -77,6 +84,12 @@ class CollectionInSchema(Schema):
 class CollectionItemSchema(Schema):
     item: ItemSchema
     note: str
+
+    @staticmethod
+    def resolve_note(obj: "CollectionMember | dict[str, Any]") -> str:
+        # CollectionMember.note is nullable; keep the API contract a plain str
+        note = obj.get("note") if isinstance(obj, dict) else obj.note
+        return note if isinstance(note, str) else ""
 
 
 def _prefetch_collection_member_items(data: list) -> None:

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -363,6 +363,27 @@ def test_shelf_api_mark_and_lookup():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_collection_api_list_items_with_null_note():
+    user = User.register(email="nullnote@example.com", username="nullnote")
+    item = Edition.objects.create(title="Null Note Book")
+    collection = Collection.objects.create(
+        owner=user.identity, title="Null Note Collection", visibility=0
+    )
+    collection.append_item(item)
+    member = collection.ordered_members[0]
+    member.note = None
+    member.save()
+
+    response = Client().get(f"/api/collection/{collection.uuid}/item/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["data"][0]["item"]["uuid"] == item.uuid
+    assert payload["data"][0]["note"] == ""
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_collection_api_crud_and_items():
     user = User.register(email="collector@example.com", username="collector")
     item = Edition.objects.create(title="Collection Book")


### PR DESCRIPTION
## Summary

`GET /api/collection/{uuid}/item/` (and the `/me/` variant) returned a 500 when a static collection contained members whose `note` is `NULL` — `CollectionMember.note` is nullable (and is stored as `None` e.g. by federation sync in `merge_relinked_items`), but `CollectionItemSchema` declares `note: str`, so pydantic response validation raised `ValidationError`.

This adds a `resolve_note` resolver that serializes an unset note as `""`, consistent with how dynamic collections and the ActivityPub serializer (`self.note or ""`) already treat empty notes, keeping the public API contract a plain string.

Fixes NEODB-SOCIAL-49E

## Test plan

- Added `test_collection_api_list_items_with_null_note`: member with `note=None` serializes with `note == ""` (verified it fails with a 500 without the fix).
- `pytest tests/journal/test_api.py -k collection`: 11 passed.
- `pre-commit run -a`: all hooks pass.