### PR TITLE
Correct page head metadata and document markup; include articles in sitemap

### DIFF
--- a/neodb/catalog/templates/discover.html
+++ b/neodb/catalog/templates/discover.html
@@ -17,7 +17,7 @@
     <meta property="og:url" content="{{ site_url }}">
     <meta property="og:image" content="{{ site_logo }}">
     <meta property="og:site_name" content="{{ site_name }}">
-    <meta rel="canonical" content="{{ site_url }}/discover/">
+    <link rel="canonical" href="{{ site_url }}/discover/">
     {% all_languages as languages %}
     {% for lang in languages %}
       <link rel="alternate"

--- a/neodb/catalog/templates/item_base.html
+++ b/neodb/catalog/templates/item_base.html
@@ -21,13 +21,14 @@
     {% if item.has_cover %}<meta property="og:image" content="{{ item.cover_image_url }}">{% endif %}
     <meta property="og:site_name"
           content="{{ site_name }} {% trans item.category.label %}">
-    <meta property="og:description"
+    <meta name="description"
+          property="og:description"
           content="{{ item.brief_description|slice:':300' }}">
     {% for claim in item.verified_creator_list %}
       <meta name="fediverse:creator" content="@{{ claim.owner.full_handle }}">
       {% if claim.owner.profile_uri %}<link rel="me" href="{{ claim.owner.profile_uri }}">{% endif %}
     {% endfor %}
-    <meta rel="canonical" content="{{ item.absolute_url }}">
+    <link rel="canonical" href="{{ item.absolute_url }}">
     {% all_languages as languages %}
     {% for lang in languages %}
       <link rel="alternate"

--- a/neodb/common/management/commands/sitemap.py
+++ b/neodb/common/management/commands/sitemap.py
@@ -24,15 +24,19 @@ class Command(SiteCommand):
                 ShelfMember.objects.filter(owner_id=OuterRef("owner_id"))
             )
             for cl in [Collection, Review, Article]:
+                if c <= 0:
+                    break
                 self.stdout.write(f"Collecting {cl.__name__}...")
                 pcs = cl.objects.filter(
                     visibility=0, local=True, owner__anonymous_viewable=True
                 )
                 if cl is Article:
                     pcs = pcs.filter(has_marks)
-                for p in pcs:
-                    c -= 1
+                for p in pcs.iterator():
+                    if c <= 0:
+                        break
                     f.write(p.absolute_url + "\n")
