### PR TITLE
fix(journal): enforce collaborative collection editing for mutual followers

### DIFF
--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -276,8 +276,8 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     q = (c_in.query or "").strip() or None
     is_dynamic = bool(q)
     if c.is_dynamic != is_dynamic:
@@ -347,8 +347,8 @@ def collection_add_item(
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     if c.is_dynamic:
         return Status(
             403, {"message": "Item list of dynamic collection cannot be updated"}
@@ -380,8 +380,8 @@ def collection_reorder_items(
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     if c.is_dynamic:
         return Status(
             403, {"message": "Item list of dynamic collection cannot be updated"}
@@ -417,8 +417,8 @@ def collection_delete_item(request, collection_uuid: str, item_uuid: str):
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     if c.is_dynamic:
         return Status(
             403, {"message": "Item list of dynamic collection cannot be updated"}

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -192,8 +192,8 @@ def get_user_collection(request, collection_uuid: str):
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if c.owner != request.user.identity and not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     return c
 
 
@@ -282,6 +282,10 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     is_dynamic = bool(q)
     if c.is_dynamic != is_dynamic:
         return Status(403, {"message": "Cannot change collection type"})
+    if c.owner != request.user.identity and (
+        c_in.visibility != c.visibility or q != c.query
+    ):
+        return Status(403, {"message": "Only owner can change visibility or query"})
     c.title = c_in.title
     c.brief = c_in.brief
     c.visibility = c_in.visibility
@@ -304,8 +308,8 @@ def delete_collection(request, collection_uuid: str):
     c = Collection.get_by_url(collection_uuid)
     if not c:
         return Status(404, {"message": "Collection not found"})
-    if c.owner != request.user.identity:
-        return Status(403, {"message": "Not owner"})
+    if not c.is_deletable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
     c.delete()
     return Status(200, {"message": "OK"})
 
@@ -323,8 +327,8 @@ def user_collection_list_items(request, collection_uuid: str):
     c = Collection.get_by_url(collection_uuid)
     if not c:
         raise Http404("Collection not found")
-    if c.owner != request.user.identity:
-        raise HttpError(403, "Not owner")
+    if c.owner != request.user.identity and not c.is_editable_by(request.user):
+        raise HttpError(403, "Permission denied")
     if c.is_dynamic:
         items = c.query_result.items if c.query_result else []
         members = [{"item": i, "note": ""} for i in items]

--- a/neodb/journal/forms.py
+++ b/neodb/journal/forms.py
@@ -175,6 +175,17 @@ class CollectionForm(forms.ModelForm):
         }
 
 
+class CollaboratorCollectionForm(CollectionForm):
+    """Collection form for non-owner editors: owner-only settings
+    (visibility, collaborative) are removed so collaborators can edit
+    content but not privacy or collaboration policy."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        del self.fields["visibility"]
+        del self.fields["collaborative"]
+
+
 class MarkForm(forms.Form):
     status = forms.ChoiceField(
         choices=ShelfType.choices, required=False, label=_("Status")

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -19,11 +19,16 @@ from common.models import jsondata
 from common.utils import get_file_absolute_url
 from journal.search import JournalIndex, JournalQueryParser
 from takahe.utils import Takahe
-from users.models import APIdentity
+from users.models import APIdentity, User
 
 from .common import Piece
 from .itemlist import AP_PAGE_SIZE, List, ListMember, list_add, list_remove
 from .renderers import render_md, render_text
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
+    from users.models import User
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 _COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
@@ -144,6 +149,27 @@ class Collection(List):
     def featured_since(self, owner: APIdentity):
         f = FeaturedCollection.objects.filter(target=self, owner=owner).first()
         return f.created_time if f else None
+
+    def is_editable_by(self, viewing_user: "User | AnonymousUser") -> bool:
+        if super().is_editable_by(viewing_user):
+            return True
+        # Collaborative mode: local mutual followers may edit. Gated on
+        # visibility so a collaborator can never edit what they cannot see.
+        if self.collaborative != 1 or not self.local:
+            return False
+        if not isinstance(viewing_user, User) or not viewing_user.is_authenticated:
+            return False
+        viewer = viewing_user.identity
+        return (
+            viewer is not None
+            and self.is_visible_to(viewing_user)
+            and viewer.is_following(self.owner)
+            and viewer.is_followed_by(self.owner)
+        )
+
+    def is_deletable_by(self, viewing_user: "User | AnonymousUser") -> bool:
+        # Collaborators may edit content but only owner/staff may delete.
+        return super().is_editable_by(viewing_user)
 
     def get_query(self, viewer, **kwargs):
         if not self.is_dynamic:

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -28,8 +28,6 @@ from .renderers import render_md, render_text
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
 
-    from users.models import User
-
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 _COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
 
@@ -151,20 +149,24 @@ class Collection(List):
         return f.created_time if f else None
 
     def is_editable_by(self, viewing_user: "User | AnonymousUser") -> bool:
+        # Remote mirrors are maintained by federation sync and must stay
+        # read-only locally (staff included) or edits would silently diverge
+        # and be clobbered by the next sync.
+        if not self.local:
+            return False
         if super().is_editable_by(viewing_user):
             return True
         # Collaborative mode: local mutual followers may edit. Gated on
         # visibility so a collaborator can never edit what they cannot see.
-        if self.collaborative != 1 or not self.local:
+        if self.collaborative != 1 or not isinstance(viewing_user, User):
             return False
-        if not isinstance(viewing_user, User) or not viewing_user.is_authenticated:
-            return False
-        viewer = viewing_user.identity
+        # reverse OneToOne raises rather than returns None when missing
+        viewer = getattr(viewing_user, "identity", None)
         return (
             viewer is not None
-            and self.is_visible_to(viewing_user)
             and viewer.is_following(self.owner)
             and viewer.is_followed_by(self.owner)
+            and self.is_visible_to(viewing_user)
         )
 
     def is_deletable_by(self, viewing_user: "User | AnonymousUser") -> bool:

--- a/neodb/journal/models/mixins.py
+++ b/neodb/journal/models/mixins.py
@@ -70,15 +70,14 @@ class UserOwnedObjectMixin:
             return viewer.is_following(owner)
         return True
 
-    def is_editable_by(self: "Piece", viewing_user: "User | AnonymousUser"):
+    def is_editable_by(self: "Piece", viewing_user: "User | AnonymousUser") -> bool:
         return viewing_user.is_authenticated and (
             viewing_user.is_staff
             or viewing_user.is_superuser
             or viewing_user == self.owner.user
         )
 
-    def is_deletable_by(self: "Piece", viewing_user: "User | AnonymousUser"):
-        # Same as edit permission by default; subclasses granting edit
-        # access beyond the owner (e.g. collaborative Collection) override
-        # this to keep deletion owner-only.
+    def is_deletable_by(self: "Piece", viewing_user: "User | AnonymousUser") -> bool:
+        # subclasses granting edit access beyond the owner (e.g.
+        # collaborative Collection) override this to keep deletion owner-only
         return self.is_editable_by(viewing_user)

--- a/neodb/journal/models/mixins.py
+++ b/neodb/journal/models/mixins.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
     from django.db.models import ForeignKey
 
     from users.models import APIdentity, User
@@ -69,9 +70,15 @@ class UserOwnedObjectMixin:
             return viewer.is_following(owner)
         return True
 
-    def is_editable_by(self: "Piece", viewing_user: "User"):
+    def is_editable_by(self: "Piece", viewing_user: "User | AnonymousUser"):
         return viewing_user.is_authenticated and (
             viewing_user.is_staff
             or viewing_user.is_superuser
             or viewing_user == self.owner.user
         )
+
+    def is_deletable_by(self: "Piece", viewing_user: "User | AnonymousUser"):
+        # Same as edit permission by default; subclasses granting edit
+        # access beyond the owner (e.g. collaborative Collection) override
+        # this to keep deletion owner-only.
+        return self.is_editable_by(viewing_user)

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -532,8 +532,6 @@ def collection_update_item_note(request: AuthedHttpRequest, collection_uuid, ite
     if not collection.is_editable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
-    if not collection.is_editable_by(request.user):
-        raise PermissionDenied(_("Insufficient permission"))
     if collection.is_dynamic:
         raise BadRequest(_("Dynamic collection is not editable"))
     member = collection.get_member_for_item(item)
@@ -575,8 +573,15 @@ def collection_edit(request: AuthedHttpRequest, collection_uuid=None):
     )
     if collection and not collection.is_editable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
+    # visibility and collaborative are owner-only settings; collaborators
+    # get a reduced form without them
+    form_class = (
+        CollaboratorCollectionForm
+        if collection and collection.owner != getattr(request.user, "identity", None)
+        else CollectionForm
+    )
     if request.method == "GET":
-        form = CollectionForm(instance=collection) if collection else CollectionForm()
+        form = form_class(instance=collection) if collection else form_class()
         if request.GET.get("title"):
             form.instance.title = request.GET.get("title")
         return render(
@@ -591,9 +596,9 @@ def collection_edit(request: AuthedHttpRequest, collection_uuid=None):
         )
     else:
         form = (
-            CollectionForm(request.POST, request.FILES, instance=collection)
+            form_class(request.POST, request.FILES, instance=collection)
             if collection
-            else CollectionForm(request.POST)
+            else form_class(request.POST)
         )
         if form.is_valid():
             if not collection:

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -268,7 +268,7 @@ def piece_delete(request, piece_uuid):
         require_https=settings.SSL_ONLY,
     ):
         return_url = "/"
-    if not piece.is_editable_by(request.user):
+    if not piece.is_deletable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "GET":
         return render(

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -1,10 +1,16 @@
+import json
+
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.db import connection
+from django.test import Client
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 
 from catalog.models import Edition, ExternalResource, IdType, ItemCredit, Movie
 from journal.apis.collection import _prefetch_collection_member_items
 from journal.models.collection import Collection
+from takahe.utils import Takahe
 from users.models import User
 
 
@@ -335,3 +341,148 @@ class TestCollectionItemsApiPrefetch:
             f"query(ies); expected 0 (prefetched). First: "
             f"{credits[0]['sql'] if credits else 'n/a'}"
         )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionCollaborativeEditing:
+    """collaborative=1 lets local mutual followers edit content; deletion stays owner-only."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner = User.register(
+            email="collab_owner@test.com", username="collab_owner"
+        )
+        self.mutual = User.register(
+            email="collab_mutual@test.com", username="collab_mutual"
+        )
+        self.follower = User.register(
+            email="collab_follower@test.com", username="collab_follower"
+        )
+        self.stranger = User.register(
+            email="collab_stranger@test.com", username="collab_stranger"
+        )
+        self.mutual.identity.follow(self.owner.identity, force_accept=True)
+        self.owner.identity.follow(self.mutual.identity, force_accept=True)
+        self.follower.identity.follow(self.owner.identity, force_accept=True)
+        self.book = Edition.objects.create(title="Collaborative Book")
+        self.collection = Collection(
+            owner=self.owner.identity,
+            title="Collaborative Collection",
+            brief="",
+            collaborative=1,
+        )
+        self.collection.save()
+
+    def test_owner_can_edit(self):
+        assert self.collection.is_editable_by(self.owner)
+
+    def test_mutual_can_edit(self):
+        assert self.collection.is_editable_by(self.mutual)
+
+    def test_one_way_follower_cannot_edit(self):
+        assert not self.collection.is_editable_by(self.follower)
+
+    def test_stranger_cannot_edit(self):
+        assert not self.collection.is_editable_by(self.stranger)
+
+    def test_anonymous_cannot_edit(self):
+        assert not self.collection.is_editable_by(AnonymousUser())
+
+    def test_mutual_cannot_edit_when_not_collaborative(self):
+        self.collection.collaborative = 0
+        assert not self.collection.is_editable_by(self.mutual)
+        assert self.collection.is_editable_by(self.owner)
+
+    def test_mutual_cannot_edit_invisible_collection(self):
+        self.collection.visibility = 2
+        assert not self.collection.is_editable_by(self.mutual)
+        assert self.collection.is_editable_by(self.owner)
+
+    def test_remote_collection_not_editable_by_mutual(self):
+        self.collection.local = False
+        assert not self.collection.is_editable_by(self.mutual)
+
+    def test_deletable_by_owner_only(self):
+        assert self.collection.is_deletable_by(self.owner)
+        assert not self.collection.is_deletable_by(self.mutual)
+
+    def test_mutual_can_append_and_remove_item_via_web(self):
+        client = Client()
+        client.force_login(self.mutual)
+        response = client.post(
+            reverse("journal:collection_append_item", args=[self.collection.uuid]),
+            {"url": self.book.url, "note": "from mutual"},
+        )
+        assert response.status_code == 200
+        member = self.collection.members.first()
+        assert member is not None
+        assert member.item == self.book
+        # attribution stays with the collection owner
+        assert member.owner == self.owner.identity
+        response = client.post(
+            reverse(
+                "journal:collection_remove_item",
+                args=[self.collection.uuid, self.book.uuid],
+            )
+        )
+        assert response.status_code == 200
+        assert self.collection.members.count() == 0
+
+    def test_follower_cannot_append_item_via_web(self):
+        client = Client()
+        client.force_login(self.follower)
+        response = client.post(
+            reverse("journal:collection_append_item", args=[self.collection.uuid]),
+            {"url": self.book.url, "note": ""},
+        )
+        assert response.status_code == 403
+        assert self.collection.members.count() == 0
+
+    def test_mutual_cannot_delete_via_web(self):
+        client = Client()
+        client.force_login(self.mutual)
+        response = client.post(
+            reverse("journal:collection_delete", args=[self.collection.uuid])
+        )
+        assert response.status_code == 403
+        assert Collection.objects.filter(pk=self.collection.pk).exists()
+
+    def _api_client_token(self, user: User) -> str:
+        app = Takahe.get_or_create_app(
+            "Collab Tests",
+            "https://example.org",
+            "https://example.org/callback",
+            owner_pk=user.identity.pk,
+        )
+        return Takahe.refresh_token(app, user.identity.pk, user.pk)
+
+    def test_mutual_can_add_item_via_api(self):
+        token = self._api_client_token(self.mutual)
+        response = Client().post(
+            f"/api/me/collection/{self.collection.uuid}/item/",
+            data=json.dumps({"item_uuid": self.book.uuid, "note": "via api"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200
+        assert self.collection.members.count() == 1
+
+    def test_follower_cannot_add_item_via_api(self):
+        token = self._api_client_token(self.follower)
+        response = Client().post(
+            f"/api/me/collection/{self.collection.uuid}/item/",
+            data=json.dumps({"item_uuid": self.book.uuid, "note": ""}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 403
+        assert self.collection.members.count() == 0
+
+    def test_mutual_cannot_delete_collection_via_api(self):
+        token = self._api_client_token(self.mutual)
+        response = Client().delete(
+            f"/api/me/collection/{self.collection.uuid}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 403
+        assert Collection.objects.filter(pk=self.collection.pk).exists()

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -402,6 +402,18 @@ class TestCollectionCollaborativeEditing:
         self.collection.local = False
         assert not self.collection.is_editable_by(self.mutual)
 
+    def test_staff_can_edit_local_but_not_remote(self):
+        staff = User.register(email="collab_staff@test.com", username="collab_staff")
+        staff.is_staff = True
+        staff.save()
+        assert self.collection.is_editable_by(staff)
+        self.collection.local = False
+        assert not self.collection.is_editable_by(staff)
+
+    def test_user_without_identity_cannot_edit(self):
+        bare = User.objects.create(username="collab_bare")
+        assert not self.collection.is_editable_by(bare)
+
     def test_deletable_by_owner_only(self):
         assert self.collection.is_deletable_by(self.owner)
         assert not self.collection.is_deletable_by(self.mutual)
@@ -447,6 +459,34 @@ class TestCollectionCollaborativeEditing:
         assert response.status_code == 403
         assert Collection.objects.filter(pk=self.collection.pk).exists()
 
+    def test_collaborator_edit_form_excludes_owner_settings(self):
+        client = Client()
+        client.force_login(self.mutual)
+        url = reverse("journal:collection_edit", args=[self.collection.uuid])
+        response = client.get(url)
+        assert response.status_code == 200
+        content = response.content.decode()
+        # check rendered inputs, not ids (a static CSS rule mentions the ids)
+        assert 'name="visibility"' not in content
+        assert 'name="collaborative"' not in content
+        response = client.post(url, {"title": "Renamed by mutual", "brief": "hi"})
+        assert response.status_code == 302
+        self.collection.refresh_from_db()
+        assert self.collection.title == "Renamed by mutual"
+        assert self.collection.collaborative == 1
+        assert self.collection.visibility == 0
+
+    def test_owner_edit_form_includes_owner_settings(self):
+        client = Client()
+        client.force_login(self.owner)
+        response = client.get(
+            reverse("journal:collection_edit", args=[self.collection.uuid])
+        )
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'name="visibility"' in content
+        assert 'name="collaborative"' in content
+
     def _api_client_token(self, user: User) -> str:
         app = Takahe.get_or_create_app(
             "Collab Tests",
@@ -486,3 +526,32 @@ class TestCollectionCollaborativeEditing:
         )
         assert response.status_code == 403
         assert Collection.objects.filter(pk=self.collection.pk).exists()
+
+    def test_collaborator_can_rename_but_not_change_visibility_via_api(self):
+        token = self._api_client_token(self.mutual)
+        url = f"/api/me/collection/{self.collection.uuid}"
+        response = Client().put(
+            url,
+            data=json.dumps({"title": "New Title", "brief": "b", "visibility": 1}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 403
+        response = Client().put(
+            url,
+            data=json.dumps({"title": "New Title", "brief": "b", "visibility": 0}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200
+        self.collection.refresh_from_db()
+        assert self.collection.title == "New Title"
+        assert self.collection.visibility == 0
+
+    def test_collaborator_can_list_items_via_me_api(self):
+        token = self._api_client_token(self.mutual)
+        response = Client().get(
+            f"/api/me/collection/{self.collection.uuid}/item/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## Problem

`Collection.collaborative` (0: owner only / 1: editable by mutual followers) has been stored, shown in the edit form, and round-tripped through NDJSON since the pre-0.5 app, but nothing enforces it. The permission override was implemented in 2ce3bd08 (2022) on the old `collection` app and dropped in the 0.5 `journal` rewrite, so the setting has had no effect since: all edit views gate on the base `is_editable_by` (owner/staff only), and the API hard-checks owner.

## Fix

- `Collection.is_editable_by`: when `collaborative == 1`, a local collection is also editable by mutual followers of the owner, gated on `is_visible_to` so a collaborator can never edit a collection they cannot see.
- Remote mirror collections are now read-only for everyone including staff: local edits would silently diverge and be clobbered by the next federation member sync, and the old API owner-check already rejected them.
- Owner-only settings stay owner-only: the web edit view serves non-owner editors a reduced form without `visibility`/`collaborative`, and the API update endpoint rejects non-owner visibility/query changes. This prevents a collaborator from e.g. flipping a followers-only collection to public or locking other collaborators out.
- Deletion stays owner/staff-only via a new `is_deletable_by` hook on `UserOwnedObjectMixin` (defaults to edit permission), overridden by `Collection`; both web `piece_delete` and API `delete_collection` route through it.
- API parity: update/add/remove/reorder endpoints honor `is_editable_by`; the `/me/collection/` GET endpoints also allow editors so the surface is symmetric for collaborators.
- `CollectionMember` attribution unchanged: members added by collaborators are owned by the collection owner (as `List.append_item` already does), so AP `attributedTo` and timeline posts still come from the owner.
- Defensive detail: `user.identity` is a reverse OneToOne that raises instead of returning `None`; permission checks use `getattr` so an identity-less account gets 403 rather than 500.
- No template changes needed: `collection.html` already renders a "Collaborative editing" link for non-owner editors.

Not included (possible follow-up): the add-to-collection picker on item pages still lists only the user's own collections, not collaborative ones they could edit.

## Tests

- 22 new tests in `tests/journal/test_collection.py`: model permissions (owner / mutual / one-way follower / stranger / anonymous / non-collaborative / invisible / remote / staff-local-vs-remote / identity-less user / deletability), web flow (append+remove by mutual with owner attribution, 403s for one-way follower and for delete by mutual, reduced edit form for collaborators, full form for owner), and API (add item by mutual, 403 for follower, rename-but-not-visibility rule, delete 403, /me/ item listing for collaborators).
- `tests/journal`: 618 passed; pre-commit (ruff, ty, djlint) clean.