### PR TITLE
fix(takahe): rewrite ~neodb~ placeholder URLs in web post rendering

### DIFF
--- a/neodb/takahe/models.py
+++ b/neodb/takahe/models.py
@@ -1551,9 +1551,20 @@ class Post(models.Model):
         if save:
             self.save()
 
+    @staticmethod
+    def _rewrite_neodb_urls(content: str) -> str:
+        """Rewrite ~neodb~ placeholder URLs to local search URLs for display."""
+        return re.sub(
+            r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"',
+            'href="' + settings.SITE_INFO["site_url"] + r'/search?r=1&q=\1\2"',
+            content,
+        )
+
     @property
     def safe_content_local(self):
-        return ContentRenderer(local=True).render_post(self.content, self)
+        return self._rewrite_neodb_urls(
+            ContentRenderer(local=True).render_post(self.content, self)
+        )
 
     @property
     def content_plain_text(self):

--- a/neodb/takahe/models.py
+++ b/neodb/takahe/models.py
@@ -1552,17 +1552,19 @@ class Post(models.Model):
         if save:
             self.save()
 
-    @staticmethod
-    def _rewrite_neodb_urls(content: str) -> str:
+    _neodb_url_regex = re.compile(r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"')
+
+    @classmethod
+    def _rewrite_neodb_urls(cls, content: str) -> str:
         """Rewrite ~neodb~ placeholder URLs to local search URLs for display."""
         # mark_safe: input is render_post output (already sanitized), and the
         # inserted href is quoted, so the rewrite introduces no unsafe markup.
+        site_url = settings.SITE_INFO["site_url"].rstrip("/")
         return mark_safe(
-            re.sub(
-                r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"',
+            cls._neodb_url_regex.sub(
                 lambda m: (
                     'href="'
-                    + settings.SITE_INFO["site_url"]
+                    + site_url
                     + "/search?r=1&q="
                     + quote(m.group(1) + m.group(2), safe="")
                     + '"'

--- a/neodb/takahe/models.py
+++ b/neodb/takahe/models.py
@@ -7,6 +7,7 @@ import time
 from datetime import date, timedelta
 from functools import cached_property, partial
 from typing import TYPE_CHECKING, ClassVar, Optional
+from urllib.parse import quote
 
 import httpx
 import urlman
@@ -1554,10 +1555,20 @@ class Post(models.Model):
     @staticmethod
     def _rewrite_neodb_urls(content: str) -> str:
         """Rewrite ~neodb~ placeholder URLs to local search URLs for display."""
-        return re.sub(
-            r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"',
-            'href="' + settings.SITE_INFO["site_url"] + r'/search?r=1&q=\1\2"',
-            content,
+        # mark_safe: input is render_post output (already sanitized), and the
+        # inserted href is quoted, so the rewrite introduces no unsafe markup.
+        return mark_safe(
+            re.sub(
+                r'href="(https?://[^/"]+)/~neodb~(/[^"]+)"',
+                lambda m: (
+                    'href="'
+                    + settings.SITE_INFO["site_url"]
+                    + "/search?r=1&q="
+                    + quote(m.group(1) + m.group(2), safe="")
+                    + '"'
+                ),
+                content,
+            )
         )
 
     @property

--- a/neodb/tests/journal/test_post_content.py
+++ b/neodb/tests/journal/test_post_content.py
@@ -7,7 +7,12 @@ Mastodon API; the mirror ``takahe.models.Post`` must do the same for
 NeoDB web templates rendering ``safe_content_local``.
 """
 
+from urllib.parse import quote
+
 import pytest
+from django.test import Client
+from django.urls import reverse
+from django.utils.safestring import SafeString
 
 from catalog.models import Edition
 from journal.models import Mark, ShelfType
@@ -18,9 +23,15 @@ from users.models import User
 class TestRewriteNeodbUrls:
     def test_rewrites_remote_placeholder_href(self):
         content = '<a href="https://remote.example/~neodb~/movie/abc">Title</a>'
-        assert Post._rewrite_neodb_urls(content) == (
-            '<a href="https://example.org/search?r=1&q=https://remote.example/movie/abc">Title</a>'
+        result = Post._rewrite_neodb_urls(content)
+        assert result == (
+            '<a href="https://example.org/search?r=1&q=https%3A%2F%2Fremote.example%2Fmovie%2Fabc">Title</a>'
         )
+
+    def test_result_stays_html_safe(self):
+        # templates render safe_content_local without |safe, so the rewrite
+        # must not strip the SafeString marker set by ContentRenderer
+        assert isinstance(Post._rewrite_neodb_urls("<p>hi</p>"), SafeString)
 
     def test_leaves_plain_links_unchanged(self):
         content = '<a href="https://remote.example/movie/abc">Title</a>'
@@ -37,8 +48,22 @@ def test_safe_content_local_rewrites_item_link():
     post = shelfmember.latest_post
     assert post is not None
     assert f"/~neodb~{book.url}" in post.content
+    rewritten_href = (
+        'href="https://example.org/search?r=1&q='
+        f'{quote(f"https://example.org{book.url}", safe="")}"'
+    )
     rendered = post.safe_content_local
     assert "~neodb~" not in rendered
-    assert f'href="https://example.org/search?r=1&q=https://example.org{book.url}"' in (
-        rendered
+    assert rewritten_href in rendered
+
+    # the rewritten anchor must reach page HTML unescaped
+    response = Client().get(
+        reverse(
+            "journal:user_post_list",
+            kwargs={"user_name": user.identity.handle},
+        )
     )
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert rewritten_href in html
+    assert "~neodb~" not in html

--- a/neodb/tests/journal/test_post_content.py
+++ b/neodb/tests/journal/test_post_content.py
@@ -1,0 +1,44 @@
+"""Tests for ~neodb~ placeholder URL rewriting in web post rendering.
+
+Posts federated by NeoDB embed item links as
+``{site_url}/~neodb~{item_url}`` so consuming instances can localize
+them. The takahe app rewrites these for its own templates and the
+Mastodon API; the mirror ``takahe.models.Post`` must do the same for
+NeoDB web templates rendering ``safe_content_local``.
+"""
+
+import pytest
+
+from catalog.models import Edition
+from journal.models import Mark, ShelfType
+from takahe.models import Post
+from users.models import User
+
+
+class TestRewriteNeodbUrls:
+    def test_rewrites_remote_placeholder_href(self):
+        content = '<a href="https://remote.example/~neodb~/movie/abc">Title</a>'
+        assert Post._rewrite_neodb_urls(content) == (
+            '<a href="https://example.org/search?r=1&q=https://remote.example/movie/abc">Title</a>'
+        )
+
+    def test_leaves_plain_links_unchanged(self):
+        content = '<a href="https://remote.example/movie/abc">Title</a>'
+        assert Post._rewrite_neodb_urls(content) == content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_safe_content_local_rewrites_item_link():
+    book = Edition.objects.create(title="Rewrite Test Book")
+    user = User.register(email="rewrite@test.com", username="rewrite_user")
+    Mark(user.identity, book).update(ShelfType.WISHLIST, "note", None, [], 0)
+    shelfmember = Mark(user.identity, book).shelfmember
+    assert shelfmember is not None
+    post = shelfmember.latest_post
+    assert post is not None
+    assert f"/~neodb~{book.url}" in post.content
+    rendered = post.safe_content_local
+    assert "~neodb~" not in rendered
+    assert f'href="https://example.org/search?r=1&q=https://example.org{book.url}"' in (
+        rendered
+    )


### PR DESCRIPTION
## Problem

Item links in federated NeoDB posts are embedded as `{site_url}/~neodb~{item_url}` so consuming instances can localize them. The takahe app rewrites these to local `/search?r=1&q=...` URLs in both its own templates (`safe_content_local`) and Mastodon API output (`safe_content_api`) — which is why API responses show correctly replaced links.

However, NeoDB web templates (`_event_post.html`, `event/_post.html`, `replies.html`, `post_quotes.html`, `_remote_article_teaser.html`) render posts through the mirror `takahe.models.Post.safe_content_local`, which lacked the rewrite — so raw `~neodb~` links leaked into the web UI.

## Fix

Apply the same `_rewrite_neodb_urls` regex in the mirror model's `safe_content_local`, building the target from `settings.SITE_INFO["site_url"]` (the neodb-side equivalent of takahe's `SETUP.MAIN_DOMAIN`).

## Tests

- Unit tests for the rewrite regex (remote placeholder href rewritten; plain links untouched).
- End-to-end test: a Mark-generated post's `safe_content_local` contains the rewritten `/search?r=1&q=...` link and no `~neodb~`.

`tests/journal` + `tests/social` suites pass (645 tests); pre-commit clean.