### PR TITLE
feat(journal): improve StoryGraph import matching with ISBN and OpenLibrary lookups

### DIFF
--- a/neodb/journal/importers/storygraph.py
+++ b/neodb/journal/importers/storygraph.py
@@ -135,17 +135,18 @@ class StoryGraphImporter(Task):
         api_url = f"https://www.googleapis.com/books/v1/volumes?country=us&q=isbn:{isbn}&maxResults=3"
         try:
             j = BasicDownloader(api_url).download().json()
+            for book in j.get("items", []):
+                identifiers = [
+                    i.get("identifier")
+                    for i in book.get("volumeInfo", {}).get("industryIdentifiers", [])
+                ]
+                if isbn not in identifiers or "id" not in book:
+                    continue
+                return cls._resolve_url(
+                    "https://books.google.com/books?id=" + book["id"]
+                )
         except Exception as e:
             logger.warning(f"Google Books ISBN lookup failed for {isbn}: {e}")
-            return None
-        for book in j.get("items", []):
-            identifiers = [
-                i.get("identifier")
-                for i in book.get("volumeInfo", {}).get("industryIdentifiers", [])
-            ]
-            if isbn not in identifiers:
-                continue
-            return cls._resolve_url("https://books.google.com/books?id=" + book["id"])
         return None
 
     @classmethod
@@ -153,13 +154,12 @@ class StoryGraphImporter(Task):
         api_url = f"https://openlibrary.org/isbn/{isbn}.json"
         try:
             j = BasicDownloader(api_url).download().json()
+            key = j.get("key", "")  # "/books/OL...M"
+            if key.startswith("/books/"):
+                return cls._resolve_url("https://openlibrary.org" + key)
         except Exception as e:
             logger.warning(f"OpenLibrary ISBN lookup failed for {isbn}: {e}")
-            return None
-        key = j.get("key", "")  # "/books/OL...M"
-        if not key.startswith("/books/"):
-            return None
-        return cls._resolve_url("https://openlibrary.org" + key)
+        return None
 
     @classmethod
     def _find_via_local_index(cls, title: str, authors: str) -> Item | None:
@@ -225,25 +225,24 @@ class StoryGraphImporter(Task):
         )
         try:
             j = BasicDownloader(api_url).download().json()
+            for work in j.get("docs", []):
+                editions = work.get("editions", {}).get("docs", [])
+                if not editions:
+                    continue
+                edition = editions[0]
+                # edition title is closer to what the user shelved than work title
+                if not _titles_match(
+                    title, edition.get("title", "")
+                ) and not _titles_match(title, work.get("title", "")):
+                    continue
+                key = edition.get("key", "")  # "/books/OL...M"
+                if not key.startswith("/books/"):
+                    continue
+                item = cls._resolve_url("https://openlibrary.org" + key)
+                if item:
+                    return item
         except Exception as e:
             logger.warning(f"OpenLibrary search failed for '{title}': {e}")
-            return None
-        for work in j.get("docs", []):
-            editions = work.get("editions", {}).get("docs", [])
-            if not editions:
-                continue
-            edition = editions[0]
-            # edition title is closer to what the user shelved than the work title
-            if not _titles_match(title, edition.get("title", "")) and not _titles_match(
-                title, work.get("title", "")
-            ):
-                continue
-            key = edition.get("key", "")  # "/books/OL...M"
-            if not key.startswith("/books/"):
-                continue
-            item = cls._resolve_url("https://openlibrary.org" + key)
-            if item:
-                return item
         return None
 
     def progress(self, mark_state: int, title: str | None = None) -> None:

--- a/neodb/journal/importers/storygraph.py
+++ b/neodb/journal/importers/storygraph.py
@@ -1,6 +1,7 @@
 import csv
+import datetime
+import os
 import re
-from datetime import datetime
 from urllib.parse import quote_plus
 
 from django.conf import settings
@@ -24,10 +25,20 @@ SHELF_MAP = {
     "did-not-finish": ShelfType.DROPPED,
 }
 
+MATCHED_EXTRA_COLUMNS = ["link", "match_source", "shelf", "collect_date"]
+
 # StoryGraph puts its own book UUID in the ISBN/UID column when the edition has no ISBN
 _RE_STORYGRAPH_UUID = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 )
+
+
+class StoryGraphCancelled(Exception):
+    """Raised by the worker when the view has flipped phase to 'cancelled'.
+
+    Same mechanism as RymCancelled: the cancel view writes ``phase=cancelled``
+    directly to the DB, so the worker re-reads it before every save and bails.
+    """
 
 
 def _first_author(authors: str) -> str:
@@ -45,20 +56,43 @@ def _escape_quotes(s: str) -> str:
     return s.replace('"', '\\"')
 
 
+def _parse_collect_date(raw: str | None) -> datetime.datetime | None:
+    if not raw:
+        return None
+    raw = raw.strip()
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            return make_aware(datetime.datetime.strptime(raw, fmt).replace(hour=22))
+        except ValueError:
+            continue
+    return None
+
+
+def _site_url_prefix() -> str:
+    return settings.SITE_INFO["site_url"].rstrip("/")
+
+
 class StoryGraphImporter(Task):
     class Meta:
         app_label = "journal"  # workaround bug in TypedModel
 
     TaskQueue = "import"
     DefaultMetadata = {
+        "phase": "matching",
+        "visibility": 0,
+        "file": None,
+        "matched_file": None,
+        "filename_hint": None,
         "total": 0,
         "processed": 0,
-        "skipped": 0,
+        "matched_local": 0,
+        "matched_external": 0,
+        "unmatched": 0,
         "imported": 0,
+        "skipped": 0,
         "failed": 0,
-        "visibility": 0,
         "failed_items": [],
-        "file": None,
+        "had_link_column": False,
     }
 
     @classmethod
@@ -70,68 +104,178 @@ class StoryGraphImporter(Task):
         except Exception:
             return False
 
+    PROGRESS_SAVE_EVERY = 25  # flush task row at most every N processed rows
+
+    def _raise_if_cancelled(self) -> None:
+        """Honour user-initiated cancellation written by the view."""
+        fresh = (
+            type(self)
+            .objects.filter(pk=self.pk)
+            .values_list("metadata", flat=True)
+            .first()
+        )
+        if fresh and fresh.get("phase") == "cancelled":
+            raise StoryGraphCancelled()
+
+    def progress(self, *, force: bool = False, **delta) -> None:
+        for k, v in delta.items():
+            self.metadata[k] = self.metadata.get(k, 0) + v
+        phase = self.metadata.get("phase", "")
+        total = self.metadata.get("total", 0)
+        done = self.metadata.get("processed", 0)
+        if phase == "matching":
+            self.message = _(
+                "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
+            ).format(
+                done=done,
+                total=total,
+                local=self.metadata.get("matched_local", 0),
+                ext=self.metadata.get("matched_external", 0),
+                none=self.metadata.get("unmatched", 0),
+            )
+        else:
+            self.message = _(
+                "Importing: {imported} imported, {skipped} skipped, {failed} failed"
+            ).format(
+                imported=self.metadata.get("imported", 0),
+                skipped=self.metadata.get("skipped", 0),
+                failed=self.metadata.get("failed", 0),
+            )
+        if force or done % self.PROGRESS_SAVE_EVERY == 0 or done == total:
+            self._raise_if_cancelled()
+            self.save(update_fields=["metadata", "message"])
+
+    def run(self) -> None:
+        phase = self.metadata.get("phase", "matching")
+        if phase == "matching":
+            self._run_matching()
+        elif phase == "importing":
+            self._run_import()
+        else:
+            logger.warning(
+                f"StoryGraphImporter run() called in unexpected phase: {phase}"
+            )
+
+    # ---- Phase 1: matching ----
+
+    def _run_matching(self) -> None:
+        in_path = self.metadata["file"]
+        out_path = self._derive_matched_path(in_path)
+        with open(in_path, encoding="utf-8-sig", newline="") as fin:
+            reader = csv.DictReader(fin)
+            fieldnames = [h.strip() for h in reader.fieldnames or []]
+            extra = [c for c in MATCHED_EXTRA_COLUMNS if c not in fieldnames]
+            # k is None for extra cells in ragged rows; drop them
+            rows = [{k.strip(): v for k, v in raw.items() if k} for raw in reader]
+        self.metadata["total"] = len(rows)
+        self.metadata["matched_file"] = out_path
+        self._raise_if_cancelled()
+        self.save(update_fields=["metadata"])
+
+        with open(out_path, "w", encoding="utf-8", newline="") as fout:
+            writer = csv.DictWriter(fout, fieldnames=fieldnames + extra)
+            writer.writeheader()
+            for row in rows:
+                self._match_row(row)
+                writer.writerow(row)
+
+        self.metadata["phase"] = "preview"
+        self.message = _(
+            "Matching complete: {local} local, {ext} external, {none} unmatched"
+        ).format(
+            local=self.metadata.get("matched_local", 0),
+            ext=self.metadata.get("matched_external", 0),
+            none=self.metadata.get("unmatched", 0),
+        )
+        self._raise_if_cancelled()
+        self.save(update_fields=["metadata", "message"])
+
+    def _match_row(self, row: dict) -> None:
+        title = (row.get("Title") or "").strip()
+        authors = (row.get("Authors") or "").strip()
+        isbn_uid = (row.get("ISBN/UID") or "").strip()
+
+        # default shelf from Read Status; unmapped statuses default to skip
+        shelf = SHELF_MAP.get((row.get("Read Status") or "").strip())
+        row.setdefault("shelf", shelf.value if shelf else "")
+
+        # default collect date: last read date for completed books, else date added
+        if not (row.get("collect_date") or "").strip():
+            if shelf == ShelfType.COMPLETE and row.get("Last Date Read"):
+                raw_date = row["Last Date Read"]
+            else:
+                raw_date = row.get("Date Added", "")
+            dt = _parse_collect_date(raw_date)
+            row["collect_date"] = dt.strftime("%Y-%m-%d") if dt else ""
+
+        # already populated link (round-trip)
+        if (row.get("link") or "").strip():
+            row.setdefault("match_source", "preset")
+            self.progress(processed=1)
+            return
+
+        match = self._match(isbn_uid, title, authors)
+        if match:
+            row["link"], row["match_source"] = match
+            if row["match_source"] == "local":
+                self.progress(processed=1, matched_local=1)
+            else:
+                self.progress(processed=1, matched_external=1)
+            return
+
+        row["link"] = ""
+        row["match_source"] = "none"
+        self.progress(processed=1, unmatched=1)
+
     @classmethod
-    def find_item(cls, isbn_uid: str, title: str = "", authors: str = ""):
-        isbn_uid = (isbn_uid or "").strip()
+    def _match(cls, isbn_uid: str, title: str, authors: str) -> tuple[str, str] | None:
+        """Return (link, match_source) for a row, or None if nothing matched."""
         id_type, id_value = detect_isbn_asin(isbn_uid)
         sg_uid = isbn_uid.lower() if _RE_STORYGRAPH_UUID.match(isbn_uid.lower()) else ""
 
-        # Step 1: ISBN/ASIN or StoryGraph UUID lookup in local DB (no network)
+        # ISBN/ASIN or StoryGraph UUID lookup in local DB (no network)
         if id_type and id_value:
             er = ExternalResource.objects.filter(
                 id_type=id_type, id_value=id_value
             ).first()
             if er and er.item:
-                return er.item
+                return er.item.url, "local"
         elif sg_uid:
             er = ExternalResource.objects.filter(
                 id_type=IdType.StoryGraph, id_value=sg_uid
             ).first()
             if er and er.item:
-                return er.item
+                return er.item.url, "local"
 
-        # Step 2: fetch the exact edition by ISBN from Google Books, then OpenLibrary
+        # exact edition by ISBN from Google Books, then OpenLibrary
         if id_type == IdType.ISBN and id_value:
-            item = cls._fetch_by_isbn_google_books(id_value)
-            if item:
-                return item
-            item = cls._fetch_by_isbn_openlibrary(id_value)
-            if item:
-                return item
+            url = cls._match_by_isbn_google_books(id_value)
+            if url:
+                return url, "googlebooks"
+            url = cls._match_by_isbn_openlibrary(id_value)
+            if url:
+                return url, "openlibrary"
 
-        # Step 3: scrape StoryGraph book page (needs a JS-rendering scrape provider)
+        # StoryGraph book page; importing it needs a JS-rendering scrape provider
         if sg_uid and settings.DOWNLOADER_PROVIDERS:
-            item = cls._resolve_url(f"https://app.thestorygraph.com/books/{sg_uid}")
-            if item:
-                return item
+            return f"https://app.thestorygraph.com/books/{sg_uid}", "storygraph"
 
-        # Step 4: title + author matching, local catalog index first then external
+        # title + author matching, local catalog index first then external
         if title:
-            item = (
-                cls._find_via_local_index(title, authors)
-                or cls._find_via_google_books(title, authors)
-                or cls._find_via_openlibrary_search(title, authors)
-            )
+            item = cls._match_via_local_index(title, authors)
             if item:
-                return item
+                return item.url, "local"
+            url = cls._match_via_google_books(title, authors)
+            if url:
+                return url, "googlebooks"
+            url = cls._match_via_openlibrary_search(title, authors)
+            if url:
+                return url, "openlibrary"
 
         return None
 
     @classmethod
-    def _resolve_url(cls, url: str) -> Item | None:
-        """Fetch a remote resource by URL and return its local item, or None."""
-        try:
-            site = SiteManager.get_site_by_url(url, detect_redirection=False)
-            if site:
-                resource = site.get_resource_ready()
-                if resource and resource.item:
-                    return resource.item
-        except Exception as e:
-            logger.warning(f"StoryGraph import: fetching {url} failed: {e}")
-        return None
-
-    @classmethod
-    def _fetch_by_isbn_google_books(cls, isbn: str) -> Item | None:
+    def _match_by_isbn_google_books(cls, isbn: str) -> str | None:
         api_url = f"https://www.googleapis.com/books/v1/volumes?country=us&q=isbn:{isbn}&maxResults=3"
         try:
             j = BasicDownloader(api_url).download().json()
@@ -142,27 +286,25 @@ class StoryGraphImporter(Task):
                 ]
                 if isbn not in identifiers or "id" not in book:
                     continue
-                return cls._resolve_url(
-                    "https://books.google.com/books?id=" + book["id"]
-                )
+                return "https://books.google.com/books?id=" + book["id"]
         except Exception as e:
             logger.warning(f"Google Books ISBN lookup failed for {isbn}: {e}")
         return None
 
     @classmethod
-    def _fetch_by_isbn_openlibrary(cls, isbn: str) -> Item | None:
+    def _match_by_isbn_openlibrary(cls, isbn: str) -> str | None:
         api_url = f"https://openlibrary.org/isbn/{isbn}.json"
         try:
             j = BasicDownloader(api_url).download().json()
             key = j.get("key", "")  # "/books/OL...M"
             if key.startswith("/books/"):
-                return cls._resolve_url("https://openlibrary.org" + key)
+                return "https://openlibrary.org" + key
         except Exception as e:
             logger.warning(f"OpenLibrary ISBN lookup failed for {isbn}: {e}")
         return None
 
     @classmethod
-    def _find_via_local_index(cls, title: str, authors: str) -> Item | None:
+    def _match_via_local_index(cls, title: str, authors: str) -> Item | None:
         first_author = _first_author(authors)
         q = f'"{_escape_quotes(title)}"'
         if first_author:
@@ -191,7 +333,7 @@ class StoryGraphImporter(Task):
         return None
 
     @classmethod
-    def _find_via_google_books(cls, title: str, authors: str) -> Item | None:
+    def _match_via_google_books(cls, title: str, authors: str) -> str | None:
         # Build query: intitle + inauthor (first author only for precision)
         q = f"intitle:{quote_plus(title)}"
         first_author = _first_author(authors)
@@ -204,19 +346,15 @@ class StoryGraphImporter(Task):
             j = BasicDownloader(api_url).download().json()
             for book in j.get("items", []):
                 result_title = book.get("volumeInfo", {}).get("title", "")
-                if not _titles_match(title, result_title):
+                if not _titles_match(title, result_title) or "id" not in book:
                     continue
-                item = cls._resolve_url(
-                    "https://books.google.com/books?id=" + book["id"]
-                )
-                if item:
-                    return item
+                return "https://books.google.com/books?id=" + book["id"]
         except Exception as e:
             logger.warning(f"Google Books search failed for '{title}': {e}")
         return None
 
     @classmethod
