### PR TITLE
fix(catalog): exclude shelved items via subquery in from_your_circles

### DIFF
--- a/neodb/catalog/recommendation.py
+++ b/neodb/catalog/recommendation.py
@@ -12,7 +12,7 @@ from heapq import nlargest
 
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, QuerySet
 from django.utils import timezone
 from loguru import logger
 
@@ -125,13 +125,15 @@ def _live_items(qs):
     return qs
 
 
-def _user_shelved_item_ids(identity_pk: int) -> set[int]:
-    return set(
-        ShelfMember.objects.filter(
-            owner_id=identity_pk,
-            parent__shelf_type__in=SHELF_TYPES_TO_EXCLUDE,
-        ).values_list("item_id", flat=True)
+def _user_shelved_members(identity_pk: int) -> QuerySet[ShelfMember]:
+    return ShelfMember.objects.filter(
+        owner_id=identity_pk,
+        parent__shelf_type__in=SHELF_TYPES_TO_EXCLUDE,
     )
+
+
+def _user_shelved_item_ids(identity_pk: int) -> set[int]:
+    return set(_user_shelved_members(identity_pk).values_list("item_id", flat=True))
 
 
 def _sibling_edition_ids(item_ids: set[int]) -> set[int]:
@@ -351,7 +353,9 @@ def from_your_circles(
     eligible_followees = [f for f in following if f not in not_discoverable]
     if not eligible_followees:
         return []
-    shelved = _user_shelved_item_ids(identity.pk)
+    # Exclude via subquery: a materialized id set would inline one bind
+    # parameter per shelved item, bloating the SQL for heavy users.
+    shelved = _user_shelved_members(identity.pk).values("item_id")
     excluded_ctypes = excluded_target_ctype_ids()
     qs = (
         ShelfMember.objects.filter(q_piece_visible_to_user(viewer))

--- a/neodb/catalog/recommendation.py
+++ b/neodb/catalog/recommendation.py
@@ -126,10 +126,12 @@ def _live_items(qs):
 
 
 def _user_shelved_members(identity_pk: int) -> QuerySet[ShelfMember]:
-    return ShelfMember.objects.filter(
+    # _base_manager skips ShelfMemberManager's default annotations (useless
+    # here); order_by() keeps subqueries free of any future default ordering.
+    return ShelfMember._base_manager.filter(
         owner_id=identity_pk,
         parent__shelf_type__in=SHELF_TYPES_TO_EXCLUDE,
-    )
+    ).order_by()
 
 
 def _user_shelved_item_ids(identity_pk: int) -> set[int]:

--- a/neodb/tests/catalog/test_recommendation.py
+++ b/neodb/tests/catalog/test_recommendation.py
@@ -22,6 +22,7 @@ from catalog.models import (
 from catalog.recommendation import (
     blended_for_discover,
     compute_for_user,
+    from_your_circles,
     similar_items,
 )
 from common.models import SiteConfig
@@ -527,4 +528,44 @@ class TestRecoItemsExternalResourcesNoNPlusOne:
             f"reading reco items' external_resources fired {len(offending)} "
             "query(ies); expected 0 (prefetched). First offending SQL: "
             f"{offending[0]['sql'] if offending else 'n/a'}"
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestFromYourCircles:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        _set(enable_recommendations=True, reco_circles_window_days=14)
+        self.viewer = User.register(email="c0@test.com", username="c_viewer")
+        self.friends = [
+            User.register(email=f"c{i + 1}@test.com", username=f"c_friend{i}")
+            for i in range(2)
+        ]
+        for f in self.friends:
+            self.viewer.identity.follow(f.identity, True)
+        self.book_a = Edition.objects.create(title="Circles A")
+        self.book_b = Edition.objects.create(title="Circles B")
+        for f in self.friends:
+            _public_mark(f.identity, self.book_a)
+            _public_mark(f.identity, self.book_b)
+
+    def test_returns_followee_items(self):
+        items = from_your_circles(self.viewer)
+        assert {i.pk for i in items} == {self.book_a.pk, self.book_b.pk}
+
+    def test_excludes_viewer_shelved(self):
+        _public_mark(self.viewer.identity, self.book_a)
+        items = from_your_circles(self.viewer)
+        assert {i.pk for i in items} == {self.book_b.pk}
+
+    def test_shelved_exclusion_uses_subquery(self):
+        # Regression for EGGPLANT-1GE: the viewer's shelved items must be
+        # excluded via a subquery, not inlined as one parameter per item.
+        _public_mark(self.viewer.identity, self.book_a)
+        with CaptureQueriesContext(connection) as ctx:
+            from_your_circles(self.viewer)
+        agg = [q["sql"] for q in ctx.captured_queries if "COUNT(DISTINCT" in q["sql"]]
+        assert len(agg) == 1
+        assert "IN (SELECT" in agg[0], (
+            f"shelved-item exclusion is not a subquery: {agg[0]}"
         )

--- a/neodb/tests/catalog/test_recommendation.py
+++ b/neodb/tests/catalog/test_recommendation.py
@@ -569,3 +569,6 @@ class TestFromYourCircles:
         assert "IN (SELECT" in agg[0], (
             f"shelved-item exclusion is not a subquery: {agg[0]}"
         )
+        # ShelfMemberManager's default annotations must not leak in either.
+        assert 'FROM "journal_rating"' not in agg[0]
+        assert 'FROM "journal_comment"' not in agg[0]


### PR DESCRIPTION
## Problem

Sentry flagged the /discover/ transaction (EGGPLANT-1GE, "Inefficient Database Queries"): the circles recommendation aggregation ran with **2,176 bind parameters — 2,146 of them in a single `NOT (item_id IN (...))` clause** — taking 225ms.

The cause is in `from_your_circles()`: it excluded the viewer's already-shelved items by materializing the full id set in Python (`_user_shelved_item_ids()`) and passing it to `.exclude(item_id__in=...)`, which inlines one literal parameter per shelved item. The clause grows linearly with the user's library, so heavy users produce multi-KB SQL that is slow to parse, plan, and evaluate.

## Fix

Keep the exclusion as a queryset (`_user_shelved_members(...).values("item_id")`) so Django renders it as a subquery and Postgres performs an anti-join instead. The materialized-set helper is unchanged for the callers that genuinely need a Python set (`similar_items`, `for_you`, `compute_for_user`).

## Tests

Added `TestFromYourCircles`:
- returns items recently shelved by followees
- excludes items the viewer already shelved
- regression: the aggregation SQL uses `IN (SELECT ...)` rather than inlined ids

`tests/catalog/test_recommendation.py` passes (25 tests), `pre-commit run -a` clean.