### PR TITLE
perf(users): sync user accounts in-job with thread pool instead of rq fanout

### DIFF
--- a/neodb/tests/users/test_jobs_sync.py
+++ b/neodb/tests/users/test_jobs_sync.py
@@ -1,0 +1,81 @@
+import threading
+
+import pytest
+
+from mastodon.models import EmailAccount, MastodonAccount
+from users.jobs import MastodonUserSync
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMastodonUserSync:
+    @pytest.fixture(autouse=True)
+    def setup_data(self, monkeypatch):
+        # interval_hours=24 makes a single batch so every user id matches
+        # regardless of the wall-clock hour the test runs at
+        monkeypatch.setattr(MastodonUserSync, "interval_hours", 24)
+        self.synced: list[int] = []
+        self.synced_kwargs: list[dict] = []
+        self.lock = threading.Lock()
+
+        def fake_sync(user_id: int, sleep_hours: int = 0, inactive_days=None):
+            with self.lock:
+                self.synced.append(user_id)
+                self.synced_kwargs.append(
+                    {"sleep_hours": sleep_hours, "inactive_days": inactive_days}
+                )
+
+        monkeypatch.setattr(User, "sync_accounts_task", fake_sync)
+
+    def _make_mastodon_user(self, username: str) -> User:
+        user = User.register(username=username)
+        MastodonAccount.objects.create(
+            handle=f"{username}@social.example",
+            user=user,
+            domain="social.example",
+            uid=username,
+        )
+        return user
+
+    def test_syncs_eligible_users_inline(self):
+        u1 = self._make_mastodon_user("alice")
+        u2 = self._make_mastodon_user("bob")
+        MastodonUserSync().run()
+        assert sorted(self.synced) == sorted([u1.pk, u2.pk])
+        assert all(
+            kw == {"sleep_hours": 24, "inactive_days": 30} for kw in self.synced_kwargs
+        )
+
+    def test_skips_email_only_users(self):
+        user = User.register(username="mailonly")
+        EmailAccount.objects.create(
+            handle="mailonly@example.com",
+            user=user,
+            domain="example.com",
+            uid="mailonly@example.com",
+        )
+        MastodonUserSync().run()
+        assert self.synced == []
+
+    def test_skips_inactive_users(self):
+        user = self._make_mastodon_user("gone")
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        MastodonUserSync().run()
+        assert self.synced == []
+
+    def test_one_failure_does_not_stop_batch(self, monkeypatch):
+        u1 = self._make_mastodon_user("crash")
+        u2 = self._make_mastodon_user("fine")
+        synced = self.synced
+        lock = self.lock
+
+        def flaky_sync(user_id: int, sleep_hours: int = 0, inactive_days=None):
+            if user_id == u1.pk:
+                raise RuntimeError("boom")
+            with lock:
+                synced.append(user_id)
+
+        monkeypatch.setattr(User, "sync_accounts_task", flaky_sync)
+        MastodonUserSync().run()
+        assert synced == [u2.pk]

--- a/neodb/users/jobs/sync.py
+++ b/neodb/users/jobs/sync.py
@@ -1,6 +1,9 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
+from functools import partial
 
-import django_rq
+from django.db import close_old_connections, connections
 from django.db.models import F
 from django.utils import timezone
 from loguru import logger
@@ -15,6 +18,21 @@ _NON_EMAIL_ACCOUNT_TYPES = [
     "mastodon.blueskyaccount",
 ]
 
+MAX_SYNC_WORKERS = 8
+
+
+def _sync_one(user_id: int, sleep_hours: int) -> bool:
+    try:
+        User.sync_accounts_task(user_id, sleep_hours=sleep_hours, inactive_days=30)
+        return True
+    except Exception as e:
+        logger.warning(f"user {user_id} accounts sync failed: {e}")
+        return False
+    finally:
+        # Django connections are thread-local; close before the pool reuses
+        # the thread to avoid connection leaks.
+        connections.close_all()
+
 
 @JobManager.register
 class MastodonUserSync(BaseJob):
@@ -25,12 +43,13 @@ class MastodonUserSync(BaseJob):
         return timedelta(hours=cls.interval_hours)
 
     def run(self):
+        start = time.time()
         batches = (24 + self.interval_hours - 1) // self.interval_hours
         if batches < 1:
             batches = 1
         batch = timezone.now().hour // self.interval_hours
         logger.info(f"User accounts sync job starts batch {batch + 1} of {batches}")
-        qs = (
+        user_ids = list(
             User.objects.exclude(
                 preference__mastodon_skip_userinfo=True,
                 preference__mastodon_skip_relationship=True,
@@ -45,21 +64,28 @@ class MastodonUserSync(BaseJob):
             .distinct()
             .values_list("id", flat=True)
         )
-        queue = django_rq.get_queue("cron")
-        dispatched = 0
-        for user_id in qs.iterator():
-            queue.enqueue(
-                User.sync_accounts_task,
-                user_id,
-                sleep_hours=self.interval_hours,
-                inactive_days=30,
-            )
-            dispatched += 1
+        failed = 0
+        if user_ids:
+            with ThreadPoolExecutor(max_workers=MAX_SYNC_WORKERS) as ex:
+                for ok in ex.map(
+                    partial(_sync_one, sleep_hours=self.interval_hours), user_ids
+                ):
+                    if not ok:
+                        failed += 1
+            close_old_connections()
         sentry_count(
-            "mastodon.usersync.dispatched",
-            dispatched,
+            "mastodon.usersync.processed",
+            len(user_ids),
             attributes={"batch": str(batch)},
         )
+        if failed:
+            sentry_count(
+                "mastodon.usersync.failed",
+                failed,
+                attributes={"batch": str(batch)},
+            )
+        t = round(time.time() - start, 1)
         logger.info(
-            f"User accounts sync dispatched {dispatched} users (batch {batch + 1} of {batches})"
+            f"User accounts sync finished in {t}s: "
+            f"{len(user_ids)} users, {failed} failed (batch {batch + 1} of {batches})"
         )


### PR DESCRIPTION
## Problem

Since commit 76481100, `MastodonUserSync` fans out one `sync_accounts_task` per user onto the shared `cron` rq queue every 3 hours. All scheduled `BaseJob` jobs land on that same FIFO queue, so anything scheduled after a dispatch waits behind thousands of per-user tasks. With `cron` listed last on the main worker pool (and not listened to by the extra pool), the queue drains slowly and other scheduled jobs are intermittently blocked.

## Change

Sync users inline within the single `MastodonUserSync` job using a `ThreadPoolExecutor` (8 workers), the same pattern `PodcastUpdater` already uses. The cron queue stays clean while keeping the parallelism that motivated the fanout.

- per-user `try/except` so one bad account cannot kill the batch (the old sequential loop lacked this)
- worker threads close their thread-local DB connections before the pool reuses them
- sentry counters now report `mastodon.usersync.processed` / `mastodon.usersync.failed` per batch (replacing `dispatched`)
- `sync_accounts_task` itself is unchanged and still used by `sync_accounts_later` on the `mastodon` queue

With 8 threads, a batch comfortably fits the `job_timeout = interval - 5s` bound that made a plain sequential loop risky.

## Tests

Added `tests/users/test_jobs_sync.py`: eligible users synced inline with expected kwargs, email-only and inactive users skipped, and one failing user does not stop the batch. `tests/users` + `tests/mastodon` pass (except pre-existing environmental `test_lexicons` failures: `/docs` not mounted in dev container). `pre-commit run -a` clean.