-    def _find_via_openlibrary_search(cls, title: str, authors: str) -> Item | None:
+    def _match_via_openlibrary_search(cls, title: str, authors: str) -> str | None:
         first_author = _first_author(authors)
         api_url = (
             f"https://openlibrary.org/search.json?title={quote_plus(title)}"
@@ -238,126 +376,159 @@ class StoryGraphImporter(Task):
                 key = edition.get("key", "")  # "/books/OL...M"
                 if not key.startswith("/books/"):
                     continue
-                item = cls._resolve_url("https://openlibrary.org" + key)
-                if item:
-                    return item
+                return "https://openlibrary.org" + key
         except Exception as e:
             logger.warning(f"OpenLibrary search failed for '{title}': {e}")
         return None
 
-    def progress(self, mark_state: int, title: str | None = None) -> None:
-        self.metadata["processed"] += 1
-        match mark_state:
-            case 1:
-                self.metadata["imported"] += 1
-            case 0:
-                self.metadata["skipped"] += 1
-            case _:
-                self.metadata["failed"] += 1
-                if title:
-                    self.metadata["failed_items"].append(title)
-        self.message = f"{self.metadata['imported']} imported, {self.metadata['skipped']} skipped, {self.metadata['failed']} failed"
-        self.save(update_fields=["metadata", "message"])
+    # ---- Phase 2: import ----
 
-    def run(self) -> None:
-        filename = self.metadata["file"]
-        visibility = self.metadata["visibility"]
-        with open(filename, encoding="utf-8-sig") as f:
+    def _run_import(self) -> None:
+        path = self.metadata.get("matched_file")
+        if not path or not os.path.exists(path):
+            self.message = _("Matched file missing; cannot import.")
+            self.save(update_fields=["message"])
+            return
+        with open(path, encoding="utf-8-sig", newline="") as f:
             reader = csv.DictReader(f)
-            for row in reader:
-                shelf_type = SHELF_MAP.get(row.get("Read Status", ""))
-                if shelf_type is None:
-                    self.progress(0)
-                    continue
+            rows = [{k.strip(): v for k, v in r.items() if k} for r in reader]
+        self.metadata["total"] = len(rows)
+        self.metadata["processed"] = 0
+        self._raise_if_cancelled()
+        self.save(update_fields=["metadata"])
+        visibility = int(self.metadata.get("visibility", 0))
+        owner = self.user.identity
+        for row in rows:
+            try:
+                self._import_row(row, owner, visibility)
+            except StoryGraphCancelled:
+                raise
+            except Exception as e:
+                logger.exception(f"StoryGraph row import failed: {e}")
+                self._fail_row(row)
 
-                item = self.find_item(
-                    row.get("ISBN/UID", ""),
-                    title=row.get("Title", ""),
-                    authors=row.get("Authors", ""),
-                )
-                if not item:
-                    logger.warning(
-                        f"Could not find item for StoryGraph book: {row.get('Title')}"
-                    )
-                    self.progress(-1, row.get("Title"))
-                    continue
-
-                # Rating: StoryGraph uses 0.5–5.0 half-stars; NeoDB uses 1–10 integers
-                rating_raw = row.get("Star Rating", "").strip()
-                rating: int | None = None
-                if rating_raw:
-                    try:
-                        rating = round(float(rating_raw) * 2) or None
-                    except ValueError:
-                        pass
-
-                # Review text (may contain HTML)
-                review_html = row.get("Review", "").strip()
-                comment: str | None = None
-                long_review: str | None = None
-                if review_html:
-                    has_html = "<" in review_html
-                    review_text = md(review_html) if has_html else review_html
-                    if not has_html and len(review_text) < 360:
-                        comment = review_text
-                    else:
-                        long_review = review_text
-
-                # Date: last read date for completed books, date added otherwise
-                if shelf_type == ShelfType.COMPLETE and row.get("Last Date Read"):
-                    date_str = row["Last Date Read"]
-                else:
-                    date_str = row.get("Date Added", "")
-
-                dt = None
-                if date_str:
-                    try:
-                        dt = make_aware(
-                            datetime.strptime(date_str, "%Y/%m/%d").replace(hour=22)
-                        )
-                    except ValueError:
-                        pass
-
-                mark = Mark(self.user.identity, item)
-                is_downgrade = (
-                    mark.shelf_type == ShelfType.COMPLETE
-                    and shelf_type != ShelfType.COMPLETE
-                ) or (
-                    mark.shelf_type in [ShelfType.PROGRESS, ShelfType.DROPPED]
-                    and shelf_type == ShelfType.WISHLIST
-                )
-                if is_downgrade:
-                    self.progress(0)
-                    continue
-                if mark.shelf_type == shelf_type:
-                    existing_review = Review.objects.filter(
-                        owner=self.user.identity, item=item
-                    ).first()
-                    review_body = existing_review.body if existing_review else None
-                    if comment == mark.comment_text and long_review == review_body:
-                        self.progress(0)
-                        continue
-
-                mark.update(
-                    shelf_type,
-                    comment,
-                    rating,
-                    visibility=visibility,
-                    created_time=dt or timezone.now(),
-                )
-                if long_review:
-                    item_title = item.title or row.get("Title", "")
-                    title = _("a review of {item_title}").format(item_title=item_title)
-                    Review.update_item_review(
-                        item,
-                        self.user.identity,
-                        title,
-                        long_review,
-                        visibility,
-                        dt or timezone.now(),
-                    )
-                self.progress(1)
-
-        self.metadata["total"] = self.metadata["processed"]
-        self.message = f"{self.metadata['imported']} imported, {self.metadata['skipped']} skipped, {self.metadata['failed']} failed"
+        self.metadata["phase"] = "done"
+        self.message = _(
+            "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
+        ).format(
+            imported=self.metadata.get("imported", 0),
+            skipped=self.metadata.get("skipped", 0),
+            failed=self.metadata.get("failed", 0),
+        )
+        self._raise_if_cancelled()
         self.save(update_fields=["metadata", "message"])
+
+    def _fail_row(self, row: dict) -> None:
+        self.progress(processed=1, failed=1)
+        label = (row.get("Title") or "").strip() or (row.get("link") or "").strip()
+        if label:
+            self.metadata["failed_items"].append(label)
+            self._raise_if_cancelled()
+            self.save(update_fields=["metadata"])
+
+    def _import_row(self, row: dict, owner, visibility: int) -> None:
+        link = (row.get("link") or "").strip()
+        shelf_raw = (row.get("shelf") or "").strip()
+
+        if not link or not shelf_raw:
+            # no match picked, or explicit "skip" from user
+            self.progress(processed=1, skipped=1)
+            return
+        try:
+            shelf_type = ShelfType(shelf_raw)
+        except ValueError:
+            self.progress(processed=1, skipped=1)
+            return
+
+        item = self._resolve_link(link)
+        if not item:
+            self._fail_row(row)
+            return
+
+        # Rating: StoryGraph uses 0.5–5.0 half-stars; NeoDB uses 1–10 integers
+        rating_raw = (row.get("Star Rating") or "").strip()
+        rating: int | None = None
+        if rating_raw:
+            try:
+                rating = round(float(rating_raw) * 2) or None
+            except ValueError:
+                pass
+
+        # Review text (may contain HTML)
+        review_html = (row.get("Review") or "").strip()
+        comment: str | None = None
+        long_review: str | None = None
+        if review_html:
+            has_html = "<" in review_html
+            review_text = md(review_html) if has_html else review_html
+            if not has_html and len(review_text) < 360:
+                comment = review_text
+            else:
+                long_review = review_text
+
+        dt = _parse_collect_date(row.get("collect_date")) or timezone.now()
+
+        mark = Mark(owner, item)
+        is_downgrade = (
+            mark.shelf_type == ShelfType.COMPLETE and shelf_type != ShelfType.COMPLETE
+        ) or (
+            mark.shelf_type in [ShelfType.PROGRESS, ShelfType.DROPPED]
+            and shelf_type == ShelfType.WISHLIST
+        )
+        if is_downgrade:
+            self.progress(processed=1, skipped=1)
+            return
+        if mark.shelf_type == shelf_type:
+            existing_review = Review.objects.filter(owner=owner, item=item).first()
+            review_body = existing_review.body if existing_review else None
+            if comment == mark.comment_text and long_review == review_body:
+                self.progress(processed=1, skipped=1)
+                return
+
+        mark.update(
+            shelf_type,
+            comment,
+            rating,
+            visibility=visibility,
+            created_time=dt,
+        )
+        if long_review:
+            item_title = item.display_title or (row.get("Title") or "").strip()
+            Review.update_item_review(
+                item,
+                owner,
+                _("a review of {item_title}").format(item_title=item_title),
+                long_review,
+                visibility,
+                dt,
+            )
+        self.progress(processed=1, imported=1)
+
+    def _resolve_link(self, url: str) -> Item | None:
+        site_url = _site_url_prefix() + "/"
+        if url.startswith("/") or url.startswith(site_url):
+            item = Item.get_by_url(url, resolve_merge=True)
+            if item and not item.is_deleted:
+                return item
+            return None
+        site = SiteManager.get_site_by_url(url, detect_redirection=False)
+        if not site:
+            return None
+        item = site.get_item()
+        if item:
+            return item
+        try:
+            site.get_resource_ready()
+        except Exception as e:
+            logger.warning(f"StoryGraph remote fetch failed for {url}: {e}")
+            return None
+        return site.get_item()
+
+    # ---- helpers ----
+
+    @staticmethod
+    def _derive_matched_path(in_path: str) -> str:
+        base = os.path.basename(in_path)
+        stem, _ext = os.path.splitext(base)
+        out_dir = os.path.dirname(in_path)
+        return os.path.join(out_dir, f"{stem}-matched.csv")

--- a/neodb/journal/importers/storygraph.py
+++ b/neodb/journal/importers/storygraph.py
@@ -1,7 +1,9 @@
 import csv
+import re
 from datetime import datetime
 from urllib.parse import quote_plus
 
+from django.conf import settings
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _
@@ -11,6 +13,7 @@ from markdownify import markdownify as md
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import detect_isbn_asin
+from catalog.search.index import CatalogIndex, CatalogQueryParser
 from journal.models import *
 from users.models import Task
 
@@ -20,6 +23,26 @@ SHELF_MAP = {
     "currently-reading": ShelfType.PROGRESS,
     "did-not-finish": ShelfType.DROPPED,
 }
+
+# StoryGraph puts its own book UUID in the ISBN/UID column when the edition has no ISBN
+_RE_STORYGRAPH_UUID = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _first_author(authors: str) -> str:
+    return authors.split(",")[0].strip() if authors else ""
+
+
+def _titles_match(a: str, b: str) -> bool:
+    """Accept if either title contains the other (case-insensitive)."""
+    a = (a or "").strip().lower()
+    b = (b or "").strip().lower()
+    return bool(a) and bool(b) and (a in b or b in a)
+
+
+def _escape_quotes(s: str) -> str:
+    return s.replace('"', '\\"')
 
 
 class StoryGraphImporter(Task):
@@ -49,29 +72,129 @@ class StoryGraphImporter(Task):
 
     @classmethod
     def find_item(cls, isbn_uid: str, title: str = "", authors: str = ""):
-        # Step 1: ISBN/UID lookup in local DB (no network)
-        if isbn_uid:
-            id_type, id_value = detect_isbn_asin(isbn_uid.strip())
-            if id_type and id_value:
-                er = ExternalResource.objects.filter(
-                    id_type=id_type, id_value=id_value
-                ).first()
-                if er and er.item:
-                    return er.item
+        isbn_uid = (isbn_uid or "").strip()
+        id_type, id_value = detect_isbn_asin(isbn_uid)
+        sg_uid = isbn_uid.lower() if _RE_STORYGRAPH_UUID.match(isbn_uid.lower()) else ""
 
-        # Step 2: Google Books search by title + author (network fallback)
+        # Step 1: ISBN/ASIN or StoryGraph UUID lookup in local DB (no network)
+        if id_type and id_value:
+            er = ExternalResource.objects.filter(
+                id_type=id_type, id_value=id_value
+            ).first()
+            if er and er.item:
+                return er.item
+        elif sg_uid:
+            er = ExternalResource.objects.filter(
+                id_type=IdType.StoryGraph, id_value=sg_uid
+            ).first()
+            if er and er.item:
+                return er.item
+
+        # Step 2: fetch the exact edition by ISBN from Google Books, then OpenLibrary
+        if id_type == IdType.ISBN and id_value:
+            item = cls._fetch_by_isbn_google_books(id_value)
+            if item:
+                return item
+            item = cls._fetch_by_isbn_openlibrary(id_value)
+            if item:
+                return item
+
+        # Step 3: scrape StoryGraph book page (needs a JS-rendering scrape provider)
+        if sg_uid and settings.DOWNLOADER_PROVIDERS:
+            item = cls._resolve_url(f"https://app.thestorygraph.com/books/{sg_uid}")
+            if item:
+                return item
+
+        # Step 4: title + author matching, local catalog index first then external
         if title:
-            item = cls._find_via_google_books(title, authors)
+            item = (
+                cls._find_via_local_index(title, authors)
+                or cls._find_via_google_books(title, authors)
+                or cls._find_via_openlibrary_search(title, authors)
+            )
             if item:
                 return item
 
         return None
 
     @classmethod
-    def _find_via_google_books(cls, title: str, authors: str):
+    def _resolve_url(cls, url: str) -> Item | None:
+        """Fetch a remote resource by URL and return its local item, or None."""
+        try:
+            site = SiteManager.get_site_by_url(url, detect_redirection=False)
+            if site:
+                resource = site.get_resource_ready()
+                if resource and resource.item:
+                    return resource.item
+        except Exception as e:
+            logger.warning(f"StoryGraph import: fetching {url} failed: {e}")
+        return None
+
+    @classmethod
+    def _fetch_by_isbn_google_books(cls, isbn: str) -> Item | None:
+        api_url = f"https://www.googleapis.com/books/v1/volumes?country=us&q=isbn:{isbn}&maxResults=3"
+        try:
+            j = BasicDownloader(api_url).download().json()
+        except Exception as e:
+            logger.warning(f"Google Books ISBN lookup failed for {isbn}: {e}")
+            return None
+        for book in j.get("items", []):
+            identifiers = [
+                i.get("identifier")
+                for i in book.get("volumeInfo", {}).get("industryIdentifiers", [])
+            ]
+            if isbn not in identifiers:
+                continue
+            return cls._resolve_url("https://books.google.com/books?id=" + book["id"])
+        return None
+
+    @classmethod
+    def _fetch_by_isbn_openlibrary(cls, isbn: str) -> Item | None:
+        api_url = f"https://openlibrary.org/isbn/{isbn}.json"
+        try:
+            j = BasicDownloader(api_url).download().json()
+        except Exception as e:
+            logger.warning(f"OpenLibrary ISBN lookup failed for {isbn}: {e}")
+            return None
+        key = j.get("key", "")  # "/books/OL...M"
+        if not key.startswith("/books/"):
+            return None
+        return cls._resolve_url("https://openlibrary.org" + key)
+
+    @classmethod
+    def _find_via_local_index(cls, title: str, authors: str) -> Item | None:
+        first_author = _first_author(authors)
+        q = f'"{_escape_quotes(title)}"'
+        if first_author:
+            q += f' people:"{_escape_quotes(first_author)}"'
+        q += " category:book"
+        try:
+            parser = CatalogQueryParser(q, page=1, page_size=5)
+            hits = list(CatalogIndex.instance().search(parser).items)
+        except Exception as e:
+            logger.warning(f"StoryGraph local index search failed: {e}")
+            return None
+        author_lc = first_author.lower()
+        for it in hits:
+            if not isinstance(it, Edition):
+                continue
+            titles = [(t.get("text") or "") for t in it.localized_title or []]
+            titles.append(it.title or "")
+            title_ok = any(_titles_match(title, t) for t in titles)
+            author_names = it.credit_names_by_role("author") + (it.author or [])
+            author_ok = (not author_lc) or any(
+                author_lc in (a or "").lower() or (a or "").lower() in author_lc
+                for a in author_names
+            )
+            if title_ok and author_ok:
+                return it
+        return None
+
+    @classmethod
+    def _find_via_google_books(cls, title: str, authors: str) -> Item | None:
         # Build query: intitle + inauthor (first author only for precision)
         q = f"intitle:{quote_plus(title)}"
-        first_author = authors.split(",")[0].strip() if authors else ""
+        first_author = _first_author(authors)
         if first_author:
             q += f"+inauthor:{quote_plus(first_author)}"
         api_url = (
@@ -80,22 +203,47 @@ class StoryGraphImporter(Task):
         try:
             j = BasicDownloader(api_url).download().json()
             for book in j.get("items", []):
-                vi = book.get("volumeInfo", {})
-                result_title = vi.get("title", "")
-                # Accept if either title contains the other (case-insensitive)
-                if (
-                    title.lower() not in result_title.lower()
-                    and result_title.lower() not in title.lower()
-                ):
+                result_title = book.get("volumeInfo", {}).get("title", "")
+                if not _titles_match(title, result_title):
                     continue
-                url = "https://books.google.com/books?id=" + book["id"]
-                site = SiteManager.get_site_by_url(url, detect_redirection=False)
-                if site:
-                    resource = site.get_resource_ready()
-                    if resource and resource.item:
-                        return resource.item
+                item = cls._resolve_url(
+                    "https://books.google.com/books?id=" + book["id"]
+                )
+                if item:
+                    return item
         except Exception as e:
             logger.warning(f"Google Books search failed for '{title}': {e}")
+        return None
+
+    @classmethod
+    def _find_via_openlibrary_search(cls, title: str, authors: str) -> Item | None:
+        first_author = _first_author(authors)
+        api_url = (
+            f"https://openlibrary.org/search.json?title={quote_plus(title)}"
+            + (f"&author={quote_plus(first_author)}" if first_author else "")
+            + "&limit=3&fields=key,title,editions,editions.key,editions.title"
+        )
+        try:
+            j = BasicDownloader(api_url).download().json()
+        except Exception as e:
+            logger.warning(f"OpenLibrary search failed for '{title}': {e}")
+            return None
+        for work in j.get("docs", []):
+            editions = work.get("editions", {}).get("docs", [])
+            if not editions:
+                continue
+            edition = editions[0]
+            # edition title is closer to what the user shelved than the work title
+            if not _titles_match(title, edition.get("title", "")) and not _titles_match(
+                title, work.get("title", "")
+            ):
+                continue
+            key = edition.get("key", "")  # "/books/OL...M"
+            if not key.startswith("/books/"):
+                continue
+            item = cls._resolve_url("https://openlibrary.org" + key)
+            if item:
+                return item
         return None
 
     def progress(self, mark_state: int, title: str | None = None) -> None:

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 03:55-0400\n"
+"POT-Creation-Date: 2026-07-15 22:17-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -492,7 +492,7 @@ msgid "Album"
 msgstr ""
 
 #: catalog/models/common.py:142 catalog/models/common.py:159
-#: catalog/models/common.py:173 common/templates/_header.html:41
+#: catalog/models/common.py:173 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
@@ -507,7 +507,7 @@ msgid "Podcast Episode"
 msgstr ""
 
 #: catalog/models/common.py:145 catalog/models/common.py:161
-#: catalog/models/common.py:175 common/templates/_header.html:45
+#: catalog/models/common.py:175 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
@@ -522,7 +522,7 @@ msgid "Exhibition"
 msgstr ""
 
 #: catalog/models/common.py:148 catalog/models/common.py:165
-#: journal/templates/collection.html:23 journal/templates/collection.html:34
+#: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -533,7 +533,7 @@ msgid "Person / Organization"
 msgstr ""
 
 #: catalog/models/common.py:155 catalog/models/common.py:169
-#: common/templates/_header.html:25
+#: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
@@ -546,14 +546,14 @@ msgid "TV"
 msgstr ""
 
 #: catalog/models/common.py:158 catalog/models/common.py:172
-#: common/templates/_header.html:37
+#: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
 #: catalog/models/common.py:160 catalog/models/common.py:174
-#: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:33
+#: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
@@ -763,12 +763,12 @@ msgid "character name"
 msgstr ""
 
 #: catalog/models/item.py:249 catalog/models/item.py:281
-#: journal/models/collection.py:89
+#: journal/models/collection.py:93
 msgid "title"
 msgstr ""
 
 #: catalog/models/item.py:250 catalog/models/item.py:289
-#: journal/models/collection.py:90
+#: journal/models/collection.py:94
 msgid "description"
 msgstr ""
 
@@ -1028,6 +1028,7 @@ msgid "show time"
 msgstr ""
 
 #: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
+#: users/templates/users/storygraph_import.html:60
 msgid "Date"
 msgstr ""
 
@@ -1067,12 +1068,12 @@ msgstr ""
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:200
+#: catalog/templates/item_base.html:201
 msgid "ratings"
 msgstr ""
 
 #: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:255
+#: catalog/templates/item_base.html:256
 msgid "part of"
 msgstr ""
 
@@ -1090,14 +1091,14 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:67
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:73
 msgid "translate"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:283
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr ""
@@ -1195,11 +1196,12 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:86
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:169
-#: journal/templates/collection.html:170
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:178
+#: journal/templates/collection.html:179 journal/templates/collection.html:187
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
+#: social/templates/_post_action_menu.html:12
 msgid "Edit"
 msgstr ""
 
@@ -1233,7 +1235,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:19
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:181
+#: catalog/templates/item_base.html:182
 msgid "Creator verification"
 msgstr ""
 
@@ -1241,7 +1243,7 @@ msgstr ""
 msgid "Edit Options"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:177
+#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:178
 #: catalog/views/edit.py:81 catalog/views/edit.py:141 catalog/views/edit.py:191
 #: catalog/views/edit.py:229 catalog/views/edit.py:295
 #: catalog/views/edit.py:299 catalog/views/edit.py:317
@@ -1390,7 +1392,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:240
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:172 journal/templates/collection.html:173
+#: journal/templates/article.html:181 journal/templates/collection.html:182
 #: journal/templates/mark.html:157 journal/templates/note.html:45
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1818,7 +1820,7 @@ msgstr ""
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:281
+#: catalog/templates/item_base.html:282
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1888,67 +1890,67 @@ msgstr ""
 msgid "release year"
 msgstr ""
 
-#: catalog/templates/item_base.html:94
+#: catalog/templates/item_base.html:95
 msgid "select one of the seasons to comment"
 msgstr ""
 
-#: catalog/templates/item_base.html:128
+#: catalog/templates/item_base.html:129
 msgid "mark, comment and collect"
 msgstr ""
 
-#: catalog/templates/item_base.html:141
+#: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
 msgstr ""
 
-#: catalog/templates/item_base.html:150
+#: catalog/templates/item_base.html:151
 msgid "Related Collections"
 msgstr ""
 
-#: catalog/templates/item_base.html:165
+#: catalog/templates/item_base.html:166
 msgid "Unsupported item type."
 msgstr ""
 
-#: catalog/templates/item_base.html:175
+#: catalog/templates/item_base.html:176
 msgid "Edit this item"
 msgstr ""
 
-#: catalog/templates/item_base.html:186
+#: catalog/templates/item_base.html:187
 msgid "Last edited"
 msgstr ""
 
-#: catalog/templates/item_base.html:229
+#: catalog/templates/item_base.html:230
 msgid "No enough ratings"
 msgstr ""
 
-#: catalog/templates/item_base.html:273
+#: catalog/templates/item_base.html:274
 msgid "overview"
 msgstr ""
 
-#: catalog/templates/item_base.html:304
+#: catalog/templates/item_base.html:305
 msgid "comments"
 msgstr ""
 
-#: catalog/templates/item_base.html:307
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr ""
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:309
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr ""
 
-#: catalog/templates/item_base.html:322
+#: catalog/templates/item_base.html:323
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr ""
 
-#: catalog/templates/item_base.html:332
+#: catalog/templates/item_base.html:333
 msgid "notes"
 msgstr ""
 
@@ -2154,21 +2156,21 @@ msgstr ""
 #: journal/views/collection.py:318 journal/views/collection.py:342
 #: journal/views/collection.py:415 journal/views/collection.py:458
 #: journal/views/collection.py:496 journal/views/collection.py:508
-#: journal/views/collection.py:533 journal/views/collection.py:536
-#: journal/views/collection.py:577 journal/views/common.py:272
-#: journal/views/mark.py:245 journal/views/post.py:58 journal/views/post.py:78
-#: journal/views/post.py:100 journal/views/post.py:165
-#: journal/views/post.py:194 journal/views/post.py:267
-#: journal/views/post.py:282 journal/views/post.py:389
-#: journal/views/post.py:541 journal/views/review.py:52
-#: journal/views/review.py:69 journal/views/review.py:94
+#: journal/views/collection.py:533 journal/views/collection.py:575
+#: journal/views/common.py:272 journal/views/mark.py:245
+#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
+#: journal/views/post.py:165 journal/views/post.py:194
+#: journal/views/post.py:267 journal/views/post.py:282
+#: journal/views/post.py:389 journal/views/post.py:541
+#: journal/views/review.py:52 journal/views/review.py:69
+#: journal/views/review.py:94
 msgid "Insufficient permission"
 msgstr ""
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
 #: catalog/views/verify.py:194 journal/views/collection.py:75
 #: journal/views/collection.py:100 journal/views/collection.py:513
-#: journal/views/collection.py:608 journal/views/common.py:193
+#: journal/views/collection.py:613 journal/views/common.py:193
 #: journal/views/mark.py:171 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
@@ -3547,96 +3549,96 @@ msgstr ""
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
 
-#: common/templates/_header.html:17 common/templates/_header.html:162
+#: common/templates/_header.html:19 common/templates/_header.html:164
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr ""
 
-#: common/templates/_header.html:22
+#: common/templates/_header.html:24
 msgid "All Items"
 msgstr ""
 
-#: common/templates/_header.html:29
+#: common/templates/_header.html:31
 msgid "Movie & TV"
 msgstr ""
 
-#: common/templates/_header.html:48
+#: common/templates/_header.html:50
 msgid "People & Organizations"
 msgstr ""
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:52
 msgid "Journal"
 msgstr ""
 
-#: common/templates/_header.html:52 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr ""
 
-#: common/templates/_header.html:87
+#: common/templates/_header.html:89
 msgid "Explore"
 msgstr ""
 
-#: common/templates/_header.html:91
+#: common/templates/_header.html:93
 msgid "Feed"
 msgstr ""
 
-#: common/templates/_header.html:96 journal/templates/profile.html:13
+#: common/templates/_header.html:98 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr ""
 
-#: common/templates/_header.html:112 common/templates/common/scan.html:9
+#: common/templates/_header.html:114 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr ""
 
-#: common/templates/_header.html:116 social/templates/notification.html:12
+#: common/templates/_header.html:118 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr ""
 
-#: common/templates/_header.html:120 users/models/task.py:21
+#: common/templates/_header.html:122 users/models/task.py:21
 #: users/templates/users/account.html:228
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
 
-#: common/templates/_header.html:123
+#: common/templates/_header.html:125
 msgid "Data"
 msgstr ""
 
-#: common/templates/_header.html:126 common/templates/_header.html:144
+#: common/templates/_header.html:128 common/templates/_header.html:146
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr ""
 
-#: common/templates/_header.html:129
+#: common/templates/_header.html:131
 msgid "Account"
 msgstr ""
 
-#: common/templates/_header.html:133
+#: common/templates/_header.html:135
 msgid "Manage"
 msgstr ""
 
-#: common/templates/_header.html:137
+#: common/templates/_header.html:139
 msgid "Logout"
 msgstr ""
 
-#: common/templates/_header.html:141
+#: common/templates/_header.html:143
 msgid "Sign up or Login"
 msgstr ""
 
-#: common/templates/_header.html:158
+#: common/templates/_header.html:160
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr ""
 
-#: common/templates/_header.html:160
+#: common/templates/_header.html:162
 msgid "name of a person or company"
 msgstr ""
 
-#: common/templates/_header.html:177
+#: common/templates/_header.html:179
 msgid "Open"
 msgstr ""
 
@@ -3669,7 +3671,7 @@ msgstr ""
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:214 journal/forms.py:186
+#: common/templates/_sidebar.html:214 journal/forms.py:197
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4563,7 +4565,7 @@ msgstr ""
 msgid "Content (Markdown)"
 msgstr ""
 
-#: journal/forms.py:41 journal/forms.py:195 journal/templates/comment.html:62
+#: journal/forms.py:41 journal/forms.py:206 journal/templates/comment.html:62
 #: journal/templates/mark.html:115 journal/views/note.py:29
 msgid "Crosspost to timeline"
 msgstr ""
@@ -4577,13 +4579,13 @@ msgid "When saving, replace leading spaces with full-width spaces"
 msgstr ""
 
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
-#: journal/forms.py:188 journal/templates/collection_share.html:24
+#: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:207 users/templates/users/data.html:258
-#: users/templates/users/data.html:321 users/templates/users/data.html:380
-#: users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:155
+#: users/templates/users/data.html:206 users/templates/users/data.html:269
+#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
+#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr ""
 
@@ -4611,25 +4613,26 @@ msgstr ""
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:156 journal/templates/collection.html:184
+#: journal/forms.py:156 journal/templates/collection.html:187
+#: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:180 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:535
+#: journal/forms.py:191 users/templates/users/crossposts.html:51
+#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
-#: journal/forms.py:182 journal/templates/comment.html:16
+#: journal/forms.py:193 journal/templates/comment.html:16
 msgid "Comment"
 msgstr ""
 
-#: journal/forms.py:184
+#: journal/forms.py:195
 msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:499
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4639,26 +4642,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:183
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:388
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:411
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -4667,7 +4670,7 @@ msgstr ""
 msgid "(may contain sensitive content)"
 msgstr ""
 
-#: journal/models/collection.py:37 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:41 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -4675,60 +4678,60 @@ msgstr ""
 msgid "note"
 msgstr ""
 
-#: journal/models/collection.py:104
+#: journal/models/collection.py:108
 msgid "search query for dynamic collection"
 msgstr ""
 
-#: journal/models/collection.py:419 journal/templatetags/collection.py:35
+#: journal/models/collection.py:452 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:424 journal/templatetags/collection.py:43
+#: journal/models/collection.py:457 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:429 journal/templatetags/collection.py:51
+#: journal/models/collection.py:462 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:434 journal/templatetags/collection.py:59
+#: journal/models/collection.py:467 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:439 journal/templatetags/collection.py:67
+#: journal/models/collection.py:472 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:444 journal/templatetags/collection.py:75
+#: journal/models/collection.py:477 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:450 journal/templatetags/collection.py:83
+#: journal/models/collection.py:483 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] ""
 msgstr[1] ""
 
-#: journal/models/collection.py:458 journal/templatetags/collection.py:91
+#: journal/models/collection.py:491 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -4740,12 +4743,12 @@ msgstr[1] ""
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:216
-#: users/templates/users/data.html:267 users/templates/users/data.html:329
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:164 users/templates/users/data.html:215
+#: users/templates/users/data.html:277 users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
+#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr ""
 
@@ -4753,12 +4756,13 @@ msgstr ""
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:224 users/templates/users/data.html:275
-#: users/templates/users/data.html:337 users/templates/users/data.html:397
+#: users/templates/users/data.html:115 users/templates/users/data.html:172
+#: users/templates/users/data.html:223 users/templates/users/data.html:285
+#: users/templates/users/data.html:345
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
+#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr ""
 
@@ -4766,12 +4770,13 @@ msgstr ""
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:345 users/templates/users/data.html:405
+#: users/templates/users/data.html:123 users/templates/users/data.html:180
+#: users/templates/users/data.html:231 users/templates/users/data.html:293
+#: users/templates/users/data.html:353
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
+#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr ""
 
@@ -4812,6 +4817,7 @@ msgid "Retrying"
 msgstr ""
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
@@ -5351,7 +5357,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:104
+#: journal/templates/_list_item.html:100 journal/templates/article.html:113
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5481,7 +5487,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:163 journal/templates/collection.html:159
+#: journal/templates/article.html:172 journal/templates/collection.html:168
 msgid "Quote"
 msgstr ""
 
@@ -5490,7 +5496,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:154 journal/templates/collection.html:150
+#: journal/templates/article.html:163 journal/templates/collection.html:159
 msgid "Reply"
 msgstr ""
 
@@ -5507,19 +5513,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:85 social/templates/_event_post.html:81
+#: journal/templates/article.html:94 social/templates/_event_post.html:81
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:87 social/templates/_event_post.html:83
+#: journal/templates/article.html:96 social/templates/_event_post.html:83
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:117
+#: journal/templates/article.html:126
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:128
+#: journal/templates/article.html:137
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -5580,18 +5586,18 @@ msgstr ""
 msgid "DEC"
 msgstr ""
 
-#: journal/templates/collection.html:65
+#: journal/templates/collection.html:71
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr ""
 
-#: journal/templates/collection.html:77
+#: journal/templates/collection.html:86
 msgid "created a collection"
 msgstr ""
 
-#: journal/templates/collection.html:166
+#: journal/templates/collection.html:175
 msgid "Query"
 msgstr ""
 
@@ -5901,7 +5907,7 @@ msgid "shared {username}'s collection"
 msgstr ""
 
 #: journal/views/collection.py:460 journal/views/collection.py:498
-#: journal/views/collection.py:510 journal/views/collection.py:538
+#: journal/views/collection.py:510 journal/views/collection.py:536
 msgid "Dynamic collection is not editable"
 msgstr ""
 
@@ -6524,31 +6530,31 @@ msgstr ""
 msgid "Article"
 msgstr ""
 
-#: takahe/models.py:450
+#: takahe/models.py:451
 msgid "Display Name"
 msgstr ""
 
-#: takahe/models.py:452
+#: takahe/models.py:453
 msgid "Bio"
 msgstr ""
 
-#: takahe/models.py:454
+#: takahe/models.py:455
 msgid "Manually approve new followers"
 msgstr ""
 
-#: takahe/models.py:458
+#: takahe/models.py:459
 msgid "Include profile, marks and posts in discovery"
 msgstr ""
 
-#: takahe/models.py:461
+#: takahe/models.py:462
 msgid "Include posts in search results"
 msgstr ""
 
-#: takahe/models.py:479
+#: takahe/models.py:480
 msgid "Profile picture"
 msgstr ""
 
-#: takahe/models.py:486
+#: takahe/models.py:487
 msgid "Header picture"
 msgstr ""
 
@@ -6674,10 +6680,12 @@ msgid "Create new album"
 msgstr ""
 
 #: users/templates/users/_rym_row.html:28
+#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr ""
 
 #: users/templates/users/_rym_row.html:39
+#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr ""
 
@@ -6687,6 +6695,7 @@ msgid "Import from RateYourMusic"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:9
+#: users/templates/users/_storygraph_section.html:9
 msgid "Review pending matches"
 msgstr ""
 
@@ -6695,6 +6704,7 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:16
+#: users/templates/users/_storygraph_section.html:16
 msgid "Cancel import"
 msgstr ""
 
@@ -6703,7 +6713,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/data.html:141
+#: users/templates/users/_storygraph_section.html:31
 msgid "Upload the downloaded CSV file below."
 msgstr ""
 
@@ -6712,15 +6722,39 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
+#: users/templates/users/_storygraph_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
+#: users/templates/users/_storygraph_section.html:40
 msgid "Upload and match"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:46
+#: users/templates/users/_storygraph_section.html:46
 msgid "Download previous matches"
+msgstr ""
+
+#: users/templates/users/_storygraph_row.html:30
+msgid "Create new book"
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:5
+#: users/templates/users/_storygraph_section.html:21
+msgid "Import from StoryGraph"
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:15
+msgid "Cancel the StoryGraph import? Progress will be discarded."
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:29
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:33
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7011,9 +7045,9 @@ msgid "CSV file"
 msgstr ""
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:235 users/templates/users/data.html:286
-#: users/templates/users/data.html:350 users/templates/users/data.html:410
+#: users/templates/users/data.html:126 users/templates/users/data.html:183
+#: users/templates/users/data.html:234 users/templates/users/data.html:298
+#: users/templates/users/data.html:358
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7157,7 +7191,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:308
+#: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
 
@@ -7189,140 +7223,128 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:133
-msgid "Import from StoryGraph"
-msgstr ""
-
-#: users/templates/users/data.html:139
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
-msgstr ""
-
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:134
 msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:140
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:143
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:146
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:201
+#: users/templates/users/data.html:149
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:236 users/templates/users/data.html:287
+#: users/templates/users/data.html:184 users/templates/users/data.html:235
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:191
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:197
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:200
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:254
+#: users/templates/users/data.html:202
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:295
+#: users/templates/users/data.html:243
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:298
+#: users/templates/users/data.html:246
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:304
+#: users/templates/users/data.html:252
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:263
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:319
+#: users/templates/users/data.html:267
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:348
+#: users/templates/users/data.html:296
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:306
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:364
+#: users/templates/users/data.html:312
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:366
+#: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:376
+#: users/templates/users/data.html:324
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:437
+#: users/templates/users/data.html:385
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:463
+#: users/templates/users/data.html:411
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:436
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:460
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:516
+#: users/templates/users/data.html:464
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:523
+#: users/templates/users/data.html:471
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:531
+#: users/templates/users/data.html:479
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:534
+#: users/templates/users/data.html:482
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:539
+#: users/templates/users/data.html:487
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:496
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7726,6 +7748,7 @@ msgid "Review RateYourMusic Matches"
 msgstr ""
 
 #: users/templates/users/rym_import.html:39
+#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7734,6 +7757,7 @@ msgid ""
 msgstr ""
 
 #: users/templates/users/rym_import.html:45
+#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr ""
 
@@ -7742,26 +7766,32 @@ msgid "Title / Artist"
 msgstr ""
 
 #: users/templates/users/rym_import.html:58
+#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr ""
 
 #: users/templates/users/rym_import.html:59
+#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr ""
 
 #: users/templates/users/rym_import.html:71
+#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr ""
 
 #: users/templates/users/rym_import.html:75
+#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr ""
 
 #: users/templates/users/rym_import.html:95
+#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr ""
 
 #: users/templates/users/rym_import.html:96
+#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr ""
 
@@ -7881,6 +7911,15 @@ msgstr ""
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
+#: users/templates/users/storygraph_import.html:9
+#: users/templates/users/storygraph_import.html:37
+msgid "Review StoryGraph Matches"
+msgstr ""
+
+#: users/templates/users/storygraph_import.html:57
+msgid "Title / Author"
+msgstr ""
+
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr ""
@@ -7966,136 +8005,141 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:223 users/views/data.py:252
+#: users/views/data.py:230 users/views/data.py:259
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:246
+#: users/views/data.py:253
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:264
+#: users/views/data.py:271
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:279 users/views/data.py:299
+#: users/views/data.py:286 users/views/data.py:306
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:313
+#: users/views/data.py:320
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:327
+#: users/views/data.py:334
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:382
+#: users/views/data.py:389
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:385
+#: users/views/data.py:392
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:413
+#: users/views/data.py:420
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
-#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
-#: users/views/data.py:769
+#: users/views/data.py:430 users/views/data.py:463 users/views/data.py:686
+#: users/views/data.py:901 users/views/data.py:926 users/views/data.py:950
+#: users/views/data.py:974
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:492
+#: users/views/data.py:497 users/views/data.py:720
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:517
+#: users/views/data.py:522 users/views/data.py:749
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:537
+#: users/views/data.py:542
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:545 users/views/data.py:655
+#: users/views/data.py:550 users/views/data.py:660 users/views/data.py:779
+#: users/views/data.py:884
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:641
+#: users/views/data.py:646 users/views/data.py:870
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:651
+#: users/views/data.py:656 users/views/data.py:880
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:889
+#: users/views/data.py:771
+msgid "No StoryGraph import to preview."
+msgstr ""
+
+#: users/views/data.py:1094
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:911
+#: users/views/data.py:1116
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:927
+#: users/views/data.py:1132
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:932
+#: users/views/data.py:1137
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:942 users/views/data.py:993
+#: users/views/data.py:1147 users/views/data.py:1198
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:949
+#: users/views/data.py:1154
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:954
+#: users/views/data.py:1159
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:980
+#: users/views/data.py:1185
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:985
+#: users/views/data.py:1190
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:998
+#: users/views/data.py:1203
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1009
+#: users/views/data.py:1214
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1015
+#: users/views/data.py:1220
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1073
+#: users/views/data.py:1278
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1089
+#: users/views/data.py:1294
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1093
+#: users/views/data.py:1298
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1102
+#: users/views/data.py:1307
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 03:55-0400\n"
+"POT-Creation-Date: 2026-07-15 22:17-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -491,7 +491,7 @@ msgid "Album"
 msgstr "专辑"
 
 #: catalog/models/common.py:142 catalog/models/common.py:159
-#: catalog/models/common.py:173 common/templates/_header.html:41
+#: catalog/models/common.py:173 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
@@ -506,7 +506,7 @@ msgid "Podcast Episode"
 msgstr "播客单集"
 
 #: catalog/models/common.py:145 catalog/models/common.py:161
-#: catalog/models/common.py:175 common/templates/_header.html:45
+#: catalog/models/common.py:175 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
@@ -521,7 +521,7 @@ msgid "Exhibition"
 msgstr "展览"
 
 #: catalog/models/common.py:148 catalog/models/common.py:165
-#: journal/templates/collection.html:23 journal/templates/collection.html:34
+#: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
@@ -532,7 +532,7 @@ msgid "Person / Organization"
 msgstr "人物 / 团体"
 
 #: catalog/models/common.py:155 catalog/models/common.py:169
-#: common/templates/_header.html:25
+#: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
@@ -545,14 +545,14 @@ msgid "TV"
 msgstr "剧集"
 
 #: catalog/models/common.py:158 catalog/models/common.py:172
-#: common/templates/_header.html:37
+#: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
 #: catalog/models/common.py:160 catalog/models/common.py:174
-#: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:33
+#: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
@@ -762,12 +762,12 @@ msgid "character name"
 msgstr "角色名"
 
 #: catalog/models/item.py:249 catalog/models/item.py:281
-#: journal/models/collection.py:89
+#: journal/models/collection.py:93
 msgid "title"
 msgstr "标题"
 
 #: catalog/models/item.py:250 catalog/models/item.py:289
-#: journal/models/collection.py:90
+#: journal/models/collection.py:94
 msgid "description"
 msgstr "描述"
 
@@ -1027,6 +1027,7 @@ msgid "show time"
 msgstr "上映时间"
 
 #: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
+#: users/templates/users/storygraph_import.html:60
 msgid "Date"
 msgstr "日期"
 
@@ -1066,12 +1067,12 @@ msgstr "无法加载条目，请确认链接正确。部分网站可能删除条
 #: catalog/templates/_item_card_metadata_tvseason.html:7
 #: catalog/templates/_item_card_metadata_tvshow.html:7
 #: catalog/templates/_item_card_metadata_work.html:7
-#: catalog/templates/item_base.html:200
+#: catalog/templates/item_base.html:201
 msgid "ratings"
 msgstr "个评分"
 
 #: catalog/templates/_item_card_metadata_base.html:34
-#: catalog/templates/item_base.html:255
+#: catalog/templates/item_base.html:256
 msgid "part of"
 msgstr "所属"
 
@@ -1089,14 +1090,14 @@ msgid "hide this tooltip"
 msgstr "不再提示"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:67
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:73
 msgid "translate"
 msgstr "翻译"
 
 #: catalog/templates/_item_comments.html:92
 #: catalog/templates/_item_comments_by_episode.html:80
 #: catalog/templates/_item_notes.html:88
-#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:283
+#: catalog/templates/_item_reviews.html:44 catalog/templates/item_base.html:284
 #: catalog/templates/podcast_episode_data.html:41
 msgid "show more"
 msgstr "显示更多"
@@ -1194,11 +1195,12 @@ msgstr "我的笔记"
 #: catalog/templates/_item_user_pieces.html:86
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:169
-#: journal/templates/collection.html:170
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:178
+#: journal/templates/collection.html:179 journal/templates/collection.html:187
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
 #: journal/templates/post_compose.html:16 journal/templates/tag_edit.html:16
+#: social/templates/_post_action_menu.html:12
 msgid "Edit"
 msgstr "编辑"
 
@@ -1232,7 +1234,7 @@ msgstr "回到条目"
 #: catalog/templates/_sidebar_edit.html:19
 #: catalog/templates/catalog_verify.html:11
 #: catalog/templates/catalog_verify.html:17
-#: catalog/templates/item_base.html:181
+#: catalog/templates/item_base.html:182
 msgid "Creator verification"
 msgstr "创作者验证"
 
@@ -1240,7 +1242,7 @@ msgstr "创作者验证"
 msgid "Edit Options"
 msgstr "编辑选项"
 
-#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:177
+#: catalog/templates/_sidebar_edit.html:27 catalog/templates/item_base.html:178
 #: catalog/views/edit.py:81 catalog/views/edit.py:141 catalog/views/edit.py:191
 #: catalog/views/edit.py:229 catalog/views/edit.py:295
 #: catalog/views/edit.py:299 catalog/views/edit.py:317
@@ -1389,7 +1391,7 @@ msgstr "合并到另一条目"
 #: catalog/templates/_sidebar_edit.html:240
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:172 journal/templates/collection.html:173
+#: journal/templates/article.html:181 journal/templates/collection.html:182
 #: journal/templates/mark.html:157 journal/templates/note.html:45
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1817,7 +1819,7 @@ msgstr "热门标签"
 
 #: catalog/templates/discover.html:229
 #: catalog/templates/discover_original_podcasts.html:25
-#: catalog/templates/item_base.html:281
+#: catalog/templates/item_base.html:282
 #: catalog/templates/item_mark_list.html:71
 #: catalog/templates/item_review_list.html:51
 #: catalog/templates/people_works.html:28
@@ -1887,67 +1889,67 @@ msgstr "系统繁忙，请稍等几秒钟再搜索。"
 msgid "release year"
 msgstr "发行年份"
 
-#: catalog/templates/item_base.html:94
+#: catalog/templates/item_base.html:95
 msgid "select one of the seasons to comment"
 msgstr "这是全剧条目，以下是可标记的单季"
 
-#: catalog/templates/item_base.html:128
+#: catalog/templates/item_base.html:129
 msgid "mark, comment and collect"
 msgstr "标签 · 短评 · 评论 · 收藏"
 
-#: catalog/templates/item_base.html:141
+#: catalog/templates/item_base.html:142
 msgid "Login or register to review or add this item to your collection."
 msgstr "登录后可管理标记收藏。"
 
-#: catalog/templates/item_base.html:150
+#: catalog/templates/item_base.html:151
 msgid "Related Collections"
 msgstr "相关收藏单"
 
-#: catalog/templates/item_base.html:165
+#: catalog/templates/item_base.html:166
 msgid "Unsupported item type."
 msgstr "此类数据尚未支持。"
 
-#: catalog/templates/item_base.html:175
+#: catalog/templates/item_base.html:176
 msgid "Edit this item"
 msgstr "编辑这个条目"
 
-#: catalog/templates/item_base.html:186
+#: catalog/templates/item_base.html:187
 msgid "Last edited"
 msgstr "最近编辑"
 
-#: catalog/templates/item_base.html:229
+#: catalog/templates/item_base.html:230
 msgid "No enough ratings"
 msgstr "评分人数不足"
 
-#: catalog/templates/item_base.html:273
+#: catalog/templates/item_base.html:274
 msgid "overview"
 msgstr "简介"
 
-#: catalog/templates/item_base.html:304
+#: catalog/templates/item_base.html:305
 msgid "comments"
 msgstr "短评"
 
-#: catalog/templates/item_base.html:307
+#: catalog/templates/item_base.html:308
 #: catalog/templates/item_mark_list.html:22
 #: catalog/templates/item_mark_list.html:25
 #: catalog/templates/item_review_list.html:21
 msgid "marks"
 msgstr "标记"
 
-#: catalog/templates/item_base.html:308
+#: catalog/templates/item_base.html:309
 #: catalog/templates/item_mark_list.html:23
 #: catalog/templates/item_mark_list.html:26
 #: catalog/templates/item_review_list.html:22
 msgid "marks from who you follow"
 msgstr "好友标记"
 
-#: catalog/templates/item_base.html:322
+#: catalog/templates/item_base.html:323
 #: catalog/templates/item_mark_list.html:28
 #: catalog/templates/item_review_list.html:23
 msgid "reviews"
 msgstr "评论"
 
-#: catalog/templates/item_base.html:332
+#: catalog/templates/item_base.html:333
 msgid "notes"
 msgstr "笔记"
 
@@ -2153,21 +2155,21 @@ msgstr "条目不可被删除。"
 #: journal/views/collection.py:318 journal/views/collection.py:342
 #: journal/views/collection.py:415 journal/views/collection.py:458
 #: journal/views/collection.py:496 journal/views/collection.py:508
-#: journal/views/collection.py:533 journal/views/collection.py:536
-#: journal/views/collection.py:577 journal/views/common.py:272
-#: journal/views/mark.py:245 journal/views/post.py:58 journal/views/post.py:78
-#: journal/views/post.py:100 journal/views/post.py:165
-#: journal/views/post.py:194 journal/views/post.py:267
-#: journal/views/post.py:282 journal/views/post.py:389
-#: journal/views/post.py:541 journal/views/review.py:52
-#: journal/views/review.py:69 journal/views/review.py:94
+#: journal/views/collection.py:533 journal/views/collection.py:575
+#: journal/views/common.py:272 journal/views/mark.py:245
+#: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
+#: journal/views/post.py:165 journal/views/post.py:194
+#: journal/views/post.py:267 journal/views/post.py:282
+#: journal/views/post.py:389 journal/views/post.py:541
+#: journal/views/review.py:52 journal/views/review.py:69
+#: journal/views/review.py:94
 msgid "Insufficient permission"
 msgstr "权限不足"
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
 #: catalog/views/verify.py:194 journal/views/collection.py:75
 #: journal/views/collection.py:100 journal/views/collection.py:513
-#: journal/views/collection.py:608 journal/views/common.py:193
+#: journal/views/collection.py:613 journal/views/common.py:193
 #: journal/views/mark.py:171 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
@@ -3546,96 +3548,96 @@ msgstr "关于"
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr "这是%(site_name)s的临时镜像，请尽可能使用<a href=\"%(site_url)s%(request.get_full_path)s\">原始站点</a>。"
 
-#: common/templates/_header.html:17 common/templates/_header.html:162
+#: common/templates/_header.html:19 common/templates/_header.html:164
 msgid "title, creator, ISBN, item url, @user, @user@instance"
 msgstr "标题、创作者、ISBN、站外条目链接、@用户名、@用户名@实例"
 
-#: common/templates/_header.html:22
+#: common/templates/_header.html:24
 msgid "All Items"
 msgstr "全部"
 
-#: common/templates/_header.html:29
+#: common/templates/_header.html:31
 msgid "Movie & TV"
 msgstr "影视"
 
-#: common/templates/_header.html:48
+#: common/templates/_header.html:50
 msgid "People & Organizations"
 msgstr "人物与团体"
 
-#: common/templates/_header.html:50
+#: common/templates/_header.html:52
 msgid "Journal"
 msgstr "记录"
 
-#: common/templates/_header.html:52 journal/templates/user_post_list.html:10
+#: common/templates/_header.html:54 journal/templates/user_post_list.html:10
 #: journal/templates/user_post_list.html:23
 msgid "Posts"
 msgstr "帖文"
 
-#: common/templates/_header.html:87
+#: common/templates/_header.html:89
 msgid "Explore"
 msgstr "发现"
 
-#: common/templates/_header.html:91
+#: common/templates/_header.html:93
 msgid "Feed"
 msgstr "动态"
 
-#: common/templates/_header.html:96 journal/templates/profile.html:13
+#: common/templates/_header.html:98 journal/templates/profile.html:13
 #: users/templates/users/preferences.html:46
 msgid "Home"
 msgstr "主页"
 
-#: common/templates/_header.html:112 common/templates/common/scan.html:9
+#: common/templates/_header.html:114 common/templates/common/scan.html:9
 #: common/templates/common/scan.html:42
 msgid "Scan Barcode"
 msgstr "扫描条形码"
 
-#: common/templates/_header.html:116 social/templates/notification.html:12
+#: common/templates/_header.html:118 social/templates/notification.html:12
 #: social/templates/notification.html:53
 msgid "Notification"
 msgstr "通知"
 
-#: common/templates/_header.html:120 users/models/task.py:21
+#: common/templates/_header.html:122 users/models/task.py:21
 #: users/templates/users/account.html:228
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "等待"
 
-#: common/templates/_header.html:123
+#: common/templates/_header.html:125
 msgid "Data"
 msgstr "数据"
 
-#: common/templates/_header.html:126 common/templates/_header.html:144
+#: common/templates/_header.html:128 common/templates/_header.html:146
 #: users/templates/users/preferences.html:12
 #: users/templates/users/preferences.html:23
 #: users/templates/users/preferences_anonymous.html:13
 msgid "Preferences"
 msgstr "设置"
 
-#: common/templates/_header.html:129
+#: common/templates/_header.html:131
 msgid "Account"
 msgstr "账号"
 
-#: common/templates/_header.html:133
+#: common/templates/_header.html:135
 msgid "Manage"
 msgstr "管理"
 
-#: common/templates/_header.html:137
+#: common/templates/_header.html:139
 msgid "Logout"
 msgstr "登出"
 
-#: common/templates/_header.html:141
+#: common/templates/_header.html:143
 msgid "Sign up or Login"
 msgstr "注册或登录"
 
-#: common/templates/_header.html:158
+#: common/templates/_header.html:160
 msgid "title or content  category:tv  status:complete  rating:8..10  date:2021-09-11..2022-02"
 msgstr "搜索你的评论或条目，可加过滤条件如 category:tv status:complete rating:8..10 date:2021-09-11..2022-02"
 
-#: common/templates/_header.html:160
+#: common/templates/_header.html:162
 msgid "name of a person or company"
 msgstr "人物或公司名称"
 
-#: common/templates/_header.html:177
+#: common/templates/_header.html:179
 msgid "Open"
 msgstr "打开"
 
@@ -3668,7 +3670,7 @@ msgstr "正在阅读"
 msgid "Currently watching"
 msgstr "正在追看"
 
-#: common/templates/_sidebar.html:214 journal/forms.py:186
+#: common/templates/_sidebar.html:214 journal/forms.py:197
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4583,7 +4585,7 @@ msgstr "标题"
 msgid "Content (Markdown)"
 msgstr "内容 （Markdown格式）"
 
-#: journal/forms.py:41 journal/forms.py:195 journal/templates/comment.html:62
+#: journal/forms.py:41 journal/forms.py:206 journal/templates/comment.html:62
 #: journal/templates/mark.html:115 journal/views/note.py:29
 msgid "Crosspost to timeline"
 msgstr "转发到时间轴"
@@ -4597,13 +4599,13 @@ msgid "When saving, replace leading spaces with full-width spaces"
 msgstr "保存时将行首空格替换为全角"
 
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
-#: journal/forms.py:188 journal/templates/collection_share.html:24
+#: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:207 users/templates/users/data.html:258
-#: users/templates/users/data.html:321 users/templates/users/data.html:380
-#: users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:155
+#: users/templates/users/data.html:206 users/templates/users/data.html:269
+#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
+#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr "可见性"
 
@@ -4631,25 +4633,26 @@ msgstr "仅创建者"
 msgid "owner and their local mutuals"
 msgstr "创建者和他们的本地互关"
 
-#: journal/forms.py:156 journal/templates/collection.html:184
+#: journal/forms.py:156 journal/templates/collection.html:187
+#: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:180 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:535
+#: journal/forms.py:191 users/templates/users/crossposts.html:51
+#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "状态"
 
-#: journal/forms.py:182 journal/templates/comment.html:16
+#: journal/forms.py:193 journal/templates/comment.html:16
 msgid "Comment"
 msgstr "短评"
 
-#: journal/forms.py:184
+#: journal/forms.py:195
 msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:499
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4659,26 +4662,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:168
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:178
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:233
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:183
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:348
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:388
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:376
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:411
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -4687,7 +4690,7 @@ msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
-#: journal/models/collection.py:37 journal/templates/add_to_collection.html:39
+#: journal/models/collection.py:41 journal/templates/add_to_collection.html:39
 #: journal/templates/collection_edit.html:64
 #: journal/templates/collection_share.html:63
 #: journal/templates/collection_update_item_note.html:3
@@ -4695,60 +4698,60 @@ msgstr "（可能包含剧透或敏感内容）"
 msgid "note"
 msgstr "备注"
 
-#: journal/models/collection.py:104
+#: journal/models/collection.py:108
 msgid "search query for dynamic collection"
 msgstr "动态收藏单查询条件"
 
-#: journal/models/collection.py:419 journal/templatetags/collection.py:35
+#: journal/models/collection.py:452 journal/templatetags/collection.py:35
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d 本书"
 msgstr[1] "%(count)d 本书"
 
-#: journal/models/collection.py:424 journal/templatetags/collection.py:43
+#: journal/models/collection.py:457 journal/templatetags/collection.py:43
 #, python-format
 msgid "%(count)d movie"
 msgid_plural "%(count)d movies"
 msgstr[0] "%(count)d 部电影"
 msgstr[1] "%(count)d 部电影"
 
-#: journal/models/collection.py:429 journal/templatetags/collection.py:51
+#: journal/models/collection.py:462 journal/templatetags/collection.py:51
 #, python-format
 msgid "%(count)d tv show"
 msgid_plural "%(count)d tv shows"
 msgstr[0] "%(count)d 部电视剧"
 msgstr[1] "%(count)d 部电视剧"
 
-#: journal/models/collection.py:434 journal/templatetags/collection.py:59
+#: journal/models/collection.py:467 journal/templatetags/collection.py:59
 #, python-format
 msgid "%(count)d album"
 msgid_plural "%(count)d albums"
 msgstr[0] "%(count)d 张专辑"
 msgstr[1] "%(count)d 张专辑"
 
-#: journal/models/collection.py:439 journal/templatetags/collection.py:67
+#: journal/models/collection.py:472 journal/templatetags/collection.py:67
 #, python-format
 msgid "%(count)d game"
 msgid_plural "%(count)d games"
 msgstr[0] "%(count)d 个游戏"
 msgstr[1] "%(count)d 个游戏"
 
-#: journal/models/collection.py:444 journal/templatetags/collection.py:75
+#: journal/models/collection.py:477 journal/templatetags/collection.py:75
 #, python-format
 msgid "%(count)d podcast"
 msgid_plural "%(count)d podcasts"
 msgstr[0] "%(count)d 个播客"
 msgstr[1] "%(count)d 个播客"
 
-#: journal/models/collection.py:450 journal/templatetags/collection.py:83
+#: journal/models/collection.py:483 journal/templatetags/collection.py:83
 #, python-format
 msgid "%(count)d performance"
 msgid_plural "%(count)d performances"
 msgstr[0] "%(count)d 场演出"
 msgstr[1] "%(count)d 场演出"
 
-#: journal/models/collection.py:458 journal/templatetags/collection.py:91
+#: journal/models/collection.py:491 journal/templatetags/collection.py:91
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
@@ -4760,12 +4763,12 @@ msgstr[1] "%(count)d 个条目"
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:216
-#: users/templates/users/data.html:267 users/templates/users/data.html:329
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:164 users/templates/users/data.html:215
+#: users/templates/users/data.html:277 users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
+#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr "公开"
 
@@ -4773,12 +4776,13 @@ msgstr "公开"
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:224 users/templates/users/data.html:275
-#: users/templates/users/data.html:337 users/templates/users/data.html:397
+#: users/templates/users/data.html:115 users/templates/users/data.html:172
+#: users/templates/users/data.html:223 users/templates/users/data.html:285
+#: users/templates/users/data.html:345
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
+#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr "仅关注者"
 
@@ -4786,12 +4790,13 @@ msgstr "仅关注者"
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:345 users/templates/users/data.html:405
+#: users/templates/users/data.html:123 users/templates/users/data.html:180
+#: users/templates/users/data.html:231 users/templates/users/data.html:293
+#: users/templates/users/data.html:353
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
+#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
@@ -4832,6 +4837,7 @@ msgid "Retrying"
 msgstr "重试中"
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "页码"
 
@@ -5371,7 +5377,7 @@ msgstr "更新标记"
 msgid "Update note"
 msgstr "修改备注"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:104
+#: journal/templates/_list_item.html:100 journal/templates/article.html:113
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5501,7 +5507,7 @@ msgid "View post"
 msgstr "查看帖文"
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:163 journal/templates/collection.html:159
+#: journal/templates/article.html:172 journal/templates/collection.html:168
 msgid "Quote"
 msgstr "引用"
 
@@ -5510,7 +5516,7 @@ msgid "reply"
 msgstr "回应"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:154 journal/templates/collection.html:150
+#: journal/templates/article.html:163 journal/templates/collection.html:159
 msgid "Reply"
 msgstr "回应"
 
@@ -5527,19 +5533,19 @@ msgstr "添加到收藏单"
 msgid "Create a new collection"
 msgstr "创建新收藏单"
 
-#: journal/templates/article.html:85 social/templates/_event_post.html:81
+#: journal/templates/article.html:94 social/templates/_event_post.html:81
 msgid "wrote a review"
 msgstr "写了评论"
 
-#: journal/templates/article.html:87 social/templates/_event_post.html:83
+#: journal/templates/article.html:96 social/templates/_event_post.html:83
 msgid "wrote an article"
 msgstr "写了文章"
 
-#: journal/templates/article.html:117
+#: journal/templates/article.html:126
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr "文章可能包含敏感内容，点击显示全文。"
 
-#: journal/templates/article.html:128
+#: journal/templates/article.html:137
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "作者已设置仅限已登录用户查看。"
 
@@ -5600,18 +5606,18 @@ msgstr "十一月"
 msgid "DEC"
 msgstr "十二月"
 
-#: journal/templates/collection.html:65
+#: journal/templates/collection.html:71
 #: journal/templates/collection_share.html:12
 #: journal/templates/collection_share.html:66
 #: journal/templates/wrapped_share.html:59
 msgid "Share"
 msgstr "分享"
 
-#: journal/templates/collection.html:77
+#: journal/templates/collection.html:86
 msgid "created a collection"
 msgstr "创建了收藏单"
 
-#: journal/templates/collection.html:166
+#: journal/templates/collection.html:175
 msgid "Query"
 msgstr "查询"
 
@@ -5966,7 +5972,7 @@ msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
 #: journal/views/collection.py:460 journal/views/collection.py:498
-#: journal/views/collection.py:510 journal/views/collection.py:538
+#: journal/views/collection.py:510 journal/views/collection.py:536
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
@@ -6648,31 +6654,31 @@ msgstr "帖文"
 msgid "Article"
 msgstr "文章"
 
-#: takahe/models.py:450
+#: takahe/models.py:451
 msgid "Display Name"
 msgstr "昵称"
 
-#: takahe/models.py:452
+#: takahe/models.py:453
 msgid "Bio"
 msgstr "简介"
 
-#: takahe/models.py:454
+#: takahe/models.py:455
 msgid "Manually approve new followers"
 msgstr "手工审核关注者"
 
-#: takahe/models.py:458
+#: takahe/models.py:459
 msgid "Include profile, marks and posts in discovery"
 msgstr "允许个人资料、标记和帖文包含在发现中"
 
-#: takahe/models.py:461
+#: takahe/models.py:462
 msgid "Include posts in search results"
 msgstr "允许个人帖文包含在搜索结果中"
 
-#: takahe/models.py:479
+#: takahe/models.py:480
 msgid "Profile picture"
 msgstr "头像"
 
-#: takahe/models.py:486
+#: takahe/models.py:487
 msgid "Header picture"
 msgstr "背景图片"
 
@@ -6798,10 +6804,12 @@ msgid "Create new album"
 msgstr "新建专辑"
 
 #: users/templates/users/_rym_row.html:28
+#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr "然后将链接粘贴到上方；留空则跳过该行。"
 
 #: users/templates/users/_rym_row.html:39
+#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr "(跳过)"
 
@@ -6811,6 +6819,7 @@ msgid "Import from RateYourMusic"
 msgstr "从RateYourMusic导入"
 
 #: users/templates/users/_rym_section.html:9
+#: users/templates/users/_storygraph_section.html:9
 msgid "Review pending matches"
 msgstr "审阅待处理的匹配"
 
@@ -6819,6 +6828,7 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr "取消 RateYourMusic 导入？进度将被丢弃。"
 
 #: users/templates/users/_rym_section.html:16
+#: users/templates/users/_storygraph_section.html:16
 msgid "Cancel import"
 msgstr "取消导入"
 
@@ -6827,7 +6837,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/data.html:141
+#: users/templates/users/_storygraph_section.html:31
 msgid "Upload the downloaded CSV file below."
 msgstr "在下方上传下载到的 CSV 文件。"
 
@@ -6836,16 +6846,40 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/_rym_section.html:36
+#: users/templates/users/_storygraph_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
 
 #: users/templates/users/_rym_section.html:40
+#: users/templates/users/_storygraph_section.html:40
 msgid "Upload and match"
 msgstr "上传并匹配"
 
 #: users/templates/users/_rym_section.html:46
+#: users/templates/users/_storygraph_section.html:46
 msgid "Download previous matches"
 msgstr "下载先前的匹配"
+
+#: users/templates/users/_storygraph_row.html:30
+msgid "Create new book"
+msgstr "新建图书"
+
+#: users/templates/users/_storygraph_section.html:5
+#: users/templates/users/_storygraph_section.html:21
+msgid "Import from StoryGraph"
+msgstr "从StoryGraph导入"
+
+#: users/templates/users/_storygraph_section.html:15
+msgid "Cancel the StoryGraph import? Progress will be discarded."
+msgstr "取消 StoryGraph 导入？进度将被丢弃。"
+
+#: users/templates/users/_storygraph_section.html:29
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
+
+#: users/templates/users/_storygraph_section.html:33
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "图书将按 ISBN 进行匹配——优先查询本地条目库，然后是 Google Books 和 OpenLibrary——如无结果则按标题加作者搜索。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/account.html:11
 msgid "Account Information"
@@ -7135,9 +7169,9 @@ msgid "CSV file"
 msgstr "CSV 文件"
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:235 users/templates/users/data.html:286
-#: users/templates/users/data.html:350 users/templates/users/data.html:410
+#: users/templates/users/data.html:126 users/templates/users/data.html:183
+#: users/templates/users/data.html:234 users/templates/users/data.html:298
+#: users/templates/users/data.html:358
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -7281,7 +7315,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:308
+#: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -7313,140 +7347,128 @@ msgstr "在 Goodreads，点击 <a href=\"https://www.goodreads.com/review/import
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr "在下方上传下载的 <code>goodreads_library_export.csv</code> 文件。"
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr "将导入想读、在读、已读和放弃的书籍及其评论。"
 
-#: users/templates/users/data.html:133
-msgid "Import from StoryGraph"
-msgstr "从StoryGraph导入"
-
-#: users/templates/users/data.html:139
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
-
-#: users/templates/users/data.html:146
-msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
-msgstr "书籍首先通过 ISBN 匹配，然后通过 Google Books 按标题和作者匹配。<b>StoryGraph 导出的元数据有限</b>（许多书籍缺少 ISBN），部分条目可能匹配失败或匹配错误——请在导入后查看失败条目列表。"
-
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:134
 msgid "Import from Letterboxd"
 msgstr "导入Letterboxd标记"
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:140
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr "在 letterboxd.com 网站，点击 <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">Settings 中的 DATA</a>；或在其 App 中，进入 Settings 后点击 Advanced Settings，再点击 EXPORT YOUR DATA"
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:143
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr "下载名称类似 <code>letterboxd-username-2018-03-11-07-52-utc.zip</code> 的文件，请勿解压"
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:146
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr "zip 文件中以下文件将被处理：<code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 
-#: users/templates/users/data.html:201
+#: users/templates/users/data.html:149
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr "导出文件不含片单的公开、不公开或私密状态，因此所有导入的标记、评论和收藏单都将以下方选择的可见性创建"
 
-#: users/templates/users/data.html:236 users/templates/users/data.html:287
+#: users/templates/users/data.html:184 users/templates/users/data.html:235
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "导入时仅更新正向变化(未标->想看->已看)标记；不足360字符的评论会作为短评添加。"
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:191
 msgid "Import from Trakt"
 msgstr "导入Trakt标记"
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:197
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr "在<a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt设置 - 数据</a>页面，点击<b>Export now</b>，等待下载链接出现。"
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:200
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 
-#: users/templates/users/data.html:254
+#: users/templates/users/data.html:202
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
-#: users/templates/users/data.html:295
+#: users/templates/users/data.html:243
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:298
+#: users/templates/users/data.html:246
 msgid "Login with Steam"
 msgstr "使用 Steam 登录"
 
-#: users/templates/users/data.html:304
+#: users/templates/users/data.html:252
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:263
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:319
+#: users/templates/users/data.html:267
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:348
+#: users/templates/users/data.html:296
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:306
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:364
+#: users/templates/users/data.html:312
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:366
+#: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:376
+#: users/templates/users/data.html:324
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:437
+#: users/templates/users/data.html:385
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:463
+#: users/templates/users/data.html:411
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:436
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:460
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:516
+#: users/templates/users/data.html:464
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:523
+#: users/templates/users/data.html:471
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:531
+#: users/templates/users/data.html:479
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:534
+#: users/templates/users/data.html:482
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:539
+#: users/templates/users/data.html:487
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:496
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7850,6 +7872,7 @@ msgid "Review RateYourMusic Matches"
 msgstr "审阅 RateYourMusic 匹配结果"
 
 #: users/templates/users/rym_import.html:39
+#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7861,6 +7884,7 @@ msgstr ""
 "            "
 
 #: users/templates/users/rym_import.html:45
+#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr "下载已匹配的 CSV"
 
@@ -7869,26 +7893,32 @@ msgid "Title / Artist"
 msgstr "标题 / 艺术家"
 
 #: users/templates/users/rym_import.html:58
+#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr "匹配链接"
 
 #: users/templates/users/rym_import.html:59
+#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr "标记"
 
 #: users/templates/users/rym_import.html:71
+#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr "上一页"
 
 #: users/templates/users/rym_import.html:75
+#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr "下一页"
 
 #: users/templates/users/rym_import.html:95
+#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr "确认导入"
 
 #: users/templates/users/rym_import.html:96
+#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr "返回"
 
@@ -8008,6 +8038,15 @@ msgstr "选中则允许反向覆盖标记状态（如在玩->想玩，或玩过-
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr "Steam资料必须公开可见才能导入"
 
+#: users/templates/users/storygraph_import.html:9
+#: users/templates/users/storygraph_import.html:37
+msgid "Review StoryGraph Matches"
+msgstr "审阅 StoryGraph 匹配结果"
+
+#: users/templates/users/storygraph_import.html:57
+msgid "Title / Author"
+msgstr "标题 / 作者"
+
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr "失败条目"
@@ -8096,136 +8135,141 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:223 users/views/data.py:252
+#: users/views/data.py:230 users/views/data.py:259
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:246
+#: users/views/data.py:253
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:264
+#: users/views/data.py:271
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:279 users/views/data.py:299
+#: users/views/data.py:286 users/views/data.py:306
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:313
+#: users/views/data.py:320
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:327
+#: users/views/data.py:334
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:382
+#: users/views/data.py:389
 msgid "Account no longer linked."
 msgstr "账户已不再关联。"
 
-#: users/views/data.py:385
+#: users/views/data.py:392
 msgid "Content is no longer public."
 msgstr "内容已不再公开。"
 
-#: users/views/data.py:413
+#: users/views/data.py:420
 msgid "Retry did not complete, please try again."
 msgstr "重试未完成，请再试一次。"
 
-#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
-#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
-#: users/views/data.py:769
+#: users/views/data.py:430 users/views/data.py:463 users/views/data.py:686
+#: users/views/data.py:901 users/views/data.py:926 users/views/data.py:950
+#: users/views/data.py:974
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:492
+#: users/views/data.py:497 users/views/data.py:720
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:517
+#: users/views/data.py:522 users/views/data.py:749
 msgid "Cancelled."
 msgstr "已取消。"
 
-#: users/views/data.py:537
+#: users/views/data.py:542
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:545 users/views/data.py:655
+#: users/views/data.py:550 users/views/data.py:660 users/views/data.py:779
+#: users/views/data.py:884
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:641
+#: users/views/data.py:646 users/views/data.py:870
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:651
+#: users/views/data.py:656 users/views/data.py:880
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:889
+#: users/views/data.py:771
+msgid "No StoryGraph import to preview."
+msgstr "暂无可预览的 StoryGraph 导入任务。"
+
+#: users/views/data.py:1094
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:911
+#: users/views/data.py:1116
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:927
+#: users/views/data.py:1132
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:932
+#: users/views/data.py:1137
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:942 users/views/data.py:993
+#: users/views/data.py:1147 users/views/data.py:1198
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:949
+#: users/views/data.py:1154
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:954
+#: users/views/data.py:1159
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:980
+#: users/views/data.py:1185
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:985
+#: users/views/data.py:1190
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:998
+#: users/views/data.py:1203
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:1009
+#: users/views/data.py:1214
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:1015
+#: users/views/data.py:1220
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:1073
+#: users/views/data.py:1278
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:1089
+#: users/views/data.py:1294
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:1093
+#: users/views/data.py:1298
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:1102
+#: users/views/data.py:1307
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/neodb/test_data/https___openlibrary_org_isbn_9780140328721_json
+++ b/neodb/test_data/https___openlibrary_org_isbn_9780140328721_json
@@ -1,0 +1,7 @@
+{
+  "key": "/books/OL7353617M",
+  "title": "Fantastic Mr. Fox",
+  "isbn_10": ["0140328726"],
+  "isbn_13": ["9780140328721"],
+  "type": {"key": "/type/edition"}
+}

--- a/neodb/test_data/https___openlibrary_org_search_json_title_Fantastic_Mr_Fox_author_Roald_Dahl_limit_3_fields_key_title_editions_editions_key_editions_title
+++ b/neodb/test_data/https___openlibrary_org_search_json_title_Fantastic_Mr_Fox_author_Roald_Dahl_limit_3_fields_key_title_editions_editions_key_editions_title
@@ -1,0 +1,20 @@
+{
+  "numFound": 1,
+  "start": 0,
+  "docs": [
+    {
+      "key": "/works/OL45804W",
+      "title": "Fantastic Mr Fox",
+      "editions": {
+        "numFound": 1,
+        "start": 0,
+        "docs": [
+          {
+            "key": "/books/OL7353617M",
+            "title": "Fantastic Mr. Fox"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/neodb/test_data/https___www_googleapis_com_books_v1_volumes_country_us_q_isbn_9780140328721_maxResults_3
+++ b/neodb/test_data/https___www_googleapis_com_books_v1_volumes_country_us_q_isbn_9780140328721_maxResults_3
@@ -1,0 +1,4 @@
+{
+  "kind": "books#volumes",
+  "totalItems": 0
+}

--- a/neodb/test_data/https___www_googleapis_com_books_v1_volumes_country_us_q_isbn_9780547928227_maxResults_3
+++ b/neodb/test_data/https___www_googleapis_com_books_v1_volumes_country_us_q_isbn_9780547928227_maxResults_3
@@ -1,0 +1,18 @@
+{
+  "kind": "books#volumes",
+  "totalItems": 1,
+  "items": [
+    {
+      "kind": "books#volume",
+      "id": "hobbit_test_id",
+      "volumeInfo": {
+        "title": "The Hobbit",
+        "authors": ["J.R.R. Tolkien"],
+        "industryIdentifiers": [
+          {"type": "ISBN_10", "identifier": "0547928227"},
+          {"type": "ISBN_13", "identifier": "9780547928227"}
+        ]
+      }
+    }
+  ]
+}

--- a/neodb/test_data/https___www_googleapis_com_books_v1_volumes_hobbit_test_id
+++ b/neodb/test_data/https___www_googleapis_com_books_v1_volumes_hobbit_test_id
@@ -1,0 +1,17 @@
+{
+  "kind": "books#volume",
+  "id": "hobbit_test_id",
+  "volumeInfo": {
+    "title": "The Hobbit",
+    "authors": ["J.R.R. Tolkien"],
+    "publishedDate": "2012-09-18",
+    "publisher": "Houghton Mifflin Harcourt",
+    "pageCount": 300,
+    "language": "en",
+    "description": "Bilbo Baggins is a hobbit who enjoys a comfortable life, rarely traveling any farther than his pantry or cellar.",
+    "industryIdentifiers": [
+      {"type": "ISBN_10", "identifier": "0547928227"},
+      {"type": "ISBN_13", "identifier": "9780547928227"}
+    ]
+  }
+}

--- a/neodb/test_data/storygraph_library_export.csv
+++ b/neodb/test_data/storygraph_library_export.csv
@@ -5,3 +5,6 @@ The Little Prince,Antoine de Saint-Exupéry,Richard Howard (Translator),97801520
 Fahrenheit 451,Ray Bradbury,"",9781451673265,hardcover,to-read,2022/04/02,"","",0,"",,,,,,,,,"",,scifi,No
 Tales from Earthsea,Ursula K. Le Guin,"","",digital,read,2026/04/02,2026/04/02,2026/04/02,1,"",,,,,,,3.5,"A great short story collection","",,"scifi",Yes
 Unknown Book,Unknown Author,"",notanisbn,paperback,read,2024/01/01,2024/01/02,,1,"",,,,,,,2.0,,"",,"",No
+The Hobbit,J.R.R. Tolkien,"",9780547928227,paperback,read,2023/05/01,2023/06/01,2023/06/01,1,"",,,,,,,4.5,,"",,fantasy,No
+Fantastic Mr Fox,Roald Dahl,"",9780140328721,hardcover,to-read,2023/07/01,"","",0,"",,,,,,,,,"",,kids,No
+The Memory Police,Yoko Ogawa,Stephen Snyder (Translator),fbdd6b7c-f512-47f2-aa94-d8bf0d5f5175,digital,read,2024/03/01,2024/03/15,2024/03/15,1,"",,,,,,,4.0,,"",,"",Yes

--- a/neodb/tests/journal/test_storygraph.py
+++ b/neodb/tests/journal/test_storygraph.py
@@ -1,10 +1,12 @@
+import csv
 import io
+import shutil
 from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
 
-from catalog.common.downloaders import use_local_response
+from catalog.common.downloaders import set_mock_mode, use_local_response
 from catalog.models import Edition, ExternalResource, IdType
 from journal.importers import StoryGraphImporter
 from journal.models import Mark, ShelfType
@@ -28,6 +30,11 @@ def _make_edition_with_isbn(isbn13: str, title: str) -> Edition:
     return _make_edition_with_resource(IdType.ISBN, isbn13, title)
 
 
+def _read_matched(path: str) -> dict[str, dict]:
+    with open(path, encoding="utf-8-sig", newline="") as f:
+        return {row["Title"]: row for row in csv.DictReader(f)}
+
+
 @pytest.mark.django_db(databases="__all__")
 class TestStoryGraphImporter:
     CSV_PATH = "test_data/storygraph_library_export.csv"
@@ -49,6 +56,23 @@ class TestStoryGraphImporter:
             IdType.StoryGraph, self.SG_UUID, "The Memory Police"
         )
 
+    @pytest.fixture
+    def local_response(self):
+        # use_local_response can't be combined with other fixtures (its
+        # wrapper only accepts self), so mock mode is a fixture here
+        set_mock_mode(True)
+        yield
+        set_mock_mode(False)
+
+    def _create_matching_task(self, tmp_path):
+        # matching writes "<file>-matched.csv" next to the input, so copy the
+        # test csv to a scratch dir first
+        src = tmp_path / "storygraph_library_export.csv"
+        shutil.copyfile(self.CSV_PATH, src)
+        return StoryGraphImporter.create(
+            self.user, phase="matching", file=str(src), filename_hint="export.csv"
+        )
+
     def test_validate_file(self):
         with open(self.CSV_PATH, "rb") as f:
             assert StoryGraphImporter.validate_file(f)
@@ -57,22 +81,80 @@ class TestStoryGraphImporter:
         bad = io.BytesIO(b"Book Id,Title,Author\n1,Foo,Bar\n")
         assert not StoryGraphImporter.validate_file(bad)
 
-    @use_local_response
-    def test_import_csv(self):
-        task = StoryGraphImporter.create(self.user, visibility=0, file=self.CSV_PATH)
+    def test_matching_phase(self, tmp_path, local_response):
+        task = self._create_matching_task(tmp_path)
         # skip the catalog index so results don't depend on search availability
         with patch.object(
-            StoryGraphImporter, "_find_via_local_index", return_value=None
+            StoryGraphImporter, "_match_via_local_index", return_value=None
         ):
             task.run()
 
-        # 8 imported (4 by local ISBN + 1 by StoryGraph UUID + 1 via Google Books
-        # title search + 1 via Google Books ISBN + 1 via OpenLibrary ISBN),
-        # 0 skipped, 1 failed (bad ISBN, no match anywhere)
+        assert task.metadata["phase"] == "preview"
+        # 5 local (4 by ISBN + 1 by StoryGraph UUID), 3 external (1 Google
+        # Books by ISBN + 1 OpenLibrary by ISBN + 1 Google Books title search),
+        # 1 unmatched (bad ISBN, no match anywhere)
+        assert task.metadata["matched_local"] == 5
+        assert task.metadata["matched_external"] == 3
+        assert task.metadata["unmatched"] == 1
+
+        rows = _read_matched(task.metadata["matched_file"])
+        assert len(rows) == 9
+
+        row = rows["Brave New World"]
+        assert row["link"] == self.brave_new_world.url
+        assert row["match_source"] == "local"
+        assert row["shelf"] == "complete"
+        assert row["collect_date"] == "2022-06-15"
+
+        row = rows["1984"]
+        assert row["link"] == self.nineteen_eighty_four.url
+        assert row["shelf"] == "progress"
+        assert row["collect_date"] == "2022-04-02"
+
+        assert rows["The Little Prince"]["shelf"] == "dropped"
+        assert rows["Fahrenheit 451"]["shelf"] == "wishlist"
+
+        row = rows["The Memory Police"]
+        assert row["link"] == self.memory_police.url
+        assert row["match_source"] == "local"
+
+        # ISBN not in local DB, matched via Google Books ISBN query
+        row = rows["The Hobbit"]
+        assert row["link"] == "https://books.google.com/books?id=hobbit_test_id"
+        assert row["match_source"] == "googlebooks"
+
+        # Google Books has no result for the ISBN, matched via OpenLibrary
+        row = rows["Fantastic Mr Fox"]
+        assert row["link"] == "https://openlibrary.org/books/OL7353617M"
+        assert row["match_source"] == "openlibrary"
+
+        # no ISBN, matched via Google Books title + author search
+        row = rows["Tales from Earthsea"]
+        assert row["link"] == "https://books.google.com/books?id=earthsea_test_id"
+        assert row["match_source"] == "googlebooks"
+
+        row = rows["Unknown Book"]
+        assert row["link"] == ""
+        assert row["match_source"] == "none"
+
+    def test_import_phase(self, tmp_path, local_response):
+        task = self._create_matching_task(tmp_path)
+        with patch.object(
+            StoryGraphImporter, "_match_via_local_index", return_value=None
+        ):
+            task.run()
+        assert task.metadata["phase"] == "preview"
+
+        task.metadata["phase"] = "importing"
+        task.metadata["visibility"] = 0
+        task.save(update_fields=["metadata"])
+        task.run()
+
+        assert task.metadata["phase"] == "done"
+        # 8 imported, 1 skipped (unmatched row has no link)
         assert task.metadata["imported"] == 8
-        assert task.metadata["skipped"] == 0
-        assert task.metadata["failed"] == 1
-        assert task.metadata["failed_items"] == ["Unknown Book"]
+        assert task.metadata["skipped"] == 1
+        assert task.metadata["failed"] == 0
 
         # Brave New World: read, rating=4.0 -> grade=8
         mark = Mark(self.identity, self.brave_new_world)
@@ -92,12 +174,12 @@ class TestStoryGraphImporter:
         mark = Mark(self.identity, self.fahrenheit)
         assert mark.shelf_type == ShelfType.WISHLIST
 
-        # The Memory Police: matched by StoryGraph UUID in local DB, no network
+        # The Memory Police: matched by StoryGraph UUID in local DB
         mark = Mark(self.identity, self.memory_police)
         assert mark.shelf_type == ShelfType.COMPLETE
         assert mark.rating_grade == 8
 
-        # Tales from Earthsea: found via Google Books title search, read, 3.5->7
+        # Tales from Earthsea: fetched from Google Books during import, 3.5->7
         earthsea = Edition.objects.filter(
             primary_lookup_id_type=IdType.ISBN,
             primary_lookup_id_value="9780152047641",
@@ -106,8 +188,9 @@ class TestStoryGraphImporter:
         mark = Mark(self.identity, earthsea)
         assert mark.shelf_type == ShelfType.COMPLETE
         assert mark.rating_grade == 7
+        assert mark.comment_text == "A great short story collection"
 
-        # The Hobbit: ISBN not in local DB, fetched from Google Books by ISBN
+        # The Hobbit: fetched from Google Books by ISBN
         hobbit = Edition.objects.filter(
             primary_lookup_id_type=IdType.ISBN,
             primary_lookup_id_value="9780547928227",
@@ -117,8 +200,7 @@ class TestStoryGraphImporter:
         assert mark.shelf_type == ShelfType.COMPLETE
         assert mark.rating_grade == 9
 
-        # Fantastic Mr Fox: Google Books has no result for the ISBN,
-        # fetched from OpenLibrary by ISBN instead
+        # Fantastic Mr Fox: fetched from OpenLibrary
         fox = Edition.objects.filter(
             primary_lookup_id_type=IdType.ISBN,
             primary_lookup_id_value="9780140328721",
@@ -127,25 +209,27 @@ class TestStoryGraphImporter:
         mark = Mark(self.identity, fox)
         assert mark.shelf_type == ShelfType.WISHLIST
 
-    def test_find_item_by_isbn(self):
-        item = StoryGraphImporter.find_item("9780060929879")
-        assert item == self.brave_new_world
+    def test_match_by_isbn_local(self):
+        assert StoryGraphImporter._match("9780060929879", "", "") == (
+            self.brave_new_world.url,
+            "local",
+        )
 
-    def test_find_item_by_storygraph_uid(self):
-        item = StoryGraphImporter.find_item(self.SG_UUID)
-        assert item == self.memory_police
+    def test_match_by_storygraph_uid_local(self):
+        assert StoryGraphImporter._match(self.SG_UUID, "", "") == (
+            self.memory_police.url,
+            "local",
+        )
+
+    def test_match_missing(self):
+        # no ISBN and no title → None without any network call
+        assert StoryGraphImporter._match("", "", "") is None
+        # bad ISBN, no title → None
+        assert StoryGraphImporter._match("notanisbn", "", "") is None
 
     @use_local_response
-    def test_find_via_openlibrary_search(self):
-        item = StoryGraphImporter._find_via_openlibrary_search(
+    def test_match_via_openlibrary_search(self):
+        url = StoryGraphImporter._match_via_openlibrary_search(
             "Fantastic Mr Fox", "Roald Dahl"
         )
-        assert item is not None
-        assert item.primary_lookup_id_type == IdType.ISBN
-        assert item.primary_lookup_id_value == "9780140328721"
-
-    def test_find_item_missing(self):
-        # No ISBN and no title → None without any network call
-        assert StoryGraphImporter.find_item("", title="") is None
-        # Bad ISBN, no title → None
-        assert StoryGraphImporter.find_item("notanisbn", title="") is None
+        assert url == "https://openlibrary.org/books/OL7353617M"

--- a/neodb/tests/journal/test_storygraph.py
+++ b/neodb/tests/journal/test_storygraph.py
@@ -1,4 +1,5 @@
 import io
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -10,22 +11,27 @@ from journal.models import Mark, ShelfType
 from users.models import User
 
 
-def _make_edition_with_isbn(isbn13: str, title: str) -> Edition:
+def _make_edition_with_resource(id_type: IdType, id_value: str, title: str) -> Edition:
     edition = Edition.objects.create(title=title)
     ExternalResource.objects.create(
         item=edition,
-        id_type=IdType.ISBN,
-        id_value=isbn13,
-        url=f"https://openlibrary.org/isbn/{isbn13}",
+        id_type=id_type,
+        id_value=id_value,
+        url=f"https://example.org/{id_type}/{id_value}",
         scraped_time=timezone.now(),
         metadata={"title": title},
     )
     return edition
 
 
+def _make_edition_with_isbn(isbn13: str, title: str) -> Edition:
+    return _make_edition_with_resource(IdType.ISBN, isbn13, title)
+
+
 @pytest.mark.django_db(databases="__all__")
 class TestStoryGraphImporter:
     CSV_PATH = "test_data/storygraph_library_export.csv"
+    SG_UUID = "fbdd6b7c-f512-47f2-aa94-d8bf0d5f5175"
 
     @pytest.fixture(autouse=True)
     def setup_data(self):
@@ -39,6 +45,9 @@ class TestStoryGraphImporter:
             "9780152023980", "The Little Prince"
         )
         self.fahrenheit = _make_edition_with_isbn("9781451673265", "Fahrenheit 451")
+        self.memory_police = _make_edition_with_resource(
+            IdType.StoryGraph, self.SG_UUID, "The Memory Police"
+        )
 
     def test_validate_file(self):
         with open(self.CSV_PATH, "rb") as f:
@@ -51,12 +60,19 @@ class TestStoryGraphImporter:
     @use_local_response
     def test_import_csv(self):
         task = StoryGraphImporter.create(self.user, visibility=0, file=self.CSV_PATH)
-        task.run()
+        # skip the catalog index so results don't depend on search availability
+        with patch.object(
+            StoryGraphImporter, "_find_via_local_index", return_value=None
+        ):
+            task.run()
 
-        # 5 imported (4 by ISBN + 1 via Google Books), 0 skipped, 1 failed (bad ISBN)
-        assert task.metadata["imported"] == 5
+        # 8 imported (4 by local ISBN + 1 by StoryGraph UUID + 1 via Google Books
+        # title search + 1 via Google Books ISBN + 1 via OpenLibrary ISBN),
+        # 0 skipped, 1 failed (bad ISBN, no match anywhere)
+        assert task.metadata["imported"] == 8
         assert task.metadata["skipped"] == 0
         assert task.metadata["failed"] == 1
+        assert task.metadata["failed_items"] == ["Unknown Book"]
 
         # Brave New World: read, rating=4.0 -> grade=8
         mark = Mark(self.identity, self.brave_new_world)
@@ -76,8 +92,12 @@ class TestStoryGraphImporter:
         mark = Mark(self.identity, self.fahrenheit)
         assert mark.shelf_type == ShelfType.WISHLIST
 
-        # Tales from Earthsea: found via Google Books fallback, read, rating=3.5->7
-        # Google Books returns ISBN 9780152047641, which becomes primary_lookup_id
+        # The Memory Police: matched by StoryGraph UUID in local DB, no network
+        mark = Mark(self.identity, self.memory_police)
+        assert mark.shelf_type == ShelfType.COMPLETE
+        assert mark.rating_grade == 8
+
+        # Tales from Earthsea: found via Google Books title search, read, 3.5->7
         earthsea = Edition.objects.filter(
             primary_lookup_id_type=IdType.ISBN,
             primary_lookup_id_value="9780152047641",
@@ -87,9 +107,42 @@ class TestStoryGraphImporter:
         assert mark.shelf_type == ShelfType.COMPLETE
         assert mark.rating_grade == 7
 
+        # The Hobbit: ISBN not in local DB, fetched from Google Books by ISBN
+        hobbit = Edition.objects.filter(
+            primary_lookup_id_type=IdType.ISBN,
+            primary_lookup_id_value="9780547928227",
+        ).first()
+        assert hobbit is not None
+        mark = Mark(self.identity, hobbit)
+        assert mark.shelf_type == ShelfType.COMPLETE
+        assert mark.rating_grade == 9
+
+        # Fantastic Mr Fox: Google Books has no result for the ISBN,
+        # fetched from OpenLibrary by ISBN instead
+        fox = Edition.objects.filter(
+            primary_lookup_id_type=IdType.ISBN,
+            primary_lookup_id_value="9780140328721",
+        ).first()
+        assert fox is not None
+        mark = Mark(self.identity, fox)
+        assert mark.shelf_type == ShelfType.WISHLIST
+
     def test_find_item_by_isbn(self):
         item = StoryGraphImporter.find_item("9780060929879")
         assert item == self.brave_new_world
+
+    def test_find_item_by_storygraph_uid(self):
+        item = StoryGraphImporter.find_item(self.SG_UUID)
+        assert item == self.memory_police
+
+    @use_local_response
+    def test_find_via_openlibrary_search(self):
+        item = StoryGraphImporter._find_via_openlibrary_search(
+            "Fantastic Mr Fox", "Roald Dahl"
+        )
+        assert item is not None
+        assert item.primary_lookup_id_type == IdType.ISBN
+        assert item.primary_lookup_id_value == "9780140328721"
 
     def test_find_item_missing(self):
         # No ISBN and no title → None without any network call

--- a/neodb/users/templates/users/_storygraph_row.html
+++ b/neodb/users/templates/users/_storygraph_row.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+{% url 'users:storygraph_save_row' row.index as save_url %}
+<tr id="storygraph-row-{{ row.index }}">
+  <td>
+    <div>
+      <strong>{{ row.title }}</strong>
+    </div>
+    <small>
+      {{ row.authors }}
+      {% if row.isbn_uid %}
+        <br>
+        {{ row.isbn_uid }}
+      {% endif %}
+    </small>
+  </td>
+  <td>
+    <input type="text"
+           name="link"
+           value="{{ row.link }}"
+           placeholder="https://… or /book/…"
+           hx-post="{{ save_url }}"
+           hx-trigger="change"
+           hx-include="closest tr"
+           hx-target="closest tr"
+           hx-swap="outerHTML">
+    {% if not row.link %}
+      <div>
+        <a href="/catalog/create/Edition?title={{ row.title|urlencode }}"
+           target="_blank"
+           rel="noopener">{% trans 'Create new book' %}</a>
+        <small>{% trans 'then paste the link above; leave blank to skip this row.' %}</small>
+      </div>
+    {% endif %}
+  </td>
+  <td>
+    <select name="shelf"
+            hx-post="{{ save_url }}"
+            hx-trigger="change"
+            hx-include="closest tr"
+            hx-target="closest tr"
+            hx-swap="outerHTML">
+      <option value="" {% if not row.shelf %}selected{% endif %}>{% trans '(skip)' %}</option>
+      {% for value, label in shelf_choices %}
+        <option value="{{ value }}" {% if row.shelf == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </td>
+  <td>
+    <input type="date"
+           name="collect_date"
+           value="{{ row.collect_date }}"
+           hx-post="{{ save_url }}"
+           hx-trigger="change"
+           hx-include="closest tr"
+           hx-target="closest tr"
+           hx-swap="outerHTML">
+  </td>
+</tr>

--- a/neodb/users/templates/users/_storygraph_section.html
+++ b/neodb/users/templates/users/_storygraph_section.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+{% with phase=storygraph_task.metadata.phase %}
+  {% if storygraph_task and phase and phase != 'done' and phase != 'cancelled' %}
+    <details open>
+      <summary>{% trans 'Import from StoryGraph' %}</summary>
+      {% include "users/user_task_status.html" with task=storygraph_task %}
+      <div role="group">
+        {% if phase == 'preview' %}
+          <a href="{% url 'users:storygraph_preview' %}"
+             role="button"
+             class="secondary">{% trans 'Review pending matches' %}</a>
+        {% endif %}
+        <button type="button"
+                hx-post="{% url 'users:storygraph_cancel' %}"
+                hx-target="#storygraph"
+                hx-swap="innerHTML"
+                hx-confirm="{% trans 'Cancel the StoryGraph import? Progress will be discarded.' %}"
+                class="secondary outline">{% trans 'Cancel import' %}</button>
+      </div>
+    </details>
+  {% else %}
+    <details {% if storygraph_task and phase == 'done' %}open{% endif %}>
+      <summary>{% trans 'Import from StoryGraph' %}</summary>
+      <form hx-post="{% url 'users:import_storygraph' %}"
+            hx-target="#storygraph"
+            hx-swap="innerHTML"
+            enctype="multipart/form-data">
+        {% csrf_token %}
+        <ul>
+          <li>
+            {% blocktrans %}On StoryGraph, click <a href="https://app.thestorygraph.com/user-export" target="_blank" rel="noopener"><b>Export your library</b></a> to download your library as a CSV file.{% endblocktrans %}
+          </li>
+          <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
+          <li>
+            {% blocktrans %}Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import.{% endblocktrans %}
+          </li>
+          <li>
+            {% blocktrans %}You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match.{% endblocktrans %}
+          </li>
+        </ul>
+        <input type="file" name="file" required accept=".csv">
+        <input type="submit" value="{% trans 'Upload and match' %}" />
+      </form>
+      {% if storygraph_task and phase == 'done' and storygraph_task.metadata.matched_file %}
+        <p>
+          <a href="{% url 'users:storygraph_download' %}"
+             role="button"
+             class="secondary outline">{% trans 'Download previous matches' %}</a>
+        </p>
+      {% endif %}
+      {% if storygraph_task and phase == 'done' %}
+        {% include "users/user_task_status.html" with task=storygraph_task %}
+      {% endif %}
+    </details>
+  {% endif %}
+{% endwith %}

--- a/neodb/users/templates/users/data.html
+++ b/neodb/users/templates/users/data.html
@@ -128,59 +128,7 @@
             </form>
           </details>
         </article>
-        <article>
-          <details>
-            <summary>{% trans 'Import from StoryGraph' %}</summary>
-            <form hx-post="{% url 'users:import_storygraph' %}"
-                  enctype="multipart/form-data">
-              {% csrf_token %}
-              <ul>
-                <li>
-                  {% blocktrans %}On StoryGraph, click <a href="https://app.thestorygraph.com/user-export" target="_blank" rel="noopener"><b>Export your library</b></a> to download your library as a CSV file.{% endblocktrans %}
-                </li>
-                <li>{% blocktrans %}Upload the downloaded CSV file below.{% endblocktrans %}</li>
-                <li>
-                  {% trans 'want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported.' %}
-                </li>
-                <li>
-                  {% blocktrans %}Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import.{% endblocktrans %}
-                </li>
-              </ul>
-              <input type="file" name="file" required accept=".csv">
-              <p>
-                {% trans 'Visibility' %}:
-                <br>
-                <label for="sg_visibility_0">
-                  <input type="radio"
-                         name="visibility"
-                         value="0"
-                         required=""
-                         id="sg_visibility_0"
-                         checked>
-                  {% trans 'Public' %}
-                </label>
-                <label for="sg_visibility_1">
-                  <input type="radio"
-                         name="visibility"
-                         value="1"
-                         required=""
-                         id="sg_visibility_1">
-                  {% trans 'Followers Only' %}
-                </label>
-                <label for="sg_visibility_2">
-                  <input type="radio"
-                         name="visibility"
-                         value="2"
-                         required=""
-                         id="sg_visibility_2">
-                  {% trans 'Mentioned Only' %}
-                </label>
-              </p>
-              <input type="submit" value="{% trans 'Import' %}" />
-              {% include "users/user_task_status.html" with task=storygraph_task %}
-            </form>
-          </details>
-        </article>
+        <article id="storygraph">{% include "users/_storygraph_section.html" %}</article>
         <article>
           <details>
             <summary>{% trans 'Import from Letterboxd' %}</summary>

--- a/neodb/users/templates/users/storygraph_import.html
+++ b/neodb/users/templates/users/storygraph_import.html
@@ -1,0 +1,101 @@
+{% load static %}
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans 'Review StoryGraph Matches' %}</title>
+    {% include "common_libs.html" %}
+    <style>
+    main.storygraph-preview {
+      max-width: none;
+      width: 100%;
+      padding: calc(2 * var(--pico-spacing));
+      margin: 0;
+    }
+    main.storygraph-preview table { width: 100%; table-layout: fixed; }
+    main.storygraph-preview table th, main.storygraph-preview table td { word-break: break-word; vertical-align: top; }
+    main.storygraph-preview table td input[type="text"] { width: 100%; box-sizing: border-box; }
+    </style>
+    <script>
+    document.addEventListener('htmx:responseError', (event) => {
+      let response = event.detail.xhr.response;
+      let body = response ? response : `Request error: ${event.detail.xhr.statusText}`;
+      alert(body);
+    });
+    document.addEventListener('htmx:configRequest', (event) => {
+      event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+    });
+    </script>
+  </head>
+  <body>
+    {% include "_header.html" %}
+    <main class="storygraph-preview">
+      <article>
+        <h3>{% trans 'Review StoryGraph Matches' %}</h3>
+        <p>
+          {% blocktrans with total=total local=task.metadata.matched_local external=task.metadata.matched_external unmatched=task.metadata.unmatched %}
+              Matched {{ local }} locally, {{ external }} externally, {{ unmatched }} unmatched out of {{ total }} rows.
+            {% endblocktrans %}
+        </p>
+        <p>
+          <a href="{% url 'users:storygraph_download' %}">
+            <i class="fa fa-download"></i> {% trans 'Download matched CSV' %}
+          </a>
+        </p>
+        <table>
+          <colgroup>
+            <col style="width:20%">
+            <col style="width:50%">
+            <col style="width:15%">
+            <col style="width:15%">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>{% trans 'Title / Author' %}</th>
+              <th>{% trans 'Matched Link' %}</th>
+              <th>{% trans 'Shelf' %}</th>
+              <th>{% trans 'Date' %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+              {% include "users/_storygraph_row.html" %}
+            {% endfor %}
+          </tbody>
+        </table>
+        <p>
+          {% if has_prev %}
+            <a href="?page={{ page|add:'-1' }}">&laquo; {% trans 'Prev' %}</a>
+          {% endif %}
+          {% trans 'Page' %} {{ page }}
+          {% if has_next %}
+            <a href="?page={{ page|add:'1' }}">{% trans 'Next' %} &raquo;</a>
+          {% endif %}
+        </p>
+        <form method="post" action="{% url 'users:storygraph_confirm' %}">
+          {% csrf_token %}
+          <fieldset>
+            <legend>{% trans 'Visibility' %}</legend>
+            <label>
+              <input type="radio" name="visibility" value="0" checked>
+              {% trans 'Public' %}
+            </label>
+            <label>
+              <input type="radio" name="visibility" value="1">
+              {% trans 'Followers Only' %}
+            </label>
+            <label>
+              <input type="radio" name="visibility" value="2">
+              {% trans 'Mentioned Only' %}
+            </label>
+          </fieldset>
+          <button type="submit">{% trans 'Confirm Import' %}</button>
+          <a href="{% url 'users:data' %}">{% trans 'Back' %}</a>
+        </form>
+      </article>
+    </main>
+  </body>
+</html>

--- a/neodb/users/urls.py
+++ b/neodb/users/urls.py
@@ -23,6 +23,23 @@ urlpatterns = [
     path("data/import/rym/cancel", rym_cancel, name="rym_cancel"),
     path("data/import/rym/download", rym_download, name="rym_download"),
     path("data/import/storygraph", import_storygraph, name="import_storygraph"),
+    path(
+        "data/import/storygraph/preview", storygraph_preview, name="storygraph_preview"
+    ),
+    path(
+        "data/import/storygraph/row/<int:i>",
+        storygraph_save_row,
+        name="storygraph_save_row",
+    ),
+    path(
+        "data/import/storygraph/confirm", storygraph_confirm, name="storygraph_confirm"
+    ),
+    path("data/import/storygraph/cancel", storygraph_cancel, name="storygraph_cancel"),
+    path(
+        "data/import/storygraph/download",
+        storygraph_download,
+        name="storygraph_download",
+    ),
     path("data/import/douban", import_douban, name="import_douban"),
     path("data/import/letterboxd", import_letterboxd, name="import_letterboxd"),
     path("data/import/trakt", import_trakt, name="import_trakt"),

--- a/neodb/users/views/data.py
+++ b/neodb/users/views/data.py
@@ -2,6 +2,7 @@ import copy
 import csv
 import datetime
 import os
+import shutil
 
 import django_rq
 from django.conf import settings
@@ -198,14 +199,20 @@ def user_task_status(request, task_type: str):
             return redirect(reverse("users:data"))
     task = task_cls.latest_task(request.user)
     if (
-        task_cls is RymImporter
-        and task
+        task
         and task.state == Task.States.complete
         and task.metadata.get("phase") in ("preview", "done")
     ):
-        # Matching or importing just finished — swap the whole RYM section
+        # Matching or importing just finished — swap the whole section
         # so the cancel button is replaced by the Review/Download/upload UI.
-        return render(request, "users/_rym_section.html", {"rym_task": task})
+        if task_cls is RymImporter:
+            return render(request, "users/_rym_section.html", {"rym_task": task})
+        if task_cls is StoryGraphImporter:
+            return render(
+                request,
+                "users/_storygraph_section.html",
+                {"storygraph_task": task},
+            )
     return render(request, "users/user_task_status.html", {"task": task})
 
 
@@ -475,8 +482,6 @@ def import_rym_upload(request):
     uploaded_name = getattr(request.FILES["file"], "name", "rym_export.csv")
     if had_link:
         # already matched; copy to matched_file and skip phase 1
-        import shutil
-
         stem, _ext = os.path.splitext(os.path.basename(f))
         matched = os.path.join(os.path.dirname(f), f"{stem}-matched.csv")
         shutil.copyfile(f, matched)
@@ -664,6 +669,15 @@ def rym_download(request):
     return response
 
 
+def _storygraph_active_task(user):
+    task = StoryGraphImporter.latest_task(user)
+    if not task:
+        return None
+    if task.metadata.get("phase") not in ("matching", "preview", "importing", "done"):
+        return None
+    return task
+
+
 @login_required
 def import_storygraph(request):
     if request.method != "POST":
@@ -679,13 +693,204 @@ def import_storygraph(request):
     with open(f, "wb+") as destination:
         for chunk in request.FILES["file"].chunks():
             destination.write(chunk)
+    # detect 'link' column for round-trip
+    had_link = False
+    with open(f, encoding="utf-8-sig", newline="") as fp:
+        reader = csv.reader(fp)
+        try:
+            headers = next(reader)
+            had_link = "link" in [h.strip() for h in headers]
+        except StopIteration:
+            pass
+    uploaded_name = getattr(request.FILES["file"], "name", "storygraph_export.csv")
+    if had_link:
+        # already matched; copy to matched_file and skip phase 1
+        stem, _ext = os.path.splitext(os.path.basename(f))
+        matched = os.path.join(os.path.dirname(f), f"{stem}-matched.csv")
+        shutil.copyfile(f, matched)
+        task = StoryGraphImporter.create(
+            request.user,
+            phase="preview",
+            file=f,
+            matched_file=matched,
+            filename_hint=uploaded_name,
+            had_link_column=True,
+        )
+        task.state = Task.States.complete
+        task.message = _("Loaded from uploaded matched file.")
+        task.save(update_fields=["state", "message"])
+        if request.headers.get("HX-Request"):
+            return render(
+                request, "users/_storygraph_section.html", {"storygraph_task": task}
+            )
+        return redirect(reverse("users:data") + "#storygraph")
     task = StoryGraphImporter.create(
         request.user,
-        visibility=int(request.POST.get("visibility", 0)),
+        phase="matching",
         file=f,
+        filename_hint=uploaded_name,
     )
     task.enqueue()
-    return redirect(reverse("users:user_task_status", args=(task.type,)))
+    if request.headers.get("HX-Request"):
+        # Replace the section in place so the page doesn't reload during upload.
+        return render(
+            request, "users/_storygraph_section.html", {"storygraph_task": task}
+        )
+    return redirect(reverse("users:data") + "#storygraph")
+
+
+@login_required
+@require_http_methods(["POST"])
+def storygraph_cancel(request):
+    task = StoryGraphImporter.latest_task(request.user)
+    if task and task.metadata.get("phase") in ("matching", "preview", "importing"):
+        task.metadata["phase"] = "cancelled"
+        task.state = Task.States.failed
+        task.message = _("Cancelled.")
+        task.save(update_fields=["metadata", "state", "message"])
+        # Best-effort: drop the job if still queued. A running worker
+        # picks up phase=cancelled on its next progress save and bails;
+        # the not-yet-enqueued case (had_link round-trip) is skipped.
+        if task.pk:
+            try:
+                django_rq.get_queue(task.TaskQueue).remove(task.job_id)
+            except Exception as e:
+                logger.warning(f"StoryGraph cancel: failed to remove job: {e}")
+    if request.headers.get("HX-Request"):
+        return render(
+            request, "users/_storygraph_section.html", {"storygraph_task": None}
+        )
+    return redirect(reverse("users:data") + "#storygraph")
+
+
+@login_required
+def storygraph_preview(request):
+    task = _storygraph_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        messages.add_message(
+            request, messages.ERROR, _("No StoryGraph import to preview.")
+        )
+        return redirect(reverse("users:data"))
+    if task.metadata.get("phase") == "done":
+        # import already applied; preview/matched-CSV are no longer relevant
+        return redirect(reverse("users:data") + "#storygraph")
+    path = task.metadata["matched_file"]
+    if not os.path.exists(path):
+        messages.add_message(request, messages.ERROR, _("Matched file missing."))
+        return redirect(reverse("users:data"))
+    try:
+        page = max(1, int(request.GET.get("page", 1)))
+    except TypeError, ValueError:
+        page = 1
+    page_size = 100
+    with open(path, encoding="utf-8-sig", newline="") as fp:
+        reader = csv.DictReader(fp)
+        all_rows = list(reader)
+    total = len(all_rows)
+    start = (page - 1) * page_size
+    end = start + page_size
+    rows = [
+        _storygraph_row_for_template(start + i, raw)
+        for i, raw in enumerate(all_rows[start:end])
+    ]
+    return render(
+        request,
+        "users/storygraph_import.html",
+        {
+            "task": task,
+            "rows": rows,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "has_prev": page > 1,
+            "has_next": end < total,
+            "shelf_choices": ShelfType.choices,
+        },
+    )
+
+
+def _storygraph_row_for_template(index: int, raw: dict) -> dict:
+    review = (raw.get("Review") or "").strip()
+    excerpt = (review[:14] + "…") if len(review) > 15 else review
+    return {
+        "index": index,
+        "title": raw.get("Title", ""),
+        "authors": raw.get("Authors", ""),
+        "isbn_uid": raw.get("ISBN/UID", ""),
+        "link": raw.get("link", ""),
+        "match_source": raw.get("match_source", ""),
+        "shelf": raw.get("shelf", ""),
+        "collect_date": raw.get("collect_date", ""),
+        "rating": raw.get("Star Rating", ""),
+        "review_excerpt": excerpt,
+    }
+
+
+@login_required
+@require_http_methods(["POST"])
+def storygraph_save_row(request, i: int):
+    task = _storygraph_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        raise BadRequest("no matched file")
+    if task.metadata.get("phase") not in ("preview",):
+        raise BadRequest("cannot edit in current phase")
+    updates = {
+        "link": (request.POST.get("link") or "").strip(),
+        "shelf": (request.POST.get("shelf") or "").strip(),
+        "collect_date": (request.POST.get("collect_date") or "").strip(),
+    }
+    row = update_row_in_matched_file(task.metadata["matched_file"], i, updates)
+    if row is None:
+        raise BadRequest("row index out of range")
+    return render(
+        request,
+        "users/_storygraph_row.html",
+        {
+            "row": _storygraph_row_for_template(i, row),
+            "shelf_choices": ShelfType.choices,
+            "task": task,
+        },
+    )
+
+
+@login_required
+@require_http_methods(["POST"])
+def storygraph_confirm(request):
+    task = _storygraph_active_task(request.user)
+    if not task or task.metadata.get("phase") != "preview":
+        return redirect(reverse("users:data"))
+    task.metadata["visibility"] = int(request.POST.get("visibility", 0))
+    task.metadata["phase"] = "importing"
+    task.metadata["processed"] = 0
+    task.metadata["imported"] = 0
+    task.metadata["skipped"] = 0
+    task.metadata["failed"] = 0
+    task.metadata["failed_items"] = []
+    task.state = Task.States.pending
+    task.message = _("Starting import...")
+    task.save(update_fields=["metadata", "state", "message"])
+    task.enqueue()
+    return redirect(reverse("users:data") + "#storygraph")
+
+
+@login_required
+def storygraph_download(request):
+    task = _storygraph_active_task(request.user)
+    if not task or not task.metadata.get("matched_file"):
+        messages.add_message(request, messages.ERROR, _("No matched file available."))
+        return redirect(reverse("users:data"))
+    path = task.metadata["matched_file"]
+    if not os.path.exists(path):
+        messages.add_message(request, messages.ERROR, _("Matched file missing."))
+        return redirect(reverse("users:data"))
+    response = HttpResponse()
+    response["X-Accel-Redirect"] = settings.MEDIA_URL + path[len(settings.MEDIA_ROOT) :]
+    response["Content-Type"] = "text/csv"
+    hint = task.metadata.get("filename_hint") or "storygraph_export.csv"
+    stem, _ext = os.path.splitext(hint)
+    filename = f"{stem}-matched.csv"
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response
 
 
 @login_required

--- a/neodb/users/views/data.py
+++ b/neodb/users/views/data.py
@@ -205,14 +205,22 @@ def user_task_status(request, task_type: str):
     ):
         # Matching or importing just finished — swap the whole section
         # so the cancel button is replaced by the Review/Download/upload UI.
+        # The poller lives in the status div, so retarget the swap to the
+        # section container to avoid nesting a section inside the old one.
         if task_cls is RymImporter:
-            return render(request, "users/_rym_section.html", {"rym_task": task})
+            response = render(request, "users/_rym_section.html", {"rym_task": task})
+            response["HX-Retarget"] = "#rym"
+            response["HX-Reswap"] = "innerHTML"
+            return response
         if task_cls is StoryGraphImporter:
-            return render(
+            response = render(
                 request,
                 "users/_storygraph_section.html",
                 {"storygraph_task": task},
             )
+            response["HX-Retarget"] = "#storygraph"
+            response["HX-Reswap"] = "innerHTML"
+            return response
     return render(request, "users/user_task_status.html", {"task": task})
 
 


### PR DESCRIPTION
## Problem

StoryGraph imports matched very few books: an ISBN in the export was only checked against the local catalog, and the only network fallback was a Google Books title search. Any book whose ISBN wasn't already known locally usually failed to match, and failures were silent until the import finished.

## Changes

### Multi-source matching pipeline

Rework `StoryGraphImporter` matching, following the approach used by the RYM importer:

1. Local DB lookup by ISBN/ASIN, or by StoryGraph book UUID (StoryGraph puts its own UUID in the `ISBN/UID` column when the edition has no ISBN)
2. **New:** match the exact edition by ISBN — Google Books `q=isbn:` first, then OpenLibrary `/isbn/{isbn}.json`
3. **New:** link the StoryGraph book page by UUID when a JS-rendering scrape provider is configured (`DOWNLOADER_PROVIDERS`)
4. Title+author fallbacks: **new** local catalog index search (like RYM `_local_match`), then the existing Google Books `intitle:`/`inauthor:` search, then **new** OpenLibrary title/author search

### RYM-style match preview UI

The importer is now two-phase like RYM: a fast matching phase records candidate links in a matched CSV (no page scraping), then a preview page lets the user review each row — edit the matched link, pick a shelf or skip, adjust the date — before confirming the import, which fetches items and creates marks. Includes cancellation in every phase, matched-CSV download, and re-upload round-trip (the `link` column is honoured and matching is skipped). New views/URLs (`preview`, `row/<i>`, `confirm`, `cancel`, `download`), templates mirroring the RYM ones, and zh_Hans translations.

## Tests

Importer tests rewritten for both phases with offline fixtures: matching assertions per source (local ISBN, local StoryGraph UUID, Google Books ISBN, OpenLibrary ISBN when Google Books is empty, Google Books title search, unmatched), and import-phase assertions for shelves, ratings, and comments. The catalog index step is stubbed so results don't depend on search availability. Also fixed a crash on ragged CSV rows (extra cells vs header).