### PR TITLE
feat(journal): consistent edit entry points for collections, reviews and articles

### DIFF
--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.db import models, transaction
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
@@ -122,6 +123,10 @@ class Collection(List):
     @property
     def cover_image_url(self) -> str | None:
         return get_file_absolute_url(self.cover)
+
+    @property
+    def edit_url(self) -> str:
+        return reverse("journal:collection_edit", args=[self.uuid])
 
     @property
     def is_dynamic(self):

--- a/neodb/journal/templates/article.html
+++ b/neodb/journal/templates/article.html
@@ -78,7 +78,10 @@
                     </a>
                   </span>
                 {% endif %}
-                {% include "_post_action_menu.html" with post=article.latest_post piece=article %}
+                {% if request.user.is_authenticated and request.user.identity == article.owner %}
+                  {% firstof article.edit_url as piece_edit_url %}
+                {% endif %}
+                {% include "_post_action_menu.html" with post=article.latest_post piece=article piece_edit_url=piece_edit_url %}
                 {% include "action_open_post.html" with post=article.latest_post %}
               </span>
               <span class="post_author">

--- a/neodb/journal/templates/collection.html
+++ b/neodb/journal/templates/collection.html
@@ -71,7 +71,10 @@
                        title="{% trans "Share" %}"><i class="fa-solid fa-share-nodes"></i></a>
                   </span>
                 {% endif %}
-                {% include "_post_action_menu.html" with post=collection.latest_post piece=collection %}
+                {% if editable %}
+                  {% firstof collection.edit_url as piece_edit_url %}
+                {% endif %}
+                {% include "_post_action_menu.html" with post=collection.latest_post piece=collection piece_edit_url=piece_edit_url %}
                 {% include "action_open_post.html" with post=collection.latest_post %}
               </span>
               <span class="post_author">
@@ -177,18 +180,21 @@
               <span>
                 <a href="{% url 'journal:collection_delete' collection.uuid %}">{% trans 'Delete' %}</a>
               </span>
+            {% elif editable %}
+              <span>
+                <a href="{% url 'journal:collection_edit' collection.uuid %}"
+                   title="{% trans 'Collaborative editing' %}">{% trans 'Edit' %}</a>
+              </span>
             {% endif %}
           </span>
           <span class="action inline">
             {% if collection.latest_post %}
               {% include "action_open_post.html" with post=collection.latest_post %}
             {% endif %}
-            <span><a>{{ collection.created_time|date }}</a></span>
-            {% if editable and request.user.identity != collection.owner %}
-              <span>
-                <a href="{% url 'journal:collection_edit' collection.uuid %}">{% trans 'Collaborative editing' %}</a>
-              </span>
+            {% if collection.collaborative == 1 %}
+              <span><small><i class="fa-solid fa-users" title="{% trans 'Collaborative editing' %}"></i></small></span>
             {% endif %}
+            <span><a>{{ collection.created_time|date }}</a></span>
           </span>
         </section>
         {% if collection.latest_post %}

--- a/neodb/social/templates/_post_action_menu.html
+++ b/neodb/social/templates/_post_action_menu.html
@@ -6,6 +6,13 @@
         <i class="fa-solid fa-ellipsis"></i>
       </summary>
       <ul role="menu">
+        {% if piece_edit_url %}
+          <li>
+            <span>
+              <a href="{{ piece_edit_url }}" title="{% trans 'Edit' %}">{% trans "Edit" %}</a>
+            </span>
+          </li>
+        {% endif %}
         {% if post.author_id == request.user.identity.pk %}
           <li>{% include "action_pin_post.html" with menu_label=1 %}</li>
           {% if not piece %}


### PR DESCRIPTION
## Summary
- Collaborators on a collaborative collection now see an **Edit** link in the same action row as the owner's (with a *Collaborative editing* tooltip), replacing the separate link that sat in the timestamp row. Delete, and the Query link for dynamic collections, remain owner-only.
- A `fa-users` icon, styled like the visibility lock icon, is shown left of the date at the bottom of the collection page when the collection is collaboratively editable.
- The post `...` action menu accepts a generic `piece_edit_url`: collection, review and article pages now offer an **Edit** entry there to anyone allowed to edit the piece (owner, or mutual-follower collaborator for collaborative collections). `Collection.edit_url` was added to match the existing property on `Article` and `Review`.

## Notes
- Permission logic is unchanged: editing is still enforced server-side by `Collection.is_editable_by` via the existing `editable` context flag; this only changes where the entry points appear.
- Feed events (`_event_post.html`) don't pass `piece_edit_url`, so their menu is unchanged.