### PR TITLE
feat(social): cap long post content in sidebars with click to expand

### DIFF
--- a/neodb/catalog/templates/_discover_popular_posts.html
+++ b/neodb/catalog/templates/_discover_popular_posts.html
@@ -1,1 +1,1 @@
-{% include "posts.html" with posts=popular_posts %}
+{% include "posts.html" with posts=popular_posts collapse_content=1 %}

--- a/neodb/common/templates/_sidebar.html
+++ b/neodb/common/templates/_sidebar.html
@@ -245,7 +245,7 @@
             <small><a href="{% url 'journal:user_post_list' identity.handle %}"
    title="{% trans 'show all' %}"><i class="fa-solid fa-list"></i></a></small>
           </summary>
-          <div style="font-size:80%">{% include "posts.html" with posts=recent_posts %}</div>
+          <div style="font-size:80%">{% include "posts.html" with posts=recent_posts collapse_content=1 %}</div>
         </details>
       </article>
     </section>

--- a/neodb/social/templates/_event_post.html
+++ b/neodb/social/templates/_event_post.html
@@ -133,57 +133,56 @@
                 {% endif %}
               {% endfor %}
             </div>
-            <div id="content_{{ post.pk }}"
-                 class="content{% if collapse_content %} tldr{% endif %}"
-                 {% if collapse_content %}_="on click toggle .tldr on me"{% endif %}>
-              {% if piece and piece.classname == 'note' %}
-                <blockquote style="margin:0; padding-top:0; padding-bottom:0">
-                  {{ post.safe_content_local|default:"" }}
-                </blockquote>
-              {% elif piece.classname == 'article' or piece.classname == 'review' %}
-                {% include "_article_teaser.html" with article=piece %}
-              {% elif post.type == 'Article' %}
-                {% include "_remote_article_teaser.html" with post=post show_full=show_full %}
-              {% else %}
-                {{ post.safe_content_local|default:"" }}
-              {% endif %}
-            </div>
-            {% if post.type == 'Question' %}
-              {% include "post_question.html" %}
-            {% endif %}
-            {% if post.quoted_post_ or post.quote_url %}
-              <blockquote class="quote-post{% if collapse_content %} tldr{% endif %}"
-                          {% if collapse_content %}_="on click toggle .tldr on me"{% endif %}>
-                {% if post.quoted_post_ %}
-                  <a class="nickname"
-                     href="{% url 'journal:post_view' post.quoted_post_.author.handle post.quoted_post_.pk %}">{{ post.quoted_post_.author.name | default:post.quoted_post_.author.handle }}</a>:
-                  {{ post.quoted_post_.safe_content_local|default:"" }}
-                {% else %}
-                  <a href="{{ post.quote_url }}" target="_blank" rel="noopener">{{ post.quote_url }}</a>
-                {% endif %}
-              </blockquote>
-            {% endif %}
-          </div>
-          <div class="embed-cover">
-            {% if piece and piece.classname == 'note' %}
-              {% if item %}
-                <a href="{{ item.url }}" title="{{ item.display_title }}">
-                  <img src="{{ item.cover_image_url }}"
-                       title="{{ item.display_title }}"
-                       alt="cover">
-                </a>
-              {% endif %}
-            {% endif %}
-          </div>
+            <div id="content_{{ post.pk }}" class="content{% if collapse_content %} tldr{% endif %}" {% if collapse_content %}_="on click if no (closest <a/> to target) toggle .tldr on me"{% endif %}
+          >
+          {% if piece and piece.classname == 'note' %}
+            <blockquote style="margin:0; padding-top:0; padding-bottom:0">
+              {{ post.safe_content_local|default:"" }}
+            </blockquote>
+          {% elif piece.classname == 'article' or piece.classname == 'review' %}
+            {% include "_article_teaser.html" with article=piece %}
+          {% elif post.type == 'Article' %}
+            {% include "_remote_article_teaser.html" with post=post show_full=show_full %}
+          {% else %}
+            {{ post.safe_content_local|default:"" }}
+          {% endif %}
         </div>