+                    c -= 1
 
             self.stdout.write("Collecting Catalog Items...")
             ratings = (

--- a/neodb/common/management/commands/sitemap.py
+++ b/neodb/common/management/commands/sitemap.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 
 from django.conf import settings
-from django.db.models import Count
+from django.db.models import Count, Exists, OuterRef
 
 from catalog.models import *
 from common.management.base import SiteCommand
@@ -18,11 +18,18 @@ class Command(SiteCommand):
         os.close(fd)
         with open(temp, "w") as f:
             c = 50000
-            for cl in [Collection, Review]:
+            # articles only count if the author has marked something,
+            # so accounts created just to publish don't get listed
+            has_marks = Exists(
+                ShelfMember.objects.filter(owner_id=OuterRef("owner_id"))
+            )
+            for cl in [Collection, Review, Article]:
                 self.stdout.write(f"Collecting {cl.__name__}...")
                 pcs = cl.objects.filter(
                     visibility=0, local=True, owner__anonymous_viewable=True
                 )
+                if cl is Article:
+                    pcs = pcs.filter(has_marks)
                 for p in pcs:
                     c -= 1
                     f.write(p.absolute_url + "\n")

--- a/neodb/common/static/scss/_header.scss
+++ b/neodb/common/static/scss/_header.scss
@@ -5,6 +5,10 @@ body {
     &>nav {
       ul.nav-logo {
         margin-left: var(--pico-nav-link-spacing-horizontal);
+
+        li {
+          padding: 0;
+        }
       }
 
       .nav-search form {

--- a/neodb/common/static/scss/_layout.scss
+++ b/neodb/common/static/scss/_layout.scss
@@ -128,6 +128,13 @@
     margin: 0;
   }
 
+  // page title uses h1 for document outline; render it at h3 scale
+  main hgroup h1 {
+    --pico-font-size: 1.5rem;
+    --pico-line-height: 1.175;
+    --pico-typography-spacing-top: 1.5rem;
+  }
+
   main {
     display: grid;
     grid-template-columns: auto 25%;

--- a/neodb/common/templates/_header.html
+++ b/neodb/common/templates/_header.html
@@ -4,9 +4,11 @@
 <header class="container-fluid">
   <nav>
     <ul class="nav-logo">
-      <a href="{% url 'common:home' %}">
-        <img src="{{ site_logo }}" alt="" />
-      </a>
+      <li>
+        <a href="{% url 'common:home' %}">
+          <img src="{{ site_logo }}" alt="{{ site_name }}" />
+        </a>
+      </li>
     </ul>
     <ul class="nav-search {% if request.GET.q %}unhide{% endif %}">
       <li>

--- a/neodb/common/templates/common_libs.html
+++ b/neodb/common/templates/common_libs.html
@@ -5,7 +5,7 @@
   {% tz_detect %}
 {% endif %}
 <script src="{{ cdn_url }}/npm/cash-dom@8.1.5/dist/cash.min.js"></script>
-<script type="text/javascript">
+<script>
   if (!$.fn.is_visible) $.fn.is_visible = function () {
     return this.filter((_, elt) => (elt.offsetWidth || elt.offsetHeight || elt.getClientRects().length)).length > 0;
   };
@@ -27,17 +27,15 @@
         href="{{ cdn_url }}/npm/@picocss/pico@2.1.1/css/pico.{{ site_color }}.min.css" />
 {% endif %}
 <link href="{% sass_src 'scss/neodb.scss' %}{% if debug_enabled %}?r={% now "U" %}{% endif %}"
-      rel="stylesheet"
-      type="text/css" />
+      rel="stylesheet" />
 <link href="{{ cdn_url }}/npm/@fortawesome/fontawesome-free@7.2.0/css/all.min.css"
-      rel="stylesheet"
-      type="text/css">
+      rel="stylesheet">
 <link rel="manifest" href="{% url 'common:manifest' %}" />
 <link rel="search"
       type="application/opensearchdescription+xml"
       title="{{ site_name }}"
       href="{% url 'common:opensearch' %}">
-<script defer>
+<script>
 (function(){
   const s = localStorage.getItem("user_style");
   if (s) {
@@ -69,7 +67,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-title" content="{{ site_name }}">
 {% if request.META.HTTP_HOST == site_domain %}
-  <style type="text/css">.hide_unless_alter_domain{display:none;}</style>
+  <style>.hide_unless_alter_domain{display:none;}</style>
 {% else %}
   <meta name="robots" content="noindex">
 {% endif %}

--- a/neodb/journal/templates/action_like_post.html
+++ b/neodb/journal/templates/action_like_post.html
@@ -8,13 +8,13 @@
     <a class="activated"
        hx-post="{% url 'journal:post_unlike' post.pk %}"
        title="{% trans "Liked" %}">
-      <i class="fa-solid fa-heart }}"></i>
+      <i class="fa-solid fa-heart"></i>
       <span class="metrics">{{ post.stats.likes }}</span>
     </a>
   {% else %}
     <a hx-post="{% url 'journal:post_like' post.pk %}"
        title="{% trans "Like" %}">
-      <i class="fa-regular fa-heart }}"></i>
+      <i class="fa-regular fa-heart"></i>
       {% if post.stats.likes %}<span class="metrics">{{ post.stats.likes }}</span>{% endif %}
     </a>
   {% endif %}

--- a/neodb/journal/templates/article.html
+++ b/neodb/journal/templates/article.html
@@ -17,13 +17,19 @@
     {% else %}
       <meta property="og:title" content="{{ article.title }}">
     {% endif %}
+    <meta name="description"
+          property="og:description"
+          content="{{ article.brief_description }}">
     <meta property="og:type" content="article">
-    <meta property="og:article:author"
-          content="{{ article.owner.display_name }}">
+    <meta property="article:author" content="{{ article.owner.display_name }}">
+    <meta property="article:published_time"
+          content="{{ article.created_time | date:'c' }}">
+    <meta property="article:modified_time"
+          content="{{ article.edited_time | date:'c' }}">
     <meta property="og:url" content="{{ article.absolute_url }}">
     <meta property="og:site_name" content="{{ site_name }}">
     <meta name="fediverse:creator" content="@{{ article.owner.full_handle }}">
-    <meta rel="canonical" content="{{ article.absolute_url }}">
+    <link rel="canonical" href="{{ article.absolute_url }}">
     <meta name="lastmodified" content="{{ article.edited_time | date:'r' }}">
     {% if article.classname == "review" %}
       <meta property="og:image" content="{{ article.item.cover|thumb:'normal' }}">
@@ -93,9 +99,9 @@
         <article>
           <header>
             <hgroup>
-              <h3>
+              <h1>
                 <span id="{{ article.classname }}_{{ article.uuid }}_title">{{ article.title }}</span>
-              </h3>
+              </h1>
             </hgroup>
             <p class="piece-summary article-summary">
               {% if article.classname == "article" %}

--- a/neodb/journal/templates/collection.html
+++ b/neodb/journal/templates/collection.html
@@ -13,17 +13,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:title" content="{{ collection.title }}">
-    <meta property="og:description" content="{{ collection.description }}">
+    <meta name="description"
+          property="og:description"
+          content="{{ collection.description }}">
     <meta property="og:type" content="article">
-    <meta property="og:article:author"
+    <meta property="article:author"
           content="{{ collection.owner.display_name }}">
+    <meta property="article:published_time"
+          content="{{ collection.created_time | date:'c' }}">
+    <meta property="article:modified_time"
+          content="{{ collection.edited_time | date:'c' }}">
     <meta property="og:url" content="{{ collection.absolute_url }}">
     {% if collection.cover_image_url %}<meta property="og:image" content="{{ collection.cover_image_url }}">{% endif %}
     <meta property="og:site_name"
           content="{{ site_name }} {% trans 'Collection' %}">
     <meta name="fediverse:creator"
           content="@{{ collection.owner.full_handle }}">
-    <meta rel="canonical" content="{{ collection.absolute_url }}">
+    <link rel="canonical" href="{{ collection.absolute_url }}">
     <meta name="lastmodified" content="{{ collection.edited_time | date:'r' }}" />
     {% if collection.latest_post %}
       <link rel="alternate"
@@ -81,10 +87,10 @@
         {% endif %}
         <section>
           <hgroup>
-            <h3>
+            <h1>
               {{ collection.title }}
               {% if collection.visibility > 0 %}<small><i class="fa-solid fa-lock"></i></small>{% endif %}
-            </h3>
+            </h1>
           </hgroup>
           <div class="owner-info">
             <div class="info">
@@ -99,7 +105,7 @@
                 <p>
                   <progress value="{{ stats.percentage }}"
                             max="100"
-                            title="{{ stats.percentage }}%" />
+                            title="{{ stats.percentage }}%"></progress>
                 </p>
               {% endif %}
               <div class="markdown-content">{{ collection.html_content | safe }}</div>

--- a/neodb/social/templates/single_post.html
+++ b/neodb/social/templates/single_post.html
@@ -19,7 +19,11 @@
     {% endif %}
     <meta property="og:site_name" content="{{ site_name }}">
     <meta property="og:type" content="article">
-    <meta property="og:article:author" content="{{ owner.display_name }}">
+    <meta property="article:author" content="{{ owner.display_name }}">
+    <meta property="article:published_time"
+          content="{{ post.published | date:'c' }}">
+    <meta property="article:modified_time"
+          content="{{ post.updated | date:'c' }}">
     {% if post.item.has_cover %}<meta property="og:image" content="{{ post.item.cover|thumb:'normal' }}">{% endif %}
     {% if post.type == 'Article' %}
       <meta property="og:description"

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -766,3 +766,37 @@ class TestArticleFeed:
         assert self.client.get(self.feed_url).status_code == 404
         # ReviewFeed shares the same guard
         assert self.client.get(f"{self.identity.url}feed/reviews/").status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestArticlePageMarkup:
+    """The /article/<uuid> page head and document structure."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="art_page@test.com", username="art_page")
+        self.identity = self.user.identity
+        self.client = Client()
+        self.client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+
+    def test_article_page_head_and_title(self):
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="Anatomy of a Page",
+            body="## Section\n\nbody text",
+            summary="A one-line teaser.",
+            visibility=0,
+        )
+        resp = self.client.get(article.url)
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        assert f'<link rel="canonical" href="{article.absolute_url}">' in html
+        # single meta carries both the plain and the OpenGraph description
+        assert 'name="description"' in html
+        assert 'property="og:description"' in html
+        assert "A one-line teaser." in html
+        assert 'property="article:author"' in html
+        assert 'property="article:published_time"' in html
+        assert 'property="article:modified_time"' in html
+        # the page title is the document's only h1; body headings start at h2
+        assert html.count("<h1>") == 1


### PR DESCRIPTION
## What

Template and markup corrections for the article, collection, item, discover, and single-post pages, plus shared header/libs includes:

- The canonical URL was emitted as `<meta rel="canonical" content=...>`, which no consumer recognizes; it is now a proper `<link rel="canonical" href=...>` element (article, collection, item, discover pages).
- Article pages had no description metadata at all; a single `<meta name="description" property="og:description">` is now emitted from the article summary (same combined-tag pattern the discover page already used). Item and collection pages gained the `name="description"` half on their existing OpenGraph description.
- OpenGraph article properties were namespaced `og:article:*`, which is not part of the protocol; they are now `article:author`, plus new `article:published_time` / `article:modified_time` (article, collection, single-post pages).
- Article and collection titles rendered as `<h3>` with `<h2>` sections below and no `<h1>` anywhere on the page; the title is now the document's single `<h1>`, with its visual size pinned to the previous scale via SCSS.
- The like button emitted a literal `}}` inside its icon class attribute (`class="fa-regular fa-heart }}"`).
- The nav logo was an `<a>` directly inside `<ul>`; it is now wrapped in `<li>` (with Pico's li padding zeroed to keep the layout identical) and the logo image has alt text so the home link has an accessible name.
- Removed an invalid `defer` on an inline script, obsolete `type="text/css"` / `type="text/javascript"` attributes, and a self-closed `<progress />`.

The sitemap command now also lists public local articles, but only for authors who have marked at least one item, so accounts created solely to publish content are not surfaced.

## Testing

- New regression test `TestArticlePageMarkup` asserts the article page head (canonical link, description meta, article:* properties) and that the page has exactly one `h1`.
- Existing journal/catalog page tests pass (`tests/journal/test_article.py`, `test_article_search.py`, `test_collection.py`, `test_conditional_get.py`, `test_pages.py`).
- Verified end to end on a dev instance: rendered article page shows the corrected head and body markup; sitemap generation verified to exclude an author with no marks and include the same author after their first mark.