### PR TITLE
fix(nginx): cache proxied remote media regardless of origin cache headers

### DIFF
--- a/misc/nginx.conf.d/neodb-dev.conf
+++ b/misc/nginx.conf.d/neodb-dev.conf
@@ -92,6 +92,17 @@ server {
         proxy_ssl_server_name on;
         add_header X-Takahe-Accel "HIT";
 
+        # Remote origins may reply with Cache-Control: private, Vary or
+        # Set-Cookie, which would prevent nginx from storing the response;
+        # ignore them so proxy_cache_valid below applies, and hide them so
+        # browsers/CDNs can cache the proxied copy. X-Accel-* headers from
+        # untrusted remote servers must not be honored either.
+        proxy_ignore_headers Cache-Control Expires Set-Cookie Vary X-Accel-Redirect X-Accel-Expires X-Accel-Limit-Rate X-Accel-Buffering X-Accel-Charset;
+        proxy_hide_header Cache-Control;
+        proxy_hide_header Expires;
+        proxy_hide_header Set-Cookie;
+        proxy_hide_header Vary;
+
         # Cache these responses too
         proxy_cache takahe;
         # Cache after a single request

--- a/misc/nginx.conf.d/neodb-dev.conf
+++ b/misc/nginx.conf.d/neodb-dev.conf
@@ -90,6 +90,9 @@ server {
         # Proxy the remote file through to the client
         proxy_pass $takahe_realuri;
         proxy_ssl_server_name on;
+        # Don't inherit the server-wide 900s connect timeout for arbitrary
+        # remote hosts; fail fast so proxy_cache_use_stale can kick in
+        proxy_connect_timeout 15s;
         add_header X-Takahe-Accel "HIT";
 
         # Remote origins may reply with Cache-Control: private, Vary or
@@ -102,6 +105,9 @@ server {
         proxy_hide_header Expires;
         proxy_hide_header Set-Cookie;
         proxy_hide_header Vary;
+        # add_header deliberately skips 4xx/5xx, so error passthroughs are
+        # never marked cacheable to browsers
+        add_header Cache-Control "public, max-age=1209600";
 
         # Cache these responses too
         proxy_cache takahe;
@@ -110,8 +116,12 @@ server {
         proxy_cache_key $takahe_realuri;
         proxy_cache_valid 200 304 720h;
         proxy_cache_valid 301 307 12h;
-        proxy_cache_valid 500 502 503 504 0s;
+        proxy_cache_valid 500 501 502 503 504 505 507 508 0s;
         proxy_cache_valid any 72h;
+        # Serve a stale copy instead of the error when the remote is down,
+        # and refresh expired entries in the background instead of blocking
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_background_update on;
         add_header X-Cache $upstream_cache_status;
     }
     location ~* ^/@([^/]+)/posts/\d+/ {

--- a/misc/nginx.conf.d/neodb.conf
+++ b/misc/nginx.conf.d/neodb.conf
@@ -105,6 +105,17 @@ server {
         proxy_ssl_server_name on;
         add_header X-Takahe-Accel "HIT";
 
+        # Remote origins may reply with Cache-Control: private, Vary or
+        # Set-Cookie, which would prevent nginx from storing the response;
+        # ignore them so proxy_cache_valid below applies, and hide them so
+        # browsers/CDNs can cache the proxied copy. X-Accel-* headers from
+        # untrusted remote servers must not be honored either.
+        proxy_ignore_headers Cache-Control Expires Set-Cookie Vary X-Accel-Redirect X-Accel-Expires X-Accel-Limit-Rate X-Accel-Buffering X-Accel-Charset;
+        proxy_hide_header Cache-Control;
+        proxy_hide_header Expires;
+        proxy_hide_header Set-Cookie;
+        proxy_hide_header Vary;
+
         # Cache these responses too
         proxy_cache takahe;
         # Cache after a single request

--- a/misc/nginx.conf.d/neodb.conf
+++ b/misc/nginx.conf.d/neodb.conf
@@ -103,6 +103,9 @@ server {
         # Proxy the remote file through to the client
         proxy_pass $takahe_realuri;
         proxy_ssl_server_name on;
+        # Don't inherit the server-wide 900s connect timeout for arbitrary
+        # remote hosts; fail fast so proxy_cache_use_stale can kick in
+        proxy_connect_timeout 15s;
         add_header X-Takahe-Accel "HIT";
 
         # Remote origins may reply with Cache-Control: private, Vary or
@@ -115,6 +118,9 @@ server {
         proxy_hide_header Expires;
         proxy_hide_header Set-Cookie;
         proxy_hide_header Vary;
+        # add_header deliberately skips 4xx/5xx, so error passthroughs are
+        # never marked cacheable to browsers
+        add_header Cache-Control "public, max-age=1209600";
 
         # Cache these responses too
         proxy_cache takahe;
@@ -123,8 +129,12 @@ server {
         proxy_cache_key $takahe_realuri;
         proxy_cache_valid 200 304 720h;
         proxy_cache_valid 301 307 12h;
-        proxy_cache_valid 500 502 503 504 0s;
+        proxy_cache_valid 500 501 502 503 504 505 507 508 0s;
         proxy_cache_valid any 72h;
+        # Serve a stale copy instead of the error when the remote is down,
+        # and refresh expired entries in the background instead of blocking
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_background_update on;
         add_header X-Cache $upstream_cache_status;
     }
     location ~* ^/@([^/]+)/posts/\d+/ {

--- a/takahe/mediaproxy/views.py
+++ b/takahe/mediaproxy/views.py
@@ -32,7 +32,9 @@ class BaseProxyView(View):
                 headers={
                     "X-Accel-Redirect": "/__takahe_accel__/",
                     "X-Takahe-RealUri": remote_url,
-                    "Cache-Control": "public",
+                    # nginx copies this to the final response; give browsers
+                    # a real TTL since remote cache headers are hidden there
+                    "Cache-Control": "public, max-age=86400",
                 },
             )
         else:

--- a/takahe/mediaproxy/views.py
+++ b/takahe/mediaproxy/views.py
@@ -34,7 +34,7 @@ class BaseProxyView(View):
                     "X-Takahe-RealUri": remote_url,
                     # nginx copies this to the final response; give browsers
                     # a real TTL since remote cache headers are hidden there
-                    "Cache-Control": "public, max-age=86400",
+                    "Cache-Control": "public, max-age=1209600",
                 },
             )
         else:

--- a/takahe/mediaproxy/views.py
+++ b/takahe/mediaproxy/views.py
@@ -32,9 +32,9 @@ class BaseProxyView(View):
                 headers={
                     "X-Accel-Redirect": "/__takahe_accel__/",
                     "X-Takahe-RealUri": remote_url,
-                    # nginx copies this to the final response; give browsers
-                    # a real TTL since remote cache headers are hidden there
-                    "Cache-Control": "public, max-age=1209600",
+                    # No Cache-Control here: nginx copies it through the
+                    # accel redirect onto every response including error
+                    # passthroughs; the client TTL is added by nginx instead
                 },
             )
         else:


### PR DESCRIPTION
## Problem

Images served via `/proxy/...` (e.g. `/proxy/identity_icon/<id>/`) load slowly on every browser refresh, while local `/m/...` media loads fast.

Remote origins (e.g. Bluesky's CDN for bridged accounts' avatars) reply with `Cache-Control: private` and `Vary: Authorization`. nginx honors upstream cache directives by default, so the `proxy_cache` in the `/__takahe_accel__/real/` location never stored anything (`X-Cache: MISS` on every request) and nginx re-downloaded the file from the remote server on every page load. Clients also received conflicting `Cache-Control: public` + `Cache-Control: private` with no max-age, so browsers could not cache the image either.

## Fix

- In the accel location of both nginx confs, `proxy_ignore_headers Cache-Control Expires Set-Cookie Vary` so `proxy_cache_valid` applies, plus `proxy_hide_header` for those headers so browsers/CDNs can cache the proxied copy. Also ignore `X-Accel-*` headers from untrusted remote servers as hardening.
- In takahe's `BaseProxyView` accel response, send `Cache-Control: public, max-age=1209600` (nginx copies this header through the X-Accel internal redirect to the final response), giving clients a real 14-day TTL.

## Verification

Tested end-to-end with a local nginx container plus mock takahe/remote upstreams, where the mock remote returns `Cache-Control: private`, `Vary: Authorization`, `Set-Cookie`, and a rogue `X-Accel-Redirect`:

- before: `X-Cache: MISS` on every request; after: MISS then HIT, remote fetched exactly once
- final response carries a single `Cache-Control: public, max-age=1209600`; remote's `private`/`Vary`/`Set-Cookie` no longer leak to clients
- rogue `X-Accel-Redirect` from remote is ignored

`uv run pre-commit run -a` passes.


## Error handling (follow-up commits)

- 5xx from the remote is never stored by nginx (`proxy_cache_valid 5xx 0s`) and never marked cacheable to browsers: the client `Cache-Control` moved from the takahe accel response to nginx `add_header`, which skips 4xx/5xx, so a transient remote error can no longer be cached client-side for 14 days.
- When the remote errors or is unreachable, nginx serves a stale cached copy (`proxy_cache_use_stale` + `proxy_cache_background_update`), verified: with the remote origin stopped, an expired entry is served with `X-Cache: STALE` in ~20ms.
- Remote connect timeout capped at 15s in the accel location instead of inheriting the server-wide 900s.