-      </div>
-    </div>
-    <div id="quote_{{ post.pk }}"></div>
-    <div id="replies_{{ post.pk }}"
-         {% if show_replies %} hx-get="{% url 'journal:post_replies' post.pk %}{% if show_all_actions %}?header=1{% endif %}
-         "
-         hx-swap="outerHTML"
-         hx-trigger="revealed"
-         {% endif %}></div>
-  </section>
+        {% if post.type == 'Question' %}
+          {% include "post_question.html" %}
+        {% endif %}
+        {% if post.quoted_post_ or post.quote_url %}
+          <blockquote class="quote-post{% if collapse_content %} tldr{% endif %}" {% if collapse_content %}_="on click if no (closest <a/> to target) toggle .tldr on me"{% endif %}
+        >
+        {% if post.quoted_post_ %}
+          <a class="nickname"
+             href="{% url 'journal:post_view' post.quoted_post_.author.handle post.quoted_post_.pk %}">{{ post.quoted_post_.author.name | default:post.quoted_post_.author.handle }}</a>:
+          {{ post.quoted_post_.safe_content_local|default:"" }}
+        {% else %}
+          <a href="{{ post.quote_url }}" target="_blank" rel="noopener">{{ post.quote_url }}</a>
+        {% endif %}
+      </blockquote>
+    {% endif %}
+  </div>
+  <div class="embed-cover">
+    {% if piece and piece.classname == 'note' %}
+      {% if item %}
+        <a href="{{ item.url }}" title="{{ item.display_title }}">
+          <img src="{{ item.cover_image_url }}"
+               title="{{ item.display_title }}"
+               alt="cover">
+        </a>
+      {% endif %}
+    {% endif %}
+  </div>
+</div>
+</div>
+</div>
+<div id="quote_{{ post.pk }}"></div>
+<div id="replies_{{ post.pk }}"
+     {% if show_replies %} hx-get="{% url 'journal:post_replies' post.pk %}{% if show_all_actions %}?header=1{% endif %}
+     "
+     hx-swap="outerHTML"
+     hx-trigger="revealed"
+     {% endif %}></div>
+</section>
 {% endif %}

--- a/neodb/social/templates/_event_post.html
+++ b/neodb/social/templates/_event_post.html
@@ -133,56 +133,57 @@
                 {% endif %}
               {% endfor %}
             </div>
-            <div id="content_{{ post.pk }}" class="content{% if collapse_content %} tldr{% endif %}" {% if collapse_content %}_="on click if no (closest <a/> to target) toggle .tldr on me"{% endif %}
-          >
-          {% if piece and piece.classname == 'note' %}
-            <blockquote style="margin:0; padding-top:0; padding-bottom:0">
-              {{ post.safe_content_local|default:"" }}
-            </blockquote>
-          {% elif piece.classname == 'article' or piece.classname == 'review' %}
-            {% include "_article_teaser.html" with article=piece %}
-          {% elif post.type == 'Article' %}
-            {% include "_remote_article_teaser.html" with post=post show_full=show_full %}
-          {% else %}
-            {{ post.safe_content_local|default:"" }}
-          {% endif %}
+            <div id="content_{{ post.pk }}"
+                 class="content{% if collapse_content %} tldr{% endif %}"
+                 {% if collapse_content %}_="on click if not target.closest('a') toggle .tldr on me"{% endif %}>
+              {% if piece and piece.classname == 'note' %}
+                <blockquote style="margin:0; padding-top:0; padding-bottom:0">
+                  {{ post.safe_content_local|default:"" }}
+                </blockquote>
+              {% elif piece.classname == 'article' or piece.classname == 'review' %}
+                {% include "_article_teaser.html" with article=piece %}
+              {% elif post.type == 'Article' %}
+                {% include "_remote_article_teaser.html" with post=post show_full=show_full %}
+              {% else %}
+                {{ post.safe_content_local|default:"" }}
+              {% endif %}
+            </div>
+            {% if post.type == 'Question' %}
+              {% include "post_question.html" %}
+            {% endif %}
+            {% if post.quoted_post_ or post.quote_url %}
+              <blockquote class="quote-post{% if collapse_content %} tldr{% endif %}"
+                          {% if collapse_content %}_="on click if not target.closest('a') toggle .tldr on me"{% endif %}>
+                {% if post.quoted_post_ %}
+                  <a class="nickname"
+                     href="{% url 'journal:post_view' post.quoted_post_.author.handle post.quoted_post_.pk %}">{{ post.quoted_post_.author.name | default:post.quoted_post_.author.handle }}</a>:
+                  {{ post.quoted_post_.safe_content_local|default:"" }}
+                {% else %}
+                  <a href="{{ post.quote_url }}" target="_blank" rel="noopener">{{ post.quote_url }}</a>
+                {% endif %}
+              </blockquote>
+            {% endif %}
+          </div>
+          <div class="embed-cover">
+            {% if piece and piece.classname == 'note' %}
+              {% if item %}
+                <a href="{{ item.url }}" title="{{ item.display_title }}">
+                  <img src="{{ item.cover_image_url }}"
+                       title="{{ item.display_title }}"
+                       alt="cover">
+                </a>
+              {% endif %}
+            {% endif %}
+          </div>
         </div>
-        {% if post.type == 'Question' %}
-          {% include "post_question.html" %}
-        {% endif %}
-        {% if post.quoted_post_ or post.quote_url %}
-          <blockquote class="quote-post{% if collapse_content %} tldr{% endif %}" {% if collapse_content %}_="on click if no (closest <a/> to target) toggle .tldr on me"{% endif %}
-        >
-        {% if post.quoted_post_ %}
-          <a class="nickname"
-             href="{% url 'journal:post_view' post.quoted_post_.author.handle post.quoted_post_.pk %}">{{ post.quoted_post_.author.name | default:post.quoted_post_.author.handle }}</a>:
-          {{ post.quoted_post_.safe_content_local|default:"" }}
-        {% else %}
-          <a href="{{ post.quote_url }}" target="_blank" rel="noopener">{{ post.quote_url }}</a>
-        {% endif %}
-      </blockquote>
-    {% endif %}
-  </div>
-  <div class="embed-cover">
-    {% if piece and piece.classname == 'note' %}
-      {% if item %}
-        <a href="{{ item.url }}" title="{{ item.display_title }}">
-          <img src="{{ item.cover_image_url }}"
-               title="{{ item.display_title }}"
-               alt="cover">
-        </a>
-      {% endif %}
-    {% endif %}
-  </div>
-</div>
-</div>
-</div>
-<div id="quote_{{ post.pk }}"></div>
-<div id="replies_{{ post.pk }}"
-     {% if show_replies %} hx-get="{% url 'journal:post_replies' post.pk %}{% if show_all_actions %}?header=1{% endif %}
-     "
-     hx-swap="outerHTML"
-     hx-trigger="revealed"
-     {% endif %}></div>
-</section>
+      </div>
+    </div>
+    <div id="quote_{{ post.pk }}"></div>
+    <div id="replies_{{ post.pk }}"
+         {% if show_replies %} hx-get="{% url 'journal:post_replies' post.pk %}{% if show_all_actions %}?header=1{% endif %}
+         "
+         hx-swap="outerHTML"
+         hx-trigger="revealed"
+         {% endif %}></div>
+  </section>
 {% endif %}

--- a/neodb/social/templates/_event_post.html
+++ b/neodb/social/templates/_event_post.html
@@ -133,7 +133,9 @@
                 {% endif %}
               {% endfor %}
             </div>
-            <div id="content_{{ post.pk }}" class="content">
+            <div id="content_{{ post.pk }}"
+                 class="content{% if collapse_content %} tldr{% endif %}"
+                 {% if collapse_content %}_="on click toggle .tldr on me"{% endif %}>
               {% if piece and piece.classname == 'note' %}
                 <blockquote style="margin:0; padding-top:0; padding-bottom:0">
                   {{ post.safe_content_local|default:"" }}
@@ -150,7 +152,8 @@
               {% include "post_question.html" %}
             {% endif %}
             {% if post.quoted_post_ or post.quote_url %}
-              <blockquote class="quote-post">
+              <blockquote class="quote-post{% if collapse_content %} tldr{% endif %}"
+                          {% if collapse_content %}_="on click toggle .tldr on me"{% endif %}>
                 {% if post.quoted_post_ %}
                   <a class="nickname"
                      href="{% url 'journal:post_view' post.quoted_post_.author.handle post.quoted_post_.pk %}">{{ post.quoted_post_.author.name | default:post.quoted_post_.author.handle }}</a>:


### PR DESCRIPTION
## Summary
Long posts in the right sidebar (Recent Posts on /discover/ and on item pages) currently render their full content, making the sidebar extremely tall. This caps post content in sidebars at the existing `.tldr` 10-line clamp, expandable by click.

- Pass `collapse_content=1` from the two sidebar entry points of `posts.html` (`_discover_popular_posts.html` and `_sidebar.html`)
- In `_event_post.html`, apply the existing `.tldr` class + click-to-toggle (same pattern already used for comments, notes and track lists) to the post content div and quoted-post blockquote when the flag is set
- Feeds, timelines and post detail pages are unaffected

## Test plan
- `uv run pre-commit run -a` passes (djLint, ruff, ty)
- Verified the `.tldr` clamp behavior on a `div.content` with mixed block children (paragraphs, blockquote, teaser section) in the browser: clamps to ~10 lines, toggles open/closed on click