### PR TITLE
feat(catalog): unify metadata field representations across item types

### DIFF
--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -825,3 +825,98 @@ def edition_normalize_publisher_imprint_20260428(batch_size: int = 1000) -> None
         f"Edition publisher/imprint normalization: {converted} updated, "
         f"{deleted} orphan imprint credits deleted"
     )
+
+
+def unify_metadata_20260715(start_pk=0, batch_size=500, dry_run=False):
+    """One-time conversion for the metadata unification release.
+
+    Applies each class's normalize_legacy_metadata to stored Item.metadata:
+    - Movie/TVShow/TVSeason: duration and single_episode_length free text
+      or minutes -> seconds; area -> origin_country (ISO 3166-1 alpha-2);
+      showtime/year -> release_date (partial ISO, earliest entry)
+    - Album: duration ms -> seconds; media -> media_format slug list;
+      album_type -> slug list; release_date canonicalized
+    - Game: release_year -> release_date; localized release_date text -> ISO
+    - Edition: price -> "<ISO4217> <amount>" where unambiguous
+
+    Restart-safe: pk-ordered per class with a start_pk parameter, and
+    idempotent because legacy keys are removed on first conversion (the
+    duration minutes-inference only fires when legacy keys are present).
+    bulk_update skips post_save signals, so touched items are reindexed
+    synchronously at the end.
+    """
+    from catalog.models import Album, Edition, Game, Item, Movie, TVSeason, TVShow
+    from catalog.search import CatalogIndex
+
+    touched_pks: list[int] = []
+    for cls in [Movie, TVShow, TVSeason, Album, Game, Edition]:
+        qs = cls.objects.filter(
+            is_deleted=False, merged_to_item__isnull=True, pk__gte=start_pk
+        ).order_by("pk")
+        total = qs.count()
+        updated = 0
+        last_pk = start_pk
+        pending: list[Item] = []
+
+        def flush() -> None:
+            if pending:
+                if not dry_run:
+                    Item.objects.bulk_update(pending, ["metadata"])
+                pending.clear()
+
+        with tqdm(total=total, desc=f"unify_metadata:{cls.__name__}") as pbar:
+            for pk, metadata in qs.values_list("pk", "metadata").iterator(
+                chunk_size=batch_size
+            ):
+                last_pk = pk
+                pbar.update(1)
+                if not isinstance(metadata, dict) or not metadata:
+                    continue
+                new_metadata = dict(metadata)
+                try:
+                    cls.normalize_legacy_metadata(new_metadata)
+                except Exception as e:
+                    logger.error(f"unify_metadata error on {cls.__name__} {pk}: {e}")
+                    continue
+                if new_metadata != metadata:
+                    if dry_run and updated < 5:
+                        changed_keys = {
+                            k
+                            for k in set(metadata) | set(new_metadata)
+                            if metadata.get(k) != new_metadata.get(k)
+                        }
+                        logger.info(
+                            f"dry run {cls.__name__} {pk}: "
+                            f"{ {k: (metadata.get(k), new_metadata.get(k)) for k in changed_keys} }"
+                        )
+                    pending.append(Item(pk=pk, metadata=new_metadata))
+                    touched_pks.append(pk)
+                    updated += 1
+                if len(pending) >= batch_size:
+                    flush()
+                    pbar.set_postfix(updated=updated, pk=last_pk)
+            flush()
+        logger.warning(
+            f"unify_metadata {cls.__name__}: {updated} of {total} updated, last pk {last_pk}"
+        )
+
+    if dry_run:
+        logger.warning(
+            f"unify_metadata dry run complete; {len(touched_pks)} items would be updated."
+        )
+        return
+    if not touched_pks:
+        logger.warning("unify_metadata complete; no items needed updating.")
+        return
+    logger.warning(f"unify_metadata reindexing {len(touched_pks)} items.")
+    index = CatalogIndex.instance()
+    if not index.initialize_collection(max_wait=30):
+        logger.error("Index not ready; run `catalog idx-reindex` to finish.")
+        return
+    c = 0
+    for i in tqdm(range(0, len(touched_pks), 1000), desc="reindex"):
+        chunk = touched_pks[i : i + 1000]
+        items = Item.objects.filter(pk__in=chunk)
+        docs = index.items_to_docs(items)
+        c += index.replace_docs(docs)
+    logger.warning(f"unify_metadata complete; reindexed {c} docs.")

--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -827,7 +827,9 @@ def edition_normalize_publisher_imprint_20260428(batch_size: int = 1000) -> None
     )
 
 
-def unify_metadata_20260715(start_pk=0, batch_size=500, dry_run=False):
+def unify_metadata_20260715(
+    start_pk: int = 0, batch_size: int = 500, dry_run: bool = False
+) -> None:
     """One-time conversion for the metadata unification release.
 
     Applies each class's normalize_legacy_metadata to stored Item.metadata:
@@ -839,84 +841,106 @@ def unify_metadata_20260715(start_pk=0, batch_size=500, dry_run=False):
     - Game: release_year -> release_date; localized release_date text -> ISO
     - Edition: price -> "<ISO4217> <amount>" where unambiguous
 
-    Restart-safe: pk-ordered per class with a start_pk parameter, and
-    idempotent because legacy keys are removed on first conversion (the
+    Restart-safe: one pk-ordered pass over all items (resume with --start),
+    and idempotent because legacy keys are removed on first conversion (the
     duration minutes-inference only fires when legacy keys are present).
-    bulk_update skips post_save signals, so touched items are reindexed
-    synchronously at the end.
+    bulk_update skips post_save signals, so each flushed batch is reindexed
+    immediately after it is written.
     """
-    from catalog.models import Album, Edition, Game, Item, Movie, TVSeason, TVShow
+    import copy
+
+    from catalog.models import (
+        Album,
+        Edition,
+        Game,
+        Item,
+        Movie,
+        TVSeason,
+        TVShow,
+        item_content_types,
+    )
     from catalog.search import CatalogIndex
 
-    touched_pks: list[int] = []
-    for cls in [Movie, TVShow, TVSeason, Album, Game, Edition]:
-        qs = cls.objects.filter(
-            is_deleted=False, merged_to_item__isnull=True, pk__gte=start_pk
-        ).order_by("pk")
-        total = qs.count()
-        updated = 0
-        last_pk = start_pk
-        pending: list[Item] = []
+    classes = [Movie, TVShow, TVSeason, Album, Game, Edition]
+    ctype_map = {
+        ct_id: cls for cls, ct_id in item_content_types().items() if cls in classes
+    }
+    index = None
+    if not dry_run:
+        index = CatalogIndex.instance()
+        if not index.initialize_collection(max_wait=30):
+            logger.error("Index is not ready, migration aborted.")
+            return
 
-        def flush() -> None:
-            if pending:
-                if not dry_run:
-                    Item.objects.bulk_update(pending, ["metadata"])
-                pending.clear()
-
-        with tqdm(total=total, desc=f"unify_metadata:{cls.__name__}") as pbar:
-            for pk, metadata in qs.values_list("pk", "metadata").iterator(
-                chunk_size=batch_size
-            ):
-                last_pk = pk
-                pbar.update(1)
-                if not isinstance(metadata, dict) or not metadata:
-                    continue
-                new_metadata = dict(metadata)
-                try:
-                    cls.normalize_legacy_metadata(new_metadata)
-                except Exception as e:
-                    logger.error(f"unify_metadata error on {cls.__name__} {pk}: {e}")
-                    continue
-                if new_metadata != metadata:
-                    if dry_run and updated < 5:
-                        changed_keys = {
-                            k
-                            for k in set(metadata) | set(new_metadata)
-                            if metadata.get(k) != new_metadata.get(k)
-                        }
-                        logger.info(
-                            f"dry run {cls.__name__} {pk}: "
-                            f"{ {k: (metadata.get(k), new_metadata.get(k)) for k in changed_keys} }"
-                        )
-                    pending.append(Item(pk=pk, metadata=new_metadata))
-                    touched_pks.append(pk)
-                    updated += 1
-                if len(pending) >= batch_size:
-                    flush()
-                    pbar.set_postfix(updated=updated, pk=last_pk)
-            flush()
-        logger.warning(
-            f"unify_metadata {cls.__name__}: {updated} of {total} updated, last pk {last_pk}"
+    qs = (
+        Item.objects.non_polymorphic()
+        .filter(
+            is_deleted=False,
+            merged_to_item__isnull=True,
+            polymorphic_ctype_id__in=list(ctype_map),
+            pk__gte=start_pk,
         )
+        .order_by("pk")
+    )
+    total = qs.count()
+    logger.warning(f"unify_metadata scanning {total} items (from pk {start_pk})")
+    updated = 0
+    reindexed = 0
+    last_pk = start_pk
+    pending: list = []
+
+    def flush() -> None:
+        nonlocal reindexed
+        if not pending:
+            return
+        if not dry_run:
+            Item.objects.bulk_update(pending, ["metadata"])
+            # bulk_update bypasses save()->update_index(); reindex the
+            # batch now (re-fetch polymorphic for to_indexable_doc)
+            if index:
+                items = Item.objects.filter(pk__in=[i.pk for i in pending])
+                reindexed += index.replace_docs(index.items_to_docs(items))
+        pending.clear()
+
+    with tqdm(total=total, desc="unify_metadata") as pbar:
+        for pk, ctype_id, metadata in qs.values_list(
+            "pk", "polymorphic_ctype_id", "metadata"
+        ).iterator(chunk_size=batch_size):
+            last_pk = pk
+            pbar.update(1)
+            cls = ctype_map.get(ctype_id)
+            if cls is None or not isinstance(metadata, dict) or not metadata:
+                continue
+            new_metadata = copy.deepcopy(metadata)
+            try:
+                cls.normalize_legacy_metadata(new_metadata)
+            except Exception as e:
+                logger.error(f"unify_metadata error on {cls.__name__} {pk}: {e}")
+                continue
+            if new_metadata != metadata:
+                if dry_run and updated < 20:
+                    changed_keys = {
+                        k
+                        for k in set(metadata) | set(new_metadata)
+                        if metadata.get(k) != new_metadata.get(k)
+                    }
+                    diff = {
+                        k: (metadata.get(k), new_metadata.get(k)) for k in changed_keys
+                    }
+                    logger.info(f"dry run {cls.__name__} {pk}: {diff}")
+                pending.append(Item(pk=pk, metadata=new_metadata))
+                updated += 1
+            if len(pending) >= batch_size:
+                flush()
+                pbar.set_postfix(updated=updated, pk=last_pk)
+        flush()
 
     if dry_run:
         logger.warning(
-            f"unify_metadata dry run complete; {len(touched_pks)} items would be updated."
+            f"unify_metadata dry run complete; {updated} of {total} items would be updated."
         )
-        return
-    if not touched_pks:
-        logger.warning("unify_metadata complete; no items needed updating.")
-        return
-    logger.warning(f"unify_metadata reindexing {len(touched_pks)} items.")
-    index = CatalogIndex.instance()
-    if not index.initialize_collection(max_wait=30):
-        logger.error("Index not ready; run `catalog idx-reindex` to finish.")
-        return
-    c = 0
-    for i in tqdm(range(0, len(touched_pks), 1000), desc="reindex"):
-        chunk = touched_pks[i : i + 1000]
-        items = Item.objects.filter(pk__in=chunk)
-        docs = index.items_to_docs(items)
-        c += index.replace_docs(docs)
-    logger.warning(f"unify_metadata complete; reindexed {c} docs.")
+    else:
+        logger.warning(
+            f"unify_metadata complete: {updated} of {total} items updated, "
+            f"{reindexed} docs reindexed, last pk {last_pk}."
+        )

--- a/neodb/catalog/forms.py
+++ b/neodb/catalog/forms.py
@@ -3,7 +3,16 @@ from django.utils.translation import gettext_lazy as _
 
 from catalog.models import *
 from common.forms import PreviewImageInput
-from common.models import SITE_DEFAULT_LANGUAGE, detect_language, uniq
+from common.models import (
+    SITE_DEFAULT_LANGUAGE,
+    detect_language,
+    normalize_album_types,
+    normalize_countries,
+    normalize_media_formats,
+    normalize_price,
+    parse_partial_date,
+    uniq,
+)
 from common.models.genre import normalize_genres
 from common.models.lang import normalize_languages
 
@@ -17,9 +26,6 @@ def _EditForm(item_model):
         + ["cover"]
         + ["primary_lookup_id_type", "primary_lookup_id_value"]
     )
-    if "media" in item_fields:
-        # FIXME not sure why this field is always duplicated
-        item_fields.remove("media")
 
     class EditForm(forms.ModelForm):
         id = forms.IntegerField(required=False, widget=forms.HiddenInput())
@@ -159,6 +165,23 @@ def _EditForm(item_model):
                 data["language"] = normalize_languages(data["language"])
             if "genre" in data:
                 data["genre"] = normalize_genres(data["genre"])
+            if "origin_country" in data:
+                data["origin_country"] = normalize_countries(data["origin_country"])
+            if "album_type" in data:
+                data["album_type"] = normalize_album_types(data["album_type"])
+            if "media_format" in data:
+                data["media_format"] = normalize_media_formats(data["media_format"])
+            if data.get("price"):
+                data["price"] = normalize_price(data["price"])
+            if data.get("release_date"):
+                release_date = parse_partial_date(data["release_date"])
+                if not release_date:
+                    self.add_error(
+                        "release_date",
+                        _("Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."),
+                    )
+                else:
+                    data["release_date"] = release_date
             return data
 
     return EditForm

--- a/neodb/catalog/management/commands/catalog.py
+++ b/neodb/catalog/management/commands/catalog.py
@@ -167,8 +167,14 @@ class Command(SiteCommand):
             help="Number of hours to look back for edited items (used with idx-catchup)",
         )
 
-    def migrate(self, m, start=None, batch_size=1000):
+    def migrate(self, m, start=None, batch_size=1000, dry_run=False):
         match m:
+            case "unify_metadata":
+                from catalog.common.migrations import unify_metadata_20260715
+
+                unify_metadata_20260715(
+                    start_pk=start or 0, batch_size=batch_size, dry_run=dry_run
+                )
             case "merge_works":
                 from catalog.common.migrations import merge_works_20250301
 
@@ -1034,7 +1040,12 @@ class Command(SiteCommand):
                 if not name:
                     self.stdout.write(self.style.ERROR("name is required."))
                     return
-                self.migrate(name, start=start, batch_size=int(batch_size))
+                self.migrate(
+                    name,
+                    start=start,
+                    batch_size=int(batch_size),
+                    dry_run=options.get("dry_run", False),
+                )
 
             case "idx-catchup":
                 hour = options.get("hour")

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -185,7 +185,7 @@ class Edition(Item):
     url_path = "book"
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         # Sources: federated peers running older code, ndjson restores, and
         # local DB rows that predate the field type change.

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -27,7 +27,7 @@ from django.utils.translation import gettext_lazy as _
 from loguru import logger
 from ninja import Field
 
-from common.models import uniq
+from common.models import normalize_price, uniq
 from common.models.misc import int_
 
 from .common import (
@@ -201,6 +201,10 @@ class Edition(Item):
                 metadata["imprint"] = "/".join(coerced)
             else:
                 metadata.pop("imprint", None)
+        # normalize price to "<ISO4217> <amount>" where unambiguous
+        price = metadata.get("price")
+        if isinstance(price, str) and price:
+            metadata["price"] = normalize_price(price)
 
     available_roles = [
         PeopleRole.AUTHOR,

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -96,7 +96,10 @@ class EditionInSchema(ItemInSchema):
     )
     pub_year: int | None = None
     pub_month: int | None = None
-    binding: str | None = None
+    format: str | None = None
+    binding: str | None = Field(
+        None, deprecated="Free text; use `format` (BookFormat) instead."
+    )
     price: str | None = None
     pages: int | str | None = None
     series: str | None = None

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -10,6 +10,7 @@ from common.models.duration import duration_to_seconds, format_duration
 from common.models import (
     ALBUM_TYPE_CHOICES,
     COUNTRY_CHOICES,
+    GAME_PLATFORM_CHOICES,
     LANGUAGE_CHOICES,
     LOCALE_CHOICES,
     MEDIA_FORMAT_CHOICES,
@@ -381,6 +382,10 @@ def _slug_list_field(verbose_name, choices):
 
 def AlbumTypeListField():
     return _slug_list_field(_("album type"), ALBUM_TYPE_CHOICES)
+
+
+def GamePlatformListField():
+    return _slug_list_field(_("platform"), GAME_PLATFORM_CHOICES)
 
 
 def MediaFormatListField():

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -1,6 +1,11 @@
+from functools import lru_cache
+
 from django.db import models
+from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from ninja import Schema
+
+from common.models.duration import duration_to_seconds
 
 from common.models import (
     ALBUM_TYPE_CHOICES,
@@ -190,6 +195,33 @@ class LocalizedLabelSchema(Schema):
     text: str
 
 
+class VideoFieldsResolverMixin(Schema):
+    """Shared resolvers for origin_country / release_date and their
+    deprecated aliases (area, showtime) on Movie and TV schemas."""
+
+    @staticmethod
+    def resolve_origin_country(obj) -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_area(obj) -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_showtime(obj) -> list[dict]:
+        return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
+
+    @staticmethod
+    def resolve_duration(obj) -> int | None:
+        # tolerate legacy free-text values not yet migrated; numeric
+        # values are trusted as seconds
+        return duration_to_seconds(obj.duration)
+
+    @staticmethod
+    def resolve_single_episode_length(obj) -> int | None:
+        return duration_to_seconds(getattr(obj, "single_episode_length", None))
+
+
 def get_locale_choices_for_jsonform(choices, const=False):
     """return list for jsonform schema"""
     return [{"title": v, "const" if const else "value": k} for k, v in choices]
@@ -283,6 +315,24 @@ def GenreListField(category=None):
     )
 
 
+@lru_cache(maxsize=None)
+def _country_jsonform_schema(lang: str) -> dict:
+    # ~250 display-name lookups + a sort; cache per UI language since the
+    # result is identical for every render in that language
+    choices = get_locale_choices_for_jsonform(
+        sorted(
+            ((code, country_display_name(code)) for code, _ in COUNTRY_CHOICES),
+            key=lambda x: x[1],
+        ),
+        const=True,
+    )
+    return {
+        "type": "array",
+        "items": {"oneOf": choices + [{"title": "Other", "type": "string"}]},
+        "uniqueItems": True,
+    }
+
+
 def CountryListField():
     """ArrayField of ISO 3166-1 alpha-2 codes with an "Other" passthrough.
 
@@ -291,18 +341,7 @@ def CountryListField():
     """
 
     def schema():
-        choices = get_locale_choices_for_jsonform(
-            sorted(
-                ((code, country_display_name(code)) for code, _ in COUNTRY_CHOICES),
-                key=lambda x: x[1],
-            ),
-            const=True,
-        )
-        return {
-            "type": "array",
-            "items": {"oneOf": choices + [{"title": "Other", "type": "string"}]},
-            "uniqueItems": True,
-        }
+        return _country_jsonform_schema(get_language() or "en")
 
     return jsondata.ArrayField(
         verbose_name=_("origin country"),

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -3,9 +3,13 @@ from django.utils.translation import gettext_lazy as _
 from ninja import Schema
 
 from common.models import (
+    ALBUM_TYPE_CHOICES,
+    COUNTRY_CHOICES,
     LANGUAGE_CHOICES,
     LOCALE_CHOICES,
+    MEDIA_FORMAT_CHOICES,
     SCRIPT_CHOICES,
+    country_display_name,
     genre_choices_for,
     jsondata,
 )
@@ -277,6 +281,64 @@ def GenreListField(category=None):
         default=list,
         schema=schema,
     )
+
+
+def CountryListField():
+    """ArrayField of ISO 3166-1 alpha-2 codes with an "Other" passthrough.
+
+    The schema is a callable so the dropdown labels follow the active UI
+    language at render time (django_jsonform resolves callable schemas).
+    """
+
+    def schema():
+        choices = get_locale_choices_for_jsonform(
+            sorted(
+                ((code, country_display_name(code)) for code, _ in COUNTRY_CHOICES),
+                key=lambda x: x[1],
+            ),
+            const=True,
+        )
+        return {
+            "type": "array",
+            "items": {"oneOf": choices + [{"title": "Other", "type": "string"}]},
+            "uniqueItems": True,
+        }
+
+    return jsondata.ArrayField(
+        verbose_name=_("origin country"),
+        base_field=models.CharField(blank=True, default="", max_length=100),
+        null=True,
+        blank=True,
+        default=list,
+        schema=schema,
+    )
+
+
+def _slug_list_field(verbose_name, choices):
+    def schema():
+        options = get_locale_choices_for_jsonform(choices, const=True)
+        return {
+            "type": "array",
+            "items": {"oneOf": options + [{"title": "Other", "type": "string"}]},
+            "uniqueItems": True,
+        }
+
+    return jsondata.ArrayField(
+        verbose_name=verbose_name,
+        base_field=models.CharField(blank=True, default="", max_length=100),
+        null=True,
+        blank=True,
+        default=list,
+        schema=schema,
+    )
+
+
+def AlbumTypeListField():
+    return _slug_list_field(_("album type"), ALBUM_TYPE_CHOICES)
+
+
+def MediaFormatListField():
+    return _slug_list_field(_("media format"), MEDIA_FORMAT_CHOICES)
 
 
 def LanguageListField(script=False):

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext_lazy as _
 from ninja import Schema
 
 from common.models.duration import duration_to_seconds, format_duration
-from common.models.partial_date import pad_partial_date
 
 from common.models import (
     ALBUM_TYPE_CHOICES,
@@ -196,28 +195,11 @@ class LocalizedLabelSchema(Schema):
     text: str
 
 
-class ReleaseDateResolverMixin(Schema):
-    """API emits release_date as a padded full ISO date (older peers and
-    clients type it as a strict date) plus a release_date_precision key
-    ("year"/"month"/"day") so current ingest recovers the stored partial
-    value losslessly."""
-
-    @staticmethod
-    def resolve_release_date(obj) -> str | None:
-        return pad_partial_date(obj.release_date)[0]
-
-    @staticmethod
-    def resolve_release_date_precision(obj) -> str | None:
-        return pad_partial_date(obj.release_date)[1]
-
-
-class VideoFieldsResolverMixin(ReleaseDateResolverMixin):
-    """Shared resolvers for origin_country / release_date / durations and
-    their deprecated aliases (area, showtime) on Movie and TV schemas.
-
-    duration stays a display string and single_episode_length stays
-    minutes for backward compatibility; the *_seconds fields carry the
-    canonical values."""
+class VideoFieldsResolverMixin(Schema):
+    """Shared resolvers for origin_country / release_date / length and
+    the deprecated aliases (area, showtime, duration) on Movie and TV
+    schemas. duration keeps a display-string shape for older peers and
+    clients; length carries the canonical seconds."""
 
     @staticmethod
     def resolve_origin_country(obj) -> list[str]:
@@ -232,23 +214,18 @@ class VideoFieldsResolverMixin(ReleaseDateResolverMixin):
         return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
 
     @staticmethod
+    def resolve_length(obj) -> int | None:
+        # tolerate legacy free-text values not yet migrated; numeric
+        # values are trusted as seconds
+        return duration_to_seconds(obj.length)
+
+    @staticmethod
     def resolve_duration(obj) -> str | None:
-        seconds = duration_to_seconds(obj.duration)
+        seconds = duration_to_seconds(obj.length)
         return format_duration(seconds) if seconds else None
 
     @staticmethod
-    def resolve_duration_seconds(obj) -> int | None:
-        # tolerate legacy free-text values not yet migrated; numeric
-        # values are trusted as seconds
-        return duration_to_seconds(obj.duration)
-
-    @staticmethod
     def resolve_single_episode_length(obj) -> int | None:
-        seconds = duration_to_seconds(getattr(obj, "single_episode_length", None))
-        return seconds // 60 if seconds else None
-
-    @staticmethod
-    def resolve_single_episode_length_seconds(obj) -> int | None:
         return duration_to_seconds(getattr(obj, "single_episode_length", None))
 
 

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -225,10 +225,6 @@ class VideoFieldsResolverMixin(Schema):
         seconds = duration_to_seconds(obj.length)
         return format_duration(seconds) if seconds else None
 
-    @staticmethod
-    def resolve_single_episode_length(obj) -> int | None:
-        return duration_to_seconds(getattr(obj, "single_episode_length", None))
-
 
 def get_locale_choices_for_jsonform(choices, const=False):
     """return list for jsonform schema"""

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -5,7 +5,8 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from ninja import Schema
 
-from common.models.duration import duration_to_seconds
+from common.models.duration import duration_to_seconds, format_duration
+from common.models.partial_date import pad_partial_date
 
 from common.models import (
     ALBUM_TYPE_CHOICES,
@@ -195,9 +196,28 @@ class LocalizedLabelSchema(Schema):
     text: str
 
 
-class VideoFieldsResolverMixin(Schema):
-    """Shared resolvers for origin_country / release_date and their
-    deprecated aliases (area, showtime) on Movie and TV schemas."""
+class ReleaseDateResolverMixin(Schema):
+    """API emits release_date as a padded full ISO date (older peers and
+    clients type it as a strict date) plus a release_date_precision key
+    ("year"/"month"/"day") so current ingest recovers the stored partial
+    value losslessly."""
+
+    @staticmethod
+    def resolve_release_date(obj) -> str | None:
+        return pad_partial_date(obj.release_date)[0]
+
+    @staticmethod
+    def resolve_release_date_precision(obj) -> str | None:
+        return pad_partial_date(obj.release_date)[1]
+
+
+class VideoFieldsResolverMixin(ReleaseDateResolverMixin):
+    """Shared resolvers for origin_country / release_date / durations and
+    their deprecated aliases (area, showtime) on Movie and TV schemas.
+
+    duration stays a display string and single_episode_length stays
+    minutes for backward compatibility; the *_seconds fields carry the
+    canonical values."""
 
     @staticmethod
     def resolve_origin_country(obj) -> list[str]:
@@ -212,13 +232,23 @@ class VideoFieldsResolverMixin(Schema):
         return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
 
     @staticmethod
-    def resolve_duration(obj) -> int | None:
+    def resolve_duration(obj) -> str | None:
+        seconds = duration_to_seconds(obj.duration)
+        return format_duration(seconds) if seconds else None
+
+    @staticmethod
+    def resolve_duration_seconds(obj) -> int | None:
         # tolerate legacy free-text values not yet migrated; numeric
         # values are trusted as seconds
         return duration_to_seconds(obj.duration)
 
     @staticmethod
     def resolve_single_episode_length(obj) -> int | None:
+        seconds = duration_to_seconds(getattr(obj, "single_episode_length", None))
+        return seconds // 60 if seconds else None
+
+    @staticmethod
+    def resolve_single_episode_length_seconds(obj) -> int | None:
         return duration_to_seconds(getattr(obj, "single_episode_length", None))
 
 

--- a/neodb/catalog/models/game.py
+++ b/neodb/catalog/models/game.py
@@ -7,6 +7,7 @@ from common.models import partial_date_to_int, year_of_partial_date
 from .common import (
     LIST_OF_STR_SCHEMA,
     GenreListField,
+    ReleaseDateResolverMixin,
     jsondata,
 )
 from .item import (
@@ -35,13 +36,14 @@ class GameReleaseType(models.TextChoices):
     OTHER = "other", _("Other")
 
 
-class GameInSchema(ItemInSchema):
+class GameInSchema(ReleaseDateResolverMixin, ItemInSchema):
     genre: list[str]
     developer: list[str]
     publisher: list[str]
     platform: list[str]
     release_type: str | None = None
     release_date: str | None = None
+    release_date_precision: str | None = None
     official_site: str | None = None
     # release_year is deprecated
     release_year: int | None = Field(

--- a/neodb/catalog/models/game.py
+++ b/neodb/catalog/models/game.py
@@ -1,7 +1,8 @@
-from datetime import date
-
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from ninja import Field
+
+from common.models import partial_date_to_int, year_of_partial_date
 
 from .common import (
     LIST_OF_STR_SCHEMA,
@@ -18,6 +19,7 @@ from .item import (
     PrimaryLookupIdDescriptor,
 )
 from .people import PeopleRole
+from .utils import canonicalize_release_date_key
 
 
 class GameReleaseType(models.TextChoices):
@@ -39,8 +41,16 @@ class GameInSchema(ItemInSchema):
     publisher: list[str]
     platform: list[str]
     release_type: str | None = None
-    release_date: date | None = None
+    release_date: str | None = None
     official_site: str | None = None
+    # release_year is deprecated
+    release_year: int | None = Field(
+        None, deprecated="Use the year part of `release_date` instead."
+    )
+
+    @staticmethod
+    def resolve_release_year(obj: "Game") -> int | None:
+        return obj.release_year
 
     @staticmethod
     def resolve_developer(obj: "Game") -> list[str]:
@@ -86,7 +96,6 @@ class Game(Item):
         "artist",
         "developer",
         "publisher",
-        "release_year",
         "release_date",
         "release_type",
         "genre",
@@ -127,18 +136,29 @@ class Game(Item):
         schema=LIST_OF_STR_SCHEMA,
     )
 
-    release_year = jsondata.IntegerField(
-        verbose_name=_("year of publication"), null=True, blank=True
-    )
-
-    release_date = jsondata.DateField(
+    release_date = jsondata.CharField(
         verbose_name=_("date of publication"),
-        auto_now=False,
-        auto_now_add=False,
         null=True,
         blank=True,
-        help_text=_("YYYY-MM-DD"),
+        max_length=10,
+        help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
+
+    @property
+    def release_year(self) -> int | None:
+        return year_of_partial_date(self.release_date)
+
+    @classmethod
+    def normalize_legacy_metadata(cls, metadata):
+        super().normalize_legacy_metadata(metadata)
+        # Sources: federated peers running older code, ndjson restores,
+        # and local rows that predate the unification.
+        # - release_year -> release_date when no date is known
+        # - free-text release_date (e.g. localized Steam strings) -> partial ISO
+        release_year = metadata.pop("release_year", None)
+        if release_year and not metadata.get("release_date"):
+            metadata["release_date"] = str(release_year)
+        canonicalize_release_date_key(metadata)
 
     release_type = jsondata.CharField(
         verbose_name=_("release type"),
@@ -174,9 +194,8 @@ class Game(Item):
 
     def to_indexable_doc(self):
         d = super().to_indexable_doc()
-        d["date"] = (
-            [int(self.release_date.strftime("%Y%m%d"))] if self.release_date else []
-        )
+        dt = partial_date_to_int(self.release_date)
+        d["date"] = [dt] if dt else []
         d["genre"] = self.genre or []
         d["format"] = [self.release_type] if self.release_type else []
         d["format"] += list(self.platform or [])
@@ -205,9 +224,7 @@ class Game(Item):
             ]
 
         if self.release_date:
-            data["datePublished"] = self.release_date.isoformat()
-        elif self.release_year:
-            data["datePublished"] = str(self.release_year)
+            data["datePublished"] = self.release_date
 
         if self.official_site:
             data["sameAs"] = self.official_site

--- a/neodb/catalog/models/game.py
+++ b/neodb/catalog/models/game.py
@@ -149,7 +149,7 @@ class Game(Item):
         return year_of_partial_date(self.release_date)
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         # Sources: federated peers running older code, ndjson restores,
         # and local rows that predate the unification.

--- a/neodb/catalog/models/game.py
+++ b/neodb/catalog/models/game.py
@@ -7,7 +7,6 @@ from common.models import partial_date_to_int, year_of_partial_date
 from .common import (
     LIST_OF_STR_SCHEMA,
     GenreListField,
-    ReleaseDateResolverMixin,
     jsondata,
 )
 from .item import (
@@ -36,14 +35,13 @@ class GameReleaseType(models.TextChoices):
     OTHER = "other", _("Other")
 
 
-class GameInSchema(ReleaseDateResolverMixin, ItemInSchema):
+class GameInSchema(ItemInSchema):
     genre: list[str]
     developer: list[str]
     publisher: list[str]
     platform: list[str]
     release_type: str | None = None
     release_date: str | None = None
-    release_date_precision: str | None = None
     official_site: str | None = None
     # release_year is deprecated
     release_year: int | None = Field(

--- a/neodb/catalog/models/game.py
+++ b/neodb/catalog/models/game.py
@@ -4,8 +4,11 @@ from ninja import Field
 
 from common.models import partial_date_to_int, year_of_partial_date
 
+from common.models import normalize_game_platforms
+
 from .common import (
     LIST_OF_STR_SCHEMA,
+    GamePlatformListField,
     GenreListField,
     jsondata,
 )
@@ -158,6 +161,8 @@ class Game(Item):
         release_year = metadata.pop("release_year", None)
         if release_year and not metadata.get("release_date"):
             metadata["release_date"] = str(release_year)
+        if metadata.get("platform"):
+            metadata["platform"] = normalize_game_platforms(metadata["platform"])
         canonicalize_release_date_key(metadata)
 
     release_type = jsondata.CharField(
@@ -169,11 +174,7 @@ class Game(Item):
 
     genre = GenreListField(ItemCategory.Game)
 
-    platform = jsondata.ArrayField(
-        verbose_name=_("platform"),
-        base_field=models.CharField(blank=True, default="", max_length=200),
-        default=list,
-    )
+    platform = GamePlatformListField()
 
     official_site = jsondata.CharField(
         verbose_name=_("website"), max_length=1000, null=True, blank=True

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -19,7 +19,15 @@ from loguru import logger
 from ninja import Field, Schema
 from polymorphic.models import PolymorphicModel
 
-from common.models import get_current_locales, jsondata, uniq
+from common.models import (
+    get_current_locales,
+    jsondata,
+    normalize_album_types,
+    normalize_countries,
+    normalize_media_formats,
+    parse_partial_date,
+    uniq,
+)
 from common.models.genre import normalize_genres
 from common.models.lang import normalize_languages
 from common.utils import get_file_absolute_url, json_ld_dumps
@@ -1059,10 +1067,45 @@ class Item(PolymorphicModel):
                 changed = True
         return changed
 
+    def _normalize_countries(self) -> bool:
+        changed = False
+        if hasattr(self, "origin_country") and self.origin_country:
+            countries = normalize_countries(self.origin_country)
+            if self.origin_country != countries:
+                self.origin_country = countries
+                changed = True
+        return changed
+
+    def _normalize_music_formats(self) -> bool:
+        changed = False
+        if hasattr(self, "album_type") and self.album_type:
+            album_type = normalize_album_types(self.album_type)
+            if self.album_type != album_type:
+                self.album_type = album_type
+                changed = True
+        if hasattr(self, "media_format") and self.media_format:
+            media_format = normalize_media_formats(self.media_format)
+            if self.media_format != media_format:
+                self.media_format = media_format
+                changed = True
+        return changed
+
+    def _normalize_release_date(self) -> bool:
+        rd = getattr(self, "release_date", None)
+        if isinstance(rd, str) and rd:
+            p = parse_partial_date(rd)
+            if p and p != rd:
+                self.release_date = p
+                return True
+        return False
+
     def normalize_metadata(self, override_resources=None) -> bool:
         r = self._update_primary_lookup_id(override_resources)
         r |= self._normalize_languages()
         r |= self._normalize_genres()
+        r |= self._normalize_countries()
+        r |= self._normalize_music_formats()
+        r |= self._normalize_release_date()
         return r
 
     def merge_data_from_external_resource(

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -463,12 +463,20 @@ class Item(PolymorphicModel):
             raise ValueError("cannot merge to item in a different model")
         logger.debug(f"merging {self} to {to_item}")
         self.log_action({"!merged": [str(self.merged_to_item), str(to_item)]})
+        # heal pre-migration metadata on both sides so legacy-only values
+        # (e.g. year without release_date) survive the key-based copy below
+        if isinstance(self.metadata, dict):
+            type(self).normalize_legacy_metadata(self.metadata)
+        updated = False
+        if isinstance(to_item.metadata, dict):
+            before = dict(to_item.metadata)
+            type(to_item).normalize_legacy_metadata(to_item.metadata)
+            updated |= to_item.metadata != before
         self.merged_to_item = to_item
         self.save()
         for res in self.external_resources.all():
             res.item = to_item
             res.save()
-        updated = False
         for k in to_item.METADATA_COPY_LIST:
             v = getattr(self, k)
             if v:

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -24,6 +24,7 @@ from common.models import (
     jsondata,
     normalize_album_types,
     normalize_countries,
+    normalize_game_platforms,
     normalize_media_formats,
     parse_partial_date,
     uniq,
@@ -1098,6 +1099,15 @@ class Item(PolymorphicModel):
                 changed = True
         return changed
 
+    def _normalize_platforms(self) -> bool:
+        changed = False
+        if hasattr(self, "platform") and self.platform:
+            platform = normalize_game_platforms(self.platform)
+            if self.platform != platform:
+                self.platform = platform
+                changed = True
+        return changed
+
     def _normalize_release_date(self) -> bool:
         rd = getattr(self, "release_date", None)
         if isinstance(rd, str) and rd:
@@ -1113,6 +1123,7 @@ class Item(PolymorphicModel):
         r |= self._normalize_genres()
         r |= self._normalize_countries()
         r |= self._normalize_music_formats()
+        r |= self._normalize_platforms()
         r |= self._normalize_release_date()
         return r
 

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -2,7 +2,7 @@ from django.utils.translation import gettext_lazy as _
 from ninja import Field
 
 from common.models import (
-    coerce_video_duration,
+    duration_to_seconds,
     partial_date_to_int,
     year_of_partial_date,
 )
@@ -12,6 +12,7 @@ from .common import (
     CountryListField,
     GenreListField,
     LanguageListField,
+    VideoFieldsResolverMixin,
     jsondata,
 )
 from .item import (
@@ -27,7 +28,7 @@ from .people import PeopleRole
 from .utils import normalize_legacy_video_metadata
 
 
-class MovieInSchema(ItemInSchema):
+class MovieInSchema(VideoFieldsResolverMixin, ItemInSchema):
     orig_title: str | None = None
     director: list[str]
     playwright: list[str]
@@ -45,23 +46,6 @@ class MovieInSchema(ItemInSchema):
         [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."
     )
     showtime: list[dict] = Field([], deprecated="Use `release_date` instead.")
-
-    @staticmethod
-    def resolve_origin_country(obj: "Movie") -> list[str]:
-        return obj.origin_country or []
-
-    @staticmethod
-    def resolve_area(obj: "Movie") -> list[str]:
-        return obj.origin_country or []
-
-    @staticmethod
-    def resolve_showtime(obj: "Movie") -> list[dict]:
-        return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
-
-    @staticmethod
-    def resolve_duration(obj: "Movie") -> int | None:
-        # tolerate legacy free-text values not yet migrated
-        return coerce_video_duration(obj.duration)
 
     @staticmethod
     def resolve_director(obj: "Movie") -> list[str]:
@@ -185,7 +169,7 @@ class Movie(Item):
         return year_of_partial_date(self.release_date)
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         normalize_legacy_video_metadata(metadata)
 
@@ -232,7 +216,7 @@ class Movie(Item):
         if self.release_date:
             data["dateCreated"] = self.release_date
 
-        duration = coerce_video_duration(self.duration)
+        duration = duration_to_seconds(self.duration)
         if duration:
             data["duration"] = f"PT{duration // 3600}H{(duration % 3600) // 60}M"
 

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -38,13 +38,12 @@ class MovieInSchema(VideoFieldsResolverMixin, ItemInSchema):
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
+    length: int | None = None
     duration: str | None = Field(
-        None, deprecated="Display string; use `duration_seconds` instead."
+        None, deprecated="Display string; use `length` (seconds) instead."
     )
-    duration_seconds: int | None = None
     # area and showtime are deprecated
     area: list[str] = Field(
         [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."
@@ -110,7 +109,7 @@ class Movie(Item):
         "site",
         "origin_country",
         "language",
-        "duration",
+        "length",
         "localized_description",
     ]
     orig_title = jsondata.CharField(
@@ -155,7 +154,7 @@ class Movie(Item):
     site = jsondata.URLField(verbose_name=_("website"), blank=True, max_length=200)
     origin_country = CountryListField()
     language = LanguageListField()
-    duration = jsondata.IntegerField(
+    length = jsondata.IntegerField(
         verbose_name=_("length"), null=True, blank=True, help_text=_("seconds")
     )
     season_number = jsondata.IntegerField(
@@ -220,9 +219,9 @@ class Movie(Item):
         if self.release_date:
             data["dateCreated"] = self.release_date
 
-        duration = duration_to_seconds(self.duration)
-        if duration:
-            data["duration"] = f"PT{duration // 3600}H{(duration % 3600) // 60}M"
+        length = duration_to_seconds(self.length)
+        if length:
+            data["duration"] = f"PT{length // 3600}H{(length % 3600) // 60}M"
 
         directors = self.credit_names_by_role("director")
         if directors:

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -42,7 +42,8 @@ class MovieInSchema(VideoFieldsResolverMixin, ItemInSchema):
     year: int | None = Field(
         None, deprecated="Use the year part of `release_date` instead."
     )
-    site: str | None = None
+    official_site: str | None = Field(None, alias="site")
+    site: str | None = Field(None, deprecated="Use `official_site` instead.")
     length: int | None = None
     duration: str | None = Field(
         None, deprecated="Display string; use `length` (seconds) instead."

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -38,7 +38,10 @@ class MovieInSchema(VideoFieldsResolverMixin, ItemInSchema):
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    year: int | None = None
+    # year is deprecated
+    year: int | None = Field(
+        None, deprecated="Use the year part of `release_date` instead."
+    )
     site: str | None = None
     length: int | None = None
     duration: str | None = Field(

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -38,9 +38,13 @@ class MovieInSchema(VideoFieldsResolverMixin, ItemInSchema):
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
+    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
-    duration: int | None = None
+    duration: str | None = Field(
+        None, deprecated="Display string; use `duration_seconds` instead."
+    )
+    duration_seconds: int | None = None
     # area and showtime are deprecated
     area: list[str] = Field(
         [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."

--- a/neodb/catalog/models/movie.py
+++ b/neodb/catalog/models/movie.py
@@ -1,10 +1,15 @@
-from django.db import models
 from django.utils.translation import gettext_lazy as _
+from ninja import Field
 
-from common.models.misc import int_
+from common.models import (
+    coerce_video_duration,
+    partial_date_to_int,
+    year_of_partial_date,
+)
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    CountryListField,
     GenreListField,
     LanguageListField,
     jsondata,
@@ -19,6 +24,7 @@ from .item import (
     PrimaryLookupIdDescriptor,
 )
 from .people import PeopleRole
+from .utils import normalize_legacy_video_metadata
 
 
 class MovieInSchema(ItemInSchema):
@@ -29,10 +35,33 @@ class MovieInSchema(ItemInSchema):
     producer: list[str]
     genre: list[str]
     language: list[str]
-    area: list[str]
+    origin_country: list[str]
+    release_date: str | None = None
     year: int | None = None
     site: str | None = None
-    duration: str | None = None
+    duration: int | None = None
+    # area and showtime are deprecated
+    area: list[str] = Field(
+        [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."
+    )
+    showtime: list[dict] = Field([], deprecated="Use `release_date` instead.")
+
+    @staticmethod
+    def resolve_origin_country(obj: "Movie") -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_area(obj: "Movie") -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_showtime(obj: "Movie") -> list[dict]:
+        return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
+
+    @staticmethod
+    def resolve_duration(obj: "Movie") -> int | None:
+        # tolerate legacy free-text values not yet migrated
+        return coerce_video_duration(obj.duration)
 
     @staticmethod
     def resolve_director(obj: "Movie") -> list[str]:
@@ -89,11 +118,10 @@ class Movie(Item):
         "actor",
         "producer",
         "genre",
-        "showtime",
+        "release_date",
         "site",
-        "area",
+        "origin_country",
         "language",
-        "year",
         "duration",
         "localized_description",
     ]
@@ -129,49 +157,19 @@ class Movie(Item):
         schema=LIST_OF_STR_SCHEMA,
     )
     genre = GenreListField(ItemCategory.Movie)
-    showtime = jsondata.JSONField(
-        _("release date"),
+    release_date = jsondata.CharField(
+        verbose_name=_("release date"),
         null=True,
         blank=True,
-        default=list,
-        schema={
-            "type": "list",
-            "items": {
-                "type": "dict",
-                "additionalProperties": False,
-                "keys": {
-                    "time": {
-                        "type": "string",
-                        "title": _("date"),
-                        "placeholder": _("required"),
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": _("region or event"),
-                        "placeholder": _(
-                            "Germany or Toronto International Film Festival"
-                        ),
-                    },
-                },
-                "required": ["time"],
-            },
-        },
+        max_length=10,
+        help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
     site = jsondata.URLField(verbose_name=_("website"), blank=True, max_length=200)
-    area = jsondata.ArrayField(
-        verbose_name=_("region"),
-        base_field=models.CharField(
-            blank=True,
-            default="",
-            max_length=100,
-        ),
-        null=True,
-        blank=True,
-        default=list,
-    )
+    origin_country = CountryListField()
     language = LanguageListField()
-    year = jsondata.IntegerField(verbose_name=_("year"), null=True, blank=True)
-    duration = jsondata.CharField(verbose_name=_("length"), blank=True, max_length=200)
+    duration = jsondata.IntegerField(
+        verbose_name=_("length"), null=True, blank=True, help_text=_("seconds")
+    )
     season_number = jsondata.IntegerField(
         null=True, blank=True
     )  # TODO remove after migration
@@ -181,6 +179,15 @@ class Movie(Item):
     single_episode_length = jsondata.IntegerField(
         null=True, blank=True
     )  # TODO remove after migration
+
+    @property
+    def year(self) -> int | None:
+        return year_of_partial_date(self.release_date)
+
+    @classmethod
+    def normalize_legacy_metadata(cls, metadata):
+        super().normalize_legacy_metadata(metadata)
+        normalize_legacy_video_metadata(metadata)
 
     @classmethod
     def lookup_id_type_choices(cls):
@@ -210,7 +217,7 @@ class Movie(Item):
         d = super().to_indexable_doc()
         if self.imdb:
             d["lookup_id"] = [str(self.imdb)]
-        dt = int_(self.year) * 10000
+        dt = partial_date_to_int(self.release_date)
         d["date"] = [dt] if dt else []
         d["genre"] = self.genre or []
         return d
@@ -222,11 +229,12 @@ class Movie(Item):
         if self.orig_title and self.orig_title != self.display_title:
             data["alternateName"] = self.orig_title
 
-        if self.year:
-            data["dateCreated"] = str(self.year)
+        if self.release_date:
+            data["dateCreated"] = self.release_date
 
-        if self.duration:
-            data["duration"] = self.duration
+        duration = coerce_video_duration(self.duration)
+        if duration:
+            data["duration"] = f"PT{duration // 3600}H{(duration % 3600) // 60}M"
 
         directors = self.credit_names_by_role("director")
         if directors:

--- a/neodb/catalog/models/music.py
+++ b/neodb/catalog/models/music.py
@@ -1,11 +1,19 @@
-from datetime import date
-
 from django.utils.translation import gettext_lazy as _
+from ninja import Field
+
+from common.models import (
+    coerce_album_duration,
+    normalize_album_types,
+    normalize_media_formats,
+    partial_date_to_int,
+)
 
 from .common import (
     LIST_OF_ONE_PLUS_STR_SCHEMA,
     LIST_OF_STR_SCHEMA,
+    AlbumTypeListField,
     GenreListField,
+    MediaFormatListField,
     jsondata,
 )
 from .item import (
@@ -18,6 +26,7 @@ from .item import (
     PrimaryLookupIdDescriptor,
 )
 from .people import PeopleRole
+from .utils import canonicalize_release_date_key
 
 
 class AlbumInSchema(ItemInSchema):
@@ -25,8 +34,31 @@ class AlbumInSchema(ItemInSchema):
     artist: list[str]
     company: list[str]
     duration: int | None = None
-    release_date: date | None = None
+    release_date: str | None = None
+    album_type: list[str]
+    media_format: list[str]
     track_list: str | None = None
+    # media is deprecated
+    media: str | None = Field(None, deprecated="Use `media_format` (list) instead.")
+
+    @staticmethod
+    def resolve_duration(obj: "Album") -> int | None:
+        # tolerate legacy millisecond values not yet migrated
+        return coerce_album_duration(obj.duration)
+
+    @staticmethod
+    def resolve_album_type(obj: "Album") -> list[str]:
+        # tolerate legacy free-text values not yet migrated
+        return normalize_album_types(obj.album_type)
+
+    @staticmethod
+    def resolve_media_format(obj: "Album") -> list[str]:
+        return normalize_media_formats(obj.media_format)
+
+    @staticmethod
+    def resolve_media(obj: "Album") -> str | None:
+        formats = normalize_media_formats(obj.media_format)
+        return ", ".join(formats) if formats else None
 
     @staticmethod
     def resolve_artist(obj: "Album") -> list[str]:
@@ -70,18 +102,22 @@ class Album(Item):
         "track_list",
         "localized_description",
         "album_type",
-        "media",
+        "media_format",
         "disc_count",
         "genre",
         "release_date",
         "duration",
         "bandcamp_album_id",
     ]
-    release_date = jsondata.DateField(
-        _("release date"), null=True, blank=True, help_text=_("YYYY-MM-DD")
+    release_date = jsondata.CharField(
+        _("release date"),
+        null=True,
+        blank=True,
+        max_length=10,
+        help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
     duration = jsondata.IntegerField(
-        _("length"), null=True, blank=True, help_text=_("milliseconds")
+        _("length"), null=True, blank=True, help_text=_("seconds")
     )
     artist = jsondata.JSONField(
         verbose_name=_("artist"),
@@ -99,12 +135,38 @@ class Album(Item):
         schema=LIST_OF_STR_SCHEMA,
     )
     track_list = jsondata.TextField(_("tracks"), blank=True)
-    album_type = jsondata.CharField(_("album type"), blank=True, max_length=500)
-    media = jsondata.CharField(_("media type"), blank=True, max_length=500)
+    album_type = AlbumTypeListField()
+    media_format = MediaFormatListField()
     bandcamp_album_id = jsondata.CharField(blank=True, max_length=500)
     disc_count = jsondata.IntegerField(
         _("number of discs"), blank=True, default="", max_length=500
     )
+
+    @classmethod
+    def normalize_legacy_metadata(cls, metadata):
+        super().normalize_legacy_metadata(metadata)
+        # Sources: federated peers running older code, ndjson restores,
+        # and local rows that predate the unification.
+        # - duration in milliseconds -> seconds
+        # - media (free text) -> media_format (list of slugs)
+        # - album_type free text -> list of slugs
+        duration = metadata.get("duration")
+        if duration is not None:
+            duration = coerce_album_duration(duration)
+            if duration:
+                metadata["duration"] = duration
+            else:
+                metadata.pop("duration", None)
+        media = metadata.pop("media", None)
+        if media and not metadata.get("media_format"):
+            metadata["media_format"] = normalize_media_formats(media)
+        if "album_type" in metadata:
+            album_type = normalize_album_types(metadata["album_type"])
+            if album_type:
+                metadata["album_type"] = album_type
+            else:
+                metadata.pop("album_type", None)
+        canonicalize_release_date_key(metadata)
 
     def get_embed_link(self) -> str | None:
         bandcamp_link = None
@@ -149,12 +211,10 @@ class Album(Item):
         d = super().to_indexable_doc()
         if self.barcode:
             d["lookup_id"] = [str(self.barcode)]
-        d["date"] = (
-            [int(self.release_date.strftime("%Y%m%d"))] if self.release_date else []
-        )
+        dt = partial_date_to_int(self.release_date)
+        d["date"] = [dt] if dt else []
         d["genre"] = self.genre or []
-        d["format"] = [self.album_type] if self.album_type else []
-        d["format"] += [self.media] if self.media else []
+        d["format"] = list(self.album_type or []) + list(self.media_format or [])
         return d
 
     def to_schema_org(self):
@@ -179,11 +239,10 @@ class Album(Item):
             data["publisher"] = {"@type": "Organization", "name": labels[0]}
 
         if self.release_date:
-            data["datePublished"] = self.release_date.isoformat()
+            data["datePublished"] = self.release_date
 
-        if self.duration:
-            # Convert milliseconds to ISO8601 duration format
-            seconds = self.duration // 1000
+        seconds = coerce_album_duration(self.duration)
+        if seconds:
             hours = seconds // 3600
             minutes = (seconds % 3600) // 60
             seconds = seconds % 60

--- a/neodb/catalog/models/music.py
+++ b/neodb/catalog/models/music.py
@@ -15,6 +15,7 @@ from .common import (
     AlbumTypeListField,
     GenreListField,
     MediaFormatListField,
+    ReleaseDateResolverMixin,
     jsondata,
 )
 from .item import (
@@ -30,12 +31,16 @@ from .people import PeopleRole
 from .utils import canonicalize_release_date_key
 
 
-class AlbumInSchema(ItemInSchema):
+class AlbumInSchema(ReleaseDateResolverMixin, ItemInSchema):
     genre: list[str]
     artist: list[str]
     company: list[str]
-    duration: int | None = None
+    duration: int | None = Field(
+        None, deprecated="Milliseconds; use `duration_seconds` instead."
+    )
+    duration_seconds: int | None = None
     release_date: str | None = None
+    release_date_precision: str | None = None
     album_type: list[str]
     media_format: list[str]
     track_list: str | None = None
@@ -44,6 +49,12 @@ class AlbumInSchema(ItemInSchema):
 
     @staticmethod
     def resolve_duration(obj: "Album") -> int | None:
+        # older peers and clients read this as milliseconds
+        seconds = duration_to_seconds(obj.duration)
+        return seconds * 1000 if seconds else None
+
+    @staticmethod
+    def resolve_duration_seconds(obj: "Album") -> int | None:
         # numeric values are trusted as seconds; unit inference happens
         # only on legacy ingest (normalize_legacy_metadata)
         return duration_to_seconds(obj.duration)
@@ -161,13 +172,20 @@ class Album(Item):
         # - duration in milliseconds -> seconds
         # - media (free text) -> media_format (list of slugs)
         # - album_type free text -> list of slugs
-        duration = metadata.get("duration")
-        if duration is not None:
-            duration = coerce_album_duration(duration)
-            if duration:
-                metadata["duration"] = duration
-            else:
-                metadata.pop("duration", None)
+        # a duration_seconds sibling (emitted by current peers alongside
+        # the backward-compatible ms shape) wins losslessly over the
+        # ms-threshold inference
+        seconds = metadata.pop("duration_seconds", None)
+        if isinstance(seconds, (int, float)) and int(seconds) > 0:
+            metadata["duration"] = int(seconds)
+        else:
+            duration = metadata.get("duration")
+            if duration is not None:
+                duration = coerce_album_duration(duration)
+                if duration:
+                    metadata["duration"] = duration
+                else:
+                    metadata.pop("duration", None)
         media = metadata.pop("media", None)
         if media and not metadata.get("media_format"):
             metadata["media_format"] = normalize_media_formats(media)

--- a/neodb/catalog/models/music.py
+++ b/neodb/catalog/models/music.py
@@ -3,6 +3,7 @@ from ninja import Field
 
 from common.models import (
     coerce_album_duration,
+    duration_to_seconds,
     normalize_album_types,
     normalize_media_formats,
     partial_date_to_int,
@@ -43,8 +44,9 @@ class AlbumInSchema(ItemInSchema):
 
     @staticmethod
     def resolve_duration(obj: "Album") -> int | None:
-        # tolerate legacy millisecond values not yet migrated
-        return coerce_album_duration(obj.duration)
+        # numeric values are trusted as seconds; unit inference happens
+        # only on legacy ingest (normalize_legacy_metadata)
+        return duration_to_seconds(obj.duration)
 
     @staticmethod
     def resolve_album_type(obj: "Album") -> list[str]:
@@ -143,7 +145,7 @@ class Album(Item):
     )
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         # Sources: federated peers running older code, ndjson restores,
         # and local rows that predate the unification.
@@ -241,7 +243,7 @@ class Album(Item):
         if self.release_date:
             data["datePublished"] = self.release_date
 
-        seconds = coerce_album_duration(self.duration)
+        seconds = duration_to_seconds(self.duration)
         if seconds:
             hours = seconds // 3600
             minutes = (seconds % 3600) // 60

--- a/neodb/catalog/models/music.py
+++ b/neodb/catalog/models/music.py
@@ -144,6 +144,15 @@ class Album(Item):
         _("number of discs"), blank=True, default="", max_length=500
     )
 
+    @property
+    def display_album_types(self) -> list[str]:
+        # tolerate legacy scalar values not yet migrated
+        return normalize_album_types(self.album_type)
+
+    @property
+    def display_media_formats(self) -> list[str]:
+        return normalize_media_formats(self.media_format)
+
     @classmethod
     def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)

--- a/neodb/catalog/models/music.py
+++ b/neodb/catalog/models/music.py
@@ -15,7 +15,6 @@ from .common import (
     AlbumTypeListField,
     GenreListField,
     MediaFormatListField,
-    ReleaseDateResolverMixin,
     jsondata,
 )
 from .item import (
@@ -31,16 +30,15 @@ from .people import PeopleRole
 from .utils import canonicalize_release_date_key
 
 
-class AlbumInSchema(ReleaseDateResolverMixin, ItemInSchema):
+class AlbumInSchema(ItemInSchema):
     genre: list[str]
     artist: list[str]
     company: list[str]
+    length: int | None = None
     duration: int | None = Field(
-        None, deprecated="Milliseconds; use `duration_seconds` instead."
+        None, deprecated="Milliseconds; use `length` (seconds) instead."
     )
-    duration_seconds: int | None = None
     release_date: str | None = None
-    release_date_precision: str | None = None
     album_type: list[str]
     media_format: list[str]
     track_list: str | None = None
@@ -48,16 +46,16 @@ class AlbumInSchema(ReleaseDateResolverMixin, ItemInSchema):
     media: str | None = Field(None, deprecated="Use `media_format` (list) instead.")
 
     @staticmethod
-    def resolve_duration(obj: "Album") -> int | None:
-        # older peers and clients read this as milliseconds
-        seconds = duration_to_seconds(obj.duration)
-        return seconds * 1000 if seconds else None
-
-    @staticmethod
-    def resolve_duration_seconds(obj: "Album") -> int | None:
+    def resolve_length(obj: "Album") -> int | None:
         # numeric values are trusted as seconds; unit inference happens
         # only on legacy ingest (normalize_legacy_metadata)
-        return duration_to_seconds(obj.duration)
+        return duration_to_seconds(obj.length)
+
+    @staticmethod
+    def resolve_duration(obj: "Album") -> int | None:
+        # older peers and clients read this as milliseconds
+        seconds = duration_to_seconds(obj.length)
+        return seconds * 1000 if seconds else None
 
     @staticmethod
     def resolve_album_type(obj: "Album") -> list[str]:
@@ -119,7 +117,7 @@ class Album(Item):
         "disc_count",
         "genre",
         "release_date",
-        "duration",
+        "length",
         "bandcamp_album_id",
     ]
     release_date = jsondata.CharField(
@@ -129,7 +127,7 @@ class Album(Item):
         max_length=10,
         help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
-    duration = jsondata.IntegerField(
+    length = jsondata.IntegerField(
         _("length"), null=True, blank=True, help_text=_("seconds")
     )
     artist = jsondata.JSONField(
@@ -172,20 +170,13 @@ class Album(Item):
         # - duration in milliseconds -> seconds
         # - media (free text) -> media_format (list of slugs)
         # - album_type free text -> list of slugs
-        # a duration_seconds sibling (emitted by current peers alongside
-        # the backward-compatible ms shape) wins losslessly over the
-        # ms-threshold inference
-        seconds = metadata.pop("duration_seconds", None)
-        if isinstance(seconds, (int, float)) and int(seconds) > 0:
-            metadata["duration"] = int(seconds)
-        else:
-            duration = metadata.get("duration")
-            if duration is not None:
-                duration = coerce_album_duration(duration)
-                if duration:
-                    metadata["duration"] = duration
-                else:
-                    metadata.pop("duration", None)
+        # current peers emit canonical seconds under "length"; the legacy
+        # "duration" (ms) is only used when length is absent
+        duration = metadata.pop("duration", None)
+        if not metadata.get("length") and duration is not None:
+            length = coerce_album_duration(duration)
+            if length:
+                metadata["length"] = length
         media = metadata.pop("media", None)
         if media and not metadata.get("media_format"):
             metadata["media_format"] = normalize_media_formats(media)
@@ -270,7 +261,7 @@ class Album(Item):
         if self.release_date:
             data["datePublished"] = self.release_date
 
-        seconds = duration_to_seconds(self.duration)
+        seconds = duration_to_seconds(self.length)
         if seconds:
             hours = seconds // 3600
             minutes = (seconds % 3600) // 60

--- a/neodb/catalog/models/podcast.py
+++ b/neodb/catalog/models/podcast.py
@@ -45,7 +45,8 @@ class PodcastEpisodeInSchema(ItemInSchema):
     pub_date: datetime | None = None
     media_url: str | None = None
     link: str | None = None
-    duration: int | None = None
+    length: int | None = Field(None, alias="duration")
+    duration: int | None = Field(None, deprecated="Use `length` (seconds) instead.")
 
 
 class PodcastEpisodeSchema(PodcastEpisodeInSchema, BaseSchema):

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -97,7 +97,8 @@ class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSch
     year: int | None = Field(
         None, deprecated="Use the year part of `release_date` instead."
     )
-    site: str | None = None
+    official_site: str | None = Field(None, alias="site")
+    site: str | None = Field(None, deprecated="Use `official_site` instead.")
     length: int | None = None
     duration: str | None = Field(
         None, deprecated="Display string; use `length` (seconds) instead."
@@ -133,7 +134,8 @@ class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInS
     year: int | None = Field(
         None, deprecated="Use the year part of `release_date` instead."
     )
-    site: str | None = None
+    official_site: str | None = Field(None, alias="site")
+    site: str | None = Field(None, deprecated="Use `official_site` instead.")
     length: int | None = None
     duration: str | None = Field(
         None, deprecated="Display string; use `length` (seconds) instead."

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -93,10 +93,17 @@ class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSch
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
+    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
-    duration: int | None = None
-    single_episode_length: int | None = None
+    duration: str | None = Field(
+        None, deprecated="Display string; use `duration_seconds` instead."
+    )
+    duration_seconds: int | None = None
+    single_episode_length: int | None = Field(
+        None, deprecated="Minutes; use `single_episode_length_seconds` instead."
+    )
+    single_episode_length_seconds: int | None = None
     episode_count: int | None = None
     season_uuids: list[str]
     # area and showtime are deprecated
@@ -123,10 +130,17 @@ class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInS
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
+    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
-    duration: int | None = None
-    single_episode_length: int | None = None
+    duration: str | None = Field(
+        None, deprecated="Display string; use `duration_seconds` instead."
+    )
+    duration_seconds: int | None = None
+    single_episode_length: int | None = Field(
+        None, deprecated="Minutes; use `single_episode_length_seconds` instead."
+    )
+    single_episode_length_seconds: int | None = None
     episode_count: int | None = None
     episode_uuids: list[str]
     # area and showtime are deprecated

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -103,7 +103,6 @@ class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSch
     duration: str | None = Field(
         None, deprecated="Display string; use `length` (seconds) instead."
     )
-    single_episode_length: int | None = None
     episode_count: int | None = None
     season_uuids: list[str]
     # area and showtime are deprecated
@@ -140,7 +139,6 @@ class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInS
     duration: str | None = Field(
         None, deprecated="Display string; use `length` (seconds) instead."
     )
-    single_episode_length: int | None = None
     episode_count: int | None = None
     episode_uuids: list[str]
     # area and showtime are deprecated

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -31,13 +31,19 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from loguru import logger
-from ninja import Schema
+from ninja import Field, Schema
 
+from common.models import (
+    coerce_video_duration,
+    partial_date_to_int,
+    year_of_partial_date,
+)
 from common.models.lang import RE_LOCALIZED_SEASON_NUMBERS, localize_number
-from common.models.misc import int_, uniq
+from common.models.misc import uniq
 
 from .common import (
     LIST_OF_STR_SCHEMA,
+    CountryListField,
     GenreListField,
     LanguageListField,
     jsondata,
@@ -54,9 +60,31 @@ from .item import (
     PrimaryLookupIdDescriptor,
 )
 from .people import PeopleRole
+from .utils import normalize_legacy_video_metadata
 
 
 class _TVCreditResolverMixin(Schema):
+    @staticmethod
+    def resolve_origin_country(obj: "TVShow | TVSeason") -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_area(obj: "TVShow | TVSeason") -> list[str]:
+        return obj.origin_country or []
+
+    @staticmethod
+    def resolve_showtime(obj: "TVShow | TVSeason") -> list[dict]:
+        return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
+
+    @staticmethod
+    def resolve_duration(obj: "TVShow | TVSeason") -> int | None:
+        # tolerate legacy free-text values not yet migrated
+        return coerce_video_duration(obj.duration)
+
+    @staticmethod
+    def resolve_single_episode_length(obj: "TVShow | TVSeason") -> int | None:
+        return coerce_video_duration(obj.single_episode_length)
+
     @staticmethod
     def resolve_director(obj: "TVShow | TVSeason") -> list[str]:
         return obj.credit_names_by_role("director")
@@ -83,11 +111,19 @@ class TVShowInSchema(_TVCreditResolverMixin, ItemInSchema):
     producer: list[str]
     genre: list[str]
     language: list[str]
-    area: list[str]
+    origin_country: list[str]
+    release_date: str | None = None
     year: int | None = None
     site: str | None = None
+    duration: int | None = None
+    single_episode_length: int | None = None
     episode_count: int | None = None
     season_uuids: list[str]
+    # area and showtime are deprecated
+    area: list[str] = Field(
+        [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."
+    )
+    showtime: list[dict] = Field([], deprecated="Use `release_date` instead.")
 
 
 class TVShowSchema(TVShowInSchema, BaseSchema):
@@ -105,11 +141,19 @@ class TVSeasonInSchema(_TVCreditResolverMixin, ItemInSchema):
     producer: list[str]
     genre: list[str]
     language: list[str]
-    area: list[str]
+    origin_country: list[str]
+    release_date: str | None = None
     year: int | None = None
     site: str | None = None
+    duration: int | None = None
+    single_episode_length: int | None = None
     episode_count: int | None = None
     episode_uuids: list[str]
+    # area and showtime are deprecated
+    area: list[str] = Field(
+        [], deprecated="Use `origin_country` (ISO 3166-1 alpha-2) instead."
+    )
+    showtime: list[dict] = Field([], deprecated="Use `release_date` instead.")
 
 
 class TVSeasonSchema(TVSeasonInSchema, BaseSchema):
@@ -163,11 +207,10 @@ class TVShow(Item):
         "producer",
         "localized_description",
         "genre",
-        "showtime",
+        "release_date",
         "site",
-        "area",
+        "origin_country",
         "language",
-        "year",
         "duration",
         "episode_count",
         "single_episode_length",
@@ -204,58 +247,38 @@ class TVShow(Item):
         schema=LIST_OF_STR_SCHEMA,
     )
     genre = GenreListField(ItemCategory.TV)
-    showtime = jsondata.JSONField(
-        _("show time"),
+    release_date = jsondata.CharField(
+        verbose_name=_("release date"),
         null=True,
         blank=True,
-        default=list,
-        schema={
-            "type": "list",
-            "items": {
-                "type": "dict",
-                "additionalProperties": False,
-                "keys": {
-                    "time": {
-                        "type": "string",
-                        "title": _("Date"),
-                        "placeholder": _("YYYY-MM-DD"),
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": _("Region or Event"),
-                        "placeholder": _(
-                            "Germany or Toronto International Film Festival"
-                        ),
-                    },
-                },
-                "required": ["time"],
-            },
-        },
+        max_length=10,
+        help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
     site = jsondata.URLField(verbose_name=_("website"), blank=True, max_length=200)
-    area = jsondata.ArrayField(
-        verbose_name=_("region"),
-        base_field=models.CharField(
-            blank=True,
-            default="",
-            max_length=100,
-        ),
-        null=True,
-        blank=True,
-        default=list,
-    )
+    origin_country = CountryListField()
     language = LanguageListField()
 
-    year = jsondata.IntegerField(verbose_name=_("year"), null=True, blank=True)
     single_episode_length = jsondata.IntegerField(
-        verbose_name=_("episode length"), null=True, blank=True
+        verbose_name=_("episode length"),
+        null=True,
+        blank=True,
+        help_text=_("seconds"),
     )
     season_number = jsondata.IntegerField(
         null=True, blank=True
     )  # TODO remove after migration
-    duration = jsondata.CharField(
-        blank=True, max_length=200
+    duration = jsondata.IntegerField(
+        null=True, blank=True
     )  # TODO remove after migration
+
+    @property
+    def year(self) -> int | None:
+        return year_of_partial_date(self.release_date)
+
+    @classmethod
+    def normalize_legacy_metadata(cls, metadata):
+        super().normalize_legacy_metadata(metadata)
+        normalize_legacy_video_metadata(metadata)
 
     @classmethod
     def lookup_id_type_choices(cls):
@@ -292,7 +315,7 @@ class TVShow(Item):
 
     def to_indexable_doc(self):
         d = super().to_indexable_doc()
-        dt = int_(self.year) * 10000
+        dt = partial_date_to_int(self.release_date)
         d["date"] = [dt] if dt else []
         d["genre"] = self.genre or []
         return d
@@ -326,8 +349,8 @@ class TVShow(Item):
                 {"@type": "Person", "name": person} for person in playwrights
             ]
 
-        if self.year:
-            data["datePublished"] = str(self.year)
+        if self.release_date:
+            data["datePublished"] = self.release_date
 
         if self.season_count:
             data["numberOfSeasons"] = self.season_count
@@ -335,8 +358,9 @@ class TVShow(Item):
         if self.episode_count:
             data["numberOfEpisodes"] = self.episode_count
 
-        if self.single_episode_length:
-            data["timeRequired"] = f"PT{self.single_episode_length}M"
+        episode_length = coerce_video_duration(self.single_episode_length)
+        if episode_length:
+            data["timeRequired"] = f"PT{episode_length // 60}M"
 
         if self.site:
             data["sameAs"] = self.site
@@ -405,11 +429,10 @@ class TVSeason(Item):
         "actor",
         "producer",
         "genre",
-        "showtime",
+        "release_date",
         "site",
-        "area",
+        "origin_country",
         "language",
-        "year",
         "duration",
         "single_episode_length",
         "localized_description",
@@ -446,56 +469,36 @@ class TVSeason(Item):
         schema=LIST_OF_STR_SCHEMA,
     )
     genre = GenreListField(ItemCategory.TV)
-    showtime = jsondata.JSONField(
-        _("show time"),
+    release_date = jsondata.CharField(
+        verbose_name=_("release date"),
         null=True,
         blank=True,
-        default=list,
-        schema={
-            "type": "list",
-            "items": {
-                "type": "dict",
-                "additionalProperties": False,
-                "keys": {
-                    "time": {
-                        "type": "string",
-                        "title": _("date"),
-                        "placeholder": _("required"),
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": _("region or event"),
-                        "placeholder": _(
-                            "Germany or Toronto International Film Festival"
-                        ),
-                    },
-                },
-                "required": ["time"],
-            },
-        },
+        max_length=10,
+        help_text=_("YYYY, YYYY-MM or YYYY-MM-DD"),
     )
     site = jsondata.URLField(
         verbose_name=_("website"), blank=True, default="", max_length=200
     )
-    area = jsondata.ArrayField(
-        verbose_name=_("region"),
-        base_field=models.CharField(
-            blank=True,
-            default="",
-            max_length=100,
-        ),
+    origin_country = CountryListField()
+    language = LanguageListField()
+    single_episode_length = jsondata.IntegerField(
+        verbose_name=_("episode length"),
         null=True,
         blank=True,
-        default=list,
+        help_text=_("seconds"),
     )
-    language = LanguageListField()
-    year = jsondata.IntegerField(verbose_name=_("year"), null=True, blank=True)
-    single_episode_length = jsondata.IntegerField(
-        verbose_name=_("episode length"), null=True, blank=True
-    )
-    duration = jsondata.CharField(
-        blank=True, default="", max_length=200
+    duration = jsondata.IntegerField(
+        null=True, blank=True
     )  # TODO remove after migration
+
+    @property
+    def year(self) -> int | None:
+        return year_of_partial_date(self.release_date)
+
+    @classmethod
+    def normalize_legacy_metadata(cls, metadata):
+        super().normalize_legacy_metadata(metadata)
+        normalize_legacy_video_metadata(metadata)
 
     @classmethod
     def lookup_id_type_choices(cls):
@@ -554,7 +557,7 @@ class TVSeason(Item):
 
     def to_indexable_doc(self):
         d = super().to_indexable_doc()
-        dt = int_(self.year) * 10000
+        dt = partial_date_to_int(self.release_date)
         d["date"] = [dt] if dt else []
         d["genre"] = self.genre or []
         return d
@@ -601,11 +604,12 @@ class TVSeason(Item):
                 {"@type": "Person", "name": person} for person in playwrights
             ]
 
-        if self.year:
-            data["datePublished"] = str(self.year)
+        if self.release_date:
+            data["datePublished"] = self.release_date
 
-        if self.single_episode_length:
-            data["timeRequired"] = f"PT{self.single_episode_length}M"
+        episode_length = coerce_video_duration(self.single_episode_length)
+        if episode_length:
+            data["timeRequired"] = f"PT{episode_length // 60}M"
 
         if self.all_episodes:
             data["episode"] = [

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -93,17 +93,13 @@ class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSch
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
+    length: int | None = None
     duration: str | None = Field(
-        None, deprecated="Display string; use `duration_seconds` instead."
+        None, deprecated="Display string; use `length` (seconds) instead."
     )
-    duration_seconds: int | None = None
-    single_episode_length: int | None = Field(
-        None, deprecated="Minutes; use `single_episode_length_seconds` instead."
-    )
-    single_episode_length_seconds: int | None = None
+    single_episode_length: int | None = None
     episode_count: int | None = None
     season_uuids: list[str]
     # area and showtime are deprecated
@@ -130,17 +126,13 @@ class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInS
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    release_date_precision: str | None = None
     year: int | None = None
     site: str | None = None
+    length: int | None = None
     duration: str | None = Field(
-        None, deprecated="Display string; use `duration_seconds` instead."
+        None, deprecated="Display string; use `length` (seconds) instead."
     )
-    duration_seconds: int | None = None
-    single_episode_length: int | None = Field(
-        None, deprecated="Minutes; use `single_episode_length_seconds` instead."
-    )
-    single_episode_length_seconds: int | None = None
+    single_episode_length: int | None = None
     episode_count: int | None = None
     episode_uuids: list[str]
     # area and showtime are deprecated
@@ -205,7 +197,7 @@ class TVShow(Item):
         "site",
         "origin_country",
         "language",
-        "duration",
+        "length",
         "episode_count",
         "single_episode_length",
     ]
@@ -261,9 +253,7 @@ class TVShow(Item):
     season_number = jsondata.IntegerField(
         null=True, blank=True
     )  # TODO remove after migration
-    duration = jsondata.IntegerField(
-        null=True, blank=True
-    )  # TODO remove after migration
+    length = jsondata.IntegerField(null=True, blank=True)  # TODO remove after migration
 
     @property
     def year(self) -> int | None:
@@ -427,7 +417,7 @@ class TVSeason(Item):
         "site",
         "origin_country",
         "language",
-        "duration",
+        "length",
         "single_episode_length",
         "localized_description",
     ]
@@ -481,9 +471,7 @@ class TVSeason(Item):
         blank=True,
         help_text=_("seconds"),
     )
-    duration = jsondata.IntegerField(
-        null=True, blank=True
-    )  # TODO remove after migration
+    length = jsondata.IntegerField(null=True, blank=True)  # TODO remove after migration
 
     @property
     def year(self) -> int | None:

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -93,7 +93,10 @@ class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSch
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    year: int | None = None
+    # year is deprecated
+    year: int | None = Field(
+        None, deprecated="Use the year part of `release_date` instead."
+    )
     site: str | None = None
     length: int | None = None
     duration: str | None = Field(
@@ -126,7 +129,10 @@ class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInS
     language: list[str]
     origin_country: list[str]
     release_date: str | None = None
-    year: int | None = None
+    # year is deprecated
+    year: int | None = Field(
+        None, deprecated="Use the year part of `release_date` instead."
+    )
     site: str | None = None
     length: int | None = None
     duration: str | None = Field(

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -34,7 +34,7 @@ from loguru import logger
 from ninja import Field, Schema
 
 from common.models import (
-    coerce_video_duration,
+    duration_to_seconds,
     partial_date_to_int,
     year_of_partial_date,
 )
@@ -46,6 +46,7 @@ from .common import (
     CountryListField,
     GenreListField,
     LanguageListField,
+    VideoFieldsResolverMixin,
     jsondata,
 )
 from .item import (
@@ -65,27 +66,6 @@ from .utils import normalize_legacy_video_metadata
 
 class _TVCreditResolverMixin(Schema):
     @staticmethod
-    def resolve_origin_country(obj: "TVShow | TVSeason") -> list[str]:
-        return obj.origin_country or []
-
-    @staticmethod
-    def resolve_area(obj: "TVShow | TVSeason") -> list[str]:
-        return obj.origin_country or []
-
-    @staticmethod
-    def resolve_showtime(obj: "TVShow | TVSeason") -> list[dict]:
-        return [{"time": obj.release_date, "region": ""}] if obj.release_date else []
-
-    @staticmethod
-    def resolve_duration(obj: "TVShow | TVSeason") -> int | None:
-        # tolerate legacy free-text values not yet migrated
-        return coerce_video_duration(obj.duration)
-
-    @staticmethod
-    def resolve_single_episode_length(obj: "TVShow | TVSeason") -> int | None:
-        return coerce_video_duration(obj.single_episode_length)
-
-    @staticmethod
     def resolve_director(obj: "TVShow | TVSeason") -> list[str]:
         return obj.credit_names_by_role("director")
 
@@ -102,7 +82,7 @@ class _TVCreditResolverMixin(Schema):
         return obj.credit_names_by_role("producer")
 
 
-class TVShowInSchema(_TVCreditResolverMixin, ItemInSchema):
+class TVShowInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSchema):
     season_count: int | None = None
     orig_title: str | None = None
     director: list[str]
@@ -132,7 +112,7 @@ class TVShowSchema(TVShowInSchema, BaseSchema):
     pass
 
 
-class TVSeasonInSchema(_TVCreditResolverMixin, ItemInSchema):
+class TVSeasonInSchema(VideoFieldsResolverMixin, _TVCreditResolverMixin, ItemInSchema):
     season_number: int | None = None
     orig_title: str | None = None
     director: list[str]
@@ -276,7 +256,7 @@ class TVShow(Item):
         return year_of_partial_date(self.release_date)
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         normalize_legacy_video_metadata(metadata)
 
@@ -358,7 +338,7 @@ class TVShow(Item):
         if self.episode_count:
             data["numberOfEpisodes"] = self.episode_count
 
-        episode_length = coerce_video_duration(self.single_episode_length)
+        episode_length = duration_to_seconds(self.single_episode_length)
         if episode_length:
             data["timeRequired"] = f"PT{episode_length // 60}M"
 
@@ -496,7 +476,7 @@ class TVSeason(Item):
         return year_of_partial_date(self.release_date)
 
     @classmethod
-    def normalize_legacy_metadata(cls, metadata):
+    def normalize_legacy_metadata(cls, metadata: dict) -> None:
         super().normalize_legacy_metadata(metadata)
         normalize_legacy_video_metadata(metadata)
 
@@ -607,7 +587,7 @@ class TVSeason(Item):
         if self.release_date:
             data["datePublished"] = self.release_date
 
-        episode_length = coerce_video_duration(self.single_episode_length)
+        episode_length = duration_to_seconds(self.single_episode_length)
         if episode_length:
             data["timeRequired"] = f"PT{episode_length // 60}M"
 

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -250,6 +250,8 @@ class TVShow(Item):
     origin_country = CountryListField()
     language = LanguageListField()
 
+    # collected but not displayed or exposed in API;
+    # fate undecided, likely to be deprecated
     single_episode_length = jsondata.IntegerField(
         verbose_name=_("episode length"),
         null=True,
@@ -471,6 +473,8 @@ class TVSeason(Item):
     )
     origin_country = CountryListField()
     language = LanguageListField()
+    # collected but not displayed or exposed in API;
+    # fate undecided, likely to be deprecated
     single_episode_length = jsondata.IntegerField(
         verbose_name=_("episode length"),
         null=True,

--- a/neodb/catalog/models/utils.py
+++ b/neodb/catalog/models/utils.py
@@ -1,7 +1,17 @@
 import re
 import uuid
+from typing import Any
 
+import dateparser
 from django.utils import timezone
+
+from common.models import (
+    coerce_video_duration,
+    earliest_partial_date,
+    normalize_countries,
+    parse_duration_text,
+    parse_partial_date,
+)
 
 from .common import IdType
 
@@ -104,6 +114,85 @@ def upc_to_gtin_13(upc: str):
         else:
             return None
     return s
+
+
+def canonicalize_release_date_key(metadata: dict[str, Any]) -> None:
+    """Re-canonicalize metadata["release_date"] into partial ISO form.
+
+    Falls back to dateparser for free-text dates (e.g. localized Steam
+    strings). Unparseable non-empty strings are kept as-is rather than
+    destroyed.
+    """
+    rd = metadata.get("release_date")
+    if rd is None:
+        return
+    p = parse_partial_date(rd)
+    if p is None and isinstance(rd, str) and rd.strip():
+        dp = dateparser.parse(rd.strip())
+        p = dp.date().isoformat() if dp else None
+    if p:
+        metadata["release_date"] = p
+    elif not isinstance(rd, str) or not rd.strip():
+        metadata.pop("release_date", None)
+
+
+def _coerce_duration_key(metadata: dict[str, Any], key: str, legacy: bool) -> None:
+    v = metadata.get(key)
+    if v is None:
+        return
+    if isinstance(v, str):
+        parsed = parse_duration_text(v)
+    elif isinstance(v, (int, float)):
+        # the int-means-minutes inference only applies to legacy-shaped
+        # metadata; new-shape values are already seconds
+        parsed = coerce_video_duration(v) if legacy else (int(v) or None)
+    else:
+        parsed = None
+    if parsed and parsed > 0:
+        metadata[key] = parsed
+    else:
+        metadata.pop(key, None)
+
+
+def normalize_legacy_video_metadata(metadata: dict[str, Any]) -> None:
+    """Translate legacy Movie/TVShow/TVSeason metadata shapes in place.
+
+    Sources: federated peers running older code, ndjson restores, and
+    local rows that predate the unification:
+    - duration / single_episode_length free text or minutes -> seconds
+    - area (region names) -> origin_country (ISO 3166-1 alpha-2)
+    - showtime [{time, region}] -> release_date (earliest); year fallback
+
+    Legacy shape is detected by the presence of pre-unification keys, so
+    running this on already-converted metadata is a no-op.
+    """
+    legacy = any(k in metadata for k in ("area", "showtime", "year"))
+    _coerce_duration_key(metadata, "duration", legacy)
+    _coerce_duration_key(metadata, "single_episode_length", legacy)
+    area = metadata.pop("area", None)
+    if area and not metadata.get("origin_country"):
+        if isinstance(area, str):
+            area = [area]
+        if isinstance(area, list):
+            metadata["origin_country"] = normalize_countries(
+                [a for a in area if isinstance(a, str)]
+            )
+    showtime = metadata.pop("showtime", None)
+    if not metadata.get("release_date") and isinstance(showtime, list):
+        rd = earliest_partial_date(
+            t.get("time") for t in showtime if isinstance(t, dict)
+        )
+        if rd:
+            metadata["release_date"] = rd
+        else:
+            # nothing parseable; keep the original data around
+            metadata["showtime"] = showtime
+    year = metadata.pop("year", None)
+    if year and not metadata.get("release_date"):
+        rd = parse_partial_date(year if isinstance(year, int) else str(year))
+        if rd:
+            metadata["release_date"] = rd
+    canonicalize_release_date_key(metadata)
 
 
 def resource_cover_path(resource, filename):

--- a/neodb/catalog/models/utils.py
+++ b/neodb/catalog/models/utils.py
@@ -12,6 +12,7 @@ from common.models import (
     parse_duration_text,
     parse_partial_date,
 )
+from common.models.partial_date import unpad_partial_date
 
 from .common import IdType
 
@@ -119,13 +120,22 @@ def upc_to_gtin_13(upc: str):
 def canonicalize_release_date_key(metadata: dict[str, Any]) -> None:
     """Re-canonicalize metadata["release_date"] into partial ISO form.
 
-    Falls back to dateparser for free-text dates (e.g. localized Steam
-    strings). Unparseable non-empty strings are kept as-is rather than
-    destroyed.
+    The API emits release_date as a padded full date plus a
+    release_date_precision key ("year"/"month"/"day") for backward
+    compatibility; when the precision key is present it is applied here
+    so the partial value round-trips losslessly. Otherwise falls back to
+    dateparser for free-text dates (e.g. localized Steam strings).
+    Unparseable non-empty strings are kept as-is rather than destroyed.
     """
+    precision = metadata.pop("release_date_precision", None)
     rd = metadata.get("release_date")
     if rd is None:
         return
+    if precision in ("year", "month"):
+        p = unpad_partial_date(rd if isinstance(rd, str) else None, precision)
+        if p:
+            metadata["release_date"] = p
+            return
     p = parse_partial_date(rd)
     if p is None and isinstance(rd, str) and rd.strip():
         dp = dateparser.parse(rd.strip())
@@ -137,6 +147,12 @@ def canonicalize_release_date_key(metadata: dict[str, Any]) -> None:
 
 
 def _coerce_duration_key(metadata: dict[str, Any], key: str, legacy: bool) -> None:
+    # a "<key>_seconds" sibling (emitted by current peers alongside the
+    # backward-compatible legacy shape) wins losslessly over inference
+    seconds = metadata.pop(f"{key}_seconds", None)
+    if isinstance(seconds, (int, float)) and int(seconds) > 0:
+        metadata[key] = int(seconds)
+        return
     v = metadata.get(key)
     if v is None:
         return

--- a/neodb/catalog/models/utils.py
+++ b/neodb/catalog/models/utils.py
@@ -12,7 +12,6 @@ from common.models import (
     parse_duration_text,
     parse_partial_date,
 )
-from common.models.partial_date import unpad_partial_date
 
 from .common import IdType
 
@@ -120,22 +119,13 @@ def upc_to_gtin_13(upc: str):
 def canonicalize_release_date_key(metadata: dict[str, Any]) -> None:
     """Re-canonicalize metadata["release_date"] into partial ISO form.
 
-    The API emits release_date as a padded full date plus a
-    release_date_precision key ("year"/"month"/"day") for backward
-    compatibility; when the precision key is present it is applied here
-    so the partial value round-trips losslessly. Otherwise falls back to
-    dateparser for free-text dates (e.g. localized Steam strings).
-    Unparseable non-empty strings are kept as-is rather than destroyed.
+    Falls back to dateparser for free-text dates (e.g. localized Steam
+    strings). Unparseable non-empty strings are kept as-is rather than
+    destroyed.
     """
-    precision = metadata.pop("release_date_precision", None)
     rd = metadata.get("release_date")
     if rd is None:
         return
-    if precision in ("year", "month"):
-        p = unpad_partial_date(rd if isinstance(rd, str) else None, precision)
-        if p:
-            metadata["release_date"] = p
-            return
     p = parse_partial_date(rd)
     if p is None and isinstance(rd, str) and rd.strip():
         dp = dateparser.parse(rd.strip())
@@ -147,12 +137,6 @@ def canonicalize_release_date_key(metadata: dict[str, Any]) -> None:
 
 
 def _coerce_duration_key(metadata: dict[str, Any], key: str, legacy: bool) -> None:
-    # a "<key>_seconds" sibling (emitted by current peers alongside the
-    # backward-compatible legacy shape) wins losslessly over inference
-    seconds = metadata.pop(f"{key}_seconds", None)
-    if isinstance(seconds, (int, float)) and int(seconds) > 0:
-        metadata[key] = int(seconds)
-        return
     v = metadata.get(key)
     if v is None:
         return
@@ -179,11 +163,25 @@ def normalize_legacy_video_metadata(metadata: dict[str, Any]) -> None:
     - area (region names) -> origin_country (ISO 3166-1 alpha-2)
     - showtime [{time, region}] -> release_date (earliest); year fallback
 
-    Legacy shape is detected by the presence of pre-unification keys, so
-    running this on already-converted metadata is a no-op.
+    Legacy shape is detected by the presence of pre-unification keys
+    (and the absence of the current "length" key), so running this on
+    already-converted metadata is a no-op.
     """
-    legacy = any(k in metadata for k in ("area", "showtime", "year"))
-    _coerce_duration_key(metadata, "duration", legacy)
+    legacy = "length" not in metadata and any(
+        k in metadata for k in ("area", "showtime", "year")
+    )
+    # current peers emit canonical seconds under "length"; the legacy
+    # "duration" shape is only used when length is absent
+    duration = metadata.pop("duration", None)
+    if not metadata.get("length") and duration is not None:
+        if isinstance(duration, str):
+            length = parse_duration_text(duration)
+        elif isinstance(duration, (int, float)):
+            length = coerce_video_duration(duration) if legacy else int(duration)
+        else:
+            length = None
+        if length and length > 0:
+            metadata["length"] = length
     _coerce_duration_key(metadata, "single_episode_length", legacy)
     area = metadata.pop("area", None)
     if area and not metadata.get("origin_country"):

--- a/neodb/catalog/sites/apple_music.py
+++ b/neodb/catalog/sites/apple_music.py
@@ -130,7 +130,7 @@ class AppleMusic(AbstractSite):
                 "genre": genre,
                 "release_date": release_date,
                 "track_list": "\n".join(track_list),
-                "duration": duration,
+                "length": duration,
                 "cover_image_url": image_url,
             }
         )

--- a/neodb/catalog/sites/apple_music.py
+++ b/neodb/catalog/sites/apple_music.py
@@ -118,7 +118,7 @@ class AppleMusic(AbstractSite):
         track_list = [t["name"] for t in matched_schema_data.get("tracks", [])]
         duration = round(
             sum(
-                (parse_duration(t["duration"]) or timedelta()).total_seconds() * 1000
+                (parse_duration(t["duration"]) or timedelta()).total_seconds()
                 for t in matched_schema_data.get("tracks", [])
             )
         )

--- a/neodb/catalog/sites/bandcamp.py
+++ b/neodb/catalog/sites/bandcamp.py
@@ -112,7 +112,7 @@ class Bandcamp(AbstractSite):
             "genre": genre,
             "track_list": track_list,
             "release_date": release_date,
-            "duration": duration,
+            "length": duration,
             "company": company,
             "brief": brief,
             "bandcamp_album_id": bandcamp_album_id,

--- a/neodb/catalog/sites/bangumi.py
+++ b/neodb/catalog/sites/bangumi.py
@@ -21,6 +21,7 @@ from catalog.models import (
 from catalog.models.game import GameReleaseType
 from catalog.models.utils import detect_isbn_asin
 from catalog.search import ExternalSearchResultItem, record_search_failure
+from common.models import normalize_price
 from common.models.lang import detect_language
 
 _logger = logging.getLogger(__name__)
@@ -47,8 +48,6 @@ class Bangumi(AbstractSite):
         pub_month = None
         release_date = None
         release_type = None
-        showtime = None
-        year = None
         related_resources = []
         match o["type"]:
             case 1:
@@ -98,10 +97,7 @@ class Bangumi(AbstractSite):
                     category = ItemCategory.Performance
                     model = "Performance"
                 if dt:
-                    year = dt.split("-")[0]
-                    showtime = [
-                        {"time": dt, "region": "首播日期" if is_season else "发布日期"}
-                    ]
+                    release_date = dt
             case 3:
                 model = "Album"
                 category = ItemCategory.Music
@@ -126,8 +122,6 @@ class Bangumi(AbstractSite):
             "pub_month": pub_month,
             "release_date": release_date,
             "release_type": release_type,
-            "showtime": showtime,
-            "year": year,
         }
 
     @classmethod
@@ -291,7 +285,8 @@ class Bangumi(AbstractSite):
                 case "页数":
                     pages = v
                 case "价格":
-                    price = v
+                    # bangumi is Japan-centric so bare ¥ marks mean JPY
+                    price = normalize_price(v, "JPY") if isinstance(v, str) else None
                 case "开始":
                     opening_date = v
                 case "结束":

--- a/neodb/catalog/sites/bgg.py
+++ b/neodb/catalog/sites/bgg.py
@@ -72,7 +72,7 @@ class BoardGameGeek(AbstractSite):
                     if typ == "boardgameexpansion"
                     else GameReleaseType.GAME
                 ),
-                "platform": ["Boardgame"],
+                "platform": ["boardgame"],
                 "brief": brief,
                 # "official_site": official_site,
                 "cover_image_url": cover_image_url,

--- a/neodb/catalog/sites/bgg.py
+++ b/neodb/catalog/sites/bgg.py
@@ -66,7 +66,7 @@ class BoardGameGeek(AbstractSite):
                 "publisher": publisher,
                 "designer": designer,
                 "artist": artist,
-                "release_year": year,
+                "release_date": year,
                 "release_type": (
                     GameReleaseType.EXPANSION
                     if typ == "boardgameexpansion"

--- a/neodb/catalog/sites/bookstw.py
+++ b/neodb/catalog/sites/bookstw.py
@@ -1,6 +1,7 @@
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import *
+from common.models import normalize_price
 
 
 @SiteManager.register
@@ -94,7 +95,7 @@ class BooksTW(AbstractSite):
 
         price = content.xpath("string(//div/ul/li[contains(text(),'定價：')])")
         price = (
-            price.strip().split("：", 1)[1].split("元")[0].strip() + " NTD"
+            normalize_price(price.strip().split("：", 1)[1].strip(), "TWD")
             if price
             else None
         )

--- a/neodb/catalog/sites/discogs.py
+++ b/neodb/catalog/sites/discogs.py
@@ -7,6 +7,11 @@ from django.conf import settings
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import upc_to_gtin_13
+from common.models import (
+    ALBUM_TYPE_CODES,
+    normalize_album_types,
+    normalize_media_formats,
+)
 
 
 @SiteManager.register
@@ -37,11 +42,20 @@ class DiscogsRelease(AbstractSite):
             set([company.get("name") for company in release.get("companies")])
         )
 
-        media, disc_count = None, None
         formats = release.get("formats", [])
-        if len(formats) == 1:
-            media = formats[0].get("name")
-            disc_count = formats[0].get("qty")
+        media_format = normalize_media_formats(
+            [f.get("name") for f in formats if f.get("name")]
+        )
+        # format descriptions mix release types ("Album", "EP") with other
+        # words ("Reissue", "Stereo"); keep only canonical type slugs
+        album_type = [
+            t
+            for t in normalize_album_types(
+                [d for f in formats for d in f.get("descriptions") or []]
+            )
+            if t in ALBUM_TYPE_CODES
+        ]
+        disc_count = formats[0].get("qty") if len(formats) == 1 else None
 
         identifiers = release.get("identifiers")
         barcode = None
@@ -61,9 +75,10 @@ class DiscogsRelease(AbstractSite):
                 "artist": artist,
                 "genre": genre,
                 "track_list": "\n".join(track_list),
-                # "release_date": None,  # only year provided by API
+                "release_date": (str(release["year"]) if release.get("year") else None),
                 "company": company,
-                "media": media,
+                "media_format": media_format,
+                "album_type": album_type,
                 "disc_count": disc_count,
                 "cover_image_url": image_url,
             }
@@ -107,6 +122,9 @@ class DiscogsMaster(AbstractSite):
                 "artist": artist,
                 "genre": genre,
                 "track_list": "\n".join(track_list),
+                "release_date": (
+                    str(master_release["year"]) if master_release.get("year") else None
+                ),
                 "cover_image_url": image_url,
             }
         )

--- a/neodb/catalog/sites/douban_book.py
+++ b/neodb/catalog/sites/douban_book.py
@@ -1,6 +1,7 @@
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import *
+from common.models import normalize_price
 from common.models.lang import detect_language
 
 from .douban import (
@@ -108,7 +109,8 @@ class DoubanBook(AbstractSite):
         price_elem = self.query_list(
             content, "//div[@id='info']//span[text()='定价:']/following::text()"
         )
-        price = price_elem[0].strip() if price_elem else None
+        # douban book prices default to CNY when only 元/¥ or bare numbers
+        price = normalize_price(price_elem[0].strip(), "CNY") if price_elem else None
 
         pages_elem = self.query_list(
             content, "//div[@id='info']//span[text()='页数:']/following::text()"

--- a/neodb/catalog/sites/douban_game.py
+++ b/neodb/catalog/sites/douban_game.py
@@ -1,5 +1,7 @@
 import dateparser
 
+from common.models import normalize_game_platforms
+
 from catalog.common import *
 from catalog.models import *
 from common.models.lang import detect_language
@@ -69,7 +71,7 @@ class DoubanGame(AbstractSite):
             content,
             "//dl[@class='thing-attr']//dt[text()='平台:']/following-sibling::dd[1]/a/text()",
         )
-        platform = platform_elem if platform_elem else None
+        platform = normalize_game_platforms(platform_elem) if platform_elem else None
 
         genre_elem = self.query_list(
             content,

--- a/neodb/catalog/sites/douban_movie.py
+++ b/neodb/catalog/sites/douban_movie.py
@@ -5,6 +5,11 @@ from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
+from common.models import (
+    earliest_partial_date,
+    normalize_countries,
+    parse_duration_text,
+)
 from common.models.lang import detect_language
 from common.models.misc import int_
 
@@ -119,24 +124,10 @@ class DoubanMovie(AbstractSite):
         showtime_elem = self.query_list(
             content, "//span[@property='v:initialReleaseDate']/text()"
         )
-        if showtime_elem:
-            showtime = []
-            for st in showtime_elem:
-                parts = st.split("(")
-                if len(parts) == 1:
-                    time = st.split("(")[0]
-                    region = ""
-                else:
-                    time = st.split("(")[0]
-                    region = st.split("(")[1][0:-1]
-                showtime.append(
-                    {
-                        "region": region,
-                        "time": time,
-                    }
-                )
-        else:
-            showtime = None
+        # each entry looks like "2010-09-01(中国大陆)"; keep the earliest date
+        release_date = earliest_partial_date(
+            st.split("(")[0].strip() for st in showtime_elem or []
+        )
 
         site_elem = self.query_list(
             content,
@@ -151,9 +142,11 @@ class DoubanMovie(AbstractSite):
             "//div[@id='info']//span[text()='制片国家/地区:']/following-sibling::text()[1]",
         )
         if area_elem:
-            area = [a.strip()[:100] for a in area_elem[0].split("/")]
+            origin_country = normalize_countries(
+                [a.strip()[:100] for a in area_elem[0].split("/")]
+            )
         else:
-            area = None
+            origin_country = None
 
         language_elem = self.query_list(
             content,
@@ -167,16 +160,18 @@ class DoubanMovie(AbstractSite):
         year_s = self.query_str(content, "//span[@class='year']/text()")
         year_r = re.search(r"\d+", year_s) if year_s else None
         year = int_(year_r[0]) if year_r else None
+        if not release_date and year:
+            release_date = str(year)
 
         duration_elem = self.query_list(content, "//span[@property='v:runtime']/text()")
         other_duration_elem = self.query_list(
             content, "//span[@property='v:runtime']/following-sibling::text()[1]"
         )
         if duration_elem:
-            duration = duration_elem[0].strip()
+            duration_s = duration_elem[0].strip()
             if other_duration_elem:
-                duration += other_duration_elem[0].rstrip()
-            duration = duration.split("/")[0].strip()
+                duration_s += other_duration_elem[0].rstrip()
+            duration = parse_duration_text(duration_s.split("/")[0].strip())
         else:
             duration = None
 
@@ -207,7 +202,7 @@ class DoubanMovie(AbstractSite):
             "//div[@id='info']//span[text()='单集片长:']/following-sibling::text()[1]",
         )
         single_episode_length = (
-            single_episode_length_elem[0].strip()[:100]
+            parse_duration_text(single_episode_length_elem[0].strip()[:100])
             if single_episode_length_elem
             else None
         )
@@ -247,11 +242,10 @@ class DoubanMovie(AbstractSite):
                 "playwright": playwright,
                 "actor": actor,
                 "genre": genre,
-                "showtime": showtime,
+                "release_date": release_date,
                 "site": site,
-                "area": area,
+                "origin_country": origin_country,
                 "language": language,
-                "year": year,
                 "duration": duration,
                 "season_number": season,
                 "episode_count": episodes,

--- a/neodb/catalog/sites/douban_movie.py
+++ b/neodb/catalog/sites/douban_movie.py
@@ -246,7 +246,7 @@ class DoubanMovie(AbstractSite):
                 "site": site,
                 "origin_country": origin_country,
                 "language": language,
-                "duration": duration,
+                "length": duration,
                 "season_number": season,
                 "episode_count": episodes,
                 "single_episode_length": single_episode_length,

--- a/neodb/catalog/sites/douban_music.py
+++ b/neodb/catalog/sites/douban_music.py
@@ -110,7 +110,7 @@ class DoubanMusic(AbstractSite):
             "artist": artist,
             "genre": genre,
             "release_date": release_date,
-            "duration": None,
+            "length": None,
             "company": [company] if company else [],
             "track_list": track_list,
             "brief": brief,

--- a/neodb/catalog/sites/douban_music.py
+++ b/neodb/catalog/sites/douban_music.py
@@ -3,6 +3,11 @@ import dateparser
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import upc_to_gtin_13
+from common.models import (
+    normalize_album_types,
+    normalize_media_formats,
+    parse_partial_date,
+)
 from common.models.lang import detect_language
 
 from .douban import DoubanDownloader, DoubanSearcher, extract_people_links_from_anchors
@@ -58,8 +63,11 @@ class DoubanMusic(AbstractSite):
         date_elem = self.query_list(
             content, "//div[@id='info']//span[text()='发行时间:']/following::text()[1]"
         )
-        release_date = dateparser.parse(date_elem[0].strip()) if date_elem else None
-        release_date = release_date.strftime("%Y-%m-%d") if release_date else None
+        # values may be year-only ("1965"); keep partial precision
+        release_date = parse_partial_date(date_elem[0].strip()) if date_elem else None
+        if not release_date and date_elem:
+            parsed = dateparser.parse(date_elem[0].strip())
+            release_date = parsed.strftime("%Y-%m-%d") if parsed else None
 
         company_elem = self.query_list(
             content, "//div[@id='info']//span[text()='出版者:']/following::text()[1]"
@@ -117,13 +125,13 @@ class DoubanMusic(AbstractSite):
             "//div[@id='info']//span[text()='专辑类型:']/following-sibling::text()[1]",
         )
         if other_elem:
-            data["album_type"] = other_elem[0].strip()
+            data["album_type"] = normalize_album_types(other_elem[0].strip())
         other_elem = self.query_list(
             content,
             "//div[@id='info']//span[text()='介质:']/following-sibling::text()[1]",
         )
         if other_elem:
-            data["media"] = other_elem[0].strip()
+            data["media_format"] = normalize_media_formats(other_elem[0].strip())
         other_elem = self.query_list(
             content,
             "//div[@id='info']//span[text()='ISRC:']/following-sibling::text()[1]",

--- a/neodb/catalog/sites/igdb.py
+++ b/neodb/catalog/sites/igdb.py
@@ -15,6 +15,8 @@ from django.core.cache import cache
 from igdb.wrapper import IGDBWrapper
 from loguru import logger
 
+from common.models import normalize_game_platforms
+
 from catalog.common import *
 from catalog.models import *
 from catalog.search import ExternalSearchResultItem, record_search_failure
@@ -146,7 +148,7 @@ class IGDB(AbstractSite):
                     )
         if "platforms" in r:
             ps = sorted(r["platforms"], key=lambda p: p["id"])
-            platform = [(p["name"] if p["id"] != 6 else "Windows") for p in ps]
+            platform = normalize_game_platforms([p["name"] for p in ps])
         if "first_release_date" in r:
             release_date = datetime.datetime.fromtimestamp(
                 r["first_release_date"], datetime.timezone.utc

--- a/neodb/catalog/sites/imdb.py
+++ b/neodb/catalog/sites/imdb.py
@@ -124,7 +124,9 @@ class IMDB(AbstractSite):
         brief: str = ((d.get("plot") or {}).get("plotText") or {}).get("plainText", "")
         data: dict[str, object] = {
             "title": title,
-            "year": d["releaseYear"]["year"] if d.get("releaseYear") else None,
+            "release_date": (
+                str(d["releaseYear"]["year"]) if d.get("releaseYear") else None
+            ),
             "is_series": is_series,
             "is_episode": is_episode,
             "genre": (

--- a/neodb/catalog/sites/itch.py
+++ b/neodb/catalog/sites/itch.py
@@ -10,6 +10,8 @@ from lxml import etree
 from lxml import html as lxml_html
 from lxml.html import HtmlElement
 
+from common.models import normalize_game_platforms
+
 from catalog.common import *
 from catalog.models import *
 from common.models.lang import detect_language
@@ -202,20 +204,20 @@ class Itch(AbstractSite):
         if not val:
             return []
         if isinstance(val, str):
-            return [val]
+            val = [val]
         if isinstance(val, list):
-            return [str(v) for v in val if v]
+            return normalize_game_platforms([str(v) for v in val if v])
         return []
 
     @classmethod
     def _extract_platforms_from_links(cls, content) -> list[str]:
         platform_by_path = {
-            "/games/html5": "Web",
-            "/games/platform-windows": "Windows",
-            "/games/platform-osx": "macOS",
-            "/games/platform-linux": "Linux",
-            "/games/platform-android": "Android",
-            "/games/platform-ios": "iOS",
+            "/games/html5": "web",
+            "/games/platform-windows": "windows",
+            "/games/platform-osx": "mac",
+            "/games/platform-linux": "linux",
+            "/games/platform-android": "android",
+            "/games/platform-ios": "ios",
         }
         hrefs = content.xpath("//a[@href]/@href")
         paths = []

--- a/neodb/catalog/sites/mobygames.py
+++ b/neodb/catalog/sites/mobygames.py
@@ -8,6 +8,8 @@ Wikidata property P11688 maps to MobyGames numeric game IDs.
 
 import json
 
+from common.models import normalize_game_platforms
+
 from catalog.common import *
 from catalog.models import *
 from catalog.sites.wikidata import WikiData
@@ -108,6 +110,7 @@ class MobyGames(AbstractSite):
         platform = ld_json.get("gamePlatform") or []
         if isinstance(platform, str):
             platform = [platform]
+        platform = normalize_game_platforms(platform)
 
         # Release date from JSON-LD
         release_date = ld_json.get("datePublished") or None

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -306,7 +306,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
         if track_list:
             metadata["track_list"] = track_list
         if duration:
-            metadata["duration"] = duration
+            metadata["length"] = duration
         if company:
             metadata["company"] = company
         if cover_image_url:
@@ -483,7 +483,7 @@ class MusicBrainzRelease(AbstractSite):
         if track_list:
             metadata["track_list"] = track_list
         if duration:
-            metadata["duration"] = duration
+            metadata["length"] = duration
         if company:
             metadata["company"] = company
         if cover_image_url:

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -18,6 +18,7 @@ from catalog.common import *
 from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import *
 from catalog.search import ExternalSearchResultItem, record_search_failure
+from common.models import normalize_album_types, normalize_media_formats
 from common.models.lang import detect_language
 
 _logger = logging.getLogger(__name__)
@@ -200,9 +201,20 @@ class MusicBrainzReleaseGroup(AbstractSite):
                 [tag["name"] for tag in data["tags"] if tag.get("count", 0) > 0]
             )
 
+        # Release group primary/secondary types map to album_type
+        album_type = normalize_album_types(
+            [
+                t
+                for t in [data.get("primary-type")]
+                + list(data.get("secondary-types") or [])
+                if t
+            ]
+        )
+
         # Get additional metadata from first release
         track_list = None
         duration = None
+        media_format = []
         company = []
         cover_image_url = None
         isrc = None
@@ -219,6 +231,13 @@ class MusicBrainzReleaseGroup(AbstractSite):
                     track_info = self._extract_track_info(release_data)
                     track_list = track_info["track_list"]
                     duration = track_info["duration"]
+                    media_format = normalize_media_formats(
+                        [
+                            m["format"]
+                            for m in release_data.get("media", [])
+                            if m.get("format")
+                        ]
+                    )
                     company = self._extract_label_info(release_data)
                     cover_image_url = self._get_cover_art_url(release_id)
                     isrc = _extract_first_isrc(release_data)
@@ -234,6 +253,10 @@ class MusicBrainzReleaseGroup(AbstractSite):
             "brief": None,
         }
 
+        if album_type:
+            metadata["album_type"] = album_type
+        if media_format:
+            metadata["media_format"] = media_format
         if track_list:
             metadata["track_list"] = track_list
         if duration:
@@ -302,7 +325,8 @@ class MusicBrainzReleaseGroup(AbstractSite):
 
         return {
             "track_list": "\n".join(track_list) if track_list else None,
-            "duration": total_duration if total_duration > 0 else None,
+            # MB track lengths are milliseconds; catalog stores seconds
+            "duration": total_duration // 1000 if total_duration > 0 else None,
         }
 
     def _extract_label_info(self, release_data: Dict[str, Any]) -> List[str]:
@@ -416,6 +440,20 @@ class MusicBrainzRelease(AbstractSite):
                     [tag["name"] for tag in rg["tags"] if tag.get("count", 0) > 0]
                 )
 
+        # Release group primary/secondary types map to album_type
+        rg = data.get("release-group") or {}
+        album_type = normalize_album_types(
+            [
+                t
+                for t in [rg.get("primary-type")]
+                + list(rg.get("secondary-types") or [])
+                if t
+            ]
+        )
+        media_format = normalize_media_formats(
+            [m["format"] for m in data.get("media", []) if m.get("format")]
+        )
+
         # Extract track information and duration
         track_info = self._extract_track_info(data)
         track_list = track_info["track_list"]
@@ -436,6 +474,10 @@ class MusicBrainzRelease(AbstractSite):
             "brief": None,
         }
 
+        if album_type:
+            metadata["album_type"] = album_type
+        if media_format:
+            metadata["media_format"] = media_format
         if track_list:
             metadata["track_list"] = track_list
         if duration:
@@ -494,7 +536,8 @@ class MusicBrainzRelease(AbstractSite):
 
         return {
             "track_list": "\n".join(track_list) if track_list else None,
-            "duration": total_duration if total_duration > 0 else None,
+            # MB track lengths are milliseconds; catalog stores seconds
+            "duration": total_duration // 1000 if total_duration > 0 else None,
         }
 
     def _extract_label_info(self, release_data: Dict[str, Any]) -> List[str]:

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -133,6 +133,52 @@ def _extract_first_isrc(release_data: Dict[str, Any]) -> str | None:
     return None
 
 
+def _extract_track_info(release_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract track listing and duration from release data"""
+    track_list = []
+    total_duration = 0
+
+    if "media" in release_data:
+        for medium in release_data["media"]:
+            if "tracks" in medium:
+                disc_num = medium.get("position", 1)
+                for track in medium["tracks"]:
+                    track_num = track.get("position", len(track_list) + 1)
+                    track_title = track.get("title", "Unknown Track")
+
+                    # Add disc number if multiple discs
+                    if len(release_data["media"]) > 1:
+                        track_entry = f"{disc_num}-{track_num}. {track_title}"
+                    else:
+                        track_entry = f"{track_num}. {track_title}"
+
+                    track_list.append(track_entry)
+
+                    # Add duration if available (in milliseconds). MB
+                    # returns "length": null for tracks of unknown
+                    # length, so the key can be present with a None value;
+                    # guard the value rather than just key presence.
+                    length = track.get("length")
+                    if length is not None:
+                        total_duration += int(length)
+
+    return {
+        "track_list": "\n".join(track_list) if track_list else None,
+        # MB track lengths are milliseconds; catalog stores seconds
+        "duration": total_duration // 1000 if total_duration > 0 else None,
+    }
+
+
+def _extract_label_info(release_data: Dict[str, Any]) -> List[str]:
+    """Extract label/company information from release data"""
+    labels = []
+    if "label-info" in release_data:
+        for label_info in release_data["label-info"]:
+            if "label" in label_info and "name" in label_info["label"]:
+                labels.append(label_info["label"]["name"])
+    return labels
+
+
 @SiteManager.register
 class MusicBrainzReleaseGroup(AbstractSite):
     SITE_NAME = SiteName.MusicBrainz
@@ -228,7 +274,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
             try:
                 release_data = self._get_release_details(release_id)
                 if release_data:
-                    track_info = self._extract_track_info(release_data)
+                    track_info = _extract_track_info(release_data)
                     track_list = track_info["track_list"]
                     duration = track_info["duration"]
                     media_format = normalize_media_formats(
@@ -238,7 +284,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
                             if m.get("format")
                         ]
                     )
-                    company = self._extract_label_info(release_data)
+                    company = _extract_label_info(release_data)
                     cover_image_url = self._get_cover_art_url(release_id)
                     isrc = _extract_first_isrc(release_data)
             except Exception as e:
@@ -293,50 +339,6 @@ class MusicBrainzReleaseGroup(AbstractSite):
         headers = self.get_api_headers()
         downloader = MusicBrainzDownloader(api_url, headers=headers)
         return downloader.download().json()
-
-    def _extract_track_info(self, release_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Extract track listing and duration from release data"""
-        track_list = []
-        total_duration = 0
-
-        if "media" in release_data:
-            for medium in release_data["media"]:
-                if "tracks" in medium:
-                    disc_num = medium.get("position", 1)
-                    for track in medium["tracks"]:
-                        track_num = track.get("position", len(track_list) + 1)
-                        track_title = track.get("title", "Unknown Track")
-
-                        # Add disc number if multiple discs
-                        if len(release_data["media"]) > 1:
-                            track_entry = f"{disc_num}-{track_num}. {track_title}"
-                        else:
-                            track_entry = f"{track_num}. {track_title}"
-
-                        track_list.append(track_entry)
-
-                        # Add duration if available (in milliseconds). MB
-                        # returns "length": null for tracks of unknown
-                        # length, so the key can be present with a None value;
-                        # guard the value rather than just key presence.
-                        length = track.get("length")
-                        if length is not None:
-                            total_duration += int(length)
-
-        return {
-            "track_list": "\n".join(track_list) if track_list else None,
-            # MB track lengths are milliseconds; catalog stores seconds
-            "duration": total_duration // 1000 if total_duration > 0 else None,
-        }
-
-    def _extract_label_info(self, release_data: Dict[str, Any]) -> List[str]:
-        """Extract label/company information from release data"""
-        labels = []
-        if "label-info" in release_data:
-            for label_info in release_data["label-info"]:
-                if "label" in label_info and "name" in label_info["label"]:
-                    labels.append(label_info["label"]["name"])
-        return labels
 
     def _get_cover_art_url(self, release_id: str) -> str | None:
         """Get cover art URL from Cover Art Archive"""
@@ -455,12 +457,12 @@ class MusicBrainzRelease(AbstractSite):
         )
 
         # Extract track information and duration
-        track_info = self._extract_track_info(data)
+        track_info = _extract_track_info(data)
         track_list = track_info["track_list"]
         duration = track_info["duration"]
 
         # Extract label information
-        company = self._extract_label_info(data)
+        company = _extract_label_info(data)
 
         # Get cover art
         cover_image_url = self._get_cover_art_url(self.id_value)
@@ -504,50 +506,6 @@ class MusicBrainzRelease(AbstractSite):
             pd.lookup_ids[IdType.ISRC] = isrc
 
         return pd
-
-    def _extract_track_info(self, release_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Extract track listing and duration from release data"""
-        track_list = []
-        total_duration = 0
-
-        if "media" in release_data:
-            for medium in release_data["media"]:
-                if "tracks" in medium:
-                    disc_num = medium.get("position", 1)
-                    for track in medium["tracks"]:
-                        track_num = track.get("position", len(track_list) + 1)
-                        track_title = track.get("title", "Unknown Track")
-
-                        # Add disc number if multiple discs
-                        if len(release_data["media"]) > 1:
-                            track_entry = f"{disc_num}-{track_num}. {track_title}"
-                        else:
-                            track_entry = f"{track_num}. {track_title}"
-
-                        track_list.append(track_entry)
-
-                        # Add duration if available (in milliseconds). MB
-                        # returns "length": null for tracks of unknown
-                        # length, so the key can be present with a None value;
-                        # guard the value rather than just key presence.
-                        length = track.get("length")
-                        if length is not None:
-                            total_duration += int(length)
-
-        return {
-            "track_list": "\n".join(track_list) if track_list else None,
-            # MB track lengths are milliseconds; catalog stores seconds
-            "duration": total_duration // 1000 if total_duration > 0 else None,
-        }
-
-    def _extract_label_info(self, release_data: Dict[str, Any]) -> List[str]:
-        """Extract label/company information from release data"""
-        labels = []
-        if "label-info" in release_data:
-            for label_info in release_data["label-info"]:
-                if "label" in label_info and "name" in label_info["label"]:
-                    labels.append(label_info["label"]["name"])
-        return labels
 
     def _get_cover_art_url(self, release_id) -> str | None:
         """Get cover art URL from Cover Art Archive"""

--- a/neodb/catalog/sites/rateyourmusic.py
+++ b/neodb/catalog/sites/rateyourmusic.py
@@ -20,6 +20,7 @@ import dateparser
 
 from catalog.common import *
 from catalog.models import *
+from common.models import normalize_album_types, parse_partial_date
 from common.models.lang import detect_language
 
 _logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ class RateYourMusic(AbstractSite):
         company = self._extract_labels(h, og.get("og:description"))
         cover_url = og.get("og:image")
         brief = self._extract_brief(og.get("og:description"))
-        album_type = info.get("Type") or None
+        album_type = normalize_album_types(info.get("Type"))
 
         title_lang = detect_language(title)
         localized_title = [{"lang": title_lang, "text": title}]
@@ -223,9 +224,11 @@ class RateYourMusic(AbstractSite):
         if not raw:
             return None
         cleaned = re.sub(r"\s+", " ", raw).strip()
+        # keep year-only / year-month values at partial precision
+        partial = parse_partial_date(cleaned)
+        if partial:
+            return partial
         try:
-            # Partial dates (year only / month + year) default to the first
-            # day/month rather than today's date.
             dt = dateparser.parse(
                 cleaned,
                 settings={
@@ -263,7 +266,7 @@ class RateYourMusic(AbstractSite):
             prefix = f"{num}. " if num else ""
             suffix = f" ({duration_txt})" if duration_txt else ""
             lines.append(f"{prefix}{title}{suffix}")
-        return lines, total * 1000
+        return lines, total
 
     @staticmethod
     def _extract_labels(h, og_description: str | None) -> list[str]:

--- a/neodb/catalog/sites/rateyourmusic.py
+++ b/neodb/catalog/sites/rateyourmusic.py
@@ -111,7 +111,7 @@ class RateYourMusic(AbstractSite):
             "artist": artists,
             "genre": genres,
             "track_list": "\n".join(tracks),
-            "duration": total_duration or None,
+            "length": total_duration or None,
             "release_date": release_date,
             "company": company,
             "album_type": album_type,

--- a/neodb/catalog/sites/spotify.py
+++ b/neodb/catalog/sites/spotify.py
@@ -15,7 +15,7 @@ from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import upc_to_gtin_13
 from catalog.search import record_search_failure
-from common.models import SiteConfig
+from common.models import SiteConfig, normalize_album_types, parse_partial_date
 from common.models.lang import detect_language
 
 from .douban import *
@@ -111,8 +111,11 @@ class Spotify(AbstractSite):
             else:
                 track_list.append(str(track["track_number"]) + ". " + track["name"])
         track_list = "\n".join(track_list)
-        dt = dateparser.parse(res_data["release_date"])
-        release_date = dt.strftime("%Y-%m-%d") if dt else None
+        # release_date_precision may be year/month/day; keep partial precision
+        release_date = parse_partial_date(res_data["release_date"])
+        if not release_date and res_data.get("release_date"):
+            dt = dateparser.parse(res_data["release_date"])
+            release_date = dt.strftime("%Y-%m-%d") if dt else None
 
         gtin = None
         if res_data["external_ids"].get("upc"):
@@ -131,7 +134,8 @@ class Spotify(AbstractSite):
                 "genre": genre,
                 "track_list": track_list,
                 "release_date": release_date,
-                "duration": duration,
+                "duration": duration // 1000,  # tracks sum in ms
+                "album_type": normalize_album_types(res_data.get("album_type")),
                 "company": company,
                 "brief": None,
                 "cover_image_url": res_data["images"][0]["url"],

--- a/neodb/catalog/sites/spotify.py
+++ b/neodb/catalog/sites/spotify.py
@@ -134,7 +134,7 @@ class Spotify(AbstractSite):
                 "genre": genre,
                 "track_list": track_list,
                 "release_date": release_date,
-                "duration": duration // 1000,  # tracks sum in ms
+                "length": duration // 1000,  # tracks sum in ms
                 "album_type": normalize_album_types(res_data.get("album_type")),
                 "company": company,
                 "brief": None,

--- a/neodb/catalog/sites/steam.py
+++ b/neodb/catalog/sites/steam.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from catalog.common import *
 from catalog.models import *
-from common.models import SiteConfig
+from common.models import SiteConfig, parse_partial_date
 from common.models.lang import SITE_PREFERRED_LANGUAGES
 from journal.models.renderers import html_to_text
 
@@ -76,21 +76,19 @@ class Steam(AbstractSite):
             en_data = self.download("en").get(self.id_value, {}).get("data", {})
         if not en_data or not en_data.get("name"):
             raise ParseError(self, "id")
-        # Steam returns localized free-text dates ("18 Apr, 2011"); parse
-        # to ISO instead of storing raw text
+        # Steam dates may be year-only ("2011") or localized free text
+        # ("18 Apr, 2011"); keep partial precision, then fall back to
+        # dateparser instead of storing raw text
         release_date_raw = en_data.get("release_date", {}).get("date")
-        release_date_parsed = (
-            dateparser.parse(release_date_raw) if release_date_raw else None
-        )
+        release_date = parse_partial_date(release_date_raw)
+        if not release_date and release_date_raw:
+            parsed = dateparser.parse(release_date_raw)
+            release_date = parsed.strftime("%Y-%m-%d") if parsed else None
         # merge data from IGDB, use localized Steam data if available
         d = {
             "developer": en_data.get("developers", []),
             "publisher": en_data.get("publishers", []),
-            "release_date": (
-                release_date_parsed.strftime("%Y-%m-%d")
-                if release_date_parsed
-                else None
-            ),
+            "release_date": release_date,
             "genre": [g["description"] for g in en_data.get("genres", [])],
             "platform": ["windows"],
         }

--- a/neodb/catalog/sites/steam.py
+++ b/neodb/catalog/sites/steam.py
@@ -1,5 +1,6 @@
 import logging
 
+import dateparser
 from django.conf import settings
 
 from catalog.common import *
@@ -75,16 +76,24 @@ class Steam(AbstractSite):
             en_data = self.download("en").get(self.id_value, {}).get("data", {})
         if not en_data or not en_data.get("name"):
             raise ParseError(self, "id")
+        # Steam returns localized free-text dates ("18 Apr, 2011"); parse
+        # to ISO instead of storing raw text
+        release_date_raw = en_data.get("release_date", {}).get("date")
+        release_date_parsed = (
+            dateparser.parse(release_date_raw) if release_date_raw else None
+        )
         # merge data from IGDB, use localized Steam data if available
         d = {
             "developer": en_data.get("developers", []),
             "publisher": en_data.get("publishers", []),
-            "release_date": en_data.get("release_date", {}).get("date"),
+            "release_date": (
+                release_date_parsed.strftime("%Y-%m-%d")
+                if release_date_parsed
+                else None
+            ),
             "genre": [g["description"] for g in en_data.get("genres", [])],
             "platform": ["PC"],
         }
-        if en_data["release_date"].get("date"):
-            d["release_date"] = en_data["release_date"].get("date")
         d.update(pd.metadata)
         d.update(
             {

--- a/neodb/catalog/sites/steam.py
+++ b/neodb/catalog/sites/steam.py
@@ -92,7 +92,7 @@ class Steam(AbstractSite):
                 else None
             ),
             "genre": [g["description"] for g in en_data.get("genres", [])],
-            "platform": ["PC"],
+            "platform": ["windows"],
         }
         d.update(pd.metadata)
         d.update(

--- a/neodb/catalog/sites/tmdb.py
+++ b/neodb/catalog/sites/tmdb.py
@@ -21,7 +21,7 @@ from loguru import logger
 from catalog.common import *
 from catalog.models import *
 from catalog.search import record_search_failure
-from common.models import SiteConfig
+from common.models import SiteConfig, parse_partial_date
 from common.models.lang import SITE_PREFERRED_LANGUAGES
 
 from .douban import *
@@ -166,19 +166,10 @@ class TMDB_Movie(AbstractSite):
         orig_lang = res_data["original_language"]
         if orig_title not in [t["text"] for t in localized_title]:
             localized_title.append({"lang": orig_lang, "text": orig_title})
-        year = (
-            int(res_data["release_date"].split("-")[0])
-            if res_data["release_date"]
-            else None
-        )
-        showtime = (
-            [{"time": res_data["release_date"], "region": "发布日期"}]
-            if res_data["release_date"]
-            else None
-        )
+        release_date = parse_partial_date(res_data["release_date"])
         imdb_code = res_data["imdb_id"]
-        # in minutes
-        duration = res_data["runtime"] if res_data["runtime"] else None
+        # API returns minutes
+        duration = res_data["runtime"] * 60 if res_data["runtime"] else None
 
         genre = [x["name"] for x in res_data["genres"]]
         language = list(map(lambda x: x["name"], res_data["spoken_languages"]))
@@ -190,7 +181,12 @@ class TMDB_Movie(AbstractSite):
         producer = [c["name"] for c in credits["producers"]]
         actor = [c["name"] for c in credits["cast"]]
         related_people = credits["related_people"]
-        area = []
+        # origin_country (usually 1-2 codes, matches Douban 制片国家/地区
+        # semantics) is preferred over production_countries, which lists
+        # every co-production country; older cached responses may lack it
+        origin_country = res_data.get("origin_country") or [
+            c["iso_3166_1"] for c in res_data.get("production_countries") or []
+        ]
 
         # other_info = {}
         # other_info['TMDB评分'] = res_data['vote_average']
@@ -222,11 +218,10 @@ class TMDB_Movie(AbstractSite):
                 "actor": actor,
                 "producer": producer,
                 "genre": genre,
-                "showtime": showtime,
+                "release_date": release_date,
                 "site": None,
-                "area": area,
+                "origin_country": origin_country,
                 "language": language,
-                "year": year,
                 "duration": duration,
                 "season": None,
                 "episodes": None,
@@ -335,18 +330,11 @@ class TMDB_TV(AbstractSite):
         orig_lang = res_data["original_language"]
         if orig_title not in [t["text"] for t in localized_title]:
             localized_title.append({"lang": orig_lang, "text": orig_title})
-        year = (
-            int(res_data["first_air_date"].split("-")[0])
-            if res_data["first_air_date"]
-            else None
-        )
+        release_date = parse_partial_date(res_data["first_air_date"])
         imdb_code = res_data["external_ids"]["imdb_id"]
-        showtime = (
-            [{"time": res_data["first_air_date"], "region": "首播日期"}]
-            if res_data["first_air_date"]
-            else None
-        )
-        duration = None
+        # API returns minutes
+        episode_run_time = res_data.get("episode_run_time") or []
+        single_episode_length = episode_run_time[0] * 60 if episode_run_time else None
         genre = [x["name"] for x in res_data["genres"]]
         language = list(map(lambda x: x["name"], res_data["spoken_languages"]))
         brief = res_data["overview"]
@@ -360,7 +348,7 @@ class TMDB_TV(AbstractSite):
         playwright = [c["name"] for c in credits["writers"]]
         producer = [c["name"] for c in credits["producers"]]
         actor = [c["name"] for c in credits["cast"]]
-        area = []
+        origin_country = res_data.get("origin_country") or []
 
         related_people = credits["related_people"]
         seen_ids = {int(r["id_value"]) for r in related_people}
@@ -411,16 +399,14 @@ class TMDB_TV(AbstractSite):
                 "actor": actor,
                 "producer": producer,
                 "genre": genre,
-                "showtime": showtime,
+                "release_date": release_date,
                 "site": None,
-                "area": area,
+                "origin_country": origin_country,
                 "language": language,
-                "year": year,
-                "duration": duration,
                 "season_count": res_data["number_of_seasons"],
                 "season": None,
                 "episodes": None,
-                "single_episode_length": None,
+                "single_episode_length": single_episode_length,
                 "brief": brief,
                 "cover_image_url": img_url,
                 "related_resources": season_links
@@ -494,9 +480,14 @@ class TMDB_TVSeason(AbstractSite):
         )
         r["localized_title"] = localized_title
         r["localized_description"] = localized_desc
+        r["release_date"] = parse_partial_date(res_data.get("air_date"))
         pd = ResourceContent(metadata=r)
         pd.metadata["title"] = (
             show_resource.metadata["title"] + " " + pd.metadata["title"]
+        )
+        # season endpoint has no origin_country; inherit from the show
+        pd.metadata["origin_country"] = (
+            show_resource.metadata.get("origin_country") or []
         )
         pd.metadata["required_resources"] = [
             {

--- a/neodb/catalog/sites/tmdb.py
+++ b/neodb/catalog/sites/tmdb.py
@@ -222,7 +222,7 @@ class TMDB_Movie(AbstractSite):
                 "site": None,
                 "origin_country": origin_country,
                 "language": language,
-                "duration": duration,
+                "length": duration,
                 "season": None,
                 "episodes": None,
                 "single_episode_length": None,

--- a/neodb/catalog/sites/wikidata.py
+++ b/neodb/catalog/sites/wikidata.py
@@ -937,7 +937,7 @@ class WikiData(AbstractSite):
         data.metadata["pub_date"] = self._extract_date(
             entity_data, WikidataProperties.P577
         )
-        data.metadata["duration"] = self._extract_duration(entity_data)
+        data.metadata["length"] = self._extract_duration(entity_data)
         data.metadata["guid"] = self._extract_property_value(
             entity_data, WikidataProperties.P433
         )
@@ -1094,7 +1094,7 @@ class WikiData(AbstractSite):
         # data.metadata["part_of_series"] = self._extract_property_value(
         #     entity_data, WikidataProperties.P179
         # )
-        data.metadata["duration"] = self._extract_duration(entity_data)
+        data.metadata["length"] = self._extract_duration(entity_data)
 
         # Additional properties
         # data.metadata["director"] = self._extract_string_list(entity_data, WikidataProperties.P57)

--- a/neodb/catalog/sites/wikidata.py
+++ b/neodb/catalog/sites/wikidata.py
@@ -494,7 +494,11 @@ class WikiData(AbstractSite):
         return result
 
     def _f_date(self, d: str) -> str:
-        return d.replace("-00", "-01")
+        # Wikidata pads unknown parts with 00 ("2010-00-00" = year
+        # precision); strip them to keep a partial ISO date
+        while d.endswith("-00"):
+            d = d[:-3]
+        return d
 
     def _extract_date(self, entity_data, property_id):
         """Extract a date from property value"""
@@ -537,6 +541,13 @@ class WikiData(AbstractSite):
 
         return None
 
+    # units of P2047 quantities -> factor to seconds
+    _DURATION_UNIT_FACTORS = {
+        "Q11574": 1,  # second
+        "Q7727": 60,  # minute
+        "Q25235": 3600,  # hour
+    }
+
     def _extract_duration(self, entity_data):
         """Extract duration in seconds from P2047"""
         value = self._extract_property_value(entity_data, WikidataProperties.P2047)
@@ -544,12 +555,15 @@ class WikiData(AbstractSite):
             return None
 
         if isinstance(value, dict):
-            # Wikidata stores duration as quantity
+            # Wikidata stores duration as a quantity with a unit URI;
+            # films are usually expressed in minutes
             if "amount" in value:
-                # Convert to seconds if needed
-                return int(float(value["amount"]))
+                unit = str(value.get("unit") or "").split("/")[-1]
+                factor = self._DURATION_UNIT_FACTORS.get(unit, 60)
+                return int(float(value["amount"]) * factor)
         elif isinstance(value, (int, float)):
-            return int(value)
+            # unit unknown; assume minutes like most film data
+            return int(value) * 60
 
         return None
 

--- a/neodb/catalog/sites/youtube_music.py
+++ b/neodb/catalog/sites/youtube_music.py
@@ -194,7 +194,7 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
             "release_date": release_date,
             "album_type": album_type,
             "track_list": "\n".join(track_list),
-            "duration": total_seconds if total_seconds else None,
+            "length": total_seconds if total_seconds else None,
             "cover_image_url": cover_url,
         }
     )

--- a/neodb/catalog/sites/youtube_music.py
+++ b/neodb/catalog/sites/youtube_music.py
@@ -22,6 +22,7 @@ from loguru import logger
 from catalog.common import *
 from catalog.common.downloaders import get_mock_mode
 from catalog.models import *
+from common.models import normalize_album_types
 from common.models.lang import detect_language
 
 _INNERTUBE_URL = "https://music.youtube.com/youtubei/v1/browse"
@@ -54,14 +55,14 @@ def _innertube_browse(browse_id: str) -> dict:
     return resp.json()
 
 
-def _parse_duration_ms(s: str) -> int:
-    """Convert 'M:SS' or 'H:MM:SS' string to milliseconds."""
+def _parse_duration_seconds(s: str) -> int:
+    """Convert 'M:SS' or 'H:MM:SS' string to seconds."""
     parts = s.split(":")
     try:
         if len(parts) == 2:
-            return (int(parts[0]) * 60 + int(parts[1])) * 1000
+            return int(parts[0]) * 60 + int(parts[1])
         if len(parts) == 3:
-            return (int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])) * 1000
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
     except ValueError:
         pass
     return 0
@@ -148,10 +149,9 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
         ),
         None,
     )
-    # YouTube Music only provides the release year; store as Jan 1 of that year
-    # so the DateField receives a valid YYYY-MM-DD string rather than a bare year.
-    release_date = f"{year}-01-01" if year else None
-    album_type = subtitle_texts[0] if subtitle_texts else None
+    # YouTube Music only provides the release year; keep partial precision
+    release_date = year if year else None
+    album_type = normalize_album_types(subtitle_texts[0] if subtitle_texts else None)
     thumbs = (
         header.get("thumbnail", {})
         .get("musicThumbnailRenderer", {})
@@ -171,7 +171,7 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
     )
 
     track_list = []
-    total_ms = 0
+    total_seconds = 0
     for t in tracks_raw:
         r = t.get("musicResponsiveListItemRenderer", {})
         idx = r.get("index", {}).get("runs", [{}])[0].get("text", "")
@@ -195,7 +195,7 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
             if fixed
             else ""
         )
-        total_ms += _parse_duration_ms(dur_str)
+        total_seconds += _parse_duration_seconds(dur_str)
         track_list.append(f"{idx}. {name}" if idx else name)
 
     lang = detect_language(title)
@@ -207,7 +207,7 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
             "release_date": release_date,
             "album_type": album_type,
             "track_list": "\n".join(track_list),
-            "duration": total_ms if total_ms else None,
+            "duration": total_seconds if total_seconds else None,
             "cover_image_url": cover_url,
         }
     )

--- a/neodb/catalog/sites/youtube_music.py
+++ b/neodb/catalog/sites/youtube_music.py
@@ -22,7 +22,7 @@ from loguru import logger
 from catalog.common import *
 from catalog.common.downloaders import get_mock_mode
 from catalog.models import *
-from common.models import normalize_album_types
+from common.models import normalize_album_types, parse_duration_text
 from common.models.lang import detect_language
 
 _INNERTUBE_URL = "https://music.youtube.com/youtubei/v1/browse"
@@ -53,19 +53,6 @@ def _innertube_browse(browse_id: str) -> dict:
     )
     resp.raise_for_status()
     return resp.json()
-
-
-def _parse_duration_seconds(s: str) -> int:
-    """Convert 'M:SS' or 'H:MM:SS' string to seconds."""
-    parts = s.split(":")
-    try:
-        if len(parts) == 2:
-            return int(parts[0]) * 60 + int(parts[1])
-        if len(parts) == 3:
-            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
-    except ValueError:
-        pass
-    return 0
 
 
 def _largest_thumbnail_url(thumbnails: list) -> str | None:
@@ -195,7 +182,7 @@ def _parse_mpreb_data(data: dict) -> ResourceContent:
             if fixed
             else ""
         )
-        total_seconds += _parse_duration_seconds(dur_str)
+        total_seconds += parse_duration_text(dur_str) or 0 if dur_str else 0
         track_list.append(f"{idx}. {name}" if idx else name)
 
     lang = detect_language(title)

--- a/neodb/catalog/templates/_country_list.html
+++ b/neodb/catalog/templates/_country_list.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+{% load duration %}
+{% if list %}
+  <span>
+    {% trans 'region' %}:
+    {% for p in list %}
+      {% if forloop.counter <= max %}
+        {% if not forloop.first %}/{% endif %}
+        <span>{{ p|code_to_country }}</span>
+      {% elif forloop.last %}
+        …
+      {% endif %}
+    {% endfor %}
+  </span>
+{% endif %}

--- a/neodb/catalog/templates/_item_card_metadata_game.html
+++ b/neodb/catalog/templates/_item_card_metadata_game.html
@@ -13,7 +13,7 @@
 {% block full %}
   <div class="multi-fields">
     {% include '_genre_list.html' with list=item.genre max=2 %}
-    {% include '_people.html' with people=item.platform role='platform' max=5 %}
+    {% include '_platform_list.html' with list=item.platform max=5 %}
     {% include '_credits.html' with credits=item.role_credits.developer role_label='developer' max=2 %}
     {% include '_credits.html' with credits=item.role_credits.publisher role_label='publisher' max=2 %}
   </div>

--- a/neodb/catalog/templates/_platform_list.html
+++ b/neodb/catalog/templates/_platform_list.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+{% load duration %}
+{% if list %}
+  <span>
+    {% trans 'platform' %}:
+    {% for p in list %}
+      {% if forloop.counter <= max %}
+        {% if not forloop.first %}/{% endif %}
+        <span>{{ p|code_to_platform }}</span>
+      {% elif forloop.last %}
+        …
+      {% endif %}
+    {% endfor %}
+  </span>
+{% endif %}

--- a/neodb/catalog/templates/album.html
+++ b/neodb/catalog/templates/album.html
@@ -19,7 +19,7 @@
   </div>
   <div>
     {% if item.duration %}
-      {% trans 'duration' %}: {{ item.duration|duration_format:1000 }}
+      {% trans 'duration' %}: {{ item.duration|duration_display }}
     {% endif %}
   </div>
   <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
@@ -30,12 +30,20 @@
   </div>
   <div>
     {% if item.album_type %}
-      {% trans 'album type' %}: {{ item.album_type }}
+      {% trans 'album type' %}:
+      {% for t in item.album_type %}
+        {% if not forloop.first %}/{% endif %}
+        <span>{{ t|code_to_album_type }}</span>
+      {% endfor %}
     {% endif %}
   </div>
   <div>
-    {% if item.media %}
-      {% trans 'album media' %}: {{ item.media }}
+    {% if item.media_format %}
+      {% trans 'album media' %}:
+      {% for m in item.media_format %}
+        {% if not forloop.first %}/{% endif %}
+        <span>{{ m|code_to_media_format }}</span>
+      {% endfor %}
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/album.html
+++ b/neodb/catalog/templates/album.html
@@ -29,18 +29,18 @@
     {% endif %}
   </div>
   <div>
-    {% if item.album_type %}
+    {% if item.display_album_types %}
       {% trans 'album type' %}:
-      {% for t in item.album_type %}
+      {% for t in item.display_album_types %}
         {% if not forloop.first %}/{% endif %}
         <span>{{ t|code_to_album_type }}</span>
       {% endfor %}
     {% endif %}
   </div>
   <div>
-    {% if item.media_format %}
+    {% if item.display_media_formats %}
       {% trans 'album media' %}:
-      {% for m in item.media_format %}
+      {% for m in item.display_media_formats %}
         {% if not forloop.first %}/{% endif %}
         <span>{{ m|code_to_media_format }}</span>
       {% endfor %}

--- a/neodb/catalog/templates/album.html
+++ b/neodb/catalog/templates/album.html
@@ -18,8 +18,8 @@
     {% endif %}
   </div>
   <div>
-    {% if item.duration %}
-      {% trans 'duration' %}: {{ item.duration|duration_display }}
+    {% if item.length %}
+      {% trans 'duration' %}: {{ item.length|duration_display }}
     {% endif %}
   </div>
   <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>

--- a/neodb/catalog/templates/edition.html
+++ b/neodb/catalog/templates/edition.html
@@ -27,7 +27,8 @@
     {% endif %}
   </div>
   <div>{% include '_people.html' with people=item.additional_title role='other title' max=99 %}</div>
-  <div>{% include '_credits.html' with credits=item.role_credits.publisher role_label='publishing house' max=5 %}</div>
+  {% trans 'publishing house' as publisher_label %}
+  <div>{% include '_credits.html' with credits=item.role_credits.publisher role_label=publisher_label max=5 %}</div>
   <div>
     {% if item.imprint %}
       {% trans 'imprint' %}: {{ item.imprint }}

--- a/neodb/catalog/templates/game.html
+++ b/neodb/catalog/templates/game.html
@@ -19,8 +19,6 @@
   <div>
     {% if item.release_date %}
       {% trans 'release date' %}: {{ item.release_date }}
-    {% elif item.release_year %}
-      {% trans 'release year' %}: {{ item.release_year }}
     {% endif %}
   </div>
   <div>{% include '_people.html' with people=item.platform role='platform' max=8 %}</div>

--- a/neodb/catalog/templates/game.html
+++ b/neodb/catalog/templates/game.html
@@ -6,6 +6,7 @@
 {% load mastodon %}
 {% load strip_scheme %}
 {% load thumb %}
+{% load duration %}
 <!-- class specific details -->
 {% block details %}
   <div class="tldr-2" _="on click toggle .tldr-2 on me">
@@ -21,7 +22,7 @@
       {% trans 'release date' %}: {{ item.release_date }}
     {% endif %}
   </div>
-  <div>{% include '_people.html' with people=item.platform role='platform' max=8 %}</div>
+  <div>{% include '_platform_list.html' with list=item.platform max=8 %}</div>
   <div>{% include '_genre_list.html' with list=item.genre max=5 %}</div>
   <div>{% include '_credits.html' with credits=item.role_credits.designer role_label='designer' max=3 %}</div>
   <div>{% include '_credits.html' with credits=item.role_credits.artist role_label='artist' max=3 %}</div>

--- a/neodb/catalog/templates/movie.html
+++ b/neodb/catalog/templates/movie.html
@@ -6,6 +6,7 @@
 {% load mastodon %}
 {% load strip_scheme %}
 {% load thumb %}
+{% load duration %}
 <!-- class specific details -->
 {% block details %}
   <div>{% include '_people.html' with people=item.additional_title role='' max=99 %}</div>
@@ -13,11 +14,11 @@
   <div>{% include '_credits.html' with credits=item.role_credits.playwright role_label='playwright' max=5 %}</div>
   <div>{% include '_credits.html' with credits=item.role_credits.actor role_label='actor' max=5 %}</div>
   <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
-  <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
+  <div>{% include '_country_list.html' with list=item.origin_country max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   <div>
     {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration }}
+      {% trans 'length' %}: {{ item.duration|duration_display }}
     {% endif %}
   </div>
   <div>
@@ -32,18 +33,12 @@
   </div>
   <div>
     {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length }}
+      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
     {% endif %}
   </div>
   <div>
-    {% if item.showtime %}
-      {% trans 'release date' %}:
-      {% for showtime in item.showtime %}
-        <span>{{ showtime.time }}
-          {% if showtime.region %}({{ showtime.region }}){% endif %}
-        </span>
-        {% if not forloop.last %}/{% endif %}
-      {% endfor %}
+    {% if item.release_date %}
+      {% trans 'release date' %}: <span>{{ item.release_date }}</span>
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/movie.html
+++ b/neodb/catalog/templates/movie.html
@@ -17,8 +17,8 @@
   <div>{% include '_country_list.html' with list=item.origin_country max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   <div>
-    {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration|duration_display }}
+    {% if item.length %}
+      {% trans 'length' %}: {{ item.length|duration_display }}
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/movie.html
+++ b/neodb/catalog/templates/movie.html
@@ -32,11 +32,6 @@
     {% endif %}
   </div>
   <div>
-    {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
-    {% endif %}
-  </div>
-  <div>
     {% if item.release_date %}
       {% trans 'release date' %}: <span>{{ item.release_date }}</span>
     {% endif %}

--- a/neodb/catalog/templates/tvseason.html
+++ b/neodb/catalog/templates/tvseason.html
@@ -6,6 +6,7 @@
 {% load mastodon %}
 {% load strip_scheme %}
 {% load thumb %}
+{% load duration %}
 <!-- class specific details -->
 {% block details %}
   <div>{% include '_people.html' with people=item.additional_title role='' max=99 %}</div>
@@ -25,7 +26,7 @@
   <div>{% include '_credits.html' with credits=item.role_credits.playwright role_label='playwright' max=5 %}</div>
   <div>{% include '_credits.html' with credits=item.role_credits.actor role_label='actor' max=5 %}</div>
   <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
-  <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
+  <div>{% include '_country_list.html' with list=item.origin_country max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   <div>
     {% if item.season_number %}
@@ -44,23 +45,17 @@
   </div>
   <div>
     {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length }}
+      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
     {% endif %}
   </div>
   <div>
     {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration }}
+      {% trans 'length' %}: {{ item.duration|duration_display }}
     {% endif %}
   </div>
   <div>
-    {% if item.showtime %}
-      {% trans 'release date' %}:
-      {% for showtime in item.showtime %}
-        <span>{{ showtime.time }}
-          {% if showtime.region %}({{ showtime.region }}){% endif %}
-        </span>
-        {% if not forloop.last %}/{% endif %}
-      {% endfor %}
+    {% if item.release_date %}
+      {% trans 'release date' %}: <span>{{ item.release_date }}</span>
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/tvseason.html
+++ b/neodb/catalog/templates/tvseason.html
@@ -49,8 +49,8 @@
     {% endif %}
   </div>
   <div>
-    {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration|duration_display }}
+    {% if item.length %}
+      {% trans 'length' %}: {{ item.length|duration_display }}
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/tvseason.html
+++ b/neodb/catalog/templates/tvseason.html
@@ -44,11 +44,6 @@
     {% endif %}
   </div>
   <div>
-    {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
-    {% endif %}
-  </div>
-  <div>
     {% if item.length %}
       {% trans 'length' %}: {{ item.length|duration_display }}
     {% endif %}

--- a/neodb/catalog/templates/tvshow.html
+++ b/neodb/catalog/templates/tvshow.html
@@ -39,11 +39,6 @@
     {% endif %}
   </div>
   <div>
-    {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
-    {% endif %}
-  </div>
-  <div>
     {% if item.length %}
       {% trans 'length' %}: {{ item.length|duration_display }}
     {% endif %}

--- a/neodb/catalog/templates/tvshow.html
+++ b/neodb/catalog/templates/tvshow.html
@@ -6,6 +6,7 @@
 {% load mastodon %}
 {% load strip_scheme %}
 {% load thumb %}
+{% load duration %}
 <!-- class specific details -->
 {% block details %}
   <div>{% include '_people.html' with people=item.additional_title role='' max=99 %}</div>
@@ -13,7 +14,7 @@
   <div>{% include '_credits.html' with credits=item.role_credits.playwright role_label='playwright' max=5 %}</div>
   <div>{% include '_credits.html' with credits=item.role_credits.actor role_label='actor' max=5 %}</div>
   <div>{% include '_genre_list.html' with list=item.genre max=10 %}</div>
-  <div>{% include '_people.html' with people=item.area role='region' max=10 %}</div>
+  <div>{% include '_country_list.html' with list=item.origin_country max=10 %}</div>
   <div>{% include '_language_list.html' with list=item.language max=5 %}</div>
   {% with item.all_seasons as seasons %}
     {% if seasons %}
@@ -39,23 +40,17 @@
   </div>
   <div>
     {% if item.single_episode_length %}
-      {% trans 'episode Length' %}: {{ item.single_episode_length }}
+      {% trans 'episode Length' %}: {{ item.single_episode_length|duration_display }}
     {% endif %}
   </div>
   <div>
     {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration }}
+      {% trans 'length' %}: {{ item.duration|duration_display }}
     {% endif %}
   </div>
   <div>
-    {% if item.showtime %}
-      {% trans 'release date' %}:
-      {% for showtime in item.showtime %}
-        <span>{{ showtime.time }}
-          {% if showtime.region %}({{ showtime.region }}){% endif %}
-        </span>
-        {% if not forloop.last %}/{% endif %}
-      {% endfor %}
+    {% if item.release_date %}
+      {% trans 'release date' %}: <span>{{ item.release_date }}</span>
     {% endif %}
   </div>
   <div>

--- a/neodb/catalog/templates/tvshow.html
+++ b/neodb/catalog/templates/tvshow.html
@@ -44,8 +44,8 @@
     {% endif %}
   </div>
   <div>
-    {% if item.duration %}
-      {% trans 'length' %}: {{ item.duration|duration_display }}
+    {% if item.length %}
+      {% trans 'length' %}: {{ item.length|duration_display }}
     {% endif %}
   </div>
   <div>

--- a/neodb/common/models/__init__.py
+++ b/neodb/common/models/__init__.py
@@ -9,6 +9,7 @@ from .cron import BaseJob, JobManager
 from .duration import (
     coerce_album_duration,
     coerce_video_duration,
+    duration_to_seconds,
     format_duration,
     parse_duration_text,
 )
@@ -70,6 +71,7 @@ __all__ = [
     "coerce_video_duration",
     "country_display_name",
     "detect_language",
+    "duration_to_seconds",
     "earliest_partial_date",
     "format_duration",
     "genre_choices_for",

--- a/neodb/common/models/__init__.py
+++ b/neodb/common/models/__init__.py
@@ -13,6 +13,12 @@ from .duration import (
     format_duration,
     parse_duration_text,
 )
+from .game_platform import (
+    GAME_PLATFORM_CHOICES,
+    GAME_PLATFORM_CODES,
+    normalize_game_platform,
+    normalize_game_platforms,
+)
 from .genre import (
     GENRE_CHOICES,
     GENRE_CODES,
@@ -55,6 +61,8 @@ __all__ = [
     "BaseJob",
     "COUNTRY_CHOICES",
     "COUNTRY_CODES",
+    "GAME_PLATFORM_CHOICES",
+    "GAME_PLATFORM_CODES",
     "GENRE_CHOICES",
     "GENRE_CODES",
     "JobManager",
@@ -80,6 +88,8 @@ __all__ = [
     "normalize_album_types",
     "normalize_countries",
     "normalize_country",
+    "normalize_game_platform",
+    "normalize_game_platforms",
     "normalize_genre",
     "normalize_genres",
     "normalize_media_formats",

--- a/neodb/common/models/__init__.py
+++ b/neodb/common/models/__init__.py
@@ -1,4 +1,17 @@
+from .country import (
+    COUNTRY_CHOICES,
+    COUNTRY_CODES,
+    country_display_name,
+    normalize_countries,
+    normalize_country,
+)
 from .cron import BaseJob, JobManager
+from .duration import (
+    coerce_album_duration,
+    coerce_video_duration,
+    format_duration,
+    parse_duration_text,
+)
 from .genre import (
     GENRE_CHOICES,
     GENRE_CODES,
@@ -18,13 +31,34 @@ from .lang import (
     get_current_locales,
 )
 from .misc import int_, uniq
+from .music_format import (
+    ALBUM_TYPE_CHOICES,
+    ALBUM_TYPE_CODES,
+    MEDIA_FORMAT_CHOICES,
+    MEDIA_FORMAT_CODES,
+    normalize_album_types,
+    normalize_media_formats,
+)
+from .partial_date import (
+    earliest_partial_date,
+    parse_partial_date,
+    partial_date_to_int,
+    year_of_partial_date,
+)
+from .price import normalize_price
 from .site_config import SiteConfig
 
 __all__ = [
+    "ALBUM_TYPE_CHOICES",
+    "ALBUM_TYPE_CODES",
     "BaseJob",
+    "COUNTRY_CHOICES",
+    "COUNTRY_CODES",
     "GENRE_CHOICES",
     "GENRE_CODES",
     "JobManager",
+    "MEDIA_FORMAT_CHOICES",
+    "MEDIA_FORMAT_CODES",
     "LANGUAGE_CHOICES",
     "LOCALE_CHOICES",
     "SCRIPT_CHOICES",
@@ -32,12 +66,26 @@ __all__ = [
     "SITE_PREFERRED_LANGUAGES",
     "SITE_PREFERRED_LOCALES",
     "SiteConfig",
+    "coerce_album_duration",
+    "coerce_video_duration",
+    "country_display_name",
     "detect_language",
+    "earliest_partial_date",
+    "format_duration",
     "genre_choices_for",
     "get_current_locales",
     "get_genre_categories",
+    "normalize_album_types",
+    "normalize_countries",
+    "normalize_country",
     "normalize_genre",
     "normalize_genres",
+    "normalize_media_formats",
+    "normalize_price",
+    "parse_duration_text",
+    "parse_partial_date",
+    "partial_date_to_int",
     "uniq",
     "int_",
+    "year_of_partial_date",
 ]

--- a/neodb/common/models/country.py
+++ b/neodb/common/models/country.py
@@ -121,17 +121,8 @@ _SCRAPER_ALIASES: dict[str, str] = {
 }
 
 
-def normalize_country(value: str) -> str | None:
-    """Normalize a single country value to an alpha-2 code.
-
-    Returns the code when the value is a known code, alias or name;
-    otherwise returns the input as-is (stripped) as a custom value.
-    """
-    if not value or not isinstance(value, str):
-        return None
-    v = value.strip()
-    if not v:
-        return None
+@lru_cache(maxsize=1024)
+def _normalize_country_str(v: str) -> str:
     if len(v) == 2 and v.upper() in COUNTRY_CODES:
         return v.upper()
     alias = _SCRAPER_ALIASES.get(v.lower())
@@ -141,6 +132,22 @@ def normalize_country(value: str) -> str | None:
         return pycountry.countries.lookup(v).alpha_2
     except LookupError:
         return v
+
+
+def normalize_country(value: str) -> str | None:
+    """Normalize a single country value to an alpha-2 code.
+
+    Returns the code when the value is a known code, alias or name;
+    otherwise returns the input as-is (stripped) as a custom value.
+    Cached: pycountry name lookups (and their LookupError misses for
+    custom values) are relatively expensive in bulk operations.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    return _normalize_country_str(v)
 
 
 def normalize_countries(values: list[str] | str | None) -> list[str]:

--- a/neodb/common/models/country.py
+++ b/neodb/common/models/country.py
@@ -1,0 +1,196 @@
+"""
+Country support utilities
+
+Canonical representation for item origin countries is the ISO 3166-1
+alpha-2 code ("US", "CN"). Normalization maps scraped names (Douban
+Chinese names, English names, alpha-3 codes) to codes; unknown values
+pass through as custom strings so historic regions (西德, 苏联) are
+preserved rather than mis-mapped. Display names come from pycountry's
+bundled iso3166-1 gettext catalogs, so no local translation entries are
+needed.
+
+Pattern follows common/models/genre.py.
+"""
+
+import gettext as gettext_module
+from functools import lru_cache
+
+import pycountry
+from django.utils import translation
+
+
+def _english_name(country) -> str:
+    return getattr(country, "common_name", None) or country.name
+
+
+COUNTRY_CHOICES: list[tuple[str, str]] = sorted(
+    ((c.alpha_2, _english_name(c)) for c in pycountry.countries),
+    key=lambda x: x[1],
+)
+COUNTRY_CODES: dict[str, str] = dict(COUNTRY_CHOICES)
+
+# Explicit mappings from scraped strings to alpha-2 codes, mostly the
+# names Douban uses for 制片国家/地区. Keys must be lowercase.
+_SCRAPER_ALIASES: dict[str, str] = {
+    "美国": "US",
+    "中国大陆": "CN",
+    "中国": "CN",
+    "中国香港": "HK",
+    "香港": "HK",
+    "中国台湾": "TW",
+    "台湾": "TW",
+    "中国澳门": "MO",
+    "澳门": "MO",
+    "英国": "GB",
+    "日本": "JP",
+    "韩国": "KR",
+    "朝鲜": "KP",
+    "法国": "FR",
+    "德国": "DE",
+    "意大利": "IT",
+    "西班牙": "ES",
+    "葡萄牙": "PT",
+    "加拿大": "CA",
+    "澳大利亚": "AU",
+    "新西兰": "NZ",
+    "印度": "IN",
+    "俄罗斯": "RU",
+    "泰国": "TH",
+    "荷兰": "NL",
+    "比利时": "BE",
+    "瑞士": "CH",
+    "奥地利": "AT",
+    "瑞典": "SE",
+    "丹麦": "DK",
+    "挪威": "NO",
+    "芬兰": "FI",
+    "冰岛": "IS",
+    "波兰": "PL",
+    "捷克": "CZ",
+    "匈牙利": "HU",
+    "希腊": "GR",
+    "土耳其": "TR",
+    "伊朗": "IR",
+    "以色列": "IL",
+    "埃及": "EG",
+    "南非": "ZA",
+    "巴西": "BR",
+    "墨西哥": "MX",
+    "阿根廷": "AR",
+    "智利": "CL",
+    "哥伦比亚": "CO",
+    "新加坡": "SG",
+    "马来西亚": "MY",
+    "菲律宾": "PH",
+    "越南": "VN",
+    "印度尼西亚": "ID",
+    "印尼": "ID",
+    "爱尔兰": "IE",
+    "乌克兰": "UA",
+    "罗马尼亚": "RO",
+    "保加利亚": "BG",
+    "克罗地亚": "HR",
+    "塞尔维亚": "RS",
+    "沙特阿拉伯": "SA",
+    "阿联酋": "AE",
+    "卡塔尔": "QA",
+    "黎巴嫩": "LB",
+    "蒙古": "MN",
+    "哈萨克斯坦": "KZ",
+    "尼日利亚": "NG",
+    "肯尼亚": "KE",
+    "摩洛哥": "MA",
+    "古巴": "CU",
+    "秘鲁": "PE",
+    "委内瑞拉": "VE",
+    "乌拉圭": "UY",
+    "爱沙尼亚": "EE",
+    "拉脱维亚": "LV",
+    "立陶宛": "LT",
+    "斯洛伐克": "SK",
+    "斯洛文尼亚": "SI",
+    "卢森堡": "LU",
+    "格鲁吉亚": "GE",
+    # common English shorthands pycountry.lookup does not resolve
+    "usa": "US",
+    "uk": "GB",
+    "south korea": "KR",
+    "north korea": "KP",
+    "russia": "RU",
+    "vietnam": "VN",
+}
+
+
+def normalize_country(value: str) -> str | None:
+    """Normalize a single country value to an alpha-2 code.
+
+    Returns the code when the value is a known code, alias or name;
+    otherwise returns the input as-is (stripped) as a custom value.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    if len(v) == 2 and v.upper() in COUNTRY_CODES:
+        return v.upper()
+    alias = _SCRAPER_ALIASES.get(v.lower())
+    if alias:
+        return alias
+    try:
+        return pycountry.countries.lookup(v).alpha_2
+    except LookupError:
+        return v
+
+
+def normalize_countries(values: list[str] | str | None) -> list[str]:
+    """Normalize a list of country values, deduplicated, order kept."""
+    if not values:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    result = [c for c in (normalize_country(v) for v in values) if c]
+    return list(dict.fromkeys(result))
+
+
+# Django locale -> pycountry gettext locale; anything else tries the
+# bare language subtag ("de", "fr", ...) which matches most catalogs.
+_PYCOUNTRY_LOCALE_MAP = {
+    "zh-hans": "zh_CN",
+    "zh-hant": "zh_TW",
+    "pt-br": "pt_BR",
+}
+
+
+@lru_cache(maxsize=None)
+def _iso3166_translation(locale: str) -> gettext_module.NullTranslations:
+    try:
+        return gettext_module.translation(
+            "iso3166-1", pycountry.LOCALES_DIR, languages=[locale]
+        )
+    except FileNotFoundError:
+        return gettext_module.NullTranslations()
+
+
+def country_display_name(code: str) -> str:
+    """Display name for an alpha-2 code in the active UI language.
+
+    Prefers the translated common name ("韩国") over the official one
+    ("大韩民国"). Non-code custom values are returned verbatim.
+    """
+    if not code or not isinstance(code, str):
+        return code or ""
+    country = pycountry.countries.get(alpha_2=code.upper()) if len(code) == 2 else None
+    if country is None:
+        return code
+    lang = (translation.get_language() or "en").lower()
+    if lang == "en" or lang.startswith("en-"):
+        return _english_name(country)
+    locale = _PYCOUNTRY_LOCALE_MAP.get(lang, lang.split("-")[0])
+    t = _iso3166_translation(locale)
+    for candidate in (getattr(country, "common_name", None), country.name):
+        if candidate:
+            translated = t.gettext(candidate)
+            if translated != candidate:
+                return translated
+    return _english_name(country)

--- a/neodb/common/models/country.py
+++ b/neodb/common/models/country.py
@@ -172,18 +172,11 @@ def _iso3166_translation(locale: str) -> gettext_module.NullTranslations:
         return gettext_module.NullTranslations()
 
 
-def country_display_name(code: str) -> str:
-    """Display name for an alpha-2 code in the active UI language.
-
-    Prefers the translated common name ("韩国") over the official one
-    ("大韩民国"). Non-code custom values are returned verbatim.
-    """
-    if not code or not isinstance(code, str):
-        return code or ""
-    country = pycountry.countries.get(alpha_2=code.upper()) if len(code) == 2 else None
+@lru_cache(maxsize=None)
+def _display_name(code: str, lang: str) -> str:
+    country = pycountry.countries.get(alpha_2=code)
     if country is None:
         return code
-    lang = (translation.get_language() or "en").lower()
     if lang == "en" or lang.startswith("en-"):
         return _english_name(country)
     locale = _PYCOUNTRY_LOCALE_MAP.get(lang, lang.split("-")[0])
@@ -194,3 +187,17 @@ def country_display_name(code: str) -> str:
             if translated != candidate:
                 return translated
     return _english_name(country)
+
+
+def country_display_name(code: str) -> str:
+    """Display name for an alpha-2 code in the active UI language.
+
+    Prefers the translated common name ("韩国") over the official one
+    ("大韩民国"). Non-code custom values are returned verbatim. Cached per
+    (code, language) since the mapping is static within a process.
+    """
+    if not code or not isinstance(code, str):
+        return code or ""
+    if len(code) != 2:
+        return code
+    return _display_name(code.upper(), (translation.get_language() or "en").lower())

--- a/neodb/common/models/duration.py
+++ b/neodb/common/models/duration.py
@@ -1,0 +1,111 @@
+"""
+Duration support
+
+Catalog durations are stored as integer seconds. Helpers here parse the
+free-text and mixed-unit shapes found in scraped data and legacy
+metadata, and format seconds for display ("2h 14m").
+"""
+
+import re
+
+from django.utils.dateparse import parse_duration as _django_parse_duration
+
+_RE_COLON = re.compile(r"^(\d+):(\d{1,2})(?::(\d{1,2}))?$")
+_RE_UNITS = re.compile(
+    r"(?:(\d+)\s*(?:h(?:ou)?rs?|h|小时|小時|时|時))?\s*"
+    r"(?:(\d+)\s*(?:min(?:ute)?s?|m|分钟|分鐘|分))?\s*"
+    r"(?:(\d+)\s*(?:sec(?:ond)?s?|s|秒))?",
+    re.IGNORECASE,
+)
+
+
+def parse_duration_text(value: str) -> int | None:
+    """Parse a human duration string into seconds.
+
+    Handles "148分钟", "2小时28分钟", "148 min", "2h 14m", "1:30:00",
+    "90:00" (M:SS), ISO-8601 "PT2H28M", and bare digits (minutes, the
+    Douban/TMDB convention). Returns None when nothing parses.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.isdigit():
+        return int(s) * 60 or None
+    if s.upper().startswith(("P", "PT")):
+        td = _django_parse_duration(s)
+        if td is not None:
+            return int(td.total_seconds()) or None
+    m = _RE_COLON.match(s)
+    if m:
+        a, b, c = m.group(1), m.group(2), m.group(3)
+        if c is not None:  # H:MM:SS
+            return int(a) * 3600 + int(b) * 60 + int(c) or None
+        return int(a) * 60 + int(b) or None  # M:SS
+    m = _RE_UNITS.fullmatch(s)
+    if m and any(m.groups()):
+        h, mi, sec = (int(g) if g else 0 for g in m.groups())
+        return h * 3600 + mi * 60 + sec or None
+    # units regex is anchored; retry unanchored for strings with trailing
+    # noise like "148分钟(导演剪辑版)"
+    m = _RE_UNITS.match(s)
+    if m and any(m.groups()):
+        h, mi, sec = (int(g) if g else 0 for g in m.groups())
+        return h * 3600 + mi * 60 + sec or None
+    return None
+
+
+def coerce_video_duration(value: str | int | float | None) -> int | None:
+    """Coerce a legacy Movie/TV duration value into seconds.
+
+    Strings are parsed as duration text; ints below 600 are assumed to
+    be minutes (the legacy TMDB shape stored runtimes of 1..500), larger
+    ints are already seconds. The edge: a sub-10-minute value already in
+    seconds would be misread as minutes; real legacy data does not
+    contain such values.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return parse_duration_text(value)
+    if isinstance(value, (int, float)):
+        v = int(value)
+        if v <= 0:
+            return None
+        return v * 60 if v < 600 else v
+    return None
+
+
+def coerce_album_duration(value: str | int | float | None) -> int | None:
+    """Coerce a legacy Album duration value into seconds.
+
+    Values >= 50000 are assumed to be milliseconds (the legacy Album
+    unit; even a 2-minute single is 120000 ms while a 13-hour box set is
+    only 46800 s). Smaller values are already seconds.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if not value.strip().isdigit():
+            return None
+        value = int(value.strip())
+    if isinstance(value, (int, float)):
+        v = int(value)
+        if v <= 0:
+            return None
+        return v // 1000 if v >= 50000 else v
+    return None
+
+
+def format_duration(value: int | None) -> str:
+    """Format seconds for display: "2h 14m", "45m" or "58s"."""
+    if not value:
+        return ""
+    seconds = int(value)
+    h, m, s = seconds // 3600, (seconds % 3600) // 60, seconds % 60
+    if h:
+        return f"{h}h {m}m" if m else f"{h}h"
+    if m:
+        return f"{m}m"
+    return f"{s}s"

--- a/neodb/common/models/duration.py
+++ b/neodb/common/models/duration.py
@@ -98,6 +98,22 @@ def coerce_album_duration(value: str | int | float | None) -> int | None:
     return None
 
 
+def duration_to_seconds(value: str | int | float | None) -> int | None:
+    """Read-time tolerant conversion for stored duration values.
+
+    Free-text values (pre-migration rows) are parsed; numeric values are
+    trusted as seconds. Unlike the coerce_* helpers this never applies
+    unit inference, so it is safe on already-converted data.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return parse_duration_text(value)
+    if isinstance(value, (int, float)):
+        return int(value) or None
+    return None
+
+
 def format_duration(value: int | None) -> str:
     """Format seconds for display: "2h 14m", "45m" or "58s"."""
     if not value:

--- a/neodb/common/models/game_platform.py
+++ b/neodb/common/models/game_platform.py
@@ -1,0 +1,189 @@
+"""
+Game platform support
+
+Canonical vocabulary for Game.platform, based on IGDB's platform
+database (https://api-docs.igdb.com/#platform: each platform has a
+name, abbreviation and slug, categorized as console / arcade /
+platform / operating_system / portable_console / computer). Slugs
+below follow IGDB's, cleaned up where IGDB's own slug is awkward
+(e.g. "ps4--1", "genesis-slash-megadrive"); long-tail platforms pass
+through as custom strings rather than being enumerated. "boardgame"
+is ours (BGG); IGDB does not cover tabletop games.
+
+Pattern follows common/models/genre.py.
+"""
+
+import re
+
+from django.utils.translation import pgettext_lazy
+
+GAME_PLATFORM_CATALOG = {
+    # operating systems / computers
+    "windows": "Windows",
+    "mac": "macOS",
+    "linux": "Linux",
+    "dos": "DOS",
+    "amiga": "Amiga",
+    # mobile / web
+    "ios": "iOS",
+    "android": "Android",
+    "web": pgettext_lazy("platform", "Web"),
+    # Sony
+    "ps1": "PlayStation",
+    "ps2": "PlayStation 2",
+    "ps3": "PlayStation 3",
+    "ps4": "PlayStation 4",
+    "ps5": "PlayStation 5",
+    "psp": "PSP",
+    "psvita": "PlayStation Vita",
+    # Microsoft
+    "xbox": "Xbox",
+    "xbox360": "Xbox 360",
+    "xboxone": "Xbox One",
+    "xbox-series": "Xbox Series X|S",
+    # Nintendo
+    "switch": "Nintendo Switch",
+    "switch-2": "Nintendo Switch 2",
+    "wii": "Wii",
+    "wiiu": "Wii U",
+    "n64": "Nintendo 64",
+    "gamecube": "GameCube",
+    "nes": "NES",
+    "snes": "SNES",
+    "gb": "Game Boy",
+    "gbc": "Game Boy Color",
+    "gba": "Game Boy Advance",
+    "nds": "Nintendo DS",
+    "3ds": "Nintendo 3DS",
+    # Sega
+    "dreamcast": "Dreamcast",
+    "saturn": "Sega Saturn",
+    "genesis": "Genesis/Mega Drive",
+    # other
+    "arcade": pgettext_lazy("platform", "Arcade"),
+    "boardgame": pgettext_lazy("platform", "Board Game"),
+}
+
+GAME_PLATFORM_CHOICES = list(GAME_PLATFORM_CATALOG.items())
+GAME_PLATFORM_CODES = dict(GAME_PLATFORM_CATALOG)
+
+# Scraped value -> slug. Keys must be lowercase. Sources: IGDB names
+# and abbreviations, Steam ("PC"), itch.io, MobyGames JSON-LD names,
+# Douban game platform tags, BGG.
+_PLATFORM_ALIASES: dict[str, str] = {
+    # operating systems
+    "pc": "windows",
+    "pc (microsoft windows)": "windows",
+    "microsoft windows": "windows",
+    "win": "windows",
+    "macintosh": "mac",
+    "macos": "mac",
+    "mac os": "mac",
+    "os x": "mac",
+    # web
+    "browser": "web",
+    "web browser": "web",
+    "html5": "web",
+    "网页": "web",
+    # Sony
+    "playstation": "ps1",
+    "psx": "ps1",
+    "ps": "ps1",
+    "playstation 2": "ps2",
+    "playstation 3": "ps3",
+    "playstation 4": "ps4",
+    "playstation 5": "ps5",
+    "playstation portable": "psp",
+    "playstation vita": "psvita",
+    "ps vita": "psvita",
+    "psv": "psvita",
+    # Microsoft
+    "xbox series x|s": "xbox-series",
+    "xbox series x": "xbox-series",
+    "xbox series s": "xbox-series",
+    "xbox series": "xbox-series",
+    "series-x": "xbox-series",
+    "xsx": "xbox-series",
+    "xbox one": "xboxone",
+    "xbox 360": "xbox360",
+    # Nintendo
+    "nintendo switch": "switch",
+    "ns": "switch",
+    "nintendo switch 2": "switch-2",
+    "wii u": "wiiu",
+    "nintendo 64": "n64",
+    "nintendo gamecube": "gamecube",
+    "ngc": "gamecube",
+    "nintendo entertainment system": "nes",
+    "famicom": "nes",
+    "fc": "nes",
+    "super nintendo entertainment system": "snes",
+    "super famicom": "snes",
+    "sfc": "snes",
+    "game boy": "gb",
+    "game boy color": "gbc",
+    "game boy advance": "gba",
+    "nintendo ds": "nds",
+    "nintendo 3ds": "3ds",
+    "new nintendo 3ds": "3ds",
+    # Sega
+    "sega dreamcast": "dreamcast",
+    "sega saturn": "saturn",
+    "sega mega drive/genesis": "genesis",
+    "sega mega drive": "genesis",
+    "mega drive": "genesis",
+    "sega genesis": "genesis",
+    "md": "genesis",
+    # other
+    "街机": "arcade",
+    "board game": "boardgame",
+    "tabletop game": "boardgame",
+    "tabletop": "boardgame",
+    "桌游": "boardgame",
+    "桌面游戏": "boardgame",
+}
+
+_RE_SPLIT = re.compile(r"\s*[/,;，、；]\s*")
+
+
+def normalize_game_platform(value: str) -> str | None:
+    """Normalize a single platform value to a canonical slug; unknown
+    values pass through as-is."""
+    if not value or not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    vl = v.lower()
+    if vl in GAME_PLATFORM_CODES:
+        return vl
+    if vl in _PLATFORM_ALIASES:
+        return _PLATFORM_ALIASES[vl]
+    return v
+
+
+def normalize_game_platforms(values: list[str] | str | None) -> list[str]:
+    """Normalize platform value(s) to canonical slugs, deduplicated,
+    order kept; unknown values pass through."""
+    if not values:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    result: list[str] = []
+    for value in values:
+        if not value or not isinstance(value, str):
+            continue
+        v = value.strip()
+        vl = v.lower()
+        if vl in GAME_PLATFORM_CODES or vl in _PLATFORM_ALIASES:
+            slug = normalize_game_platform(v)
+            if slug:
+                result.append(slug)
+            continue
+        # split compound values only when the whole string does not match
+        parts = [p for p in _RE_SPLIT.split(v) if p]
+        for part in parts if len(parts) > 1 else [v]:
+            slug = normalize_game_platform(part)
+            if slug:
+                result.append(slug)
+    return list(dict.fromkeys(result))

--- a/neodb/common/models/music_format.py
+++ b/neodb/common/models/music_format.py
@@ -1,0 +1,218 @@
+"""
+Album type and media format support
+
+Canonical vocabularies for Album.album_type (nature of the release,
+after MusicBrainz release-group types) and Album.media_format (physical
+or digital medium, after MusicBrainz release formats, with rare formats
+folded into their parent family). Unknown values pass through as custom
+strings.
+
+Pattern follows common/models/genre.py.
+"""
+
+import re
+
+from django.utils.translation import pgettext_lazy
+
+ALBUM_TYPE_CATALOG = {
+    "album": pgettext_lazy("album_type", "Album"),
+    "single": pgettext_lazy("album_type", "Single"),
+    "ep": pgettext_lazy("album_type", "EP"),
+    "compilation": pgettext_lazy("album_type", "Compilation"),
+    "soundtrack": pgettext_lazy("album_type", "Soundtrack"),
+    "live": pgettext_lazy("album_type", "Live"),
+    "remix": pgettext_lazy("album_type", "Remix"),
+    "dj-mix": pgettext_lazy("album_type", "DJ-Mix"),
+    "mixtape": pgettext_lazy("album_type", "Mixtape"),
+    "demo": pgettext_lazy("album_type", "Demo"),
+    "spokenword": pgettext_lazy("album_type", "Spoken Word"),
+    "audiobook": pgettext_lazy("album_type", "Audiobook"),
+    "audio-drama": pgettext_lazy("album_type", "Audio Drama"),
+    "interview": pgettext_lazy("album_type", "Interview"),
+    "broadcast": pgettext_lazy("album_type", "Broadcast"),
+    "field-recording": pgettext_lazy("album_type", "Field Recording"),
+    "other": pgettext_lazy("album_type", "Other"),
+}
+
+MEDIA_FORMAT_CATALOG = {
+    "cd": pgettext_lazy("media_format", "CD"),
+    "vinyl": pgettext_lazy("media_format", "Vinyl"),
+    "cassette": pgettext_lazy("media_format", "Cassette"),
+    "digital": pgettext_lazy("media_format", "Digital"),
+    "sacd": pgettext_lazy("media_format", "SACD"),
+    "dvd": pgettext_lazy("media_format", "DVD"),
+    "blu-ray": pgettext_lazy("media_format", "Blu-ray"),
+    "minidisc": pgettext_lazy("media_format", "MiniDisc"),
+    "vcd": pgettext_lazy("media_format", "VCD"),
+    "other": pgettext_lazy("media_format", "Other"),
+}
+
+ALBUM_TYPE_CHOICES = list(ALBUM_TYPE_CATALOG.items())
+ALBUM_TYPE_CODES = dict(ALBUM_TYPE_CATALOG)
+MEDIA_FORMAT_CHOICES = list(MEDIA_FORMAT_CATALOG.items())
+MEDIA_FORMAT_CODES = dict(MEDIA_FORMAT_CATALOG)
+
+# Scraped value -> slug. Keys must be lowercase. Sources: Douban music
+# (专辑类型/介质), Spotify album_type, Discogs formats, MusicBrainz
+# release-group types and release formats.
+_ALBUM_TYPE_ALIASES: dict[str, str] = {
+    # Douban 专辑类型
+    "专辑": "album",
+    "录音室专辑": "album",
+    "单曲": "single",
+    "迷你专辑": "ep",
+    "精选": "compilation",
+    "精选集": "compilation",
+    "合辑": "compilation",
+    "原声": "soundtrack",
+    "原声带": "soundtrack",
+    "电影原声": "soundtrack",
+    "现场": "live",
+    "现场专辑": "live",
+    "演唱会": "live",
+    "混音": "remix",
+    "有声书": "audiobook",
+    "访谈": "interview",
+    "其他": "other",
+    # Discogs format descriptions / common English variants
+    "lp": "album",
+    "mini-album": "ep",
+    "mini album": "ep",
+    "maxi-single": "single",
+    "maxi single": "single",
+    "ost": "soundtrack",
+    # MusicBrainz secondary types not matching slugs directly
+    "dj mix": "dj-mix",
+    "mixtape/street": "mixtape",
+    "street": "mixtape",
+    "spoken word": "spokenword",
+    "audio drama": "audio-drama",
+    "field recording": "field-recording",
+}
+
+_MEDIA_FORMAT_ALIASES: dict[str, str] = {
+    # CD family
+    "audio cd": "cd",
+    "compact disc": "cd",
+    "cd-r": "cd",
+    "hdcd": "cd",
+    "shm-cd": "cd",
+    "blu-spec cd": "cd",
+    "blu-spec cd2": "cd",
+    "hqcd": "cd",
+    "enhanced cd": "cd",
+    "copy control cd": "cd",
+    "8cm cd": "cd",
+    "cd+g": "cd",
+    # Vinyl family
+    "lp": "vinyl",
+    "黑胶": "vinyl",
+    "黑胶唱片": "vinyl",
+    '7" vinyl': "vinyl",
+    '10" vinyl': "vinyl",
+    '12" vinyl': "vinyl",
+    "shellac": "vinyl",
+    "acetate": "vinyl",
+    "flexi-disc": "vinyl",
+    "vinyldisc": "vinyl",
+    # Cassette / tape family
+    "磁带": "cassette",
+    "卡带": "cassette",
+    "盒带": "cassette",
+    "microcassette": "cassette",
+    "dat": "cassette",
+    "dcc": "cassette",
+    "reel-to-reel": "cassette",
+    "8-track cartridge": "cassette",
+    "cartridge": "cassette",
+    "playtape": "cassette",
+    # Digital family
+    "数字": "digital",
+    "数字专辑": "digital",
+    "数位": "digital",
+    "digital media": "digital",
+    "file": "digital",
+    "download card": "digital",
+    "usb flash drive": "digital",
+    "sd card": "digital",
+    "slotmusic": "digital",
+    "流媒体": "digital",
+    "streaming": "digital",
+    # SACD family
+    "super audio cd": "sacd",
+    "hybrid sacd": "sacd",
+    "shm-sacd": "sacd",
+    "sacd (hybrid)": "sacd",
+    # DVD family
+    "dvd-audio": "dvd",
+    "dvd audio": "dvd",
+    "dvd-video": "dvd",
+    "dualdisc": "dvd",
+    "dvdplus": "dvd",
+    # Blu-ray family
+    "blu-ray-r": "blu-ray",
+    "blu-ray audio": "blu-ray",
+    "bluray": "blu-ray",
+    "bd": "blu-ray",
+    "hd-dvd": "blu-ray",
+    "蓝光": "blu-ray",
+    # MiniDisc
+    "md": "minidisc",
+    "mini disc": "minidisc",
+    # Video media folded into vcd
+    "svcd": "vcd",
+    "cdv": "vcd",
+    "laserdisc": "vcd",
+    "ld": "vcd",
+    "vhs": "vcd",
+    "betamax": "vcd",
+    "umd": "vcd",
+    "vhd": "vcd",
+    "ced": "vcd",
+    "录像带": "vcd",
+    "其他": "other",
+}
+
+_RE_SPLIT = re.compile(r"\s*[/,;，、；]\s*")
+
+
+def _normalize_values(
+    values: list[str] | str | None,
+    codes: dict,
+    aliases: dict[str, str],
+) -> list[str]:
+    if not values:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    result: list[str] = []
+    for value in values:
+        if not value or not isinstance(value, str):
+            continue
+        v = value.strip()
+        vl = v.lower()
+        if vl in codes:
+            result.append(vl)
+        elif vl in aliases:
+            result.append(aliases[vl])
+        else:
+            # split compound values ("Album, EP") only when the whole
+            # string does not match, then map each part
+            parts = [p for p in _RE_SPLIT.split(v) if p]
+            if len(parts) > 1:
+                result.extend(_normalize_values(parts, codes, aliases))
+            else:
+                result.append(v)  # pass through as custom value
+    return list(dict.fromkeys(result))
+
+
+def normalize_album_types(values: list[str] | str | None) -> list[str]:
+    """Normalize album type value(s) to canonical slugs; unknown values
+    pass through."""
+    return _normalize_values(values, ALBUM_TYPE_CODES, _ALBUM_TYPE_ALIASES)
+
+
+def normalize_media_formats(values: list[str] | str | None) -> list[str]:
+    """Normalize media format value(s) to canonical slugs; unknown
+    values pass through."""
+    return _normalize_values(values, MEDIA_FORMAT_CODES, _MEDIA_FORMAT_ALIASES)

--- a/neodb/common/models/music_format.py
+++ b/neodb/common/models/music_format.py
@@ -31,7 +31,6 @@ ALBUM_TYPE_CATALOG = {
     "interview": pgettext_lazy("album_type", "Interview"),
     "broadcast": pgettext_lazy("album_type", "Broadcast"),
     "field-recording": pgettext_lazy("album_type", "Field Recording"),
-    "other": pgettext_lazy("album_type", "Other"),
 }
 
 MEDIA_FORMAT_CATALOG = {
@@ -44,7 +43,6 @@ MEDIA_FORMAT_CATALOG = {
     "blu-ray": pgettext_lazy("media_format", "Blu-ray"),
     "minidisc": pgettext_lazy("media_format", "MiniDisc"),
     "vcd": pgettext_lazy("media_format", "VCD"),
-    "other": pgettext_lazy("media_format", "Other"),
 }
 
 ALBUM_TYPE_CHOICES = list(ALBUM_TYPE_CATALOG.items())
@@ -73,7 +71,6 @@ _ALBUM_TYPE_ALIASES: dict[str, str] = {
     "混音": "remix",
     "有声书": "audiobook",
     "访谈": "interview",
-    "其他": "other",
     # Discogs format descriptions / common English variants
     "lp": "album",
     "mini-album": "ep",
@@ -170,7 +167,6 @@ _MEDIA_FORMAT_ALIASES: dict[str, str] = {
     "vhd": "vcd",
     "ced": "vcd",
     "录像带": "vcd",
-    "其他": "other",
 }
 
 _RE_SPLIT = re.compile(r"\s*[/,;，、；]\s*")

--- a/neodb/common/models/partial_date.py
+++ b/neodb/common/models/partial_date.py
@@ -1,0 +1,91 @@
+"""
+Partial ISO date support
+
+A "partial date" is a string of "YYYY", "YYYY-MM" or "YYYY-MM-DD" (zero
+padded). It is the canonical representation for catalog release dates,
+where sources may only know the year or the month of a release.
+"""
+
+import re
+from collections.abc import Iterable
+from datetime import date, datetime
+
+_RE_PARTIAL_DATE = re.compile(
+    r"^(\d{4})(?:[-/.](\d{1,2})(?:[-/.](\d{1,2})(?:[T ].*)?)?)?$"
+)
+
+
+def parse_partial_date(
+    value: str | int | date | datetime | None,
+) -> str | None:
+    """Parse a value into canonical partial date form, or None.
+
+    Accepts date/datetime objects, int years, and strings shaped like
+    "YYYY", "YYYY-MM", "YYYY-MM-DD" (also with "/" or "." separators, or
+    a trailing time part). Out-of-range month/day parts are truncated to
+    the valid prefix rather than rejected.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, int):
+        return str(value) if 1000 <= value <= 2999 else None
+    if not isinstance(value, str):
+        return None
+    m = _RE_PARTIAL_DATE.match(value.strip())
+    if not m:
+        return None
+    year, month, day = m.group(1), m.group(2), m.group(3)
+    if not month or not 1 <= int(month) <= 12:
+        return year
+    if not day:
+        return f"{year}-{int(month):02d}"
+    try:
+        date(int(year), int(month), int(day))
+    except ValueError:
+        return f"{year}-{int(month):02d}"
+    return f"{year}-{int(month):02d}-{int(day):02d}"
+
+
+def year_of_partial_date(value: str | None) -> int | None:
+    """Return the year of a partial date string, or None."""
+    d = parse_partial_date(value)
+    return int(d[:4]) if d else None
+
+
+def partial_date_to_int(value: str | None) -> int:
+    """Return YYYYMMDD as int, with missing month/day as 00.
+
+    Matches the catalog search index "date" facet convention, so a bare
+    year "2010" (20100000) still falls in the year:2010 filter range
+    20100000..20109999. Returns 0 for unparseable input.
+    """
+    d = parse_partial_date(value)
+    if not d:
+        return 0
+    parts = d.split("-")
+    year = int(parts[0])
+    month = int(parts[1]) if len(parts) > 1 else 0
+    day = int(parts[2]) if len(parts) > 2 else 0
+    return year * 10000 + month * 100 + day
+
+
+def _sort_key(d: str) -> tuple[int, int, int]:
+    # missing parts sort high so a specific date beats a bare year of the
+    # same year, while an earlier year always wins
+    parts = d.split("-")
+    year = int(parts[0])
+    month = int(parts[1]) if len(parts) > 1 else 13
+    day = int(parts[2]) if len(parts) > 2 else 32
+    return year, month, day
+
+
+def earliest_partial_date(
+    values: Iterable[str | int | date | datetime | None],
+) -> str | None:
+    """Return the earliest of the given dates in canonical partial form."""
+    parsed = [d for d in (parse_partial_date(v) for v in values) if d]
+    return min(parsed, key=_sort_key) if parsed else None

--- a/neodb/common/models/partial_date.py
+++ b/neodb/common/models/partial_date.py
@@ -73,41 +73,6 @@ def partial_date_to_int(value: str | None) -> int:
     return year * 10000 + month * 100 + day
 
 
-def pad_partial_date(
-    value: str | None,
-) -> tuple[str | None, str | None]:
-    """Return (full ISO date, precision) for a partial date string.
-
-    Used for backward-compatible API output: older peers/clients type
-    release_date as a strict date, so "2014" is emitted as
-    ("2014-01-01", "year") and the precision key lets current ingest
-    recover the partial value losslessly. Returns (None, None) for
-    unparseable input.
-    """
-    d = parse_partial_date(value)
-    if not d:
-        return None, None
-    parts = d.split("-")
-    if len(parts) == 1:
-        return f"{d}-01-01", "year"
-    if len(parts) == 2:
-        return f"{d}-01", "month"
-    return d, "day"
-
-
-def unpad_partial_date(value: str | None, precision: str | None) -> str | None:
-    """Inverse of pad_partial_date: truncate a padded date back to its
-    declared precision."""
-    d = parse_partial_date(value)
-    if not d:
-        return None
-    if precision == "year":
-        return d[:4]
-    if precision == "month":
-        return d[:7]
-    return d
-
-
 def _sort_key(d: str) -> tuple[int, int, int]:
     # missing parts sort high so a specific date beats a bare year of the
     # same year, while an earlier year always wins

--- a/neodb/common/models/partial_date.py
+++ b/neodb/common/models/partial_date.py
@@ -73,6 +73,41 @@ def partial_date_to_int(value: str | None) -> int:
     return year * 10000 + month * 100 + day
 
 
+def pad_partial_date(
+    value: str | None,
+) -> tuple[str | None, str | None]:
+    """Return (full ISO date, precision) for a partial date string.
+
+    Used for backward-compatible API output: older peers/clients type
+    release_date as a strict date, so "2014" is emitted as
+    ("2014-01-01", "year") and the precision key lets current ingest
+    recover the partial value losslessly. Returns (None, None) for
+    unparseable input.
+    """
+    d = parse_partial_date(value)
+    if not d:
+        return None, None
+    parts = d.split("-")
+    if len(parts) == 1:
+        return f"{d}-01-01", "year"
+    if len(parts) == 2:
+        return f"{d}-01", "month"
+    return d, "day"
+
+
+def unpad_partial_date(value: str | None, precision: str | None) -> str | None:
+    """Inverse of pad_partial_date: truncate a padded date back to its
+    declared precision."""
+    d = parse_partial_date(value)
+    if not d:
+        return None
+    if precision == "year":
+        return d[:4]
+    if precision == "month":
+        return d[:7]
+    return d
+
+
 def _sort_key(d: str) -> tuple[int, int, int]:
     # missing parts sort high so a specific date beats a bare year of the
     # same year, while an earlier year always wins

--- a/neodb/common/models/price.py
+++ b/neodb/common/models/price.py
@@ -1,0 +1,77 @@
+"""
+Price normalization
+
+Canonical price form is "<ISO 4217 code> <amount>", e.g. "CNY 26" or
+"USD 10.99". Values that cannot be normalized unambiguously (ranges,
+multiple prices, bare numbers or ¥/元 without a source hint) are kept
+as-is rather than guessed.
+"""
+
+import re
+
+_RE_CANONICAL = re.compile(r"^[A-Z]{3} \d+(\.\d+)?$")
+_RE_PREFIXED = re.compile(
+    r"^([A-Za-z]{2,4}|US\$|NT\$|HK\$|[$€£¥￥])\s*([\d,]+(?:\.\d+)?)$"
+)
+_RE_SUFFIXED = re.compile(r"^([\d,]+(?:\.\d+)?)\s*([A-Za-z]{2,4}|元|円)$")
+_RE_BARE = re.compile(r"^([\d,]+(?:\.\d+)?)$")
+
+# non-ISO codes and symbols that map to one currency unambiguously
+_CURRENCY_ALIASES = {
+    "NTD": "TWD",
+    "NT$": "TWD",
+    "RMB": "CNY",
+    "US$": "USD",
+    "USD$": "USD",
+    "HK$": "HKD",
+    "€": "EUR",
+    "EURO": "EUR",
+    "£": "GBP",
+    "円": "JPY",
+    "YEN": "JPY",
+    "WON": "KRW",
+}
+# symbols/words that are ambiguous without knowing the source site
+_HINT_ONLY = {"¥", "￥", "元"}
+
+
+def _resolve_currency(token: str, default_currency: str | None) -> str | None:
+    t = token.strip().upper()
+    if t in _CURRENCY_ALIASES:
+        return _CURRENCY_ALIASES[t]
+    if t in _HINT_ONLY or token in _HINT_ONLY:
+        return default_currency
+    if len(t) == 3 and t.isalpha():
+        return t
+    return None
+
+
+def normalize_price(value: str, default_currency: str | None = None) -> str:
+    """Normalize a scraped price into "<ISO4217> <amount>" when possible.
+
+    ``default_currency`` is a source hint (e.g. "CNY" for douban_book,
+    "JPY" for bangumi) used for bare numbers and ambiguous ¥/元 marks.
+    Idempotent; returns the input unchanged when parsing would require
+    guessing.
+    """
+    if not value or not isinstance(value, str):
+        return value
+    s = " ".join(value.split())
+    if _RE_CANONICAL.match(s):
+        return s
+    m = _RE_PREFIXED.match(s)
+    if m:
+        currency = _resolve_currency(m.group(1), default_currency)
+        if currency:
+            return f"{currency} {m.group(2).replace(',', '')}"
+        return value
+    m = _RE_SUFFIXED.match(s)
+    if m:
+        currency = _resolve_currency(m.group(2), default_currency)
+        if currency:
+            return f"{currency} {m.group(1).replace(',', '')}"
+        return value
+    m = _RE_BARE.match(s)
+    if m and default_currency:
+        return f"{default_currency} {m.group(1).replace(',', '')}"
+    return value

--- a/neodb/common/templatetags/duration.py
+++ b/neodb/common/templatetags/duration.py
@@ -8,12 +8,15 @@ from django.utils.translation import gettext as _
 
 from catalog.models import item_categories
 from catalog.views import visible_categories as _visible_categories
+from common.models.country import country_display_name
+from common.models.duration import format_duration
 from common.models.genre import GENRE_CODES
 from common.models.lang import (
     LANGUAGE_CODES,
     LOCALE_CODES,
     SCRIPT_CODES,
 )
+from common.models.music_format import ALBUM_TYPE_CODES, MEDIA_FORMAT_CODES
 
 register = template.Library()
 
@@ -106,4 +109,30 @@ def code_to_lang(code):
 @register.filter
 def code_to_genre(code):
     label = GENRE_CODES.get(code)
+    return str(label) if label else code
+
+
+@register.filter(is_safe=True)
+def duration_display(value):
+    """Format integer seconds as "2h 14m" / "45m" / "58s"."""
+    try:
+        return format_duration(int(value)) if value else ""
+    except TypeError, ValueError:
+        return str(value)
+
+
+@register.filter
+def code_to_country(code):
+    return country_display_name(code)
+
+
+@register.filter
+def code_to_album_type(code):
+    label = ALBUM_TYPE_CODES.get(code)
+    return str(label) if label else code
+
+
+@register.filter
+def code_to_media_format(code):
+    label = MEDIA_FORMAT_CODES.get(code)
     return str(label) if label else code

--- a/neodb/common/templatetags/duration.py
+++ b/neodb/common/templatetags/duration.py
@@ -16,6 +16,7 @@ from common.models.lang import (
     LOCALE_CODES,
     SCRIPT_CODES,
 )
+from common.models.game_platform import GAME_PLATFORM_CODES
 from common.models.music_format import ALBUM_TYPE_CODES, MEDIA_FORMAT_CODES
 
 register = template.Library()
@@ -135,4 +136,10 @@ def code_to_album_type(code):
 @register.filter
 def code_to_media_format(code):
     label = MEDIA_FORMAT_CODES.get(code)
+    return str(label) if label else code
+
+
+@register.filter
+def code_to_platform(code):
+    label = GAME_PLATFORM_CODES.get(code)
     return str(label) if label else code

--- a/neodb/journal/exporters/doufen.py
+++ b/neodb/journal/exporters/doufen.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from openpyxl import Workbook
 
 from catalog.models import IdType, ItemCategory, TVEpisode
+from common.models import country_display_name
 from common.utils import GenerateDateUUIDMediaFilePath
 from journal.models import Review, ShelfType, q_item_in_category
 from users.models import Task
@@ -86,7 +87,10 @@ class DoufenExporter(Task):
                     summary = (
                         str(movie.year or "")
                         + " / "
-                        + ",".join(movie.area or [])
+                        + ",".join(
+                            country_display_name(c)
+                            for c in (movie.origin_country or [])
+                        )
                         + " / "
                         + ",".join(movie.genre or [])
                         + " / "
@@ -132,7 +136,7 @@ class DoufenExporter(Task):
                 summary = (
                     ",".join(album.credit_names_by_role("artist"))
                     + " / "
-                    + (album.release_date.strftime("%Y") if album.release_date else "")
+                    + (album.release_date or "")[:4]
                 )
                 tags = ",".join(mark.tags)
                 world_rating = (album.rating / 2) if album.rating else None
@@ -216,11 +220,7 @@ class DoufenExporter(Task):
                     + " / "
                     + ",".join(game.platform or [])
                     + " / "
-                    + (
-                        game.release_date.strftime("%Y-%m-%d")
-                        if game.release_date
-                        else ""
-                    )
+                    + (game.release_date or "")
                 )
                 tags = ",".join(mark.tags)
                 world_rating = (game.rating / 2) if game.rating else None

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 20:22-0400\n"
+"POT-Creation-Date: 2026-07-15 22:16-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,12 +72,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
 #: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:211 catalog/models/common.py:229
+#: catalog/models/common.py:243 catalog/models/common.py:261
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:214 catalog/models/common.py:234
+#: catalog/models/common.py:246 catalog/models/common.py:266
 msgid "text content"
 msgstr ""
 
@@ -109,9 +109,9 @@ msgstr ""
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:264 catalog/models/movie.py:129
-#: catalog/models/performance.py:385 catalog/models/tv.py:219
-#: catalog/models/tv.py:441
+#: catalog/models/book.py:264 catalog/models/movie.py:113
+#: catalog/models/performance.py:385 catalog/models/tv.py:199
+#: catalog/models/tv.py:421
 msgid "original title"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgid "book format"
 msgstr ""
 
 #: catalog/models/book.py:295 catalog/models/game.py:132
-#: catalog/models/item.py:137 catalog/models/music.py:131
+#: catalog/models/item.py:137 catalog/models/music.py:133
 msgid "publisher"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgstr ""
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:50
+#: catalog/models/book.py:313 catalog/templates/edition.html:51
 msgid "binding"
 msgstr ""
 
@@ -153,433 +153,433 @@ msgstr ""
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:315 catalog/templates/edition.html:44
+#: catalog/models/book.py:315 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:316 catalog/templates/edition.html:69
+#: catalog/models/book.py:316 catalog/templates/edition.html:70
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:317 catalog/templates/edition.html:55
+#: catalog/models/book.py:317 catalog/templates/edition.html:56
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:318 catalog/templates/edition.html:33
+#: catalog/models/book.py:318 catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:19 common/models/lang.py:249
+#: catalog/models/common.py:24 common/models/lang.py:249
 msgid "Unknown"
 msgstr ""
 
-#: catalog/models/common.py:20
+#: catalog/models/common.py:25
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:21 catalog/models/common.py:70
+#: catalog/models/common.py:26 catalog/models/common.py:75
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:22 catalog/models/common.py:72
+#: catalog/models/common.py:27 catalog/models/common.py:77
 msgid "Google Books"
 msgstr ""
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:28
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:24 catalog/models/common.py:81
-#: catalog/models/common.py:83
+#: catalog/models/common.py:29 catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:25 catalog/models/common.py:82
+#: catalog/models/common.py:30 catalog/models/common.py:87
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:26 catalog/models/common.py:65
+#: catalog/models/common.py:31 catalog/models/common.py:70
 #: catalog/templates/movie.html:46 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr ""
 
-#: catalog/models/common.py:27
+#: catalog/models/common.py:32
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:84
+#: catalog/models/common.py:33 catalog/models/common.py:89
 msgid "Bandcamp"
 msgstr ""
 
-#: catalog/models/common.py:29
+#: catalog/models/common.py:34
 msgid "Spotify"
 msgstr ""
 
-#: catalog/models/common.py:30
+#: catalog/models/common.py:35
 msgid "IGDB"
 msgstr ""
 
-#: catalog/models/common.py:31
+#: catalog/models/common.py:36
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:104
+#: catalog/models/common.py:37 catalog/models/common.py:109
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:105
+#: catalog/models/common.py:38 catalog/models/common.py:110
 msgid "Bangumi"
 msgstr ""
 
-#: catalog/models/common.py:34
+#: catalog/models/common.py:39
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:106
+#: catalog/models/common.py:40 catalog/models/common.py:111
 msgid "Apple Podcast"
 msgstr ""
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:41
 msgid "RSS"
 msgstr ""
 
-#: catalog/models/common.py:37
+#: catalog/models/common.py:42
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:107
+#: catalog/models/common.py:43 catalog/models/common.py:112
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:109
+#: catalog/models/common.py:44 catalog/models/common.py:114
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:110
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:41 catalog/models/common.py:111
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:112
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:43 catalog/models/common.py:113
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:44 catalog/models/common.py:55
+#: catalog/models/common.py:49 catalog/models/common.py:60
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:114
+#: catalog/models/common.py:50 catalog/models/common.py:119
 msgid "Open Library"
 msgstr ""
 
-#: catalog/models/common.py:46
+#: catalog/models/common.py:51
 msgid "MusicBrainz"
 msgstr ""
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:52
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:116
+#: catalog/models/common.py:53 catalog/models/common.py:121
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:117
+#: catalog/models/common.py:54 catalog/models/common.py:122
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:108
+#: catalog/models/common.py:55 catalog/models/common.py:113
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:56
 msgid "RateYourMusic"
 msgstr ""
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:61
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/templates/edition.html:19
+#: catalog/models/common.py:62 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:63
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:64
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:60
+#: catalog/models/common.py:65
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:66
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:67
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:68
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:69
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:71
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:72
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:73
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:74
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:76
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:78
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:79
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:80
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:81
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:82
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:83
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:84
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:85
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:90
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:91
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:92
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:93
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:96
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:98
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:99
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:100
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:101
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:102
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:103
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:104
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:105
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:106
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:107
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:108
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:115
+#: catalog/models/common.py:120
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:118
+#: catalog/models/common.py:123
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:139
+#: catalog/models/common.py:144
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:140 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:145 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:146
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:142 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:148
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:144 catalog/models/common.py:160
-#: catalog/models/common.py:174 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:149 catalog/models/common.py:165
+#: catalog/models/common.py:179 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:145
+#: catalog/models/common.py:150
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:146 catalog/models/common.py:163
-#: catalog/models/common.py:177 common/templates/_header.html:43
+#: catalog/models/common.py:151 catalog/models/common.py:168
+#: catalog/models/common.py:182 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:152
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:153
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:149 catalog/models/common.py:165
-#: catalog/models/common.py:179 common/templates/_header.html:47
+#: catalog/models/common.py:154 catalog/models/common.py:170
+#: catalog/models/common.py:184 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:155
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:151
+#: catalog/models/common.py:156
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:152 catalog/models/common.py:169
+#: catalog/models/common.py:157 catalog/models/common.py:174
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:155 catalog/models/common.py:168
+#: catalog/models/common.py:160 catalog/models/common.py:173
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/models/common.py:173
+#: catalog/models/common.py:164 catalog/models/common.py:178
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:175
+#: catalog/models/common.py:166 catalog/models/common.py:180
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:162 catalog/models/common.py:176
+#: catalog/models/common.py:167 catalog/models/common.py:181
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:164 catalog/models/common.py:178
+#: catalog/models/common.py:169 catalog/models/common.py:183
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:277 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:309 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:308
+#: catalog/models/common.py:347
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:337 catalog/templates/album.html:33
+#: catalog/models/common.py:376 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:341
+#: catalog/models/common.py:380
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:346 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:385 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr ""
@@ -649,7 +649,7 @@ msgid "designer"
 msgstr ""
 
 #: catalog/models/game.py:116 catalog/models/item.py:128
-#: catalog/models/music.py:123
+#: catalog/models/music.py:125
 msgid "artist"
 msgstr ""
 
@@ -661,9 +661,9 @@ msgstr ""
 msgid "date of publication"
 msgstr ""
 
-#: catalog/models/game.py:144 catalog/models/movie.py:165
-#: catalog/models/music.py:117 catalog/models/tv.py:255
-#: catalog/models/tv.py:477
+#: catalog/models/game.py:144 catalog/models/movie.py:149
+#: catalog/models/music.py:119 catalog/models/tv.py:235
+#: catalog/models/tv.py:457
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
@@ -675,10 +675,10 @@ msgstr ""
 msgid "platform"
 msgstr ""
 
-#: catalog/models/game.py:179 catalog/models/movie.py:167
+#: catalog/models/game.py:179 catalog/models/movie.py:151
 #: catalog/models/people.py:158 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:257 catalog/models/tv.py:480
+#: catalog/models/tv.py:237 catalog/models/tv.py:460
 #: catalog/templates/game.html:32 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -687,26 +687,26 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:132
+#: catalog/models/item.py:124 catalog/models/movie.py:116
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:222 catalog/models/tv.py:444
+#: catalog/models/tv.py:202 catalog/models/tv.py:424
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/movie.py:139
+#: catalog/models/item.py:125 catalog/models/movie.py:123
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:229 catalog/models/tv.py:451
+#: catalog/models/tv.py:209 catalog/models/tv.py:431
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:146
+#: catalog/models/item.py:126 catalog/models/movie.py:130
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:236 catalog/models/tv.py:458
+#: catalog/models/tv.py:216 catalog/models/tv.py:438
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:153
-#: catalog/models/tv.py:243 catalog/models/tv.py:465
+#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/tv.py:223 catalog/models/tv.py:445
 msgid "producer"
 msgstr ""
 
@@ -793,32 +793,32 @@ msgstr ""
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1410
+#: catalog/models/item.py:1418
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1412
+#: catalog/models/item.py:1420
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1414
+#: catalog/models/item.py:1422
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1430
+#: catalog/models/item.py:1438
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1436
+#: catalog/models/item.py:1444
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1439
+#: catalog/models/item.py:1447
 msgid "url to the resource"
 msgstr ""
 
-#: catalog/models/movie.py:161 catalog/models/music.py:113
-#: catalog/models/tv.py:251 catalog/models/tv.py:473
+#: catalog/models/movie.py:145 catalog/models/music.py:115
+#: catalog/models/tv.py:231 catalog/models/tv.py:453
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
@@ -826,22 +826,22 @@ msgstr ""
 msgid "release date"
 msgstr ""
 
-#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/models/movie.py:155 catalog/models/music.py:122
 #: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
 #: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr ""
 
-#: catalog/models/movie.py:171 catalog/models/music.py:120
-#: catalog/models/tv.py:265 catalog/models/tv.py:488
+#: catalog/models/movie.py:155 catalog/models/music.py:122
+#: catalog/models/tv.py:245 catalog/models/tv.py:468
 msgid "seconds"
 msgstr ""
 
-#: catalog/models/music.py:137
+#: catalog/models/music.py:139
 msgid "tracks"
 msgstr ""
 
-#: catalog/models/music.py:142 catalog/templates/album.html:51
+#: catalog/models/music.py:144 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr ""
 
@@ -995,30 +995,30 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:194 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:174 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:197 catalog/models/tv.py:419
+#: catalog/models/tv.py:177 catalog/models/tv.py:399
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:262 catalog/models/tv.py:485
+#: catalog/models/tv.py:242 catalog/models/tv.py:465
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:416 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:396 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:510
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:664
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr ""
@@ -1825,19 +1825,23 @@ msgstr ""
 msgid "original podcasts"
 msgstr ""
 
-#: catalog/templates/edition.html:38
+#: catalog/templates/edition.html:30
+msgid "publishing house"
+msgstr ""
+
+#: catalog/templates/edition.html:39
 msgid "publication date"
 msgstr ""
 
-#: catalog/templates/edition.html:60
+#: catalog/templates/edition.html:61
 msgid "number of pages"
 msgstr ""
 
-#: catalog/templates/edition.html:84
+#: catalog/templates/edition.html:85
 msgid "other editions"
 msgstr ""
 
-#: catalog/templates/edition.html:124
+#: catalog/templates/edition.html:125
 msgid "Borrow or Buy"
 msgstr ""
 
@@ -3548,59 +3552,49 @@ msgctxt "album_type"
 msgid "Field Recording"
 msgstr ""
 
-#: common/models/music_format.py:34
-msgctxt "album_type"
-msgid "Other"
-msgstr ""
-
-#: common/models/music_format.py:38
+#: common/models/music_format.py:37
 msgctxt "media_format"
 msgid "CD"
 msgstr ""
 
-#: common/models/music_format.py:39
+#: common/models/music_format.py:38
 msgctxt "media_format"
 msgid "Vinyl"
 msgstr ""
 
-#: common/models/music_format.py:40
+#: common/models/music_format.py:39
 msgctxt "media_format"
 msgid "Cassette"
 msgstr ""
 
-#: common/models/music_format.py:41
+#: common/models/music_format.py:40
 msgctxt "media_format"
 msgid "Digital"
 msgstr ""
 
-#: common/models/music_format.py:42
+#: common/models/music_format.py:41
 msgctxt "media_format"
 msgid "SACD"
 msgstr ""
 
-#: common/models/music_format.py:43
+#: common/models/music_format.py:42
 msgctxt "media_format"
 msgid "DVD"
 msgstr ""
 
-#: common/models/music_format.py:44
+#: common/models/music_format.py:43
 msgctxt "media_format"
 msgid "Blu-ray"
 msgstr ""
 
-#: common/models/music_format.py:45
+#: common/models/music_format.py:44
 msgctxt "media_format"
 msgid "MiniDisc"
 msgstr ""
 
-#: common/models/music_format.py:46
+#: common/models/music_format.py:45
 msgctxt "media_format"
 msgid "VCD"
-msgstr ""
-
-#: common/models/music_format.py:47
-msgctxt "media_format"
-msgid "Other"
 msgstr ""
 
 #: common/templates/400.html:23

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 22:16-0400\n"
+"POT-Creation-Date: 2026-07-15 23:19-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,11 +59,11 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:260
+#: catalog/forms.py:35 catalog/models/item.py:261
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:263
+#: catalog/forms.py:40 catalog/models/item.py:264
 msgid "Primary ID Value"
 msgstr ""
 
@@ -71,515 +71,519 @@ msgstr ""
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
-#: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:243 catalog/models/common.py:261
+#: catalog/models/book.py:139 catalog/models/book.py:158
+#: catalog/models/common.py:251 catalog/models/common.py:269
 msgid "locale"
 msgstr ""
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:246 catalog/models/common.py:266
+#: catalog/models/book.py:142 catalog/models/book.py:161
+#: catalog/models/common.py:254 catalog/models/common.py:274
 msgid "text content"
 msgstr ""
 
-#: catalog/models/book.py:174
+#: catalog/models/book.py:177
 msgid "Paperback"
 msgstr ""
 
-#: catalog/models/book.py:175
+#: catalog/models/book.py:178
 msgid "Hardcover"
 msgstr ""
 
-#: catalog/models/book.py:176
+#: catalog/models/book.py:179
 msgid "eBook"
 msgstr ""
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:180
 msgid "Audiobook"
 msgstr ""
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:182
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:180 catalog/models/game.py:35
+#: catalog/models/book.py:183 catalog/models/game.py:38
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:254
+#: catalog/models/book.py:257
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:264 catalog/models/movie.py:113
-#: catalog/models/performance.py:385 catalog/models/tv.py:199
-#: catalog/models/tv.py:421
+#: catalog/models/book.py:267 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:433
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:268
+#: catalog/models/book.py:271
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:274 catalog/models/book.py:558
-#: catalog/models/item.py:122
+#: catalog/models/book.py:277 catalog/models/book.py:561
+#: catalog/models/item.py:123
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:281 catalog/models/item.py:123
+#: catalog/models/book.py:284 catalog/models/item.py:124
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:288 catalog/templates/edition.html:26
+#: catalog/models/book.py:291 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:295 catalog/models/game.py:132
-#: catalog/models/item.py:137 catalog/models/music.py:133
+#: catalog/models/book.py:298 catalog/models/game.py:135
+#: catalog/models/item.py:138 catalog/models/music.py:142
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:302
+#: catalog/models/book.py:305
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:311
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:51
+#: catalog/models/book.py:316 catalog/templates/edition.html:51
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:317
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:315 catalog/templates/edition.html:45
+#: catalog/models/book.py:318 catalog/templates/edition.html:45
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:316 catalog/templates/edition.html:70
+#: catalog/models/book.py:319 catalog/templates/edition.html:70
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:317 catalog/templates/edition.html:56
+#: catalog/models/book.py:320 catalog/templates/edition.html:56
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:318 catalog/templates/edition.html:34
+#: catalog/models/book.py:321 catalog/templates/edition.html:34
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:24 common/models/lang.py:249
+#: catalog/models/common.py:25 common/models/lang.py:249
 msgid "Unknown"
 msgstr ""
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:26
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:26 catalog/models/common.py:75
+#: catalog/models/common.py:27 catalog/models/common.py:76
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:27 catalog/models/common.py:77
+#: catalog/models/common.py:28 catalog/models/common.py:78
 msgid "Google Books"
 msgstr ""
 
-#: catalog/models/common.py:28
+#: catalog/models/common.py:29
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:86
-#: catalog/models/common.py:88
+#: catalog/models/common.py:30 catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:30 catalog/models/common.py:87
+#: catalog/models/common.py:31 catalog/models/common.py:88
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:70
+#: catalog/models/common.py:32 catalog/models/common.py:71
 #: catalog/templates/movie.html:46 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr ""
 
-#: catalog/models/common.py:32
+#: catalog/models/common.py:33
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:89
+#: catalog/models/common.py:34 catalog/models/common.py:90
 msgid "Bandcamp"
 msgstr ""
 
-#: catalog/models/common.py:34
+#: catalog/models/common.py:35
 msgid "Spotify"
 msgstr ""
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:36
 msgid "IGDB"
 msgstr ""
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:37
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:37 catalog/models/common.py:109
+#: catalog/models/common.py:38 catalog/models/common.py:110
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:110
+#: catalog/models/common.py:39 catalog/models/common.py:111
 msgid "Bangumi"
 msgstr ""
 
-#: catalog/models/common.py:39
+#: catalog/models/common.py:40
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:111
+#: catalog/models/common.py:41 catalog/models/common.py:112
 msgid "Apple Podcast"
 msgstr ""
 
-#: catalog/models/common.py:41
+#: catalog/models/common.py:42
 msgid "RSS"
 msgstr ""
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:43
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:43 catalog/models/common.py:112
+#: catalog/models/common.py:44 catalog/models/common.py:113
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:44 catalog/models/common.py:114
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:115
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:49 catalog/models/common.py:119
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:60
+#: catalog/models/common.py:50 catalog/models/common.py:61
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:119
+#: catalog/models/common.py:51 catalog/models/common.py:120
 msgid "Open Library"
 msgstr ""
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:52
 msgid "MusicBrainz"
 msgstr ""
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:53
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:53 catalog/models/common.py:121
+#: catalog/models/common.py:54 catalog/models/common.py:122
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:54 catalog/models/common.py:122
+#: catalog/models/common.py:55 catalog/models/common.py:123
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:113
+#: catalog/models/common.py:56 catalog/models/common.py:114
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:57
 msgid "RateYourMusic"
 msgstr ""
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:62
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:62 catalog/templates/edition.html:19
+#: catalog/models/common.py:63 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:64
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:77
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:79
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:80
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:91
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:97
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:99
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:100
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:120
+#: catalog/models/common.py:121
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:123
+#: catalog/models/common.py:124
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:145
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:145 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:146 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:147
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:148 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:149
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:149 catalog/models/common.py:165
-#: catalog/models/common.py:179 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:150 catalog/models/common.py:166
+#: catalog/models/common.py:180 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:151
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:151 catalog/models/common.py:168
-#: catalog/models/common.py:182 common/templates/_header.html:43
+#: catalog/models/common.py:152 catalog/models/common.py:169
+#: catalog/models/common.py:183 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:152
+#: catalog/models/common.py:153
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:153
+#: catalog/models/common.py:154
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:154 catalog/models/common.py:170
-#: catalog/models/common.py:184 common/templates/_header.html:47
+#: catalog/models/common.py:155 catalog/models/common.py:171
+#: catalog/models/common.py:185 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:155
+#: catalog/models/common.py:156
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:157
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/models/common.py:174
+#: catalog/models/common.py:158 catalog/models/common.py:175
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:160 catalog/models/common.py:173
+#: catalog/models/common.py:161 catalog/models/common.py:174
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:164 catalog/models/common.py:178
+#: catalog/models/common.py:165 catalog/models/common.py:179
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:180
+#: catalog/models/common.py:167 catalog/models/common.py:181
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:167 catalog/models/common.py:181
+#: catalog/models/common.py:168 catalog/models/common.py:182
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:183
+#: catalog/models/common.py:170 catalog/models/common.py:184
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:309 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:317 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:347
+#: catalog/models/common.py:355
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:376 catalog/templates/album.html:33
+#: catalog/models/common.py:384 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:380
+#: catalog/models/common.py:388 catalog/templates/_platform_list.html:5
+msgid "platform"
+msgstr ""
+
+#: catalog/models/common.py:392
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:385 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:397 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr ""
@@ -612,74 +616,70 @@ msgstr ""
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:30
 msgid "Main Game"
 msgstr ""
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:31
 msgid "Expansion"
 msgstr ""
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:32
 msgid "Downloadable Content"
 msgstr ""
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:33
 msgid "Mod"
 msgstr ""
 
-#: catalog/models/game.py:31
+#: catalog/models/game.py:34
 msgid "Bundle"
 msgstr ""
 
-#: catalog/models/game.py:32
+#: catalog/models/game.py:35
 msgid "Remaster"
 msgstr ""
 
-#: catalog/models/game.py:33
+#: catalog/models/game.py:36
 msgid "Remake"
 msgstr ""
 
-#: catalog/models/game.py:34
+#: catalog/models/game.py:37
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:108 catalog/models/item.py:129
+#: catalog/models/game.py:111 catalog/models/item.py:130
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:116 catalog/models/item.py:128
-#: catalog/models/music.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/music.py:134
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:124 catalog/models/item.py:138
+#: catalog/models/game.py:127 catalog/models/item.py:139
 msgid "developer"
 msgstr ""
 
-#: catalog/models/game.py:140 catalog/models/podcast.py:256
+#: catalog/models/game.py:143 catalog/models/podcast.py:257
 msgid "date of publication"
 msgstr ""
 
-#: catalog/models/game.py:144 catalog/models/movie.py:149
-#: catalog/models/music.py:119 catalog/models/tv.py:235
-#: catalog/models/tv.py:457
+#: catalog/models/game.py:147 catalog/models/movie.py:156
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:469
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
-#: catalog/models/game.py:164 catalog/templates/game.html:16
+#: catalog/models/game.py:169 catalog/templates/game.html:17
 msgid "release type"
 msgstr ""
 
-#: catalog/models/game.py:173
-msgid "platform"
-msgstr ""
-
-#: catalog/models/game.py:179 catalog/models/movie.py:151
+#: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:158 catalog/models/performance.py:258
-#: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:237 catalog/models/tv.py:460
-#: catalog/templates/game.html:32 catalog/templates/movie.html:53
+#: catalog/models/performance.py:465 catalog/models/podcast.py:89
+#: catalog/models/tv.py:251 catalog/models/tv.py:472
+#: catalog/templates/game.html:33 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
 #: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:70
@@ -687,161 +687,161 @@ msgstr ""
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/movie.py:116
+#: catalog/models/item.py:125 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:202 catalog/models/tv.py:424
+#: catalog/models/tv.py:216 catalog/models/tv.py:436
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:126 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:209 catalog/models/tv.py:431
+#: catalog/models/tv.py:223 catalog/models/tv.py:443
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:127 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:216 catalog/models/tv.py:438
+#: catalog/models/tv.py:230 catalog/models/tv.py:450
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
-#: catalog/models/tv.py:223 catalog/models/tv.py:445
+#: catalog/models/item.py:128 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:457
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:130 catalog/models/performance.py:203
+#: catalog/models/item.py:131 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:131 catalog/models/performance.py:210
+#: catalog/models/item.py:132 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:132 catalog/models/performance.py:224
+#: catalog/models/item.py:133 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:133 catalog/models/podcast.py:79
+#: catalog/models/item.py:134 catalog/models/podcast.py:80
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:134 catalog/models/performance.py:196
+#: catalog/models/item.py:135 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:238
+#: catalog/models/item.py:136 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:140
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:141
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:142
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:143
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:143 catalog/models/performance.py:231
+#: catalog/models/item.py:144 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:158 catalog/models/people.py:477
+#: catalog/models/item.py:159 catalog/models/people.py:477
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:159 catalog/models/people.py:135
+#: catalog/models/item.py:160 catalog/models/people.py:135
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:161 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:162 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:257 catalog/models/item.py:289
+#: catalog/models/item.py:258 catalog/models/item.py:290
 #: journal/models/collection.py:93
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:258 catalog/models/item.py:297
+#: catalog/models/item.py:259 catalog/models/item.py:298
 #: journal/models/collection.py:94
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:269 catalog/models/people.py:485
+#: catalog/models/item.py:270 catalog/models/people.py:485
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:271 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:272 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1418
+#: catalog/models/item.py:1429
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1420
+#: catalog/models/item.py:1431
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1422
+#: catalog/models/item.py:1433
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1438
+#: catalog/models/item.py:1449
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1444
+#: catalog/models/item.py:1455
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1447
+#: catalog/models/item.py:1458
 msgid "url to the resource"
 msgstr ""
 
-#: catalog/models/movie.py:145 catalog/models/music.py:115
-#: catalog/models/tv.py:231 catalog/models/tv.py:453
+#: catalog/models/movie.py:152 catalog/models/music.py:124
+#: catalog/models/tv.py:245 catalog/models/tv.py:465
 #: catalog/templates/_item_card_metadata_album.html:16
-#: catalog/templates/album.html:17 catalog/templates/game.html:21
+#: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
 #: catalog/templates/tvshow.html:53
 msgid "release date"
 msgstr ""
 
-#: catalog/models/movie.py:155 catalog/models/music.py:122
+#: catalog/models/movie.py:162 catalog/models/music.py:131
 #: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
 #: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr ""
 
-#: catalog/models/movie.py:155 catalog/models/music.py:122
-#: catalog/models/tv.py:245 catalog/models/tv.py:468
+#: catalog/models/movie.py:162 catalog/models/music.py:131
+#: catalog/models/tv.py:259 catalog/models/tv.py:480
 msgid "seconds"
 msgstr ""
 
-#: catalog/models/music.py:139
+#: catalog/models/music.py:148
 msgid "tracks"
 msgstr ""
 
-#: catalog/models/music.py:144 catalog/templates/album.html:51
+#: catalog/models/music.py:153 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr ""
 
@@ -995,30 +995,30 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:174 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:177 catalog/models/tv.py:399
+#: catalog/models/tv.py:191 catalog/models/tv.py:411
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:242 catalog/models/tv.py:465
+#: catalog/models/tv.py:256 catalog/models/tv.py:477
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:396 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:408 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:510
+#: catalog/models/tv.py:520
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:664
+#: catalog/models/tv.py:674
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr ""
@@ -2249,6 +2249,21 @@ msgstr ""
 
 #: catalog/views/view.py:182
 msgid "Invalid role"
+msgstr ""
+
+#: common/models/game_platform.py:30
+msgctxt "platform"
+msgid "Web"
+msgstr ""
+
+#: common/models/game_platform.py:63
+msgctxt "platform"
+msgid "Arcade"
+msgstr ""
+
+#: common/models/game_platform.py:64
+msgctxt "platform"
+msgid "Board Game"
 msgstr ""
 
 #: common/models/genre.py:21
@@ -3949,7 +3964,7 @@ msgstr ""
 msgid "Database Admin"
 msgstr ""
 
-#: common/templatetags/duration.py:58
+#: common/templatetags/duration.py:59
 msgid "just now"
 msgstr ""
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 23:19-0400\n"
+"POT-Creation-Date: 2026-07-16 20:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4694,11 +4694,11 @@ msgstr ""
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:207 users/templates/users/data.html:258
-#: users/templates/users/data.html:321 users/templates/users/data.html:380
-#: users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:155
+#: users/templates/users/data.html:206 users/templates/users/data.html:269
+#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
+#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr ""
 
@@ -4732,7 +4732,7 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:191 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:535
+#: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4755,26 +4755,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -4856,12 +4856,12 @@ msgstr[1] ""
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:216
-#: users/templates/users/data.html:267 users/templates/users/data.html:329
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:164 users/templates/users/data.html:215
+#: users/templates/users/data.html:277 users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
+#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr ""
 
@@ -4869,12 +4869,13 @@ msgstr ""
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:224 users/templates/users/data.html:275
-#: users/templates/users/data.html:337 users/templates/users/data.html:397
+#: users/templates/users/data.html:115 users/templates/users/data.html:172
+#: users/templates/users/data.html:223 users/templates/users/data.html:285
+#: users/templates/users/data.html:345
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
+#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr ""
 
@@ -4882,12 +4883,13 @@ msgstr ""
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:345 users/templates/users/data.html:405
+#: users/templates/users/data.html:123 users/templates/users/data.html:180
+#: users/templates/users/data.html:231 users/templates/users/data.html:293
+#: users/templates/users/data.html:353
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
+#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr ""
 
@@ -4928,6 +4930,7 @@ msgid "Retrying"
 msgstr ""
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
@@ -6766,10 +6769,12 @@ msgid "Create new album"
 msgstr ""
 
 #: users/templates/users/_rym_row.html:28
+#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr ""
 
 #: users/templates/users/_rym_row.html:39
+#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr ""
 
@@ -6779,6 +6784,7 @@ msgid "Import from RateYourMusic"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:9
+#: users/templates/users/_storygraph_section.html:11
 msgid "Review pending matches"
 msgstr ""
 
@@ -6787,6 +6793,7 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:16
+#: users/templates/users/_storygraph_section.html:18
 msgid "Cancel import"
 msgstr ""
 
@@ -6795,7 +6802,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/data.html:141
+#: users/templates/users/_storygraph_section.html:33
 msgid "Upload the downloaded CSV file below."
 msgstr ""
 
@@ -6804,15 +6811,39 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
+#: users/templates/users/_storygraph_section.html:38
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
+#: users/templates/users/_storygraph_section.html:42
 msgid "Upload and match"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:46
+#: users/templates/users/_storygraph_section.html:48
 msgid "Download previous matches"
+msgstr ""
+
+#: users/templates/users/_storygraph_row.html:30
+msgid "Create new book"
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:5
+#: users/templates/users/_storygraph_section.html:23
+msgid "Import from StoryGraph"
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:17
+msgid "Cancel the StoryGraph import? Progress will be discarded."
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:31
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr ""
+
+#: users/templates/users/_storygraph_section.html:35
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7103,9 +7134,9 @@ msgid "CSV file"
 msgstr ""
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:235 users/templates/users/data.html:286
-#: users/templates/users/data.html:350 users/templates/users/data.html:410
+#: users/templates/users/data.html:126 users/templates/users/data.html:183
+#: users/templates/users/data.html:234 users/templates/users/data.html:298
+#: users/templates/users/data.html:358
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7249,7 +7280,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:308
+#: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
 
@@ -7281,140 +7312,128 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:133
-msgid "Import from StoryGraph"
-msgstr ""
-
-#: users/templates/users/data.html:139
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr ""
-
-#: users/templates/users/data.html:146
-msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
-msgstr ""
-
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:134
 msgid "Import from Letterboxd"
 msgstr ""
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:140
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr ""
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:143
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr ""
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:146
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:201
+#: users/templates/users/data.html:149
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:236 users/templates/users/data.html:287
+#: users/templates/users/data.html:184 users/templates/users/data.html:235
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:191
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:197
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:200
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:254
+#: users/templates/users/data.html:202
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:295
+#: users/templates/users/data.html:243
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:298
+#: users/templates/users/data.html:246
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:304
+#: users/templates/users/data.html:252
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:263
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:319
+#: users/templates/users/data.html:267
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:348
+#: users/templates/users/data.html:296
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:306
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:364
+#: users/templates/users/data.html:312
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:366
+#: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:376
+#: users/templates/users/data.html:324
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:437
+#: users/templates/users/data.html:385
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:463
+#: users/templates/users/data.html:411
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:436
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:460
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:516
+#: users/templates/users/data.html:464
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:523
+#: users/templates/users/data.html:471
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:531
+#: users/templates/users/data.html:479
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:534
+#: users/templates/users/data.html:482
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:539
+#: users/templates/users/data.html:487
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:496
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7818,6 +7837,7 @@ msgid "Review RateYourMusic Matches"
 msgstr ""
 
 #: users/templates/users/rym_import.html:39
+#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7826,6 +7846,7 @@ msgid ""
 msgstr ""
 
 #: users/templates/users/rym_import.html:45
+#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr ""
 
@@ -7834,30 +7855,37 @@ msgid "Title / Artist"
 msgstr ""
 
 #: users/templates/users/rym_import.html:58
+#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr ""
 
 #: users/templates/users/rym_import.html:59
+#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr ""
 
 #: users/templates/users/rym_import.html:60
+#: users/templates/users/storygraph_import.html:60
 msgid "Date"
 msgstr ""
 
 #: users/templates/users/rym_import.html:71
+#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr ""
 
 #: users/templates/users/rym_import.html:75
+#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr ""
 
 #: users/templates/users/rym_import.html:95
+#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr ""
 
 #: users/templates/users/rym_import.html:96
+#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr ""
 
@@ -7977,6 +8005,15 @@ msgstr ""
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
+#: users/templates/users/storygraph_import.html:9
+#: users/templates/users/storygraph_import.html:37
+msgid "Review StoryGraph Matches"
+msgstr ""
+
+#: users/templates/users/storygraph_import.html:57
+msgid "Title / Author"
+msgstr ""
+
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr ""
@@ -8062,136 +8099,141 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:223 users/views/data.py:252
+#: users/views/data.py:238 users/views/data.py:267
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:246
+#: users/views/data.py:261
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:264
+#: users/views/data.py:279
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:279 users/views/data.py:299
+#: users/views/data.py:294 users/views/data.py:314
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:313
+#: users/views/data.py:328
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:327
+#: users/views/data.py:342
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:382
+#: users/views/data.py:397
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:385
+#: users/views/data.py:400
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:413
+#: users/views/data.py:428
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
-#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
-#: users/views/data.py:769
+#: users/views/data.py:438 users/views/data.py:471 users/views/data.py:694
+#: users/views/data.py:909 users/views/data.py:934 users/views/data.py:958
+#: users/views/data.py:982
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:492
+#: users/views/data.py:505 users/views/data.py:728
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:517
+#: users/views/data.py:530 users/views/data.py:757
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:537
+#: users/views/data.py:550
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:545 users/views/data.py:655
+#: users/views/data.py:558 users/views/data.py:668 users/views/data.py:787
+#: users/views/data.py:892
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:641
+#: users/views/data.py:654 users/views/data.py:878
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:651
+#: users/views/data.py:664 users/views/data.py:888
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:889
+#: users/views/data.py:779
+msgid "No StoryGraph import to preview."
+msgstr ""
+
+#: users/views/data.py:1102
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:911
+#: users/views/data.py:1124
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:927
+#: users/views/data.py:1140
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:932
+#: users/views/data.py:1145
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:942 users/views/data.py:993
+#: users/views/data.py:1155 users/views/data.py:1206
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:949
+#: users/views/data.py:1162
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:954
+#: users/views/data.py:1167
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:980
+#: users/views/data.py:1193
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:985
+#: users/views/data.py:1198
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:998
+#: users/views/data.py:1211
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1009
+#: users/views/data.py:1222
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1015
+#: users/views/data.py:1228
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1073
+#: users/views/data.py:1286
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1089
+#: users/views/data.py:1302
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1093
+#: users/views/data.py:1306
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1102
+#: users/views/data.py:1315
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 22:17-0400\n"
+"POT-Creation-Date: 2026-07-15 20:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,21 +59,25 @@ msgstr ""
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:29 catalog/models/item.py:252
+#: catalog/forms.py:35 catalog/models/item.py:260
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:34 catalog/models/item.py:255
+#: catalog/forms.py:40 catalog/models/item.py:263
 msgid "Primary ID Value"
 msgstr ""
 
+#: catalog/forms.py:181
+msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
+msgstr ""
+
 #: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:207 catalog/models/common.py:225
+#: catalog/models/common.py:211 catalog/models/common.py:229
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:210 catalog/models/common.py:230
+#: catalog/models/common.py:214 catalog/models/common.py:234
 msgid "text content"
 msgstr ""
 
@@ -97,473 +101,485 @@ msgstr ""
 msgid "Web Fiction"
 msgstr ""
 
-#: catalog/models/book.py:180 catalog/models/game.py:33
+#: catalog/models/book.py:180 catalog/models/game.py:35
 msgid "Other"
 msgstr ""
 
-#: catalog/models/book.py:250
+#: catalog/models/book.py:254
 msgid "subtitle"
 msgstr ""
 
-#: catalog/models/book.py:260 catalog/models/movie.py:101
-#: catalog/models/performance.py:385 catalog/models/tv.py:176
-#: catalog/models/tv.py:418
+#: catalog/models/book.py:264 catalog/models/movie.py:129
+#: catalog/models/performance.py:385 catalog/models/tv.py:219
+#: catalog/models/tv.py:441
 msgid "original title"
 msgstr ""
 
-#: catalog/models/book.py:264
+#: catalog/models/book.py:268
 msgid "other title"
 msgstr ""
 
-#: catalog/models/book.py:270 catalog/models/book.py:554
-#: catalog/models/item.py:114
+#: catalog/models/book.py:274 catalog/models/book.py:558
+#: catalog/models/item.py:122
 msgid "author"
 msgstr ""
 
-#: catalog/models/book.py:277 catalog/models/item.py:115
+#: catalog/models/book.py:281 catalog/models/item.py:123
 msgid "translator"
 msgstr ""
 
-#: catalog/models/book.py:284 catalog/templates/edition.html:26
+#: catalog/models/book.py:288 catalog/templates/edition.html:26
 msgid "book format"
 msgstr ""
 
-#: catalog/models/book.py:291 catalog/models/game.py:123
-#: catalog/models/item.py:129 catalog/models/music.py:95
+#: catalog/models/book.py:295 catalog/models/game.py:132
+#: catalog/models/item.py:137 catalog/models/music.py:131
 msgid "publisher"
 msgstr ""
 
-#: catalog/models/book.py:298
+#: catalog/models/book.py:302
 msgid "publication year"
 msgstr ""
 
-#: catalog/models/book.py:304
+#: catalog/models/book.py:308
 msgid "publication month"
 msgstr ""
 
-#: catalog/models/book.py:309 catalog/templates/edition.html:50
+#: catalog/models/book.py:313 catalog/templates/edition.html:50
 msgid "binding"
 msgstr ""
 
-#: catalog/models/book.py:310
+#: catalog/models/book.py:314
 msgid "pages"
 msgstr ""
 
-#: catalog/models/book.py:311 catalog/templates/edition.html:44
+#: catalog/models/book.py:315 catalog/templates/edition.html:44
 msgid "series"
 msgstr ""
 
-#: catalog/models/book.py:312 catalog/templates/edition.html:69
+#: catalog/models/book.py:316 catalog/templates/edition.html:69
 msgid "contents"
 msgstr ""
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:55
+#: catalog/models/book.py:317 catalog/templates/edition.html:55
 msgid "price"
 msgstr ""
 
-#: catalog/models/book.py:314 catalog/templates/edition.html:33
+#: catalog/models/book.py:318 catalog/templates/edition.html:33
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:15 common/models/lang.py:249
+#: catalog/models/common.py:19 common/models/lang.py:249
 msgid "Unknown"
 msgstr ""
 
-#: catalog/models/common.py:16
+#: catalog/models/common.py:20
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:17 catalog/models/common.py:66
+#: catalog/models/common.py:21 catalog/models/common.py:70
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:18 catalog/models/common.py:68
+#: catalog/models/common.py:22 catalog/models/common.py:72
 msgid "Google Books"
 msgstr ""
 
-#: catalog/models/common.py:19
+#: catalog/models/common.py:23
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:20 catalog/models/common.py:77
-#: catalog/models/common.py:79
+#: catalog/models/common.py:24 catalog/models/common.py:81
+#: catalog/models/common.py:83
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:21 catalog/models/common.py:78
+#: catalog/models/common.py:25 catalog/models/common.py:82
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:22 catalog/models/common.py:61
-#: catalog/templates/movie.html:51 catalog/templates/people.html:37
-#: catalog/templates/tvseason.html:68 catalog/templates/tvshow.html:63
+#: catalog/models/common.py:26 catalog/models/common.py:65
+#: catalog/templates/movie.html:46 catalog/templates/people.html:37
+#: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr ""
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:27
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:24 catalog/models/common.py:80
+#: catalog/models/common.py:28 catalog/models/common.py:84
 msgid "Bandcamp"
 msgstr ""
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:29
 msgid "Spotify"
 msgstr ""
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:30
 msgid "IGDB"
 msgstr ""
 
-#: catalog/models/common.py:27
+#: catalog/models/common.py:31
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:100
+#: catalog/models/common.py:32 catalog/models/common.py:104
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:101
+#: catalog/models/common.py:33 catalog/models/common.py:105
 msgid "Bangumi"
 msgstr ""
 
-#: catalog/models/common.py:30
+#: catalog/models/common.py:34
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:102
+#: catalog/models/common.py:35 catalog/models/common.py:106
 msgid "Apple Podcast"
 msgstr ""
 
-#: catalog/models/common.py:32
+#: catalog/models/common.py:36
 msgid "RSS"
 msgstr ""
 
-#: catalog/models/common.py:33
+#: catalog/models/common.py:37
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:34 catalog/models/common.py:103
+#: catalog/models/common.py:38 catalog/models/common.py:107
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:105
+#: catalog/models/common.py:39 catalog/models/common.py:109
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:36 catalog/models/common.py:106
+#: catalog/models/common.py:40 catalog/models/common.py:110
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:37 catalog/models/common.py:107
+#: catalog/models/common.py:41 catalog/models/common.py:111
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:108
+#: catalog/models/common.py:42 catalog/models/common.py:112
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:109
+#: catalog/models/common.py:43 catalog/models/common.py:113
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:51
+#: catalog/models/common.py:44 catalog/models/common.py:55
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:41 catalog/models/common.py:110
+#: catalog/models/common.py:45 catalog/models/common.py:114
 msgid "Open Library"
 msgstr ""
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:46
 msgid "MusicBrainz"
 msgstr ""
 
-#: catalog/models/common.py:43
+#: catalog/models/common.py:47
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:44 catalog/models/common.py:112
+#: catalog/models/common.py:48 catalog/models/common.py:116
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:113
+#: catalog/models/common.py:49 catalog/models/common.py:117
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:104
+#: catalog/models/common.py:50 catalog/models/common.py:108
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:51
 msgid "RateYourMusic"
 msgstr ""
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:56
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:53 catalog/templates/edition.html:19
+#: catalog/models/common.py:57 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:58
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:59
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:60
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:61
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:62
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:63
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:60
+#: catalog/models/common.py:64
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:66
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:67
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:68
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:69
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:71
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:73
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:74
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:75
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:76
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:77
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:78
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:79
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:80
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:85
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:86
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:87
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:88
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:91
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:93
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:94
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:95
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:96
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:97
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:98
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:99
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:100
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:101
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:102
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:103
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:115
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:114
+#: catalog/models/common.py:118
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:139
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:136 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:140 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:137
+#: catalog/models/common.py:141
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:138 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:142 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:139
+#: catalog/models/common.py:143
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:140 catalog/models/common.py:156
-#: catalog/models/common.py:170 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:144 catalog/models/common.py:160
+#: catalog/models/common.py:174 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:145
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:142 catalog/models/common.py:159
-#: catalog/models/common.py:173 common/templates/_header.html:43
+#: catalog/models/common.py:146 catalog/models/common.py:163
+#: catalog/models/common.py:177 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:147
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:148
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:145 catalog/models/common.py:161
-#: catalog/models/common.py:175 common/templates/_header.html:47
+#: catalog/models/common.py:149 catalog/models/common.py:165
+#: catalog/models/common.py:179 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:150
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:151
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:148 catalog/models/common.py:165
+#: catalog/models/common.py:152 catalog/models/common.py:169
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:151 catalog/models/common.py:164
+#: catalog/models/common.py:155 catalog/models/common.py:168
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:155 catalog/models/common.py:169
+#: catalog/models/common.py:159 catalog/models/common.py:173
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/models/common.py:171
+#: catalog/models/common.py:161 catalog/models/common.py:175
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:158 catalog/models/common.py:172
+#: catalog/models/common.py:162 catalog/models/common.py:176
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:160 catalog/models/common.py:174
+#: catalog/models/common.py:164 catalog/models/common.py:178
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:273 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:277 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:284 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:308
+msgid "origin country"
+msgstr ""
+
+#: catalog/models/common.py:337 catalog/templates/album.html:33
+msgid "album type"
+msgstr ""
+
+#: catalog/models/common.py:341
+msgid "media format"
+msgstr ""
+
+#: catalog/models/common.py:346 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr ""
@@ -596,274 +612,236 @@ msgstr ""
 msgid "no matching identity found in the feed or its linked website"
 msgstr ""
 
-#: catalog/models/game.py:25
+#: catalog/models/game.py:27
 msgid "Main Game"
 msgstr ""
 
-#: catalog/models/game.py:26
+#: catalog/models/game.py:28
 msgid "Expansion"
 msgstr ""
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:29
 msgid "Downloadable Content"
 msgstr ""
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:30
 msgid "Mod"
 msgstr ""
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:31
 msgid "Bundle"
 msgstr ""
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:32
 msgid "Remaster"
 msgstr ""
 
-#: catalog/models/game.py:31
+#: catalog/models/game.py:33
 msgid "Remake"
 msgstr ""
 
-#: catalog/models/game.py:32
+#: catalog/models/game.py:34
 msgid "Special Edition"
 msgstr ""
 
-#: catalog/models/game.py:99 catalog/models/item.py:121
+#: catalog/models/game.py:108 catalog/models/item.py:129
 msgid "designer"
 msgstr ""
 
-#: catalog/models/game.py:107 catalog/models/item.py:120
-#: catalog/models/music.py:87
+#: catalog/models/game.py:116 catalog/models/item.py:128
+#: catalog/models/music.py:123
 msgid "artist"
 msgstr ""
 
-#: catalog/models/game.py:115 catalog/models/item.py:130
+#: catalog/models/game.py:124 catalog/models/item.py:138
 msgid "developer"
 msgstr ""
 
-#: catalog/models/game.py:131
-msgid "year of publication"
-msgstr ""
-
-#: catalog/models/game.py:135 catalog/models/podcast.py:256
+#: catalog/models/game.py:140 catalog/models/podcast.py:256
 msgid "date of publication"
 msgstr ""
 
-#: catalog/models/game.py:140 catalog/models/music.py:81
-#: catalog/models/tv.py:221
-msgid "YYYY-MM-DD"
+#: catalog/models/game.py:144 catalog/models/movie.py:165
+#: catalog/models/music.py:117 catalog/models/tv.py:255
+#: catalog/models/tv.py:477
+msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr ""
 
-#: catalog/models/game.py:144 catalog/templates/game.html:16
+#: catalog/models/game.py:164 catalog/templates/game.html:16
 msgid "release type"
 msgstr ""
 
-#: catalog/models/game.py:153
+#: catalog/models/game.py:173
 msgid "platform"
 msgstr ""
 
-#: catalog/models/game.py:159 catalog/models/movie.py:160
+#: catalog/models/game.py:179 catalog/models/movie.py:167
 #: catalog/models/people.py:158 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:235 catalog/models/tv.py:478
-#: catalog/templates/game.html:34 catalog/templates/movie.html:58
+#: catalog/models/tv.py:257 catalog/models/tv.py:480
+#: catalog/templates/game.html:32 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
-#: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:75
-#: catalog/templates/tvshow.html:70
+#: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:70
+#: catalog/templates/tvshow.html:65
 msgid "website"
 msgstr ""
 
-#: catalog/models/item.py:116 catalog/models/movie.py:104
+#: catalog/models/item.py:124 catalog/models/movie.py:132
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:179 catalog/models/tv.py:421
+#: catalog/models/tv.py:222 catalog/models/tv.py:444
 msgid "director"
 msgstr ""
 
-#: catalog/models/item.py:117 catalog/models/movie.py:111
+#: catalog/models/item.py:125 catalog/models/movie.py:139
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:186 catalog/models/tv.py:428
+#: catalog/models/tv.py:229 catalog/models/tv.py:451
 msgid "playwright"
 msgstr ""
 
-#: catalog/models/item.py:118 catalog/models/movie.py:118
+#: catalog/models/item.py:126 catalog/models/movie.py:146
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:193 catalog/models/tv.py:435
+#: catalog/models/tv.py:236 catalog/models/tv.py:458
 msgid "actor"
 msgstr ""
 
-#: catalog/models/item.py:119 catalog/models/movie.py:125
-#: catalog/models/tv.py:200 catalog/models/tv.py:442
+#: catalog/models/item.py:127 catalog/models/movie.py:153
+#: catalog/models/tv.py:243 catalog/models/tv.py:465
 msgid "producer"
 msgstr ""
 
-#: catalog/models/item.py:122 catalog/models/performance.py:203
+#: catalog/models/item.py:130 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr ""
 
-#: catalog/models/item.py:123 catalog/models/performance.py:210
+#: catalog/models/item.py:131 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr ""
 
-#: catalog/models/item.py:124 catalog/models/performance.py:224
+#: catalog/models/item.py:132 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr ""
 
-#: catalog/models/item.py:125 catalog/models/podcast.py:79
+#: catalog/models/item.py:133 catalog/models/podcast.py:79
 msgid "host"
 msgstr ""
 
-#: catalog/models/item.py:126 catalog/models/performance.py:196
+#: catalog/models/item.py:134 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr ""
 
-#: catalog/models/item.py:127 catalog/models/performance.py:238
+#: catalog/models/item.py:135 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr ""
 
-#: catalog/models/item.py:131
+#: catalog/models/item.py:139
 msgid "production company"
 msgstr ""
 
-#: catalog/models/item.py:132
+#: catalog/models/item.py:140
 msgid "record label"
 msgstr ""
 
-#: catalog/models/item.py:133
+#: catalog/models/item.py:141
 msgid "distributor"
 msgstr ""
 
-#: catalog/models/item.py:134
+#: catalog/models/item.py:142
 msgid "studio"
 msgstr ""
 
-#: catalog/models/item.py:135 catalog/models/performance.py:231
+#: catalog/models/item.py:143 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr ""
 
-#: catalog/models/item.py:150 catalog/models/people.py:477
+#: catalog/models/item.py:158 catalog/models/people.py:477
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:151 catalog/models/people.py:135
+#: catalog/models/item.py:159 catalog/models/people.py:135
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:153 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:161 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:249 catalog/models/item.py:281
+#: catalog/models/item.py:257 catalog/models/item.py:289
 #: journal/models/collection.py:93
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:250 catalog/models/item.py:289
+#: catalog/models/item.py:258 catalog/models/item.py:297
 #: journal/models/collection.py:94
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:261 catalog/models/people.py:485
+#: catalog/models/item.py:269 catalog/models/people.py:485
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:263 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:271 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1367
+#: catalog/models/item.py:1410
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1369
+#: catalog/models/item.py:1412
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1371
+#: catalog/models/item.py:1414
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1387
+#: catalog/models/item.py:1430
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1393
+#: catalog/models/item.py:1436
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1396
+#: catalog/models/item.py:1439
 msgid "url to the resource"
 msgstr ""
 
-#: catalog/models/movie.py:133 catalog/models/music.py:81
+#: catalog/models/movie.py:161 catalog/models/music.py:113
+#: catalog/models/tv.py:251 catalog/models/tv.py:473
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
-#: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
-#: catalog/templates/tvshow.html:52
+#: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
+#: catalog/templates/tvshow.html:53
 msgid "release date"
 msgstr ""
 
-#: catalog/models/movie.py:145 catalog/models/tv.py:462
-#: journal/templates/_sidebar_user_mark_list.html:63
-msgid "date"
-msgstr ""
-
-#: catalog/models/movie.py:146 catalog/models/performance.py:130
-#: catalog/models/tv.py:463
-msgid "required"
-msgstr ""
-
-#: catalog/models/movie.py:150 catalog/models/tv.py:467
-msgid "region or event"
-msgstr ""
-
-#: catalog/models/movie.py:152 catalog/models/tv.py:227
-#: catalog/models/tv.py:469
-msgid "Germany or Toronto International Film Festival"
-msgstr ""
-
-#: catalog/models/movie.py:162 catalog/models/tv.py:237
-#: catalog/models/tv.py:481
-msgid "region"
-msgstr ""
-
-#: catalog/models/movie.py:173 catalog/models/tv.py:249
-#: catalog/models/tv.py:492
-msgid "year"
-msgstr ""
-
-#: catalog/models/movie.py:174 catalog/models/music.py:84
-#: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
-#: catalog/templates/tvshow.html:47
+#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
+#: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr ""
 
-#: catalog/models/music.py:84
-msgid "milliseconds"
+#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/models/tv.py:265 catalog/models/tv.py:488
+msgid "seconds"
 msgstr ""
 
-#: catalog/models/music.py:101
+#: catalog/models/music.py:137
 msgid "tracks"
 msgstr ""
 
-#: catalog/models/music.py:102 catalog/templates/album.html:33
-msgid "album type"
-msgstr ""
-
-#: catalog/models/music.py:103
-msgid "media type"
-msgstr ""
-
-#: catalog/models/music.py:106 catalog/templates/album.html:43
+#: catalog/models/music.py:142 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr ""
 
@@ -991,6 +969,10 @@ msgstr ""
 msgid "Character name for actor roles"
 msgstr ""
 
+#: catalog/models/performance.py:130
+msgid "required"
+msgstr ""
+
 #: catalog/models/performance.py:135
 msgid "optional"
 msgstr ""
@@ -1013,45 +995,36 @@ msgstr ""
 msgid "closing date"
 msgstr ""
 
-#: catalog/models/tv.py:150 catalog/templates/tvseason.html:37
-#: catalog/templates/tvshow.html:32
+#: catalog/models/tv.py:194 catalog/templates/tvseason.html:38
+#: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr ""
 
-#: catalog/models/tv.py:153 catalog/models/tv.py:395
-#: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
+#: catalog/models/tv.py:197 catalog/models/tv.py:419
+#: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr ""
 
-#: catalog/models/tv.py:208 catalog/models/tv.py:450
-msgid "show time"
-msgstr ""
-
-#: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
-#: users/templates/users/storygraph_import.html:60
-msgid "Date"
-msgstr ""
-
-#: catalog/models/tv.py:225
-msgid "Region or Event"
-msgstr ""
-
-#: catalog/models/tv.py:251 catalog/models/tv.py:494
+#: catalog/models/tv.py:262 catalog/models/tv.py:485
 msgid "episode length"
 msgstr ""
 
-#: catalog/models/tv.py:392 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:416 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr ""
 
-#: catalog/models/tv.py:527
+#: catalog/models/tv.py:530
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr ""
 
-#: catalog/models/tv.py:680
+#: catalog/models/tv.py:684
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
+msgstr ""
+
+#: catalog/templates/_country_list.html:5
+msgid "region"
 msgstr ""
 
 #: catalog/templates/_fetch_failed.html:4
@@ -1605,7 +1578,7 @@ msgstr ""
 msgid "barcode"
 msgstr ""
 
-#: catalog/templates/album.html:38
+#: catalog/templates/album.html:42
 msgid "album media"
 msgstr ""
 
@@ -1886,10 +1859,6 @@ msgstr ""
 msgid "System busy, please try again in a minute."
 msgstr ""
 
-#: catalog/templates/game.html:23
-msgid "release year"
-msgstr ""
-
 #: catalog/templates/item_base.html:95
 msgid "select one of the seasons to comment"
 msgstr ""
@@ -1965,16 +1934,16 @@ msgstr ""
 msgid "Reviews"
 msgstr ""
 
-#: catalog/templates/movie.html:25
+#: catalog/templates/movie.html:26
 msgid "number of Seasons"
 msgstr ""
 
-#: catalog/templates/movie.html:30
+#: catalog/templates/movie.html:31
 msgid "number of Episodes"
 msgstr ""
 
-#: catalog/templates/movie.html:35 catalog/templates/tvseason.html:47
-#: catalog/templates/tvshow.html:42
+#: catalog/templates/movie.html:36 catalog/templates/tvseason.html:48
+#: catalog/templates/tvshow.html:43
 msgid "episode Length"
 msgstr ""
 
@@ -2126,7 +2095,7 @@ msgstr ""
 msgid "No people matching your search query."
 msgstr ""
 
-#: catalog/templates/tvseason.html:15 catalog/templates/tvshow.html:21
+#: catalog/templates/tvseason.html:16 catalog/templates/tvshow.html:22
 msgid "all seasons"
 msgstr ""
 
@@ -3499,6 +3468,141 @@ msgstr ""
 msgid "Hakka Chinese"
 msgstr ""
 
+#: common/models/music_format.py:18
+msgctxt "album_type"
+msgid "Album"
+msgstr ""
+
+#: common/models/music_format.py:19
+msgctxt "album_type"
+msgid "Single"
+msgstr ""
+
+#: common/models/music_format.py:20
+msgctxt "album_type"
+msgid "EP"
+msgstr ""
+
+#: common/models/music_format.py:21
+msgctxt "album_type"
+msgid "Compilation"
+msgstr ""
+
+#: common/models/music_format.py:22
+msgctxt "album_type"
+msgid "Soundtrack"
+msgstr ""
+
+#: common/models/music_format.py:23
+msgctxt "album_type"
+msgid "Live"
+msgstr ""
+
+#: common/models/music_format.py:24
+msgctxt "album_type"
+msgid "Remix"
+msgstr ""
+
+#: common/models/music_format.py:25
+msgctxt "album_type"
+msgid "DJ-Mix"
+msgstr ""
+
+#: common/models/music_format.py:26
+msgctxt "album_type"
+msgid "Mixtape"
+msgstr ""
+
+#: common/models/music_format.py:27
+msgctxt "album_type"
+msgid "Demo"
+msgstr ""
+
+#: common/models/music_format.py:28
+msgctxt "album_type"
+msgid "Spoken Word"
+msgstr ""
+
+#: common/models/music_format.py:29
+msgctxt "album_type"
+msgid "Audiobook"
+msgstr ""
+
+#: common/models/music_format.py:30
+msgctxt "album_type"
+msgid "Audio Drama"
+msgstr ""
+
+#: common/models/music_format.py:31
+msgctxt "album_type"
+msgid "Interview"
+msgstr ""
+
+#: common/models/music_format.py:32
+msgctxt "album_type"
+msgid "Broadcast"
+msgstr ""
+
+#: common/models/music_format.py:33
+msgctxt "album_type"
+msgid "Field Recording"
+msgstr ""
+
+#: common/models/music_format.py:34
+msgctxt "album_type"
+msgid "Other"
+msgstr ""
+
+#: common/models/music_format.py:38
+msgctxt "media_format"
+msgid "CD"
+msgstr ""
+
+#: common/models/music_format.py:39
+msgctxt "media_format"
+msgid "Vinyl"
+msgstr ""
+
+#: common/models/music_format.py:40
+msgctxt "media_format"
+msgid "Cassette"
+msgstr ""
+
+#: common/models/music_format.py:41
+msgctxt "media_format"
+msgid "Digital"
+msgstr ""
+
+#: common/models/music_format.py:42
+msgctxt "media_format"
+msgid "SACD"
+msgstr ""
+
+#: common/models/music_format.py:43
+msgctxt "media_format"
+msgid "DVD"
+msgstr ""
+
+#: common/models/music_format.py:44
+msgctxt "media_format"
+msgid "Blu-ray"
+msgstr ""
+
+#: common/models/music_format.py:45
+msgctxt "media_format"
+msgid "MiniDisc"
+msgstr ""
+
+#: common/models/music_format.py:46
+msgctxt "media_format"
+msgid "VCD"
+msgstr ""
+
+#: common/models/music_format.py:47
+msgctxt "media_format"
+msgid "Other"
+msgstr ""
+
 #: common/templates/400.html:23
 msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr ""
@@ -3851,7 +3955,7 @@ msgstr ""
 msgid "Database Admin"
 msgstr ""
 
-#: common/templatetags/duration.py:55
+#: common/templatetags/duration.py:58
 msgid "just now"
 msgstr ""
 
@@ -4581,11 +4685,11 @@ msgstr ""
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:155
-#: users/templates/users/data.html:206 users/templates/users/data.html:269
-#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:151
+#: users/templates/users/data.html:207 users/templates/users/data.html:258
+#: users/templates/users/data.html:321 users/templates/users/data.html:380
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
-#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr ""
 
@@ -4619,7 +4723,7 @@ msgid "Collaborative editing"
 msgstr ""
 
 #: journal/forms.py:191 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
+#: users/templates/users/data.html:535
 msgid "Status"
 msgstr ""
 
@@ -4632,7 +4736,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:499
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4642,26 +4746,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:168
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:178
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:183
+#: journal/importers/rym.py:233
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:388
+#: journal/importers/rym.py:348
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:411
+#: journal/importers/rym.py:376
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -4743,12 +4847,12 @@ msgstr[1] ""
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:164 users/templates/users/data.html:215
-#: users/templates/users/data.html:277 users/templates/users/data.html:337
+#: users/templates/users/data.html:160 users/templates/users/data.html:216
+#: users/templates/users/data.html:267 users/templates/users/data.html:329
+#: users/templates/users/data.html:389
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
-#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr ""
 
@@ -4756,13 +4860,12 @@ msgstr ""
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345
+#: users/templates/users/data.html:115 users/templates/users/data.html:168
+#: users/templates/users/data.html:224 users/templates/users/data.html:275
+#: users/templates/users/data.html:337 users/templates/users/data.html:397
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
-#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr ""
 
@@ -4770,13 +4873,12 @@ msgstr ""
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353
+#: users/templates/users/data.html:123 users/templates/users/data.html:176
+#: users/templates/users/data.html:232 users/templates/users/data.html:283
+#: users/templates/users/data.html:345 users/templates/users/data.html:405
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
-#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr ""
 
@@ -4817,7 +4919,6 @@ msgid "Retrying"
 msgstr ""
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
-#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr ""
 
@@ -5414,6 +5515,10 @@ msgstr ""
 
 #: journal/templates/_sidebar_user_mark_list.html:62
 msgid "sorting"
+msgstr ""
+
+#: journal/templates/_sidebar_user_mark_list.html:63
+msgid "date"
 msgstr ""
 
 #: journal/templates/_sidebar_user_mark_list.html:64
@@ -6530,34 +6635,6 @@ msgstr ""
 msgid "Article"
 msgstr ""
 
-#: takahe/models.py:451
-msgid "Display Name"
-msgstr ""
-
-#: takahe/models.py:453
-msgid "Bio"
-msgstr ""
-
-#: takahe/models.py:455
-msgid "Manually approve new followers"
-msgstr ""
-
-#: takahe/models.py:459
-msgid "Include profile, marks and posts in discovery"
-msgstr ""
-
-#: takahe/models.py:462
-msgid "Include posts in search results"
-msgstr ""
-
-#: takahe/models.py:480
-msgid "Profile picture"
-msgstr ""
-
-#: takahe/models.py:487
-msgid "Header picture"
-msgstr ""
-
 #: users/models/task.py:22
 msgid "Started"
 msgstr ""
@@ -6680,12 +6757,10 @@ msgid "Create new album"
 msgstr ""
 
 #: users/templates/users/_rym_row.html:28
-#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr ""
 
 #: users/templates/users/_rym_row.html:39
-#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr ""
 
@@ -6695,7 +6770,6 @@ msgid "Import from RateYourMusic"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:9
-#: users/templates/users/_storygraph_section.html:9
 msgid "Review pending matches"
 msgstr ""
 
@@ -6704,7 +6778,6 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:16
-#: users/templates/users/_storygraph_section.html:16
 msgid "Cancel import"
 msgstr ""
 
@@ -6713,7 +6786,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr ""
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/_storygraph_section.html:31
+#: users/templates/users/data.html:141
 msgid "Upload the downloaded CSV file below."
 msgstr ""
 
@@ -6722,39 +6795,15 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr ""
 
 #: users/templates/users/_rym_section.html:36
-#: users/templates/users/_storygraph_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr ""
 
 #: users/templates/users/_rym_section.html:40
-#: users/templates/users/_storygraph_section.html:40
 msgid "Upload and match"
 msgstr ""
 
 #: users/templates/users/_rym_section.html:46
-#: users/templates/users/_storygraph_section.html:46
 msgid "Download previous matches"
-msgstr ""
-
-#: users/templates/users/_storygraph_row.html:30
-msgid "Create new book"
-msgstr ""
-
-#: users/templates/users/_storygraph_section.html:5
-#: users/templates/users/_storygraph_section.html:21
-msgid "Import from StoryGraph"
-msgstr ""
-
-#: users/templates/users/_storygraph_section.html:15
-msgid "Cancel the StoryGraph import? Progress will be discarded."
-msgstr ""
-
-#: users/templates/users/_storygraph_section.html:29
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr ""
-
-#: users/templates/users/_storygraph_section.html:33
-msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
 msgstr ""
 
 #: users/templates/users/account.html:11
@@ -7045,9 +7094,9 @@ msgid "CSV file"
 msgstr ""
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:126 users/templates/users/data.html:179
+#: users/templates/users/data.html:235 users/templates/users/data.html:286
+#: users/templates/users/data.html:350 users/templates/users/data.html:410
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr ""
@@ -7191,7 +7240,7 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:34 users/templates/users/data.html:308
 msgid "Import Method"
 msgstr ""
 
@@ -7223,128 +7272,140 @@ msgstr ""
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr ""
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:93 users/templates/users/data.html:143
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:134
-msgid "Import from Letterboxd"
+#: users/templates/users/data.html:133
+msgid "Import from StoryGraph"
 msgstr ""
 
-#: users/templates/users/data.html:140
-msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
-msgstr ""
-
-#: users/templates/users/data.html:143
-msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+#: users/templates/users/data.html:139
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
 msgstr ""
 
 #: users/templates/users/data.html:146
+msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
+msgstr ""
+
+#: users/templates/users/data.html:186
+msgid "Import from Letterboxd"
+msgstr ""
+
+#: users/templates/users/data.html:192
+msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
+msgstr ""
+
+#: users/templates/users/data.html:195
+msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
+msgstr ""
+
+#: users/templates/users/data.html:198
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr ""
 
-#: users/templates/users/data.html:149
+#: users/templates/users/data.html:201
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr ""
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:236 users/templates/users/data.html:287
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:243
 msgid "Import from Trakt"
 msgstr ""
 
-#: users/templates/users/data.html:197
+#: users/templates/users/data.html:249
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr ""
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:252
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr ""
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:254
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr ""
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:295
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr ""
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:298
 msgid "Login with Steam"
 msgstr ""
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:304
 msgid "Import Podcast Subscriptions"
 msgstr ""
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:315
 msgid "Mark as listening"
 msgstr ""
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:319
 msgid "Import as a new collection"
 msgstr ""
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:348
 msgid "Select OPML file"
 msgstr ""
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:358
 msgid "Import NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:312
+#: users/templates/users/data.html:364
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr ""
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:366
 msgid "Existing data may be overwritten."
 msgstr ""
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:376
 msgid "Detected format"
 msgstr ""
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:437
 msgid "Detecting format..."
 msgstr ""
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:463
 msgid "Unknown format"
 msgstr ""
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:488
 msgid "Error detecting format"
 msgstr ""
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:512
 msgid "Export NeoDB Archive"
 msgstr ""
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:516
 msgid "Export marks, reviews and notes in CSV"
 msgstr ""
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:523
 msgid "Export everything in NDJSON"
 msgstr ""
 
-#: users/templates/users/data.html:479
+#: users/templates/users/data.html:531
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr ""
 
-#: users/templates/users/data.html:482
+#: users/templates/users/data.html:534
 msgid "Last export"
 msgstr ""
 
-#: users/templates/users/data.html:487
+#: users/templates/users/data.html:539
 msgid "Download"
 msgstr ""
 
-#: users/templates/users/data.html:496
+#: users/templates/users/data.html:548
 msgid "View Annual Summary"
 msgstr ""
 
@@ -7748,7 +7809,6 @@ msgid "Review RateYourMusic Matches"
 msgstr ""
 
 #: users/templates/users/rym_import.html:39
-#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7757,7 +7817,6 @@ msgid ""
 msgstr ""
 
 #: users/templates/users/rym_import.html:45
-#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr ""
 
@@ -7766,32 +7825,30 @@ msgid "Title / Artist"
 msgstr ""
 
 #: users/templates/users/rym_import.html:58
-#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr ""
 
 #: users/templates/users/rym_import.html:59
-#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr ""
 
+#: users/templates/users/rym_import.html:60
+msgid "Date"
+msgstr ""
+
 #: users/templates/users/rym_import.html:71
-#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr ""
 
 #: users/templates/users/rym_import.html:75
-#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr ""
 
 #: users/templates/users/rym_import.html:95
-#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr ""
 
 #: users/templates/users/rym_import.html:96
-#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr ""
 
@@ -7911,15 +7968,6 @@ msgstr ""
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr ""
 
-#: users/templates/users/storygraph_import.html:9
-#: users/templates/users/storygraph_import.html:37
-msgid "Review StoryGraph Matches"
-msgstr ""
-
-#: users/templates/users/storygraph_import.html:57
-msgid "Title / Author"
-msgstr ""
-
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr ""
@@ -8005,141 +8053,136 @@ msgstr ""
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:230 users/views/data.py:259
+#: users/views/data.py:223 users/views/data.py:252
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:253
+#: users/views/data.py:246
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:271
+#: users/views/data.py:264
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:286 users/views/data.py:306
+#: users/views/data.py:279 users/views/data.py:299
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:320
+#: users/views/data.py:313
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:334
+#: users/views/data.py:327
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:389
+#: users/views/data.py:382
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:392
+#: users/views/data.py:385
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:420
+#: users/views/data.py:413
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:430 users/views/data.py:463 users/views/data.py:686
-#: users/views/data.py:901 users/views/data.py:926 users/views/data.py:950
-#: users/views/data.py:974
+#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
+#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
+#: users/views/data.py:769
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:497 users/views/data.py:720
+#: users/views/data.py:492
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:522 users/views/data.py:749
+#: users/views/data.py:517
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:542
+#: users/views/data.py:537
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:550 users/views/data.py:660 users/views/data.py:779
-#: users/views/data.py:884
+#: users/views/data.py:545 users/views/data.py:655
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:646 users/views/data.py:870
+#: users/views/data.py:641
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:656 users/views/data.py:880
+#: users/views/data.py:651
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:771
-msgid "No StoryGraph import to preview."
-msgstr ""
-
-#: users/views/data.py:1094
+#: users/views/data.py:889
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1116
+#: users/views/data.py:911
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1132
+#: users/views/data.py:927
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1137
+#: users/views/data.py:932
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1147 users/views/data.py:1198
+#: users/views/data.py:942 users/views/data.py:993
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1154
+#: users/views/data.py:949
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1159
+#: users/views/data.py:954
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1185
+#: users/views/data.py:980
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1190
+#: users/views/data.py:985
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1203
+#: users/views/data.py:998
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1214
+#: users/views/data.py:1009
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1220
+#: users/views/data.py:1015
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1278
+#: users/views/data.py:1073
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1294
+#: users/views/data.py:1089
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1298
+#: users/views/data.py:1093
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1307
+#: users/views/data.py:1102
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 20:22-0400\n"
+"POT-Creation-Date: 2026-07-15 22:16-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -71,12 +71,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "日期无效，应为 YYYY、YYYY-MM 或 YYYY-MM-DD。"
 
 #: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:211 catalog/models/common.py:229
+#: catalog/models/common.py:243 catalog/models/common.py:261
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:214 catalog/models/common.py:234
+#: catalog/models/common.py:246 catalog/models/common.py:266
 msgid "text content"
 msgstr "文本内容"
 
@@ -108,9 +108,9 @@ msgstr "其它"
 msgid "subtitle"
 msgstr "副标题"
 
-#: catalog/models/book.py:264 catalog/models/movie.py:129
-#: catalog/models/performance.py:385 catalog/models/tv.py:219
-#: catalog/models/tv.py:441
+#: catalog/models/book.py:264 catalog/models/movie.py:113
+#: catalog/models/performance.py:385 catalog/models/tv.py:199
+#: catalog/models/tv.py:421
 msgid "original title"
 msgstr "原名"
 
@@ -132,7 +132,7 @@ msgid "book format"
 msgstr "格式"
 
 #: catalog/models/book.py:295 catalog/models/game.py:132
-#: catalog/models/item.py:137 catalog/models/music.py:131
+#: catalog/models/item.py:137 catalog/models/music.py:133
 msgid "publisher"
 msgstr "出版发行"
 
@@ -144,7 +144,7 @@ msgstr "发行年份"
 msgid "publication month"
 msgstr "发行月份"
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:50
+#: catalog/models/book.py:313 catalog/templates/edition.html:51
 msgid "binding"
 msgstr "装订"
 
@@ -152,433 +152,433 @@ msgstr "装订"
 msgid "pages"
 msgstr "页数"
 
-#: catalog/models/book.py:315 catalog/templates/edition.html:44
+#: catalog/models/book.py:315 catalog/templates/edition.html:45
 msgid "series"
 msgstr "丛书"
 
-#: catalog/models/book.py:316 catalog/templates/edition.html:69
+#: catalog/models/book.py:316 catalog/templates/edition.html:70
 msgid "contents"
 msgstr "目录"
 
-#: catalog/models/book.py:317 catalog/templates/edition.html:55
+#: catalog/models/book.py:317 catalog/templates/edition.html:56
 msgid "price"
 msgstr "价格"
 
-#: catalog/models/book.py:318 catalog/templates/edition.html:33
+#: catalog/models/book.py:318 catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:19 common/models/lang.py:249
+#: catalog/models/common.py:24 common/models/lang.py:249
 msgid "Unknown"
 msgstr "未知"
 
-#: catalog/models/common.py:20
+#: catalog/models/common.py:25
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:21 catalog/models/common.py:70
+#: catalog/models/common.py:26 catalog/models/common.py:75
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:22 catalog/models/common.py:72
+#: catalog/models/common.py:27 catalog/models/common.py:77
 msgid "Google Books"
 msgstr "谷歌图书"
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:28
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:24 catalog/models/common.py:81
-#: catalog/models/common.py:83
+#: catalog/models/common.py:29 catalog/models/common.py:86
+#: catalog/models/common.py:88
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:25 catalog/models/common.py:82
+#: catalog/models/common.py:30 catalog/models/common.py:87
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:26 catalog/models/common.py:65
+#: catalog/models/common.py:31 catalog/models/common.py:70
 #: catalog/templates/movie.html:46 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr "IMDb"
 
-#: catalog/models/common.py:27
+#: catalog/models/common.py:32
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:28 catalog/models/common.py:84
+#: catalog/models/common.py:33 catalog/models/common.py:89
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
-#: catalog/models/common.py:29
+#: catalog/models/common.py:34
 msgid "Spotify"
 msgstr "Spotify"
 
-#: catalog/models/common.py:30
+#: catalog/models/common.py:35
 msgid "IGDB"
 msgstr "IGDB"
 
-#: catalog/models/common.py:31
+#: catalog/models/common.py:36
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:32 catalog/models/common.py:104
+#: catalog/models/common.py:37 catalog/models/common.py:109
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:33 catalog/models/common.py:105
+#: catalog/models/common.py:38 catalog/models/common.py:110
 msgid "Bangumi"
 msgstr "Bangumi"
 
-#: catalog/models/common.py:34
+#: catalog/models/common.py:39
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:35 catalog/models/common.py:106
+#: catalog/models/common.py:40 catalog/models/common.py:111
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:41
 msgid "RSS"
 msgstr "RSS"
 
-#: catalog/models/common.py:37
+#: catalog/models/common.py:42
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:38 catalog/models/common.py:107
+#: catalog/models/common.py:43 catalog/models/common.py:112
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:39 catalog/models/common.py:109
+#: catalog/models/common.py:44 catalog/models/common.py:114
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:40 catalog/models/common.py:110
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:41 catalog/models/common.py:111
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:42 catalog/models/common.py:112
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:43 catalog/models/common.py:113
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:44 catalog/models/common.py:55
+#: catalog/models/common.py:49 catalog/models/common.py:60
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:45 catalog/models/common.py:114
+#: catalog/models/common.py:50 catalog/models/common.py:119
 msgid "Open Library"
 msgstr "开放图书馆"
 
-#: catalog/models/common.py:46
+#: catalog/models/common.py:51
 msgid "MusicBrainz"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:52
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:48 catalog/models/common.py:116
+#: catalog/models/common.py:53 catalog/models/common.py:121
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:49 catalog/models/common.py:117
+#: catalog/models/common.py:54 catalog/models/common.py:122
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:50 catalog/models/common.py:108
+#: catalog/models/common.py:55 catalog/models/common.py:113
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:56
 msgid "RateYourMusic"
 msgstr "RateYourMusic"
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:61
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:57 catalog/templates/edition.html:19
+#: catalog/models/common.py:62 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:63
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:64
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:60
+#: catalog/models/common.py:65
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:66
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:67
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:68
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:69
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:71
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:72
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:73
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:74
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:76
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:78
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:79
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:80
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:81
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:82
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:83
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:84
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:85
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:90
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:91
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:92
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:88
+#: catalog/models/common.py:93
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:96
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:98
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:99
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz艺术家"
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:100
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:101
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:102
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:103
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:104
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:105
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:106
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:107
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:108
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:115
+#: catalog/models/common.py:120
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:118
+#: catalog/models/common.py:123
 msgid "RateYourMusic Release"
 msgstr "RateYourMusic发行"
 
-#: catalog/models/common.py:139
+#: catalog/models/common.py:144
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:140 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:145 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:146
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:142 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:148
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:144 catalog/models/common.py:160
-#: catalog/models/common.py:174 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:149 catalog/models/common.py:165
+#: catalog/models/common.py:179 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:145
+#: catalog/models/common.py:150
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:146 catalog/models/common.py:163
-#: catalog/models/common.py:177 common/templates/_header.html:43
+#: catalog/models/common.py:151 catalog/models/common.py:168
+#: catalog/models/common.py:182 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:152
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:153
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:149 catalog/models/common.py:165
-#: catalog/models/common.py:179 common/templates/_header.html:47
+#: catalog/models/common.py:154 catalog/models/common.py:170
+#: catalog/models/common.py:184 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:155
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:151
+#: catalog/models/common.py:156
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:152 catalog/models/common.py:169
+#: catalog/models/common.py:157 catalog/models/common.py:174
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:155 catalog/models/common.py:168
+#: catalog/models/common.py:160 catalog/models/common.py:173
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:159 catalog/models/common.py:173
+#: catalog/models/common.py:164 catalog/models/common.py:178
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:161 catalog/models/common.py:175
+#: catalog/models/common.py:166 catalog/models/common.py:180
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:162 catalog/models/common.py:176
+#: catalog/models/common.py:167 catalog/models/common.py:181
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:164 catalog/models/common.py:178
+#: catalog/models/common.py:169 catalog/models/common.py:183
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:277 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:309 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:308
+#: catalog/models/common.py:347
 msgid "origin country"
 msgstr "制片国家/地区"
 
-#: catalog/models/common.py:337 catalog/templates/album.html:33
+#: catalog/models/common.py:376 catalog/templates/album.html:33
 msgid "album type"
 msgstr "专辑类型"
 
-#: catalog/models/common.py:341
+#: catalog/models/common.py:380
 msgid "media format"
 msgstr "介质"
 
-#: catalog/models/common.py:346 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:385 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr "语言"
@@ -648,7 +648,7 @@ msgid "designer"
 msgstr "设计者"
 
 #: catalog/models/game.py:116 catalog/models/item.py:128
-#: catalog/models/music.py:123
+#: catalog/models/music.py:125
 msgid "artist"
 msgstr "艺术家"
 
@@ -660,9 +660,9 @@ msgstr "开发者"
 msgid "date of publication"
 msgstr "发行日期"
 
-#: catalog/models/game.py:144 catalog/models/movie.py:165
-#: catalog/models/music.py:117 catalog/models/tv.py:255
-#: catalog/models/tv.py:477
+#: catalog/models/game.py:144 catalog/models/movie.py:149
+#: catalog/models/music.py:119 catalog/models/tv.py:235
+#: catalog/models/tv.py:457
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr "YYYY、YYYY-MM 或 YYYY-MM-DD"
 
@@ -674,10 +674,10 @@ msgstr "发布类型"
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/game.py:179 catalog/models/movie.py:167
+#: catalog/models/game.py:179 catalog/models/movie.py:151
 #: catalog/models/people.py:158 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:257 catalog/models/tv.py:480
+#: catalog/models/tv.py:237 catalog/models/tv.py:460
 #: catalog/templates/game.html:32 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
@@ -686,26 +686,26 @@ msgstr "平台"
 msgid "website"
 msgstr "网站"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:132
+#: catalog/models/item.py:124 catalog/models/movie.py:116
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:222 catalog/models/tv.py:444
+#: catalog/models/tv.py:202 catalog/models/tv.py:424
 msgid "director"
 msgstr "导演"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:139
+#: catalog/models/item.py:125 catalog/models/movie.py:123
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:229 catalog/models/tv.py:451
+#: catalog/models/tv.py:209 catalog/models/tv.py:431
 msgid "playwright"
 msgstr "编剧"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:146
+#: catalog/models/item.py:126 catalog/models/movie.py:130
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:236 catalog/models/tv.py:458
+#: catalog/models/tv.py:216 catalog/models/tv.py:438
 msgid "actor"
 msgstr "演员"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:153
-#: catalog/models/tv.py:243 catalog/models/tv.py:465
+#: catalog/models/item.py:127 catalog/models/movie.py:137
+#: catalog/models/tv.py:223 catalog/models/tv.py:445
 msgid "producer"
 msgstr "制片人"
 
@@ -792,32 +792,32 @@ msgstr "元数据"
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1410
+#: catalog/models/item.py:1418
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:1412
+#: catalog/models/item.py:1420
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:1414
+#: catalog/models/item.py:1422
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1430
+#: catalog/models/item.py:1438
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1436
+#: catalog/models/item.py:1444
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1439
+#: catalog/models/item.py:1447
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
-#: catalog/models/movie.py:161 catalog/models/music.py:113
-#: catalog/models/tv.py:251 catalog/models/tv.py:473
+#: catalog/models/movie.py:145 catalog/models/music.py:115
+#: catalog/models/tv.py:231 catalog/models/tv.py:453
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
 #: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
@@ -825,22 +825,22 @@ msgstr "指向外部资源的网址"
 msgid "release date"
 msgstr "发布日期"
 
-#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/models/movie.py:155 catalog/models/music.py:122
 #: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
 #: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr "长度"
 
-#: catalog/models/movie.py:171 catalog/models/music.py:120
-#: catalog/models/tv.py:265 catalog/models/tv.py:488
+#: catalog/models/movie.py:155 catalog/models/music.py:122
+#: catalog/models/tv.py:245 catalog/models/tv.py:468
 msgid "seconds"
 msgstr "秒"
 
-#: catalog/models/music.py:137
+#: catalog/models/music.py:139
 msgid "tracks"
 msgstr "曲目"
 
-#: catalog/models/music.py:142 catalog/templates/album.html:51
+#: catalog/models/music.py:144 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr "碟片数"
 
@@ -994,30 +994,30 @@ msgstr "上演日期"
 msgid "closing date"
 msgstr "结束日期"
 
-#: catalog/models/tv.py:194 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:174 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "季数"
 
-#: catalog/models/tv.py:197 catalog/models/tv.py:419
+#: catalog/models/tv.py:177 catalog/models/tv.py:399
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "集数"
 
-#: catalog/models/tv.py:262 catalog/models/tv.py:485
+#: catalog/models/tv.py:242 catalog/models/tv.py:465
 msgid "episode length"
 msgstr "单集长度"
 
-#: catalog/models/tv.py:416 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:396 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "本季序号"
 
-#: catalog/models/tv.py:530
+#: catalog/models/tv.py:510
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:684
+#: catalog/models/tv.py:664
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
@@ -1824,19 +1824,23 @@ msgstr "近期帖文"
 msgid "original podcasts"
 msgstr "原创播客"
 
-#: catalog/templates/edition.html:38
+#: catalog/templates/edition.html:30
+msgid "publishing house"
+msgstr "出版社"
+
+#: catalog/templates/edition.html:39
 msgid "publication date"
 msgstr "发行时间"
 
-#: catalog/templates/edition.html:60
+#: catalog/templates/edition.html:61
 msgid "number of pages"
 msgstr "页数"
 
-#: catalog/templates/edition.html:84
+#: catalog/templates/edition.html:85
 msgid "other editions"
 msgstr "其它版本"
 
-#: catalog/templates/edition.html:124
+#: catalog/templates/edition.html:125
 msgid "Borrow or Buy"
 msgstr "借阅或购买"
 
@@ -3547,60 +3551,50 @@ msgctxt "album_type"
 msgid "Field Recording"
 msgstr "实地录音"
 
-#: common/models/music_format.py:34
-msgctxt "album_type"
-msgid "Other"
-msgstr "其它"
-
-#: common/models/music_format.py:38
+#: common/models/music_format.py:37
 msgctxt "media_format"
 msgid "CD"
 msgstr "CD"
 
-#: common/models/music_format.py:39
+#: common/models/music_format.py:38
 msgctxt "media_format"
 msgid "Vinyl"
 msgstr "黑胶"
 
-#: common/models/music_format.py:40
+#: common/models/music_format.py:39
 msgctxt "media_format"
 msgid "Cassette"
 msgstr "磁带"
 
-#: common/models/music_format.py:41
+#: common/models/music_format.py:40
 msgctxt "media_format"
 msgid "Digital"
 msgstr "数字"
 
-#: common/models/music_format.py:42
+#: common/models/music_format.py:41
 msgctxt "media_format"
 msgid "SACD"
 msgstr "SACD"
 
-#: common/models/music_format.py:43
+#: common/models/music_format.py:42
 msgctxt "media_format"
 msgid "DVD"
 msgstr "DVD"
 
-#: common/models/music_format.py:44
+#: common/models/music_format.py:43
 msgctxt "media_format"
 msgid "Blu-ray"
 msgstr "蓝光"
 
-#: common/models/music_format.py:45
+#: common/models/music_format.py:44
 msgctxt "media_format"
 msgid "MiniDisc"
 msgstr "MD"
 
-#: common/models/music_format.py:46
+#: common/models/music_format.py:45
 msgctxt "media_format"
 msgid "VCD"
 msgstr "VCD"
-
-#: common/models/music_format.py:47
-msgctxt "media_format"
-msgid "Other"
-msgstr "其它"
 
 #: common/templates/400.html:23
 msgid "You may have submitted invalid data, or the content may have been deleted by the author."

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 22:17-0400\n"
+"POT-Creation-Date: 2026-07-15 20:22-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -58,21 +58,25 @@ msgstr "简体中文"
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: catalog/forms.py:29 catalog/models/item.py:252
+#: catalog/forms.py:35 catalog/models/item.py:260
 msgid "Primary ID Type"
 msgstr "主要标识类型"
 
-#: catalog/forms.py:34 catalog/models/item.py:255
+#: catalog/forms.py:40 catalog/models/item.py:263
 msgid "Primary ID Value"
 msgstr "主要标识数据"
 
+#: catalog/forms.py:181
+msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
+msgstr "日期无效，应为 YYYY、YYYY-MM 或 YYYY-MM-DD。"
+
 #: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:207 catalog/models/common.py:225
+#: catalog/models/common.py:211 catalog/models/common.py:229
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:210 catalog/models/common.py:230
+#: catalog/models/common.py:214 catalog/models/common.py:234
 msgid "text content"
 msgstr "文本内容"
 
@@ -96,473 +100,485 @@ msgstr "有声书"
 msgid "Web Fiction"
 msgstr "网络作品"
 
-#: catalog/models/book.py:180 catalog/models/game.py:33
+#: catalog/models/book.py:180 catalog/models/game.py:35
 msgid "Other"
 msgstr "其它"
 
-#: catalog/models/book.py:250
+#: catalog/models/book.py:254
 msgid "subtitle"
 msgstr "副标题"
 
-#: catalog/models/book.py:260 catalog/models/movie.py:101
-#: catalog/models/performance.py:385 catalog/models/tv.py:176
-#: catalog/models/tv.py:418
+#: catalog/models/book.py:264 catalog/models/movie.py:129
+#: catalog/models/performance.py:385 catalog/models/tv.py:219
+#: catalog/models/tv.py:441
 msgid "original title"
 msgstr "原名"
 
-#: catalog/models/book.py:264
+#: catalog/models/book.py:268
 msgid "other title"
 msgstr "其它标题"
 
-#: catalog/models/book.py:270 catalog/models/book.py:554
-#: catalog/models/item.py:114
+#: catalog/models/book.py:274 catalog/models/book.py:558
+#: catalog/models/item.py:122
 msgid "author"
 msgstr "作者"
 
-#: catalog/models/book.py:277 catalog/models/item.py:115
+#: catalog/models/book.py:281 catalog/models/item.py:123
 msgid "translator"
 msgstr "译者"
 
-#: catalog/models/book.py:284 catalog/templates/edition.html:26
+#: catalog/models/book.py:288 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "格式"
 
-#: catalog/models/book.py:291 catalog/models/game.py:123
-#: catalog/models/item.py:129 catalog/models/music.py:95
+#: catalog/models/book.py:295 catalog/models/game.py:132
+#: catalog/models/item.py:137 catalog/models/music.py:131
 msgid "publisher"
 msgstr "出版发行"
 
-#: catalog/models/book.py:298
+#: catalog/models/book.py:302
 msgid "publication year"
 msgstr "发行年份"
 
-#: catalog/models/book.py:304
+#: catalog/models/book.py:308
 msgid "publication month"
 msgstr "发行月份"
 
-#: catalog/models/book.py:309 catalog/templates/edition.html:50
+#: catalog/models/book.py:313 catalog/templates/edition.html:50
 msgid "binding"
 msgstr "装订"
 
-#: catalog/models/book.py:310
+#: catalog/models/book.py:314
 msgid "pages"
 msgstr "页数"
 
-#: catalog/models/book.py:311 catalog/templates/edition.html:44
+#: catalog/models/book.py:315 catalog/templates/edition.html:44
 msgid "series"
 msgstr "丛书"
 
-#: catalog/models/book.py:312 catalog/templates/edition.html:69
+#: catalog/models/book.py:316 catalog/templates/edition.html:69
 msgid "contents"
 msgstr "目录"
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:55
+#: catalog/models/book.py:317 catalog/templates/edition.html:55
 msgid "price"
 msgstr "价格"
 
-#: catalog/models/book.py:314 catalog/templates/edition.html:33
+#: catalog/models/book.py:318 catalog/templates/edition.html:33
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:15 common/models/lang.py:249
+#: catalog/models/common.py:19 common/models/lang.py:249
 msgid "Unknown"
 msgstr "未知"
 
-#: catalog/models/common.py:16
+#: catalog/models/common.py:20
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:17 catalog/models/common.py:66
+#: catalog/models/common.py:21 catalog/models/common.py:70
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:18 catalog/models/common.py:68
+#: catalog/models/common.py:22 catalog/models/common.py:72
 msgid "Google Books"
 msgstr "谷歌图书"
 
-#: catalog/models/common.py:19
+#: catalog/models/common.py:23
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:20 catalog/models/common.py:77
-#: catalog/models/common.py:79
+#: catalog/models/common.py:24 catalog/models/common.py:81
+#: catalog/models/common.py:83
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:21 catalog/models/common.py:78
+#: catalog/models/common.py:25 catalog/models/common.py:82
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:22 catalog/models/common.py:61
-#: catalog/templates/movie.html:51 catalog/templates/people.html:37
-#: catalog/templates/tvseason.html:68 catalog/templates/tvshow.html:63
+#: catalog/models/common.py:26 catalog/models/common.py:65
+#: catalog/templates/movie.html:46 catalog/templates/people.html:37
+#: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr "IMDb"
 
-#: catalog/models/common.py:23
+#: catalog/models/common.py:27
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:24 catalog/models/common.py:80
+#: catalog/models/common.py:28 catalog/models/common.py:84
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:29
 msgid "Spotify"
 msgstr "Spotify"
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:30
 msgid "IGDB"
 msgstr "IGDB"
 
-#: catalog/models/common.py:27
+#: catalog/models/common.py:31
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:28 catalog/models/common.py:100
+#: catalog/models/common.py:32 catalog/models/common.py:104
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:29 catalog/models/common.py:101
+#: catalog/models/common.py:33 catalog/models/common.py:105
 msgid "Bangumi"
 msgstr "Bangumi"
 
-#: catalog/models/common.py:30
+#: catalog/models/common.py:34
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:31 catalog/models/common.py:102
+#: catalog/models/common.py:35 catalog/models/common.py:106
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
-#: catalog/models/common.py:32
+#: catalog/models/common.py:36
 msgid "RSS"
 msgstr "RSS"
 
-#: catalog/models/common.py:33
+#: catalog/models/common.py:37
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:34 catalog/models/common.py:103
+#: catalog/models/common.py:38 catalog/models/common.py:107
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:35 catalog/models/common.py:105
+#: catalog/models/common.py:39 catalog/models/common.py:109
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:36 catalog/models/common.py:106
+#: catalog/models/common.py:40 catalog/models/common.py:110
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:37 catalog/models/common.py:107
+#: catalog/models/common.py:41 catalog/models/common.py:111
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:38 catalog/models/common.py:108
+#: catalog/models/common.py:42 catalog/models/common.py:112
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:39 catalog/models/common.py:109
+#: catalog/models/common.py:43 catalog/models/common.py:113
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:40 catalog/models/common.py:51
+#: catalog/models/common.py:44 catalog/models/common.py:55
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:41 catalog/models/common.py:110
+#: catalog/models/common.py:45 catalog/models/common.py:114
 msgid "Open Library"
 msgstr "开放图书馆"
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:46
 msgid "MusicBrainz"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:43
+#: catalog/models/common.py:47
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:44 catalog/models/common.py:112
+#: catalog/models/common.py:48 catalog/models/common.py:116
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:45 catalog/models/common.py:113
+#: catalog/models/common.py:49 catalog/models/common.py:117
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:46 catalog/models/common.py:104
+#: catalog/models/common.py:50 catalog/models/common.py:108
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:47
+#: catalog/models/common.py:51
 msgid "RateYourMusic"
 msgstr "RateYourMusic"
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:56
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:53 catalog/templates/edition.html:19
+#: catalog/models/common.py:57 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:54
+#: catalog/models/common.py:58
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:55
+#: catalog/models/common.py:59
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:60
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:61
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:58
+#: catalog/models/common.py:62
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:59
+#: catalog/models/common.py:63
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:60
+#: catalog/models/common.py:64
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:66
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:67
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:68
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:69
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:71
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:73
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:74
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:75
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:76
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:77
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:78
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:79
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:80
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:85
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:86
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:87
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:88
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:91
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:89
+#: catalog/models/common.py:93
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:94
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz艺术家"
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:95
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:96
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:97
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:98
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:99
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:100
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:101
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:102
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:103
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:111
+#: catalog/models/common.py:115
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:114
+#: catalog/models/common.py:118
 msgid "RateYourMusic Release"
 msgstr "RateYourMusic发行"
 
-#: catalog/models/common.py:135
+#: catalog/models/common.py:139
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:136 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:140 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:137
+#: catalog/models/common.py:141
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:138 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:142 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:139
+#: catalog/models/common.py:143
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:140 catalog/models/common.py:156
-#: catalog/models/common.py:170 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:144 catalog/models/common.py:160
+#: catalog/models/common.py:174 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:141
+#: catalog/models/common.py:145
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:142 catalog/models/common.py:159
-#: catalog/models/common.py:173 common/templates/_header.html:43
+#: catalog/models/common.py:146 catalog/models/common.py:163
+#: catalog/models/common.py:177 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:143
+#: catalog/models/common.py:147
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:148
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:145 catalog/models/common.py:161
-#: catalog/models/common.py:175 common/templates/_header.html:47
+#: catalog/models/common.py:149 catalog/models/common.py:165
+#: catalog/models/common.py:179 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:150
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:151
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:148 catalog/models/common.py:165
+#: catalog/models/common.py:152 catalog/models/common.py:169
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:151 catalog/models/common.py:164
+#: catalog/models/common.py:155 catalog/models/common.py:168
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:155 catalog/models/common.py:169
+#: catalog/models/common.py:159 catalog/models/common.py:173
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:157 catalog/models/common.py:171
+#: catalog/models/common.py:161 catalog/models/common.py:175
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:158 catalog/models/common.py:172
+#: catalog/models/common.py:162 catalog/models/common.py:176
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:160 catalog/models/common.py:174
+#: catalog/models/common.py:164 catalog/models/common.py:178
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:273 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:277 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:284 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:308
+msgid "origin country"
+msgstr "制片国家/地区"
+
+#: catalog/models/common.py:337 catalog/templates/album.html:33
+msgid "album type"
+msgstr "专辑类型"
+
+#: catalog/models/common.py:341
+msgid "media format"
+msgstr "介质"
+
+#: catalog/models/common.py:346 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr "语言"
@@ -595,274 +611,236 @@ msgstr "订阅源中没有找到任何音频单集"
 msgid "no matching identity found in the feed or its linked website"
 msgstr "未在订阅源或其关联网站中找到匹配的身份标识"
 
-#: catalog/models/game.py:25
+#: catalog/models/game.py:27
 msgid "Main Game"
 msgstr "游戏"
 
-#: catalog/models/game.py:26
+#: catalog/models/game.py:28
 msgid "Expansion"
 msgstr "资料片"
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:29
 msgid "Downloadable Content"
 msgstr "可下载内容"
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:30
 msgid "Mod"
 msgstr "模组"
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:31
 msgid "Bundle"
 msgstr "合集"
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:32
 msgid "Remaster"
 msgstr "复刻"
 
-#: catalog/models/game.py:31
+#: catalog/models/game.py:33
 msgid "Remake"
 msgstr "重制"
 
-#: catalog/models/game.py:32
+#: catalog/models/game.py:34
 msgid "Special Edition"
 msgstr "特别版"
 
-#: catalog/models/game.py:99 catalog/models/item.py:121
+#: catalog/models/game.py:108 catalog/models/item.py:129
 msgid "designer"
 msgstr "设计者"
 
-#: catalog/models/game.py:107 catalog/models/item.py:120
-#: catalog/models/music.py:87
+#: catalog/models/game.py:116 catalog/models/item.py:128
+#: catalog/models/music.py:123
 msgid "artist"
 msgstr "艺术家"
 
-#: catalog/models/game.py:115 catalog/models/item.py:130
+#: catalog/models/game.py:124 catalog/models/item.py:138
 msgid "developer"
 msgstr "开发者"
 
-#: catalog/models/game.py:131
-msgid "year of publication"
-msgstr "发行年份"
-
-#: catalog/models/game.py:135 catalog/models/podcast.py:256
+#: catalog/models/game.py:140 catalog/models/podcast.py:256
 msgid "date of publication"
 msgstr "发行日期"
 
-#: catalog/models/game.py:140 catalog/models/music.py:81
-#: catalog/models/tv.py:221
-msgid "YYYY-MM-DD"
-msgstr "YYYY-MM-DD"
+#: catalog/models/game.py:144 catalog/models/movie.py:165
+#: catalog/models/music.py:117 catalog/models/tv.py:255
+#: catalog/models/tv.py:477
+msgid "YYYY, YYYY-MM or YYYY-MM-DD"
+msgstr "YYYY、YYYY-MM 或 YYYY-MM-DD"
 
-#: catalog/models/game.py:144 catalog/templates/game.html:16
+#: catalog/models/game.py:164 catalog/templates/game.html:16
 msgid "release type"
 msgstr "发布类型"
 
-#: catalog/models/game.py:153
+#: catalog/models/game.py:173
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/game.py:159 catalog/models/movie.py:160
+#: catalog/models/game.py:179 catalog/models/movie.py:167
 #: catalog/models/people.py:158 catalog/models/performance.py:258
 #: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:235 catalog/models/tv.py:478
-#: catalog/templates/game.html:34 catalog/templates/movie.html:58
+#: catalog/models/tv.py:257 catalog/models/tv.py:480
+#: catalog/templates/game.html:32 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
-#: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:75
-#: catalog/templates/tvshow.html:70
+#: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:70
+#: catalog/templates/tvshow.html:65
 msgid "website"
 msgstr "网站"
 
-#: catalog/models/item.py:116 catalog/models/movie.py:104
+#: catalog/models/item.py:124 catalog/models/movie.py:132
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:179 catalog/models/tv.py:421
+#: catalog/models/tv.py:222 catalog/models/tv.py:444
 msgid "director"
 msgstr "导演"
 
-#: catalog/models/item.py:117 catalog/models/movie.py:111
+#: catalog/models/item.py:125 catalog/models/movie.py:139
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:186 catalog/models/tv.py:428
+#: catalog/models/tv.py:229 catalog/models/tv.py:451
 msgid "playwright"
 msgstr "编剧"
 
-#: catalog/models/item.py:118 catalog/models/movie.py:118
+#: catalog/models/item.py:126 catalog/models/movie.py:146
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:193 catalog/models/tv.py:435
+#: catalog/models/tv.py:236 catalog/models/tv.py:458
 msgid "actor"
 msgstr "演员"
 
-#: catalog/models/item.py:119 catalog/models/movie.py:125
-#: catalog/models/tv.py:200 catalog/models/tv.py:442
+#: catalog/models/item.py:127 catalog/models/movie.py:153
+#: catalog/models/tv.py:243 catalog/models/tv.py:465
 msgid "producer"
 msgstr "制片人"
 
-#: catalog/models/item.py:122 catalog/models/performance.py:203
+#: catalog/models/item.py:130 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/item.py:123 catalog/models/performance.py:210
+#: catalog/models/item.py:131 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "编舞"
 
-#: catalog/models/item.py:124 catalog/models/performance.py:224
+#: catalog/models/item.py:132 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:125 catalog/models/podcast.py:79
+#: catalog/models/item.py:133 catalog/models/podcast.py:79
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/item.py:126 catalog/models/performance.py:196
+#: catalog/models/item.py:134 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "原始创作者"
 
-#: catalog/models/item.py:127 catalog/models/performance.py:238
+#: catalog/models/item.py:135 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "工作人员"
 
-#: catalog/models/item.py:131
+#: catalog/models/item.py:139
 msgid "production company"
 msgstr "制作公司"
 
-#: catalog/models/item.py:132
+#: catalog/models/item.py:140
 msgid "record label"
 msgstr "唱片公司"
 
-#: catalog/models/item.py:133
+#: catalog/models/item.py:141
 msgid "distributor"
 msgstr "发行商"
 
-#: catalog/models/item.py:134
+#: catalog/models/item.py:142
 msgid "studio"
 msgstr "工作室"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:231
+#: catalog/models/item.py:143 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "剧团"
 
-#: catalog/models/item.py:150 catalog/models/people.py:477
+#: catalog/models/item.py:158 catalog/models/people.py:477
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:151 catalog/models/people.py:135
+#: catalog/models/item.py:159 catalog/models/people.py:135
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:153 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:161 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "角色名"
 
-#: catalog/models/item.py:249 catalog/models/item.py:281
+#: catalog/models/item.py:257 catalog/models/item.py:289
 #: journal/models/collection.py:93
 msgid "title"
 msgstr "标题"
 
-#: catalog/models/item.py:250 catalog/models/item.py:289
+#: catalog/models/item.py:258 catalog/models/item.py:297
 #: journal/models/collection.py:94
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:261 catalog/models/people.py:485
+#: catalog/models/item.py:269 catalog/models/people.py:485
 msgid "metadata"
 msgstr "元数据"
 
-#: catalog/models/item.py:263 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:271 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1367
+#: catalog/models/item.py:1410
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:1369
+#: catalog/models/item.py:1412
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:1371
+#: catalog/models/item.py:1414
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1387
+#: catalog/models/item.py:1430
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1393
+#: catalog/models/item.py:1436
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1396
+#: catalog/models/item.py:1439
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
-#: catalog/models/movie.py:133 catalog/models/music.py:81
+#: catalog/models/movie.py:161 catalog/models/music.py:113
+#: catalog/models/tv.py:251 catalog/models/tv.py:473
 #: catalog/templates/_item_card_metadata_album.html:16
 #: catalog/templates/album.html:17 catalog/templates/game.html:21
-#: catalog/templates/movie.html:40 catalog/templates/tvseason.html:57
-#: catalog/templates/tvshow.html:52
+#: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
+#: catalog/templates/tvshow.html:53
 msgid "release date"
 msgstr "发布日期"
 
-#: catalog/models/movie.py:145 catalog/models/tv.py:462
-#: journal/templates/_sidebar_user_mark_list.html:63
-msgid "date"
-msgstr "日期"
-
-#: catalog/models/movie.py:146 catalog/models/performance.py:130
-#: catalog/models/tv.py:463
-msgid "required"
-msgstr "必填"
-
-#: catalog/models/movie.py:150 catalog/models/tv.py:467
-msgid "region or event"
-msgstr "地区或类型"
-
-#: catalog/models/movie.py:152 catalog/models/tv.py:227
-#: catalog/models/tv.py:469
-msgid "Germany or Toronto International Film Festival"
-msgstr "德国或多伦多国际电影节"
-
-#: catalog/models/movie.py:162 catalog/models/tv.py:237
-#: catalog/models/tv.py:481
-msgid "region"
-msgstr "地区"
-
-#: catalog/models/movie.py:173 catalog/models/tv.py:249
-#: catalog/models/tv.py:492
-msgid "year"
-msgstr "年份"
-
-#: catalog/models/movie.py:174 catalog/models/music.py:84
-#: catalog/templates/movie.html:20 catalog/templates/tvseason.html:52
-#: catalog/templates/tvshow.html:47
+#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
+#: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr "长度"
 
-#: catalog/models/music.py:84
-msgid "milliseconds"
-msgstr "微秒"
+#: catalog/models/movie.py:171 catalog/models/music.py:120
+#: catalog/models/tv.py:265 catalog/models/tv.py:488
+msgid "seconds"
+msgstr "秒"
 
-#: catalog/models/music.py:101
+#: catalog/models/music.py:137
 msgid "tracks"
 msgstr "曲目"
 
-#: catalog/models/music.py:102 catalog/templates/album.html:33
-msgid "album type"
-msgstr "专辑类型"
-
-#: catalog/models/music.py:103
-msgid "media type"
-msgstr "介质类型"
-
-#: catalog/models/music.py:106 catalog/templates/album.html:43
+#: catalog/models/music.py:142 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr "碟片数"
 
@@ -990,6 +968,10 @@ msgstr "角色"
 msgid "Character name for actor roles"
 msgstr "演员饰演的角色名称"
 
+#: catalog/models/performance.py:130
+msgid "required"
+msgstr "必填"
+
 #: catalog/models/performance.py:135
 msgid "optional"
 msgstr "可选"
@@ -1012,46 +994,37 @@ msgstr "上演日期"
 msgid "closing date"
 msgstr "结束日期"
 
-#: catalog/models/tv.py:150 catalog/templates/tvseason.html:37
-#: catalog/templates/tvshow.html:32
+#: catalog/models/tv.py:194 catalog/templates/tvseason.html:38
+#: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "季数"
 
-#: catalog/models/tv.py:153 catalog/models/tv.py:395
-#: catalog/templates/tvseason.html:42 catalog/templates/tvshow.html:37
+#: catalog/models/tv.py:197 catalog/models/tv.py:419
+#: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "集数"
 
-#: catalog/models/tv.py:208 catalog/models/tv.py:450
-msgid "show time"
-msgstr "上映时间"
-
-#: catalog/models/tv.py:220 users/templates/users/rym_import.html:60
-#: users/templates/users/storygraph_import.html:60
-msgid "Date"
-msgstr "日期"
-
-#: catalog/models/tv.py:225
-msgid "Region or Event"
-msgstr "地区或场合"
-
-#: catalog/models/tv.py:251 catalog/models/tv.py:494
+#: catalog/models/tv.py:262 catalog/models/tv.py:485
 msgid "episode length"
 msgstr "单集长度"
 
-#: catalog/models/tv.py:392 catalog/templates/tvseason.html:32
+#: catalog/models/tv.py:416 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "本季序号"
 
-#: catalog/models/tv.py:527
+#: catalog/models/tv.py:530
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:680
+#: catalog/models/tv.py:684
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
+
+#: catalog/templates/_country_list.html:5
+msgid "region"
+msgstr "地区"
 
 #: catalog/templates/_fetch_failed.html:4
 msgid "Unable to fetch from the link, please check again. Some sites may require login for certain links, please manually create them here."
@@ -1604,7 +1577,7 @@ msgstr "时长"
 msgid "barcode"
 msgstr "条形码"
 
-#: catalog/templates/album.html:38
+#: catalog/templates/album.html:42
 msgid "album media"
 msgstr "专辑介质"
 
@@ -1885,10 +1858,6 @@ msgstr "正在从%(site_label)s获取"
 msgid "System busy, please try again in a minute."
 msgstr "系统繁忙，请稍等几秒钟再搜索。"
 
-#: catalog/templates/game.html:23
-msgid "release year"
-msgstr "发行年份"
-
 #: catalog/templates/item_base.html:95
 msgid "select one of the seasons to comment"
 msgstr "这是全剧条目，以下是可标记的单季"
@@ -1964,16 +1933,16 @@ msgstr "标记"
 msgid "Reviews"
 msgstr "评论"
 
-#: catalog/templates/movie.html:25
+#: catalog/templates/movie.html:26
 msgid "number of Seasons"
 msgstr "季数"
 
-#: catalog/templates/movie.html:30
+#: catalog/templates/movie.html:31
 msgid "number of Episodes"
 msgstr "集数"
 
-#: catalog/templates/movie.html:35 catalog/templates/tvseason.html:47
-#: catalog/templates/tvshow.html:42
+#: catalog/templates/movie.html:36 catalog/templates/tvseason.html:48
+#: catalog/templates/tvshow.html:43
 msgid "episode Length"
 msgstr "单集时长"
 
@@ -2125,7 +2094,7 @@ msgstr "搜索服务暂时不可用，请稍后重试。"
 msgid "No people matching your search query."
 msgstr "没有匹配的人物。"
 
-#: catalog/templates/tvseason.html:15 catalog/templates/tvshow.html:21
+#: catalog/templates/tvseason.html:16 catalog/templates/tvshow.html:22
 msgid "all seasons"
 msgstr "本剧所有季"
 
@@ -3498,6 +3467,141 @@ msgstr "吴语"
 msgid "Hakka Chinese"
 msgstr "客家话"
 
+#: common/models/music_format.py:18
+msgctxt "album_type"
+msgid "Album"
+msgstr "专辑"
+
+#: common/models/music_format.py:19
+msgctxt "album_type"
+msgid "Single"
+msgstr "单曲"
+
+#: common/models/music_format.py:20
+msgctxt "album_type"
+msgid "EP"
+msgstr "EP"
+
+#: common/models/music_format.py:21
+msgctxt "album_type"
+msgid "Compilation"
+msgstr "合辑"
+
+#: common/models/music_format.py:22
+msgctxt "album_type"
+msgid "Soundtrack"
+msgstr "原声带"
+
+#: common/models/music_format.py:23
+msgctxt "album_type"
+msgid "Live"
+msgstr "现场"
+
+#: common/models/music_format.py:24
+msgctxt "album_type"
+msgid "Remix"
+msgstr "混音"
+
+#: common/models/music_format.py:25
+msgctxt "album_type"
+msgid "DJ-Mix"
+msgstr "DJ 混音"
+
+#: common/models/music_format.py:26
+msgctxt "album_type"
+msgid "Mixtape"
+msgstr "Mixtape"
+
+#: common/models/music_format.py:27
+msgctxt "album_type"
+msgid "Demo"
+msgstr "Demo"
+
+#: common/models/music_format.py:28
+msgctxt "album_type"
+msgid "Spoken Word"
+msgstr "朗读"
+
+#: common/models/music_format.py:29
+msgctxt "album_type"
+msgid "Audiobook"
+msgstr "有声书"
+
+#: common/models/music_format.py:30
+msgctxt "album_type"
+msgid "Audio Drama"
+msgstr "广播剧"
+
+#: common/models/music_format.py:31
+msgctxt "album_type"
+msgid "Interview"
+msgstr "访谈"
+
+#: common/models/music_format.py:32
+msgctxt "album_type"
+msgid "Broadcast"
+msgstr "广播"
+
+#: common/models/music_format.py:33
+msgctxt "album_type"
+msgid "Field Recording"
+msgstr "实地录音"
+
+#: common/models/music_format.py:34
+msgctxt "album_type"
+msgid "Other"
+msgstr "其它"
+
+#: common/models/music_format.py:38
+msgctxt "media_format"
+msgid "CD"
+msgstr "CD"
+
+#: common/models/music_format.py:39
+msgctxt "media_format"
+msgid "Vinyl"
+msgstr "黑胶"
+
+#: common/models/music_format.py:40
+msgctxt "media_format"
+msgid "Cassette"
+msgstr "磁带"
+
+#: common/models/music_format.py:41
+msgctxt "media_format"
+msgid "Digital"
+msgstr "数字"
+
+#: common/models/music_format.py:42
+msgctxt "media_format"
+msgid "SACD"
+msgstr "SACD"
+
+#: common/models/music_format.py:43
+msgctxt "media_format"
+msgid "DVD"
+msgstr "DVD"
+
+#: common/models/music_format.py:44
+msgctxt "media_format"
+msgid "Blu-ray"
+msgstr "蓝光"
+
+#: common/models/music_format.py:45
+msgctxt "media_format"
+msgid "MiniDisc"
+msgstr "MD"
+
+#: common/models/music_format.py:46
+msgctxt "media_format"
+msgid "VCD"
+msgstr "VCD"
+
+#: common/models/music_format.py:47
+msgctxt "media_format"
+msgid "Other"
+msgstr "其它"
+
 #: common/templates/400.html:23
 msgid "You may have submitted invalid data, or the content may have been deleted by the author."
 msgstr "您可能提交了无效的数据，或者相关内容已被作者删除。"
@@ -3871,7 +3975,7 @@ msgstr "Takahe管理"
 msgid "Database Admin"
 msgstr "数据库管理"
 
-#: common/templatetags/duration.py:55
+#: common/templatetags/duration.py:58
 msgid "just now"
 msgstr "刚刚"
 
@@ -4601,11 +4705,11 @@ msgstr "保存时将行首空格替换为全角"
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:155
-#: users/templates/users/data.html:206 users/templates/users/data.html:269
-#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:151
+#: users/templates/users/data.html:207 users/templates/users/data.html:258
+#: users/templates/users/data.html:321 users/templates/users/data.html:380
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
-#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr "可见性"
 
@@ -4639,7 +4743,7 @@ msgid "Collaborative editing"
 msgstr "协作编辑"
 
 #: journal/forms.py:191 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:483
+#: users/templates/users/data.html:535
 msgid "Status"
 msgstr "状态"
 
@@ -4652,7 +4756,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:499
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4662,26 +4766,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
+#: journal/importers/rym.py:168
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
+#: journal/importers/rym.py:178
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:183
+#: journal/importers/rym.py:233
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:388
+#: journal/importers/rym.py:348
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:411
+#: journal/importers/rym.py:376
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -4763,12 +4867,12 @@ msgstr[1] "%(count)d 个条目"
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:164 users/templates/users/data.html:215
-#: users/templates/users/data.html:277 users/templates/users/data.html:337
+#: users/templates/users/data.html:160 users/templates/users/data.html:216
+#: users/templates/users/data.html:267 users/templates/users/data.html:329
+#: users/templates/users/data.html:389
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
-#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr "公开"
 
@@ -4776,13 +4880,12 @@ msgstr "公开"
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:172
-#: users/templates/users/data.html:223 users/templates/users/data.html:285
-#: users/templates/users/data.html:345
+#: users/templates/users/data.html:115 users/templates/users/data.html:168
+#: users/templates/users/data.html:224 users/templates/users/data.html:275
+#: users/templates/users/data.html:337 users/templates/users/data.html:397
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
-#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr "仅关注者"
 
@@ -4790,13 +4893,12 @@ msgstr "仅关注者"
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:180
-#: users/templates/users/data.html:231 users/templates/users/data.html:293
-#: users/templates/users/data.html:353
+#: users/templates/users/data.html:123 users/templates/users/data.html:176
+#: users/templates/users/data.html:232 users/templates/users/data.html:283
+#: users/templates/users/data.html:345 users/templates/users/data.html:405
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
-#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
@@ -4837,7 +4939,6 @@ msgid "Retrying"
 msgstr "重试中"
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
-#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "页码"
 
@@ -5435,6 +5536,10 @@ msgstr "从高到低"
 #: journal/templates/_sidebar_user_mark_list.html:62
 msgid "sorting"
 msgstr "排序"
+
+#: journal/templates/_sidebar_user_mark_list.html:63
+msgid "date"
+msgstr "日期"
 
 #: journal/templates/_sidebar_user_mark_list.html:64
 msgid "rating"
@@ -6654,34 +6759,6 @@ msgstr "帖文"
 msgid "Article"
 msgstr "文章"
 
-#: takahe/models.py:451
-msgid "Display Name"
-msgstr "昵称"
-
-#: takahe/models.py:453
-msgid "Bio"
-msgstr "简介"
-
-#: takahe/models.py:455
-msgid "Manually approve new followers"
-msgstr "手工审核关注者"
-
-#: takahe/models.py:459
-msgid "Include profile, marks and posts in discovery"
-msgstr "允许个人资料、标记和帖文包含在发现中"
-
-#: takahe/models.py:462
-msgid "Include posts in search results"
-msgstr "允许个人帖文包含在搜索结果中"
-
-#: takahe/models.py:480
-msgid "Profile picture"
-msgstr "头像"
-
-#: takahe/models.py:487
-msgid "Header picture"
-msgstr "背景图片"
-
 #: users/models/task.py:22
 msgid "Started"
 msgstr "已开始"
@@ -6804,12 +6881,10 @@ msgid "Create new album"
 msgstr "新建专辑"
 
 #: users/templates/users/_rym_row.html:28
-#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr "然后将链接粘贴到上方；留空则跳过该行。"
 
 #: users/templates/users/_rym_row.html:39
-#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr "(跳过)"
 
@@ -6819,7 +6894,6 @@ msgid "Import from RateYourMusic"
 msgstr "从RateYourMusic导入"
 
 #: users/templates/users/_rym_section.html:9
-#: users/templates/users/_storygraph_section.html:9
 msgid "Review pending matches"
 msgstr "审阅待处理的匹配"
 
@@ -6828,7 +6902,6 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr "取消 RateYourMusic 导入？进度将被丢弃。"
 
 #: users/templates/users/_rym_section.html:16
-#: users/templates/users/_storygraph_section.html:16
 msgid "Cancel import"
 msgstr "取消导入"
 
@@ -6837,7 +6910,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/_storygraph_section.html:31
+#: users/templates/users/data.html:141
 msgid "Upload the downloaded CSV file below."
 msgstr "在下方上传下载到的 CSV 文件。"
 
@@ -6846,40 +6919,16 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/_rym_section.html:36
-#: users/templates/users/_storygraph_section.html:36
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
 
 #: users/templates/users/_rym_section.html:40
-#: users/templates/users/_storygraph_section.html:40
 msgid "Upload and match"
 msgstr "上传并匹配"
 
 #: users/templates/users/_rym_section.html:46
-#: users/templates/users/_storygraph_section.html:46
 msgid "Download previous matches"
 msgstr "下载先前的匹配"
-
-#: users/templates/users/_storygraph_row.html:30
-msgid "Create new book"
-msgstr "新建图书"
-
-#: users/templates/users/_storygraph_section.html:5
-#: users/templates/users/_storygraph_section.html:21
-msgid "Import from StoryGraph"
-msgstr "从StoryGraph导入"
-
-#: users/templates/users/_storygraph_section.html:15
-msgid "Cancel the StoryGraph import? Progress will be discarded."
-msgstr "取消 StoryGraph 导入？进度将被丢弃。"
-
-#: users/templates/users/_storygraph_section.html:29
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
-
-#: users/templates/users/_storygraph_section.html:33
-msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
-msgstr "图书将按 ISBN 进行匹配——优先查询本地条目库，然后是 Google Books 和 OpenLibrary——如无结果则按标题加作者搜索。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/account.html:11
 msgid "Account Information"
@@ -7169,9 +7218,9 @@ msgid "CSV file"
 msgstr "CSV 文件"
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:183
-#: users/templates/users/data.html:234 users/templates/users/data.html:298
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:126 users/templates/users/data.html:179
+#: users/templates/users/data.html:235 users/templates/users/data.html:286
+#: users/templates/users/data.html:350 users/templates/users/data.html:410
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -7315,7 +7364,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:256
+#: users/templates/users/data.html:34 users/templates/users/data.html:308
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -7347,128 +7396,140 @@ msgstr "在 Goodreads，点击 <a href=\"https://www.goodreads.com/review/import
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr "在下方上传下载的 <code>goodreads_library_export.csv</code> 文件。"
 
-#: users/templates/users/data.html:93
+#: users/templates/users/data.html:93 users/templates/users/data.html:143
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr "将导入想读、在读、已读和放弃的书籍及其评论。"
 
-#: users/templates/users/data.html:134
+#: users/templates/users/data.html:133
+msgid "Import from StoryGraph"
+msgstr "从StoryGraph导入"
+
+#: users/templates/users/data.html:139
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
+
+#: users/templates/users/data.html:146
+msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
+msgstr "书籍首先通过 ISBN 匹配，然后通过 Google Books 按标题和作者匹配。<b>StoryGraph 导出的元数据有限</b>（许多书籍缺少 ISBN），部分条目可能匹配失败或匹配错误——请在导入后查看失败条目列表。"
+
+#: users/templates/users/data.html:186
 msgid "Import from Letterboxd"
 msgstr "导入Letterboxd标记"
 
-#: users/templates/users/data.html:140
+#: users/templates/users/data.html:192
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr "在 letterboxd.com 网站，点击 <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">Settings 中的 DATA</a>；或在其 App 中，进入 Settings 后点击 Advanced Settings，再点击 EXPORT YOUR DATA"
 
-#: users/templates/users/data.html:143
+#: users/templates/users/data.html:195
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr "下载名称类似 <code>letterboxd-username-2018-03-11-07-52-utc.zip</code> 的文件，请勿解压"
 
-#: users/templates/users/data.html:146
+#: users/templates/users/data.html:198
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr "zip 文件中以下文件将被处理：<code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 
-#: users/templates/users/data.html:149
+#: users/templates/users/data.html:201
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr "导出文件不含片单的公开、不公开或私密状态，因此所有导入的标记、评论和收藏单都将以下方选择的可见性创建"
 
-#: users/templates/users/data.html:184 users/templates/users/data.html:235
+#: users/templates/users/data.html:236 users/templates/users/data.html:287
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "导入时仅更新正向变化(未标->想看->已看)标记；不足360字符的评论会作为短评添加。"
 
-#: users/templates/users/data.html:191
+#: users/templates/users/data.html:243
 msgid "Import from Trakt"
 msgstr "导入Trakt标记"
 
-#: users/templates/users/data.html:197
+#: users/templates/users/data.html:249
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr "在<a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt设置 - 数据</a>页面，点击<b>Export now</b>，等待下载链接出现。"
 
-#: users/templates/users/data.html:200
+#: users/templates/users/data.html:252
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 
-#: users/templates/users/data.html:202
+#: users/templates/users/data.html:254
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:295
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:246
+#: users/templates/users/data.html:298
 msgid "Login with Steam"
 msgstr "使用 Steam 登录"
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:304
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:263
+#: users/templates/users/data.html:315
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:267
+#: users/templates/users/data.html:319
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:296
+#: users/templates/users/data.html:348
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:306
+#: users/templates/users/data.html:358
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:312
+#: users/templates/users/data.html:364
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:314
+#: users/templates/users/data.html:366
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:324
+#: users/templates/users/data.html:376
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:385
+#: users/templates/users/data.html:437
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:411
+#: users/templates/users/data.html:463
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:436
+#: users/templates/users/data.html:488
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:460
+#: users/templates/users/data.html:512
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:464
+#: users/templates/users/data.html:516
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:471
+#: users/templates/users/data.html:523
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:479
+#: users/templates/users/data.html:531
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:482
+#: users/templates/users/data.html:534
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:487
+#: users/templates/users/data.html:539
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:496
+#: users/templates/users/data.html:548
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7872,7 +7933,6 @@ msgid "Review RateYourMusic Matches"
 msgstr "审阅 RateYourMusic 匹配结果"
 
 #: users/templates/users/rym_import.html:39
-#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7884,7 +7944,6 @@ msgstr ""
 "            "
 
 #: users/templates/users/rym_import.html:45
-#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr "下载已匹配的 CSV"
 
@@ -7893,32 +7952,30 @@ msgid "Title / Artist"
 msgstr "标题 / 艺术家"
 
 #: users/templates/users/rym_import.html:58
-#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr "匹配链接"
 
 #: users/templates/users/rym_import.html:59
-#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr "标记"
 
+#: users/templates/users/rym_import.html:60
+msgid "Date"
+msgstr "日期"
+
 #: users/templates/users/rym_import.html:71
-#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr "上一页"
 
 #: users/templates/users/rym_import.html:75
-#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr "下一页"
 
 #: users/templates/users/rym_import.html:95
-#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr "确认导入"
 
 #: users/templates/users/rym_import.html:96
-#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr "返回"
 
@@ -8038,15 +8095,6 @@ msgstr "选中则允许反向覆盖标记状态（如在玩->想玩，或玩过-
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr "Steam资料必须公开可见才能导入"
 
-#: users/templates/users/storygraph_import.html:9
-#: users/templates/users/storygraph_import.html:37
-msgid "Review StoryGraph Matches"
-msgstr "审阅 StoryGraph 匹配结果"
-
-#: users/templates/users/storygraph_import.html:57
-msgid "Title / Author"
-msgstr "标题 / 作者"
-
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr "失败条目"
@@ -8135,141 +8183,136 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:230 users/views/data.py:259
+#: users/views/data.py:223 users/views/data.py:252
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:253
+#: users/views/data.py:246
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:271
+#: users/views/data.py:264
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:286 users/views/data.py:306
+#: users/views/data.py:279 users/views/data.py:299
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:320
+#: users/views/data.py:313
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:334
+#: users/views/data.py:327
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:389
+#: users/views/data.py:382
 msgid "Account no longer linked."
 msgstr "账户已不再关联。"
 
-#: users/views/data.py:392
+#: users/views/data.py:385
 msgid "Content is no longer public."
 msgstr "内容已不再公开。"
 
-#: users/views/data.py:420
+#: users/views/data.py:413
 msgid "Retry did not complete, please try again."
 msgstr "重试未完成，请再试一次。"
 
-#: users/views/data.py:430 users/views/data.py:463 users/views/data.py:686
-#: users/views/data.py:901 users/views/data.py:926 users/views/data.py:950
-#: users/views/data.py:974
+#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
+#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
+#: users/views/data.py:769
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:497 users/views/data.py:720
+#: users/views/data.py:492
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:522 users/views/data.py:749
+#: users/views/data.py:517
 msgid "Cancelled."
 msgstr "已取消。"
 
-#: users/views/data.py:542
+#: users/views/data.py:537
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:550 users/views/data.py:660 users/views/data.py:779
-#: users/views/data.py:884
+#: users/views/data.py:545 users/views/data.py:655
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:646 users/views/data.py:870
+#: users/views/data.py:641
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:656 users/views/data.py:880
+#: users/views/data.py:651
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:771
-msgid "No StoryGraph import to preview."
-msgstr "暂无可预览的 StoryGraph 导入任务。"
-
-#: users/views/data.py:1094
+#: users/views/data.py:889
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:1116
+#: users/views/data.py:911
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:1132
+#: users/views/data.py:927
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:1137
+#: users/views/data.py:932
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:1147 users/views/data.py:1198
+#: users/views/data.py:942 users/views/data.py:993
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:1154
+#: users/views/data.py:949
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:1159
+#: users/views/data.py:954
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:1185
+#: users/views/data.py:980
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:1190
+#: users/views/data.py:985
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:1203
+#: users/views/data.py:998
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:1214
+#: users/views/data.py:1009
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:1220
+#: users/views/data.py:1015
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:1278
+#: users/views/data.py:1073
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:1294
+#: users/views/data.py:1089
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:1298
+#: users/views/data.py:1093
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:1307
+#: users/views/data.py:1102
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 22:16-0400\n"
+"POT-Creation-Date: 2026-07-15 23:19-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -58,11 +58,11 @@ msgstr "简体中文"
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: catalog/forms.py:35 catalog/models/item.py:260
+#: catalog/forms.py:35 catalog/models/item.py:261
 msgid "Primary ID Type"
 msgstr "主要标识类型"
 
-#: catalog/forms.py:40 catalog/models/item.py:263
+#: catalog/forms.py:40 catalog/models/item.py:264
 msgid "Primary ID Value"
 msgstr "主要标识数据"
 
@@ -70,515 +70,519 @@ msgstr "主要标识数据"
 msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "日期无效，应为 YYYY、YYYY-MM 或 YYYY-MM-DD。"
 
-#: catalog/models/book.py:136 catalog/models/book.py:155
-#: catalog/models/common.py:243 catalog/models/common.py:261
+#: catalog/models/book.py:139 catalog/models/book.py:158
+#: catalog/models/common.py:251 catalog/models/common.py:269
 msgid "locale"
 msgstr "区域语言"
 
-#: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:246 catalog/models/common.py:266
+#: catalog/models/book.py:142 catalog/models/book.py:161
+#: catalog/models/common.py:254 catalog/models/common.py:274
 msgid "text content"
 msgstr "文本内容"
 
-#: catalog/models/book.py:174
+#: catalog/models/book.py:177
 msgid "Paperback"
 msgstr "平装"
 
-#: catalog/models/book.py:175
+#: catalog/models/book.py:178
 msgid "Hardcover"
 msgstr "精装"
 
-#: catalog/models/book.py:176
+#: catalog/models/book.py:179
 msgid "eBook"
 msgstr "电子书"
 
-#: catalog/models/book.py:177
+#: catalog/models/book.py:180
 msgid "Audiobook"
 msgstr "有声书"
 
-#: catalog/models/book.py:179
+#: catalog/models/book.py:182
 msgid "Web Fiction"
 msgstr "网络作品"
 
-#: catalog/models/book.py:180 catalog/models/game.py:35
+#: catalog/models/book.py:183 catalog/models/game.py:38
 msgid "Other"
 msgstr "其它"
 
-#: catalog/models/book.py:254
+#: catalog/models/book.py:257
 msgid "subtitle"
 msgstr "副标题"
 
-#: catalog/models/book.py:264 catalog/models/movie.py:113
-#: catalog/models/performance.py:385 catalog/models/tv.py:199
-#: catalog/models/tv.py:421
+#: catalog/models/book.py:267 catalog/models/movie.py:120
+#: catalog/models/performance.py:385 catalog/models/tv.py:213
+#: catalog/models/tv.py:433
 msgid "original title"
 msgstr "原名"
 
-#: catalog/models/book.py:268
+#: catalog/models/book.py:271
 msgid "other title"
 msgstr "其它标题"
 
-#: catalog/models/book.py:274 catalog/models/book.py:558
-#: catalog/models/item.py:122
+#: catalog/models/book.py:277 catalog/models/book.py:561
+#: catalog/models/item.py:123
 msgid "author"
 msgstr "作者"
 
-#: catalog/models/book.py:281 catalog/models/item.py:123
+#: catalog/models/book.py:284 catalog/models/item.py:124
 msgid "translator"
 msgstr "译者"
 
-#: catalog/models/book.py:288 catalog/templates/edition.html:26
+#: catalog/models/book.py:291 catalog/templates/edition.html:26
 msgid "book format"
 msgstr "格式"
 
-#: catalog/models/book.py:295 catalog/models/game.py:132
-#: catalog/models/item.py:137 catalog/models/music.py:133
+#: catalog/models/book.py:298 catalog/models/game.py:135
+#: catalog/models/item.py:138 catalog/models/music.py:142
 msgid "publisher"
 msgstr "出版发行"
 
-#: catalog/models/book.py:302
+#: catalog/models/book.py:305
 msgid "publication year"
 msgstr "发行年份"
 
-#: catalog/models/book.py:308
+#: catalog/models/book.py:311
 msgid "publication month"
 msgstr "发行月份"
 
-#: catalog/models/book.py:313 catalog/templates/edition.html:51
+#: catalog/models/book.py:316 catalog/templates/edition.html:51
 msgid "binding"
 msgstr "装订"
 
-#: catalog/models/book.py:314
+#: catalog/models/book.py:317
 msgid "pages"
 msgstr "页数"
 
-#: catalog/models/book.py:315 catalog/templates/edition.html:45
+#: catalog/models/book.py:318 catalog/templates/edition.html:45
 msgid "series"
 msgstr "丛书"
 
-#: catalog/models/book.py:316 catalog/templates/edition.html:70
+#: catalog/models/book.py:319 catalog/templates/edition.html:70
 msgid "contents"
 msgstr "目录"
 
-#: catalog/models/book.py:317 catalog/templates/edition.html:56
+#: catalog/models/book.py:320 catalog/templates/edition.html:56
 msgid "price"
 msgstr "价格"
 
-#: catalog/models/book.py:318 catalog/templates/edition.html:34
+#: catalog/models/book.py:321 catalog/templates/edition.html:34
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:24 common/models/lang.py:249
+#: catalog/models/common.py:25 common/models/lang.py:249
 msgid "Unknown"
 msgstr "未知"
 
-#: catalog/models/common.py:25
+#: catalog/models/common.py:26
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:26 catalog/models/common.py:75
+#: catalog/models/common.py:27 catalog/models/common.py:76
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:27 catalog/models/common.py:77
+#: catalog/models/common.py:28 catalog/models/common.py:78
 msgid "Google Books"
 msgstr "谷歌图书"
 
-#: catalog/models/common.py:28
+#: catalog/models/common.py:29
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:29 catalog/models/common.py:86
-#: catalog/models/common.py:88
+#: catalog/models/common.py:30 catalog/models/common.py:87
+#: catalog/models/common.py:89
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:30 catalog/models/common.py:87
+#: catalog/models/common.py:31 catalog/models/common.py:88
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:31 catalog/models/common.py:70
+#: catalog/models/common.py:32 catalog/models/common.py:71
 #: catalog/templates/movie.html:46 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:63 catalog/templates/tvshow.html:58
 msgid "IMDb"
 msgstr "IMDb"
 
-#: catalog/models/common.py:32
+#: catalog/models/common.py:33
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:33 catalog/models/common.py:89
+#: catalog/models/common.py:34 catalog/models/common.py:90
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
-#: catalog/models/common.py:34
+#: catalog/models/common.py:35
 msgid "Spotify"
 msgstr "Spotify"
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:36
 msgid "IGDB"
 msgstr "IGDB"
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:37
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:37 catalog/models/common.py:109
+#: catalog/models/common.py:38 catalog/models/common.py:110
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:38 catalog/models/common.py:110
+#: catalog/models/common.py:39 catalog/models/common.py:111
 msgid "Bangumi"
 msgstr "Bangumi"
 
-#: catalog/models/common.py:39
+#: catalog/models/common.py:40
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:40 catalog/models/common.py:111
+#: catalog/models/common.py:41 catalog/models/common.py:112
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
-#: catalog/models/common.py:41
+#: catalog/models/common.py:42
 msgid "RSS"
 msgstr "RSS"
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:43
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:43 catalog/models/common.py:112
+#: catalog/models/common.py:44 catalog/models/common.py:113
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:44 catalog/models/common.py:114
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:45 catalog/models/common.py:115
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:49 catalog/models/common.py:119
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:49 catalog/models/common.py:60
+#: catalog/models/common.py:50 catalog/models/common.py:61
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:50 catalog/models/common.py:119
+#: catalog/models/common.py:51 catalog/models/common.py:120
 msgid "Open Library"
 msgstr "开放图书馆"
 
-#: catalog/models/common.py:51
+#: catalog/models/common.py:52
 msgid "MusicBrainz"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:53
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:53 catalog/models/common.py:121
+#: catalog/models/common.py:54 catalog/models/common.py:122
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:54 catalog/models/common.py:122
+#: catalog/models/common.py:55 catalog/models/common.py:123
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:55 catalog/models/common.py:113
+#: catalog/models/common.py:56 catalog/models/common.py:114
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:56
+#: catalog/models/common.py:57
 msgid "RateYourMusic"
 msgstr "RateYourMusic"
 
-#: catalog/models/common.py:61
+#: catalog/models/common.py:62
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:62 catalog/templates/edition.html:19
+#: catalog/models/common.py:63 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:64
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:77
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:79
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:80
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:90
+#: catalog/models/common.py:91
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:96
+#: catalog/models/common.py:97
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:99
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:100
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz艺术家"
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:120
+#: catalog/models/common.py:121
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:123
+#: catalog/models/common.py:124
 msgid "RateYourMusic Release"
 msgstr "RateYourMusic发行"
 
-#: catalog/models/common.py:144
+#: catalog/models/common.py:145
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:145 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:146 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:147
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:148 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:149
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:149 catalog/models/common.py:165
-#: catalog/models/common.py:179 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:150 catalog/models/common.py:166
+#: catalog/models/common.py:180 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:151
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:151 catalog/models/common.py:168
-#: catalog/models/common.py:182 common/templates/_header.html:43
+#: catalog/models/common.py:152 catalog/models/common.py:169
+#: catalog/models/common.py:183 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:152
+#: catalog/models/common.py:153
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:153
+#: catalog/models/common.py:154
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:154 catalog/models/common.py:170
-#: catalog/models/common.py:184 common/templates/_header.html:47
+#: catalog/models/common.py:155 catalog/models/common.py:171
+#: catalog/models/common.py:185 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:155
+#: catalog/models/common.py:156
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:157
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:157 catalog/models/common.py:174
+#: catalog/models/common.py:158 catalog/models/common.py:175
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:160 catalog/models/common.py:173
+#: catalog/models/common.py:161 catalog/models/common.py:174
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:164 catalog/models/common.py:178
+#: catalog/models/common.py:165 catalog/models/common.py:179
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:166 catalog/models/common.py:180
+#: catalog/models/common.py:167 catalog/models/common.py:181
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:167 catalog/models/common.py:181
+#: catalog/models/common.py:168 catalog/models/common.py:182
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:169 catalog/models/common.py:183
+#: catalog/models/common.py:170 catalog/models/common.py:184
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:309 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:317 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:347
+#: catalog/models/common.py:355
 msgid "origin country"
 msgstr "制片国家/地区"
 
-#: catalog/models/common.py:376 catalog/templates/album.html:33
+#: catalog/models/common.py:384 catalog/templates/album.html:33
 msgid "album type"
 msgstr "专辑类型"
 
-#: catalog/models/common.py:380
+#: catalog/models/common.py:388 catalog/templates/_platform_list.html:5
+msgid "platform"
+msgstr "平台"
+
+#: catalog/models/common.py:392
 msgid "media format"
 msgstr "介质"
 
-#: catalog/models/common.py:385 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:397 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr "语言"
@@ -611,74 +615,70 @@ msgstr "订阅源中没有找到任何音频单集"
 msgid "no matching identity found in the feed or its linked website"
 msgstr "未在订阅源或其关联网站中找到匹配的身份标识"
 
-#: catalog/models/game.py:27
+#: catalog/models/game.py:30
 msgid "Main Game"
 msgstr "游戏"
 
-#: catalog/models/game.py:28
+#: catalog/models/game.py:31
 msgid "Expansion"
 msgstr "资料片"
 
-#: catalog/models/game.py:29
+#: catalog/models/game.py:32
 msgid "Downloadable Content"
 msgstr "可下载内容"
 
-#: catalog/models/game.py:30
+#: catalog/models/game.py:33
 msgid "Mod"
 msgstr "模组"
 
-#: catalog/models/game.py:31
+#: catalog/models/game.py:34
 msgid "Bundle"
 msgstr "合集"
 
-#: catalog/models/game.py:32
+#: catalog/models/game.py:35
 msgid "Remaster"
 msgstr "复刻"
 
-#: catalog/models/game.py:33
+#: catalog/models/game.py:36
 msgid "Remake"
 msgstr "重制"
 
-#: catalog/models/game.py:34
+#: catalog/models/game.py:37
 msgid "Special Edition"
 msgstr "特别版"
 
-#: catalog/models/game.py:108 catalog/models/item.py:129
+#: catalog/models/game.py:111 catalog/models/item.py:130
 msgid "designer"
 msgstr "设计者"
 
-#: catalog/models/game.py:116 catalog/models/item.py:128
-#: catalog/models/music.py:125
+#: catalog/models/game.py:119 catalog/models/item.py:129
+#: catalog/models/music.py:134
 msgid "artist"
 msgstr "艺术家"
 
-#: catalog/models/game.py:124 catalog/models/item.py:138
+#: catalog/models/game.py:127 catalog/models/item.py:139
 msgid "developer"
 msgstr "开发者"
 
-#: catalog/models/game.py:140 catalog/models/podcast.py:256
+#: catalog/models/game.py:143 catalog/models/podcast.py:257
 msgid "date of publication"
 msgstr "发行日期"
 
-#: catalog/models/game.py:144 catalog/models/movie.py:149
-#: catalog/models/music.py:119 catalog/models/tv.py:235
-#: catalog/models/tv.py:457
+#: catalog/models/game.py:147 catalog/models/movie.py:156
+#: catalog/models/music.py:128 catalog/models/tv.py:249
+#: catalog/models/tv.py:469
 msgid "YYYY, YYYY-MM or YYYY-MM-DD"
 msgstr "YYYY、YYYY-MM 或 YYYY-MM-DD"
 
-#: catalog/models/game.py:164 catalog/templates/game.html:16
+#: catalog/models/game.py:169 catalog/templates/game.html:17
 msgid "release type"
 msgstr "发布类型"
 
-#: catalog/models/game.py:173
-msgid "platform"
-msgstr "平台"
-
-#: catalog/models/game.py:179 catalog/models/movie.py:151
+#: catalog/models/game.py:180 catalog/models/movie.py:158
 #: catalog/models/people.py:158 catalog/models/performance.py:258
-#: catalog/models/performance.py:465 catalog/models/podcast.py:88
-#: catalog/models/tv.py:237 catalog/models/tv.py:460
-#: catalog/templates/game.html:32 catalog/templates/movie.html:53
+#: catalog/models/performance.py:465 catalog/models/podcast.py:89
+#: catalog/models/tv.py:251 catalog/models/tv.py:472
+#: catalog/templates/game.html:33 catalog/templates/movie.html:53
 #: catalog/templates/people.html:44 catalog/templates/performance.html:35
 #: catalog/templates/performanceproduction.html:35
 #: catalog/templates/podcast.html:30 catalog/templates/tvseason.html:70
@@ -686,161 +686,161 @@ msgstr "平台"
 msgid "website"
 msgstr "网站"
 
-#: catalog/models/item.py:124 catalog/models/movie.py:116
+#: catalog/models/item.py:125 catalog/models/movie.py:123
 #: catalog/models/performance.py:182 catalog/models/performance.py:389
-#: catalog/models/tv.py:202 catalog/models/tv.py:424
+#: catalog/models/tv.py:216 catalog/models/tv.py:436
 msgid "director"
 msgstr "导演"
 
-#: catalog/models/item.py:125 catalog/models/movie.py:123
+#: catalog/models/item.py:126 catalog/models/movie.py:130
 #: catalog/models/performance.py:189 catalog/models/performance.py:396
-#: catalog/models/tv.py:209 catalog/models/tv.py:431
+#: catalog/models/tv.py:223 catalog/models/tv.py:443
 msgid "playwright"
 msgstr "编剧"
 
-#: catalog/models/item.py:126 catalog/models/movie.py:130
+#: catalog/models/item.py:127 catalog/models/movie.py:137
 #: catalog/models/performance.py:217 catalog/models/performance.py:424
-#: catalog/models/tv.py:216 catalog/models/tv.py:438
+#: catalog/models/tv.py:230 catalog/models/tv.py:450
 msgid "actor"
 msgstr "演员"
 
-#: catalog/models/item.py:127 catalog/models/movie.py:137
-#: catalog/models/tv.py:223 catalog/models/tv.py:445
+#: catalog/models/item.py:128 catalog/models/movie.py:144
+#: catalog/models/tv.py:237 catalog/models/tv.py:457
 msgid "producer"
 msgstr "制片人"
 
-#: catalog/models/item.py:130 catalog/models/performance.py:203
+#: catalog/models/item.py:131 catalog/models/performance.py:203
 #: catalog/models/performance.py:410
 msgid "composer"
 msgstr "作曲"
 
-#: catalog/models/item.py:131 catalog/models/performance.py:210
+#: catalog/models/item.py:132 catalog/models/performance.py:210
 #: catalog/models/performance.py:417
 msgid "choreographer"
 msgstr "编舞"
 
-#: catalog/models/item.py:132 catalog/models/performance.py:224
+#: catalog/models/item.py:133 catalog/models/performance.py:224
 #: catalog/models/performance.py:431
 msgid "performer"
 msgstr "表演者"
 
-#: catalog/models/item.py:133 catalog/models/podcast.py:79
+#: catalog/models/item.py:134 catalog/models/podcast.py:80
 msgid "host"
 msgstr "主播"
 
-#: catalog/models/item.py:134 catalog/models/performance.py:196
+#: catalog/models/item.py:135 catalog/models/performance.py:196
 #: catalog/models/performance.py:403
 msgid "original creator"
 msgstr "原始创作者"
 
-#: catalog/models/item.py:135 catalog/models/performance.py:238
+#: catalog/models/item.py:136 catalog/models/performance.py:238
 #: catalog/models/performance.py:445
 msgid "crew"
 msgstr "工作人员"
 
-#: catalog/models/item.py:139
+#: catalog/models/item.py:140
 msgid "production company"
 msgstr "制作公司"
 
-#: catalog/models/item.py:140
+#: catalog/models/item.py:141
 msgid "record label"
 msgstr "唱片公司"
 
-#: catalog/models/item.py:141
+#: catalog/models/item.py:142
 msgid "distributor"
 msgstr "发行商"
 
-#: catalog/models/item.py:142
+#: catalog/models/item.py:143
 msgid "studio"
 msgstr "工作室"
 
-#: catalog/models/item.py:143 catalog/models/performance.py:231
+#: catalog/models/item.py:144 catalog/models/performance.py:231
 #: catalog/models/performance.py:438
 msgid "troupe"
 msgstr "剧团"
 
-#: catalog/models/item.py:158 catalog/models/people.py:477
+#: catalog/models/item.py:159 catalog/models/people.py:477
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:159 catalog/models/people.py:135
+#: catalog/models/item.py:160 catalog/models/people.py:135
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:161 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:162 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "角色名"
 
-#: catalog/models/item.py:257 catalog/models/item.py:289
+#: catalog/models/item.py:258 catalog/models/item.py:290
 #: journal/models/collection.py:93
 msgid "title"
 msgstr "标题"
 
-#: catalog/models/item.py:258 catalog/models/item.py:297
+#: catalog/models/item.py:259 catalog/models/item.py:298
 #: journal/models/collection.py:94
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:269 catalog/models/people.py:485
+#: catalog/models/item.py:270 catalog/models/people.py:485
 msgid "metadata"
 msgstr "元数据"
 
-#: catalog/models/item.py:271 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:272 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1418
+#: catalog/models/item.py:1429
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:1420
+#: catalog/models/item.py:1431
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:1422
+#: catalog/models/item.py:1433
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1438
+#: catalog/models/item.py:1449
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1444
+#: catalog/models/item.py:1455
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1447
+#: catalog/models/item.py:1458
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
-#: catalog/models/movie.py:145 catalog/models/music.py:115
-#: catalog/models/tv.py:231 catalog/models/tv.py:453
+#: catalog/models/movie.py:152 catalog/models/music.py:124
+#: catalog/models/tv.py:245 catalog/models/tv.py:465
 #: catalog/templates/_item_card_metadata_album.html:16
-#: catalog/templates/album.html:17 catalog/templates/game.html:21
+#: catalog/templates/album.html:17 catalog/templates/game.html:22
 #: catalog/templates/movie.html:41 catalog/templates/tvseason.html:58
 #: catalog/templates/tvshow.html:53
 msgid "release date"
 msgstr "发布日期"
 
-#: catalog/models/movie.py:155 catalog/models/music.py:122
+#: catalog/models/movie.py:162 catalog/models/music.py:131
 #: catalog/templates/movie.html:21 catalog/templates/tvseason.html:53
 #: catalog/templates/tvshow.html:48
 msgid "length"
 msgstr "长度"
 
-#: catalog/models/movie.py:155 catalog/models/music.py:122
-#: catalog/models/tv.py:245 catalog/models/tv.py:468
+#: catalog/models/movie.py:162 catalog/models/music.py:131
+#: catalog/models/tv.py:259 catalog/models/tv.py:480
 msgid "seconds"
 msgstr "秒"
 
-#: catalog/models/music.py:139
+#: catalog/models/music.py:148
 msgid "tracks"
 msgstr "曲目"
 
-#: catalog/models/music.py:144 catalog/templates/album.html:51
+#: catalog/models/music.py:153 catalog/templates/album.html:51
 msgid "number of discs"
 msgstr "碟片数"
 
@@ -994,30 +994,30 @@ msgstr "上演日期"
 msgid "closing date"
 msgstr "结束日期"
 
-#: catalog/models/tv.py:174 catalog/templates/tvseason.html:38
+#: catalog/models/tv.py:188 catalog/templates/tvseason.html:38
 #: catalog/templates/tvshow.html:33
 msgid "number of seasons"
 msgstr "季数"
 
-#: catalog/models/tv.py:177 catalog/models/tv.py:399
+#: catalog/models/tv.py:191 catalog/models/tv.py:411
 #: catalog/templates/tvseason.html:43 catalog/templates/tvshow.html:38
 msgid "number of episodes"
 msgstr "集数"
 
-#: catalog/models/tv.py:242 catalog/models/tv.py:465
+#: catalog/models/tv.py:256 catalog/models/tv.py:477
 msgid "episode length"
 msgstr "单集长度"
 
-#: catalog/models/tv.py:396 catalog/templates/tvseason.html:33
+#: catalog/models/tv.py:408 catalog/templates/tvseason.html:33
 msgid "season number"
 msgstr "本季序号"
 
-#: catalog/models/tv.py:510
+#: catalog/models/tv.py:520
 #, python-brace-format
 msgid "{show_title} Season {season_number}"
 msgstr "{show_title} 第{season_number}季"
 
-#: catalog/models/tv.py:664
+#: catalog/models/tv.py:674
 #, python-brace-format
 msgid "{season_title} E{episode_number}"
 msgstr "{season_title} 第{episode_number}集"
@@ -2249,6 +2249,21 @@ msgstr "条目已不存在"
 #: catalog/views/view.py:182
 msgid "Invalid role"
 msgstr "无效职务或角色。"
+
+#: common/models/game_platform.py:30
+msgctxt "platform"
+msgid "Web"
+msgstr "网页"
+
+#: common/models/game_platform.py:63
+msgctxt "platform"
+msgid "Arcade"
+msgstr "街机"
+
+#: common/models/game_platform.py:64
+msgctxt "platform"
+msgid "Board Game"
+msgstr "桌面游戏"
 
 #: common/models/genre.py:21
 msgctxt "genre"
@@ -3969,7 +3984,7 @@ msgstr "Takahe管理"
 msgid "Database Admin"
 msgstr "数据库管理"
 
-#: common/templatetags/duration.py:58
+#: common/templatetags/duration.py:59
 msgid "just now"
 msgstr "刚刚"
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-15 23:19-0400\n"
+"POT-Creation-Date: 2026-07-16 20:50-0400\n"
 "PO-Revision-Date: 2025-04-27 04:24+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -4714,11 +4714,11 @@ msgstr "保存时将行首空格替换为全角"
 #: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
 #: journal/forms.py:199 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:151
-#: users/templates/users/data.html:207 users/templates/users/data.html:258
-#: users/templates/users/data.html:321 users/templates/users/data.html:380
-#: users/templates/users/rym_import.html:81
+#: users/templates/users/data.html:98 users/templates/users/data.html:155
+#: users/templates/users/data.html:206 users/templates/users/data.html:269
+#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
+#: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr "可见性"
 
@@ -4752,7 +4752,7 @@ msgid "Collaborative editing"
 msgstr "协作编辑"
 
 #: journal/forms.py:191 users/templates/users/crossposts.html:51
-#: users/templates/users/data.html:535
+#: users/templates/users/data.html:483
 msgid "Status"
 msgstr "状态"
 
@@ -4765,7 +4765,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:144
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:203
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:500
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4775,26 +4775,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:168
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:128
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:178
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:138
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:233
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:184
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:348
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:389
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:376
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:412
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -4876,12 +4876,12 @@ msgstr[1] "%(count)d 个条目"
 #: journal/templates/mark.html:88 journal/templates/post_compose.html:58
 #: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
 #: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:160 users/templates/users/data.html:216
-#: users/templates/users/data.html:267 users/templates/users/data.html:329
-#: users/templates/users/data.html:389
+#: users/templates/users/data.html:164 users/templates/users/data.html:215
+#: users/templates/users/data.html:277 users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
+#: users/templates/users/storygraph_import.html:84
 msgid "Public"
 msgstr "公开"
 
@@ -4889,12 +4889,13 @@ msgstr "公开"
 #: journal/templates/collection_share.html:46 journal/templates/comment.html:42
 #: journal/templates/mark.html:95 journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
-#: users/templates/users/data.html:115 users/templates/users/data.html:168
-#: users/templates/users/data.html:224 users/templates/users/data.html:275
-#: users/templates/users/data.html:337 users/templates/users/data.html:397
+#: users/templates/users/data.html:115 users/templates/users/data.html:172
+#: users/templates/users/data.html:223 users/templates/users/data.html:285
+#: users/templates/users/data.html:345
 #: users/templates/users/preferences.html:63
 #: users/templates/users/rym_import.html:88
 #: users/templates/users/steam_import.html:132
+#: users/templates/users/storygraph_import.html:88
 msgid "Followers Only"
 msgstr "仅关注者"
 
@@ -4902,12 +4903,13 @@ msgstr "仅关注者"
 #: journal/templates/comment.html:49 journal/templates/mark.html:102
 #: journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
-#: users/templates/users/data.html:123 users/templates/users/data.html:176
-#: users/templates/users/data.html:232 users/templates/users/data.html:283
-#: users/templates/users/data.html:345 users/templates/users/data.html:405
+#: users/templates/users/data.html:123 users/templates/users/data.html:180
+#: users/templates/users/data.html:231 users/templates/users/data.html:293
+#: users/templates/users/data.html:353
 #: users/templates/users/preferences.html:70
 #: users/templates/users/rym_import.html:92
 #: users/templates/users/steam_import.html:136
+#: users/templates/users/storygraph_import.html:92
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
@@ -4948,6 +4950,7 @@ msgid "Retrying"
 msgstr "重试中"
 
 #: journal/models/note.py:34 users/templates/users/rym_import.html:73
+#: users/templates/users/storygraph_import.html:73
 msgid "Page"
 msgstr "页码"
 
@@ -6890,10 +6893,12 @@ msgid "Create new album"
 msgstr "新建专辑"
 
 #: users/templates/users/_rym_row.html:28
+#: users/templates/users/_storygraph_row.html:31
 msgid "then paste the link above; leave blank to skip this row."
 msgstr "然后将链接粘贴到上方；留空则跳过该行。"
 
 #: users/templates/users/_rym_row.html:39
+#: users/templates/users/_storygraph_row.html:42
 msgid "(skip)"
 msgstr "(跳过)"
 
@@ -6903,6 +6908,7 @@ msgid "Import from RateYourMusic"
 msgstr "从RateYourMusic导入"
 
 #: users/templates/users/_rym_section.html:9
+#: users/templates/users/_storygraph_section.html:11
 msgid "Review pending matches"
 msgstr "审阅待处理的匹配"
 
@@ -6911,6 +6917,7 @@ msgid "Cancel the RateYourMusic import? Progress will be discarded."
 msgstr "取消 RateYourMusic 导入？进度将被丢弃。"
 
 #: users/templates/users/_rym_section.html:16
+#: users/templates/users/_storygraph_section.html:18
 msgid "Cancel import"
 msgstr "取消导入"
 
@@ -6919,7 +6926,7 @@ msgid "On RateYourMusic, go to your profile and use the <b>Export your music cat
 msgstr "在 RateYourMusic 个人资料页面，使用 <b>Export your music catalog</b> 选项将你的收藏导出为 CSV 文件。"
 
 #: users/templates/users/_rym_section.html:31
-#: users/templates/users/data.html:141
+#: users/templates/users/_storygraph_section.html:33
 msgid "Upload the downloaded CSV file below."
 msgstr "在下方上传下载到的 CSV 文件。"
 
@@ -6928,16 +6935,40 @@ msgid "Albums are matched by title + artist (and year if present) — first agai
 msgstr "专辑将按照标题加艺术家（若有年份则一并使用）进行匹配——优先查询本地条目库，然后是 MusicBrainz，最后是 Spotify。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/_rym_section.html:36
+#: users/templates/users/_storygraph_section.html:38
 msgid "You can also re-upload a previously-downloaded matched CSV — the existing <code>link</code> column will be honoured as the default match."
 msgstr "你也可以重新上传之前下载的匹配 CSV——已有的 <code>link</code> 列将作为默认匹配项。"
 
 #: users/templates/users/_rym_section.html:40
+#: users/templates/users/_storygraph_section.html:42
 msgid "Upload and match"
 msgstr "上传并匹配"
 
 #: users/templates/users/_rym_section.html:46
+#: users/templates/users/_storygraph_section.html:48
 msgid "Download previous matches"
 msgstr "下载先前的匹配"
+
+#: users/templates/users/_storygraph_row.html:30
+msgid "Create new book"
+msgstr "新建图书"
+
+#: users/templates/users/_storygraph_section.html:5
+#: users/templates/users/_storygraph_section.html:23
+msgid "Import from StoryGraph"
+msgstr "从StoryGraph导入"
+
+#: users/templates/users/_storygraph_section.html:17
+msgid "Cancel the StoryGraph import? Progress will be discarded."
+msgstr "取消 StoryGraph 导入？进度将被丢弃。"
+
+#: users/templates/users/_storygraph_section.html:31
+msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
+msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
+
+#: users/templates/users/_storygraph_section.html:35
+msgid "Books are matched by ISBN — first against the local catalog, then Google Books and OpenLibrary — with a title + author search as fallback. After auto-matching, you'll preview the matches in a table, edit any link or shelf status, and confirm the import."
+msgstr "图书将按 ISBN 进行匹配——优先查询本地条目库，然后是 Google Books 和 OpenLibrary——如无结果则按标题加作者搜索。自动匹配完成后，可以在表格中预览匹配结果，编辑链接或标记状态，再确认导入。"
 
 #: users/templates/users/account.html:11
 msgid "Account Information"
@@ -7227,9 +7258,9 @@ msgid "CSV file"
 msgstr "CSV 文件"
 
 #: users/templates/users/account.html:445 users/templates/users/data.html:74
-#: users/templates/users/data.html:126 users/templates/users/data.html:179
-#: users/templates/users/data.html:235 users/templates/users/data.html:286
-#: users/templates/users/data.html:350 users/templates/users/data.html:410
+#: users/templates/users/data.html:126 users/templates/users/data.html:183
+#: users/templates/users/data.html:234 users/templates/users/data.html:298
+#: users/templates/users/data.html:358
 #: users/templates/users/steam_import.html:140
 msgid "Import"
 msgstr "导入"
@@ -7373,7 +7404,7 @@ msgstr "导入豆瓣标记和评论"
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr "在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆坟)</a>导出时勾选<mark>书影音游剧</mark>和<mark>评论</mark>。<br>选择从豆伴(豆坟)导出的<code>.xlsx</code>文件"
 
-#: users/templates/users/data.html:34 users/templates/users/data.html:308
+#: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "导入方式"
 
@@ -7405,140 +7436,128 @@ msgstr "在 Goodreads，点击 <a href=\"https://www.goodreads.com/review/import
 msgid "Upload the downloaded <code>goodreads_library_export.csv</code> file below."
 msgstr "在下方上传下载的 <code>goodreads_library_export.csv</code> 文件。"
 
-#: users/templates/users/data.html:93 users/templates/users/data.html:143
+#: users/templates/users/data.html:93
 msgid "want-to-read / currently-reading / read / did-not-finish books and their reviews will be imported."
 msgstr "将导入想读、在读、已读和放弃的书籍及其评论。"
 
-#: users/templates/users/data.html:133
-msgid "Import from StoryGraph"
-msgstr "从StoryGraph导入"
-
-#: users/templates/users/data.html:139
-msgid "On StoryGraph, click <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> to download your library as a CSV file."
-msgstr "在 StoryGraph，点击 <a href=\"https://app.thestorygraph.com/user-export\" target=\"_blank\" rel=\"noopener\"><b>Export your library</b></a> 将书库下载为 CSV 文件。"
-
-#: users/templates/users/data.html:146
-msgid "Books are matched first by ISBN, then by title and author via Google Books. <b>The StoryGraph export has limited metadata</b> (many books lack ISBNs), so some items may fail to match or be matched incorrectly — please review the failed items list after import."
-msgstr "书籍首先通过 ISBN 匹配，然后通过 Google Books 按标题和作者匹配。<b>StoryGraph 导出的元数据有限</b>（许多书籍缺少 ISBN），部分条目可能匹配失败或匹配错误——请在导入后查看失败条目列表。"
-
-#: users/templates/users/data.html:186
+#: users/templates/users/data.html:134
 msgid "Import from Letterboxd"
 msgstr "导入Letterboxd标记"
 
-#: users/templates/users/data.html:192
+#: users/templates/users/data.html:140
 msgid "on letterboxd.com, click <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">DATA in Settings</a>; or in its app, tap Advanced Settings in Settings, tap EXPORT YOUR DATA"
 msgstr "在 letterboxd.com 网站，点击 <a href=\"https://letterboxd.com/settings/data/\" target=\"_blank\" rel=\"noopener\">Settings 中的 DATA</a>；或在其 App 中，进入 Settings 后点击 Advanced Settings，再点击 EXPORT YOUR DATA"
 
-#: users/templates/users/data.html:195
+#: users/templates/users/data.html:143
 msgid "download file with name like <code>letterboxd-username-2018-03-11-07-52-utc.zip</code>, do not unzip"
 msgstr "下载名称类似 <code>letterboxd-username-2018-03-11-07-52-utc.zip</code> 的文件，请勿解压"
 
-#: users/templates/users/data.html:198
+#: users/templates/users/data.html:146
 msgid "the following files in the zip file will be processed: <code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 msgstr "zip 文件中以下文件将被处理：<code>reviews.csv</code> <code>ratings.csv</code> <code>watched.csv</code> <code>watchlist.csv</code> <code>lists/*.csv</code>"
 
-#: users/templates/users/data.html:201
+#: users/templates/users/data.html:149
 msgid "exported file does not indicate whether a list is private, unlisted or public, so all imported marks, reviews and collections will be created with the visibility selected below"
 msgstr "导出文件不含片单的公开、不公开或私密状态，因此所有导入的标记、评论和收藏单都将以下方选择的可见性创建"
 
-#: users/templates/users/data.html:236 users/templates/users/data.html:287
+#: users/templates/users/data.html:184 users/templates/users/data.html:235
 msgid "Only forward changes(none->to-watch->watched) will be imported."
 msgstr "导入时仅更新正向变化(未标->想看->已看)标记；不足360字符的评论会作为短评添加。"
 
-#: users/templates/users/data.html:243
+#: users/templates/users/data.html:191
 msgid "Import from Trakt"
 msgstr "导入Trakt标记"
 
-#: users/templates/users/data.html:249
+#: users/templates/users/data.html:197
 msgid "On <a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt Settings - Data</a>, click <b>Export now</b> and wait for the download link to appear."
 msgstr "在<a href=\"https://app.trakt.tv/settings/data\" target=\"_blank\" rel=\"noopener\">Trakt设置 - 数据</a>页面，点击<b>Export now</b>，等待下载链接出现。"
 
-#: users/templates/users/data.html:252
+#: users/templates/users/data.html:200
 msgid "Upload the downloaded <code>.zip</code> file below, do not unzip."
 msgstr "上传下载的<code>.zip</code>文件，无需解压。"
 
-#: users/templates/users/data.html:254
+#: users/templates/users/data.html:202
 msgid "Ratings, watched movies/shows and watchlist will be imported."
 msgstr "将导入评分、已看的电影/剧集和想看列表。"
 
-#: users/templates/users/data.html:295
+#: users/templates/users/data.html:243
 #: users/templates/users/steam_import.html:18
 msgid "Import from Steam Wishlist / Library"
 msgstr "导入Steam游戏库和愿望清单"
 
-#: users/templates/users/data.html:298
+#: users/templates/users/data.html:246
 msgid "Login with Steam"
 msgstr "使用 Steam 登录"
 
-#: users/templates/users/data.html:304
+#: users/templates/users/data.html:252
 msgid "Import Podcast Subscriptions"
 msgstr "导入播客订阅列表 (OPML)"
 
-#: users/templates/users/data.html:315
+#: users/templates/users/data.html:263
 msgid "Mark as listening"
 msgstr "标记为在听"
 
-#: users/templates/users/data.html:319
+#: users/templates/users/data.html:267
 msgid "Import as a new collection"
 msgstr "导入为新收藏单"
 
-#: users/templates/users/data.html:348
+#: users/templates/users/data.html:296
 msgid "Select OPML file"
 msgstr "选择OPML文件"
 
-#: users/templates/users/data.html:358
+#: users/templates/users/data.html:306
 msgid "Import NeoDB Archive"
 msgstr "导入NeoDB备份"
 
-#: users/templates/users/data.html:364
+#: users/templates/users/data.html:312
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
 msgstr "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</code>压缩包。"
 
-#: users/templates/users/data.html:366
+#: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."
 msgstr "现有数据可能会被覆盖。"
 
-#: users/templates/users/data.html:376
+#: users/templates/users/data.html:324
 msgid "Detected format"
 msgstr "检测到格式"
 
-#: users/templates/users/data.html:437
+#: users/templates/users/data.html:385
 msgid "Detecting format..."
 msgstr "检测格式中"
 
-#: users/templates/users/data.html:463
+#: users/templates/users/data.html:411
 msgid "Unknown format"
 msgstr "未知格式"
 
-#: users/templates/users/data.html:488
+#: users/templates/users/data.html:436
 msgid "Error detecting format"
 msgstr "检测格式出错"
 
-#: users/templates/users/data.html:512
+#: users/templates/users/data.html:460
 msgid "Export NeoDB Archive"
 msgstr "导出NeoDB备份"
 
-#: users/templates/users/data.html:516
+#: users/templates/users/data.html:464
 msgid "Export marks, reviews and notes in CSV"
 msgstr "导出标记、短评和评论 （CSV格式）"
 
-#: users/templates/users/data.html:523
+#: users/templates/users/data.html:471
 msgid "Export everything in NDJSON"
 msgstr "导出标记、短评和评论 （NDJSON格式）"
 
-#: users/templates/users/data.html:531
+#: users/templates/users/data.html:479
 msgid "Export marks and reviews in XLSX (Doufen format)"
 msgstr "导出标记、短评和评论 （豆坟xlsx格式）"
 
-#: users/templates/users/data.html:534
+#: users/templates/users/data.html:482
 msgid "Last export"
 msgstr "最近导出"
 
-#: users/templates/users/data.html:539
+#: users/templates/users/data.html:487
 msgid "Download"
 msgstr "下载"
 
-#: users/templates/users/data.html:548
+#: users/templates/users/data.html:496
 msgid "View Annual Summary"
 msgstr "查看年度小结"
 
@@ -7942,6 +7961,7 @@ msgid "Review RateYourMusic Matches"
 msgstr "审阅 RateYourMusic 匹配结果"
 
 #: users/templates/users/rym_import.html:39
+#: users/templates/users/storygraph_import.html:39
 #, python-format
 msgid ""
 "\n"
@@ -7953,6 +7973,7 @@ msgstr ""
 "            "
 
 #: users/templates/users/rym_import.html:45
+#: users/templates/users/storygraph_import.html:45
 msgid "Download matched CSV"
 msgstr "下载已匹配的 CSV"
 
@@ -7961,30 +7982,37 @@ msgid "Title / Artist"
 msgstr "标题 / 艺术家"
 
 #: users/templates/users/rym_import.html:58
+#: users/templates/users/storygraph_import.html:58
 msgid "Matched Link"
 msgstr "匹配链接"
 
 #: users/templates/users/rym_import.html:59
+#: users/templates/users/storygraph_import.html:59
 msgid "Shelf"
 msgstr "标记"
 
 #: users/templates/users/rym_import.html:60
+#: users/templates/users/storygraph_import.html:60
 msgid "Date"
 msgstr "日期"
 
 #: users/templates/users/rym_import.html:71
+#: users/templates/users/storygraph_import.html:71
 msgid "Prev"
 msgstr "上一页"
 
 #: users/templates/users/rym_import.html:75
+#: users/templates/users/storygraph_import.html:75
 msgid "Next"
 msgstr "下一页"
 
 #: users/templates/users/rym_import.html:95
+#: users/templates/users/storygraph_import.html:95
 msgid "Confirm Import"
 msgstr "确认导入"
 
 #: users/templates/users/rym_import.html:96
+#: users/templates/users/storygraph_import.html:96
 msgid "Back"
 msgstr "返回"
 
@@ -8104,6 +8132,15 @@ msgstr "选中则允许反向覆盖标记状态（如在玩->想玩，或玩过-
 msgid "To import from Steam, your game details must be visible to public in Steam privacy settings."
 msgstr "Steam资料必须公开可见才能导入"
 
+#: users/templates/users/storygraph_import.html:9
+#: users/templates/users/storygraph_import.html:37
+msgid "Review StoryGraph Matches"
+msgstr "审阅 StoryGraph 匹配结果"
+
+#: users/templates/users/storygraph_import.html:57
+msgid "Title / Author"
+msgstr "标题 / 作者"
+
 #: users/templates/users/user_task_status.html:29
 msgid "Failed items"
 msgstr "失败条目"
@@ -8192,136 +8229,141 @@ msgstr "账户删除进行中。"
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:223 users/views/data.py:252
+#: users/views/data.py:238 users/views/data.py:267
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:246
+#: users/views/data.py:261
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:264
+#: users/views/data.py:279
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:279 users/views/data.py:299
+#: users/views/data.py:294 users/views/data.py:314
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:313
+#: users/views/data.py:328
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:327
+#: users/views/data.py:342
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:382
+#: users/views/data.py:397
 msgid "Account no longer linked."
 msgstr "账户已不再关联。"
 
-#: users/views/data.py:385
+#: users/views/data.py:400
 msgid "Content is no longer public."
 msgstr "内容已不再公开。"
 
-#: users/views/data.py:413
+#: users/views/data.py:428
 msgid "Retry did not complete, please try again."
 msgstr "重试未完成，请再试一次。"
 
-#: users/views/data.py:423 users/views/data.py:456 users/views/data.py:672
-#: users/views/data.py:696 users/views/data.py:721 users/views/data.py:745
-#: users/views/data.py:769
+#: users/views/data.py:438 users/views/data.py:471 users/views/data.py:694
+#: users/views/data.py:909 users/views/data.py:934 users/views/data.py:958
+#: users/views/data.py:982
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:492
+#: users/views/data.py:505 users/views/data.py:728
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:517
+#: users/views/data.py:530 users/views/data.py:757
 msgid "Cancelled."
 msgstr "已取消。"
 
-#: users/views/data.py:537
+#: users/views/data.py:550
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:545 users/views/data.py:655
+#: users/views/data.py:558 users/views/data.py:668 users/views/data.py:787
+#: users/views/data.py:892
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:641
+#: users/views/data.py:654 users/views/data.py:878
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:651
+#: users/views/data.py:664 users/views/data.py:888
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:889
+#: users/views/data.py:779
+msgid "No StoryGraph import to preview."
+msgstr "暂无可预览的 StoryGraph 导入任务。"
+
+#: users/views/data.py:1102
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:911
+#: users/views/data.py:1124
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:927
+#: users/views/data.py:1140
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:932
+#: users/views/data.py:1145
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:942 users/views/data.py:993
+#: users/views/data.py:1155 users/views/data.py:1206
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:949
+#: users/views/data.py:1162
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:954
+#: users/views/data.py:1167
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:980
+#: users/views/data.py:1193
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:985
+#: users/views/data.py:1198
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:998
+#: users/views/data.py:1211
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:1009
+#: users/views/data.py:1222
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:1015
+#: users/views/data.py:1228
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:1073
+#: users/views/data.py:1286
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:1089
+#: users/views/data.py:1302
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:1093
+#: users/views/data.py:1306
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:1102
+#: users/views/data.py:1315
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/neodb/tests/catalog/test_book.py
+++ b/neodb/tests/catalog/test_book.py
@@ -377,7 +377,7 @@ class TestBooksTW:
         assert site.resource.metadata.get("pub_month") == 2
         assert site.resource.metadata.get("binding") == "平裝"
         assert site.resource.metadata.get("pages") == 792
-        assert site.resource.metadata.get("price") == "1050 NTD"
+        assert site.resource.metadata.get("price") == "TWD 1050"
         assert site.resource.id_type == IdType.BooksTW
         assert site.resource.id_value == "0010947886"
         assert site.resource.item is not None

--- a/neodb/tests/catalog/test_game.py
+++ b/neodb/tests/catalog/test_game.py
@@ -134,7 +134,7 @@ class TestItch:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.itch == "games/3268593"
-        assert site.resource.item.platform == ["Web"]
+        assert site.resource.item.platform == ["web"]
         assert site.resource.item.display_description.startswith(
             "The Unsolvable Mystery"
         )
@@ -234,7 +234,7 @@ class TestBoardGameGeek:
 
         assert len(site.resource.item.localized_title) == 16
         assert isinstance(site.resource.item, Game)
-        assert site.resource.item.platform == ["Boardgame"]
+        assert site.resource.item.platform == ["boardgame"]
         assert site.resource.item.genre[0] == "Economic"
         assert site.resource.item.designer == ["Jacob Fryxelius"]
 
@@ -269,7 +269,7 @@ class TestMobyGames:
         assert isinstance(site.resource.item, Game)
         assert site.resource.item.developer == ["Valve Corporation"]
         assert "action" in site.resource.item.genre
-        assert "Windows" in site.resource.item.platform
+        assert "windows" in site.resource.item.platform
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_index.py
+++ b/neodb/tests/catalog/test_index.py
@@ -274,7 +274,7 @@ class TestCatalogSearch:
         self.movie1.imdb = "tt0068646"
         self.movie1.director = ["Francis Ford Coppola"]
         self.movie1.actor = ["Marlon Brando", "Al Pacino", "James Caan"]
-        self.movie1.year = 1972
+        self.movie1.release_date = "1972"
         self.movie1.language = ["it"]
         self.movie1.save()
         self.movie1.sync_credits_from_metadata()
@@ -284,7 +284,7 @@ class TestCatalogSearch:
         self.movie2.imdb = "tt0071562"
         self.movie2.director = ["Francis Ford Coppola"]
         self.movie2.actor = ["Al Pacino", "Robert De Niro", "Robert Duvall"]
-        self.movie2.year = 1974
+        self.movie2.release_date = "1974"
         self.movie2.language = ["it", "en"]
         self.movie2.save()
         self.movie2.sync_credits_from_metadata()
@@ -299,7 +299,7 @@ class TestCatalogSearch:
             "Joseph Gordon-Levitt",
             "Ellen Page",
         ]
-        self.movie3.year = 2010
+        self.movie3.release_date = "2010"
         self.movie3.language = ["en"]
         self.movie3.save()
         self.movie3.sync_credits_from_metadata()

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -179,7 +179,11 @@ class TestDeprecatedApiAliases:
         o = m.ap_object
         assert o["year"] == 2010
         assert o["release_date"] == "2010-07-16"
-        assert o["duration"] == 8880
+        assert o["release_date_precision"] == "day"
+        # duration keeps its legacy display-string shape for older
+        # peers/clients; duration_seconds carries the canonical value
+        assert o["duration"] == "2h 28m"
+        assert o["duration_seconds"] == 8880
         assert o["origin_country"] == ["US", "GB"]
         assert o["area"] == ["US", "GB"]
         assert o["showtime"] == [{"time": "2010-07-16", "region": ""}]
@@ -192,7 +196,7 @@ class TestDeprecatedApiAliases:
                 "duration": "148分钟",
             }
         )
-        assert m.ap_object["duration"] == 8880
+        assert m.ap_object["duration_seconds"] == 8880
 
     def test_album_media_alias(self):
         a = Album.objects.create(
@@ -208,7 +212,9 @@ class TestDeprecatedApiAliases:
         assert o["album_type"] == ["album"]
         assert o["media_format"] == ["cd", "vinyl"]
         assert o["media"] == "cd, vinyl"
-        assert o["duration"] == 2368
+        # legacy shape stays milliseconds for older peers/clients
+        assert o["duration"] == 2368000
+        assert o["duration_seconds"] == 2368
 
     def test_short_and_long_durations_not_recoerced_at_read_time(self):
         # unit inference happens only on legacy ingest; stored seconds are
@@ -220,7 +226,7 @@ class TestDeprecatedApiAliases:
                 "release_date": "2020",
             }
         )
-        assert m.ap_object["duration"] == 480
+        assert m.ap_object["duration_seconds"] == 480
         assert m.to_schema_org()["duration"] == "PT0H8M"
         a = Album.objects.create(
             metadata={
@@ -229,7 +235,39 @@ class TestDeprecatedApiAliases:
                 "duration": 55200,  # 15h20m box set
             }
         )
-        assert a.ap_object["duration"] == 55200
+        assert a.ap_object["duration_seconds"] == 55200
+        assert a.ap_object["duration"] == 55200000
+
+    def test_ap_object_round_trips_losslessly(self):
+        # what one current server emits, another ingests without loss
+        m = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Short"}],
+                "duration": 480,
+                "release_date": "2020",
+            }
+        )
+        o = m.ap_object
+        assert o["release_date"] == "2020-01-01"
+        assert o["release_date_precision"] == "year"
+        assert o["duration"] == "8m"
+        md = {k: v for k, v in o.items()}
+        Movie.normalize_legacy_metadata(md)
+        assert md["release_date"] == "2020"
+        assert md["duration"] == 480
+        a = Album.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Box"}],
+                "artist": ["Y"],
+                "duration": 55200,
+                "release_date": "1997-05",
+            }
+        )
+        oa = a.ap_object
+        md = {k: v for k, v in oa.items()}
+        Album.normalize_legacy_metadata(md)
+        assert md["duration"] == 55200
+        assert md["release_date"] == "1997-05"
 
     def test_merge_preserves_legacy_year(self):
         src = Movie.objects.create(
@@ -254,7 +292,10 @@ class TestDeprecatedApiAliases:
             }
         )
         o = g.ap_object
-        assert o["release_date"] == "1995"
+        # padded for older peers typing this as a strict date; precision
+        # lets current peers recover the partial value
+        assert o["release_date"] == "1995-01-01"
+        assert o["release_date_precision"] == "year"
         assert o["release_year"] == 1995
 
 

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -174,6 +174,7 @@ class TestDeprecatedApiAliases:
                 "release_date": "2010-07-16",
                 "length": 8880,
                 "origin_country": ["US", "GB"],
+                "site": "https://example.org/inception",
             }
         )
         o = m.ap_object
@@ -186,6 +187,9 @@ class TestDeprecatedApiAliases:
         assert o["origin_country"] == ["US", "GB"]
         assert o["area"] == ["US", "GB"]
         assert o["showtime"] == [{"time": "2010-07-16", "region": ""}]
+        # official_site is aliased to the internal site attribute
+        assert o["official_site"] == "https://example.org/inception"
+        assert o["site"] == "https://example.org/inception"
 
     def test_movie_stale_legacy_metadata_tolerated(self):
         # pre-migration rows must not break schema validation; the legacy

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -101,6 +101,13 @@ class TestNormalizeLegacyAlbumMetadata:
         assert md["media_format"] == ["cd"]
         assert "media" not in md
 
+    def test_display_properties_tolerate_legacy_scalars(self):
+        # templates iterate these; a pre-migration string value must not
+        # be iterated character by character
+        a = Album(metadata={"album_type": "专辑", "media_format": ["cd"]})
+        assert a.display_album_types == ["album"]
+        assert a.display_media_formats == ["cd"]
+
 
 class TestNormalizeLegacyGameMetadata:
     def test_release_year_fallback(self):

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -188,14 +188,25 @@ class TestDeprecatedApiAliases:
         assert o["showtime"] == [{"time": "2010-07-16", "region": ""}]
 
     def test_movie_stale_legacy_metadata_tolerated(self):
-        # pre-migration rows must not break schema validation
+        # pre-migration rows must not break schema validation; the legacy
+        # duration key surfaces as null length until the migration runs
         m = Movie.objects.create(
             metadata={
                 "localized_title": [{"lang": "en", "text": "Old"}],
                 "duration": "148分钟",
             }
         )
-        assert m.ap_object["length"] == 8880
+        o = m.ap_object
+        assert o["length"] is None
+        assert o["duration"] is None
+        # a corrupt/hand-edited string in length still parses at read time
+        m2 = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Odd"}],
+                "length": "148分钟",
+            }
+        )
+        assert m2.ap_object["length"] == 8880
 
     def test_album_media_alias(self):
         a = Album.objects.create(

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -17,7 +17,7 @@ class TestNormalizeLegacyVideoMetadata:
         }
         Movie.normalize_legacy_metadata(md)
         assert md == {
-            "duration": 8880,
+            "length": 8880,
             "origin_country": ["US", "GB"],
             "release_date": "2010-07-16",
         }
@@ -26,14 +26,14 @@ class TestNormalizeLegacyVideoMetadata:
         # legacy TMDB shape: int minutes alongside year/showtime keys
         md = {"duration": 148, "year": 2010}
         Movie.normalize_legacy_metadata(md)
-        assert md["duration"] == 8880
+        assert md["length"] == 8880
         assert md["release_date"] == "2010"
 
     def test_movie_int_seconds_without_marker_untouched(self):
-        # new-shape metadata: a 8-minute short stored in seconds stays
-        md = {"duration": 480, "release_date": "2020-01-01"}
+        # new-shape metadata: length in seconds is never re-inferred
+        md = {"length": 480, "release_date": "2020-01-01"}
         Movie.normalize_legacy_metadata(md)
-        assert md["duration"] == 480
+        assert md["length"] == 480
 
     def test_year_only_fallback(self):
         md = {"year": 1994}
@@ -68,7 +68,7 @@ class TestNormalizeLegacyVideoMetadata:
         }
         Movie.normalize_legacy_metadata(md)
         converted = dict(md)
-        assert converted["duration"] == 480
+        assert converted["length"] == 480
         Movie.normalize_legacy_metadata(md)
         assert md == converted
 
@@ -83,16 +83,16 @@ class TestNormalizeLegacyAlbumMetadata:
         }
         Album.normalize_legacy_metadata(md)
         assert md == {
-            "duration": 2368,
+            "length": 2368,
             "media_format": ["cd"],
             "album_type": ["album"],
             "release_date": "2015-02-23",
         }
 
     def test_seconds_untouched(self):
-        md = {"duration": 2368, "album_type": ["album"]}
+        md = {"length": 2368, "album_type": ["album"]}
         Album.normalize_legacy_metadata(md)
-        assert md["duration"] == 2368
+        assert md["length"] == 2368
         assert md["album_type"] == ["album"]
 
     def test_media_format_not_overwritten(self):
@@ -172,18 +172,17 @@ class TestDeprecatedApiAliases:
             metadata={
                 "localized_title": [{"lang": "en", "text": "Inception"}],
                 "release_date": "2010-07-16",
-                "duration": 8880,
+                "length": 8880,
                 "origin_country": ["US", "GB"],
             }
         )
         o = m.ap_object
         assert o["year"] == 2010
         assert o["release_date"] == "2010-07-16"
-        assert o["release_date_precision"] == "day"
         # duration keeps its legacy display-string shape for older
-        # peers/clients; duration_seconds carries the canonical value
+        # peers/clients; length carries the canonical seconds
         assert o["duration"] == "2h 28m"
-        assert o["duration_seconds"] == 8880
+        assert o["length"] == 8880
         assert o["origin_country"] == ["US", "GB"]
         assert o["area"] == ["US", "GB"]
         assert o["showtime"] == [{"time": "2010-07-16", "region": ""}]
@@ -196,7 +195,7 @@ class TestDeprecatedApiAliases:
                 "duration": "148分钟",
             }
         )
-        assert m.ap_object["duration_seconds"] == 8880
+        assert m.ap_object["length"] == 8880
 
     def test_album_media_alias(self):
         a = Album.objects.create(
@@ -205,7 +204,7 @@ class TestDeprecatedApiAliases:
                 "artist": ["Y"],
                 "album_type": ["album"],
                 "media_format": ["cd", "vinyl"],
-                "duration": 2368,
+                "length": 2368,
             }
         )
         o = a.ap_object
@@ -214,7 +213,7 @@ class TestDeprecatedApiAliases:
         assert o["media"] == "cd, vinyl"
         # legacy shape stays milliseconds for older peers/clients
         assert o["duration"] == 2368000
-        assert o["duration_seconds"] == 2368
+        assert o["length"] == 2368
 
     def test_short_and_long_durations_not_recoerced_at_read_time(self):
         # unit inference happens only on legacy ingest; stored seconds are
@@ -222,20 +221,20 @@ class TestDeprecatedApiAliases:
         m = Movie.objects.create(
             metadata={
                 "localized_title": [{"lang": "en", "text": "Short"}],
-                "duration": 480,  # 8-minute short film
+                "length": 480,  # 8-minute short film
                 "release_date": "2020",
             }
         )
-        assert m.ap_object["duration_seconds"] == 480
+        assert m.ap_object["length"] == 480
         assert m.to_schema_org()["duration"] == "PT0H8M"
         a = Album.objects.create(
             metadata={
                 "localized_title": [{"lang": "en", "text": "Box"}],
                 "artist": ["Y"],
-                "duration": 55200,  # 15h20m box set
+                "length": 55200,  # 15h20m box set
             }
         )
-        assert a.ap_object["duration_seconds"] == 55200
+        assert a.ap_object["length"] == 55200
         assert a.ap_object["duration"] == 55200000
 
     def test_ap_object_round_trips_losslessly(self):
@@ -243,30 +242,30 @@ class TestDeprecatedApiAliases:
         m = Movie.objects.create(
             metadata={
                 "localized_title": [{"lang": "en", "text": "Short"}],
-                "duration": 480,
+                "length": 480,
                 "release_date": "2020",
             }
         )
         o = m.ap_object
-        assert o["release_date"] == "2020-01-01"
-        assert o["release_date_precision"] == "year"
+        assert o["release_date"] == "2020"
         assert o["duration"] == "8m"
+        assert o["length"] == 480
         md = {k: v for k, v in o.items()}
         Movie.normalize_legacy_metadata(md)
         assert md["release_date"] == "2020"
-        assert md["duration"] == 480
+        assert md["length"] == 480
         a = Album.objects.create(
             metadata={
                 "localized_title": [{"lang": "en", "text": "Box"}],
                 "artist": ["Y"],
-                "duration": 55200,
+                "length": 55200,
                 "release_date": "1997-05",
             }
         )
         oa = a.ap_object
         md = {k: v for k, v in oa.items()}
         Album.normalize_legacy_metadata(md)
-        assert md["duration"] == 55200
+        assert md["length"] == 55200
         assert md["release_date"] == "1997-05"
 
     def test_merge_preserves_legacy_year(self):
@@ -292,10 +291,7 @@ class TestDeprecatedApiAliases:
             }
         )
         o = g.ap_object
-        # padded for older peers typing this as a strict date; precision
-        # lets current peers recover the partial value
-        assert o["release_date"] == "1995-01-01"
-        assert o["release_date_precision"] == "year"
+        assert o["release_date"] == "1995"
         assert o["release_year"] == 1995
 
 
@@ -330,13 +326,13 @@ class TestUnifyMetadataMigration:
         m.refresh_from_db()
         a.refresh_from_db()
         g.refresh_from_db()
-        assert m.metadata["duration"] == 8880
+        assert m.metadata["length"] == 8880
         assert m.metadata["origin_country"] == ["US"]
         assert m.metadata["release_date"] == "2010-07-16"
         assert "area" not in m.metadata
         assert "showtime" not in m.metadata
         assert "year" not in m.metadata
-        assert a.metadata["duration"] == 2368
+        assert a.metadata["length"] == 2368
         assert a.metadata["media_format"] == ["cd"]
         assert a.metadata["album_type"] == ["album"]
         assert "media" not in a.metadata

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -1,0 +1,267 @@
+import pytest
+
+from catalog.common.migrations import unify_metadata_20260715
+from catalog.models import Album, Edition, Game, Movie, TVSeason, TVShow
+
+
+class TestNormalizeLegacyVideoMetadata:
+    def test_movie_full_legacy_shape(self):
+        md = {
+            "duration": "148分钟",
+            "area": ["美国", "英国"],
+            "showtime": [
+                {"time": "2010-09-01", "region": "中国大陆"},
+                {"time": "2010-07-16", "region": "美国"},
+            ],
+            "year": 2010,
+        }
+        Movie.normalize_legacy_metadata(md)
+        assert md == {
+            "duration": 8880,
+            "origin_country": ["US", "GB"],
+            "release_date": "2010-07-16",
+        }
+
+    def test_movie_int_minutes_with_legacy_marker(self):
+        # legacy TMDB shape: int minutes alongside year/showtime keys
+        md = {"duration": 148, "year": 2010}
+        Movie.normalize_legacy_metadata(md)
+        assert md["duration"] == 8880
+        assert md["release_date"] == "2010"
+
+    def test_movie_int_seconds_without_marker_untouched(self):
+        # new-shape metadata: a 8-minute short stored in seconds stays
+        md = {"duration": 480, "release_date": "2020-01-01"}
+        Movie.normalize_legacy_metadata(md)
+        assert md["duration"] == 480
+
+    def test_year_only_fallback(self):
+        md = {"year": 1994}
+        Movie.normalize_legacy_metadata(md)
+        assert md == {"release_date": "1994"}
+
+    def test_unparseable_showtime_kept(self):
+        md = {"showtime": [{"time": "someday", "region": ""}]}
+        Movie.normalize_legacy_metadata(md)
+        assert md["showtime"] == [{"time": "someday", "region": ""}]
+        assert "release_date" not in md
+
+    def test_existing_release_date_wins(self):
+        md = {"release_date": "2001-01-01", "year": 1999, "showtime": []}
+        Movie.normalize_legacy_metadata(md)
+        assert md["release_date"] == "2001-01-01"
+        assert "year" not in md
+
+    def test_tv_single_episode_length(self):
+        md = {"single_episode_length": "45分钟", "year": 2018}
+        TVShow.normalize_legacy_metadata(md)
+        assert md["single_episode_length"] == 2700
+        md2 = {"single_episode_length": 45, "area": []}
+        TVSeason.normalize_legacy_metadata(md2)
+        assert md2["single_episode_length"] == 2700
+
+    def test_idempotent(self):
+        md = {
+            "duration": "8分钟",
+            "area": ["美国"],
+            "year": 2020,
+        }
+        Movie.normalize_legacy_metadata(md)
+        converted = dict(md)
+        assert converted["duration"] == 480
+        Movie.normalize_legacy_metadata(md)
+        assert md == converted
+
+
+class TestNormalizeLegacyAlbumMetadata:
+    def test_full_legacy_shape(self):
+        md = {
+            "duration": 2368000,
+            "media": "Audio CD",
+            "album_type": "专辑",
+            "release_date": "2015-02-23",
+        }
+        Album.normalize_legacy_metadata(md)
+        assert md == {
+            "duration": 2368,
+            "media_format": ["cd"],
+            "album_type": ["album"],
+            "release_date": "2015-02-23",
+        }
+
+    def test_seconds_untouched(self):
+        md = {"duration": 2368, "album_type": ["album"]}
+        Album.normalize_legacy_metadata(md)
+        assert md["duration"] == 2368
+        assert md["album_type"] == ["album"]
+
+    def test_media_format_not_overwritten(self):
+        md = {"media": "Vinyl", "media_format": ["cd"]}
+        Album.normalize_legacy_metadata(md)
+        assert md["media_format"] == ["cd"]
+        assert "media" not in md
+
+
+class TestNormalizeLegacyGameMetadata:
+    def test_release_year_fallback(self):
+        md = {"release_year": 1995}
+        Game.normalize_legacy_metadata(md)
+        assert md == {"release_date": "1995"}
+
+    def test_release_year_ignored_when_date_present(self):
+        md = {"release_year": 1995, "release_date": "1995-06-01"}
+        Game.normalize_legacy_metadata(md)
+        assert md == {"release_date": "1995-06-01"}
+
+    def test_localized_steam_date(self):
+        md = {"release_date": "18 kwietnia 2011"}
+        Game.normalize_legacy_metadata(md)
+        assert md == {"release_date": "2011-04-18"}
+
+
+class TestNormalizeLegacyEditionMetadata:
+    def test_price(self):
+        md = {"price": "USD 26.00"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "USD 26.00"
+        md = {"price": "450 NTD"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "TWD 450"
+
+    def test_ambiguous_price_kept(self):
+        md = {"price": "19.00元"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "19.00元"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestDerivedProperties:
+    def test_movie_year(self):
+        m = Movie(metadata={"release_date": "2010-07-16"})
+        assert m.year == 2010
+        assert Movie(metadata={}).year is None
+
+    def test_game_release_year(self):
+        g = Game(metadata={"release_date": "1995"})
+        assert g.release_year == 1995
+
+    def test_indexable_dates(self):
+        m = Movie.objects.create(metadata={"release_date": "2010"})
+        assert m.to_indexable_doc()["date"] == [20100000]
+        m2 = Movie.objects.create(metadata={"release_date": "2010-09-10"})
+        assert m2.to_indexable_doc()["date"] == [20100910]
+        a = Album.objects.create(
+            metadata={"release_date": "2014", "album_type": ["ep"]}
+        )
+        d = a.to_indexable_doc()
+        assert d["date"] == [20140000]
+        assert d["format"] == ["ep"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestDeprecatedApiAliases:
+    def test_movie_aliases(self):
+        m = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Inception"}],
+                "release_date": "2010-07-16",
+                "duration": 8880,
+                "origin_country": ["US", "GB"],
+            }
+        )
+        o = m.ap_object
+        assert o["year"] == 2010
+        assert o["release_date"] == "2010-07-16"
+        assert o["duration"] == 8880
+        assert o["origin_country"] == ["US", "GB"]
+        assert o["area"] == ["US", "GB"]
+        assert o["showtime"] == [{"time": "2010-07-16", "region": ""}]
+
+    def test_movie_stale_legacy_metadata_tolerated(self):
+        # pre-migration rows must not break schema validation
+        m = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Old"}],
+                "duration": "148分钟",
+            }
+        )
+        assert m.ap_object["duration"] == 8880
+
+    def test_album_media_alias(self):
+        a = Album.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "X"}],
+                "artist": ["Y"],
+                "album_type": ["album"],
+                "media_format": ["cd", "vinyl"],
+                "duration": 2368,
+            }
+        )
+        o = a.ap_object
+        assert o["album_type"] == ["album"]
+        assert o["media_format"] == ["cd", "vinyl"]
+        assert o["media"] == "cd, vinyl"
+        assert o["duration"] == 2368
+
+    def test_game_release_year_alias(self):
+        g = Game.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "G"}],
+                "release_date": "1995",
+            }
+        )
+        o = g.ap_object
+        assert o["release_date"] == "1995"
+        assert o["release_year"] == 1995
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestUnifyMetadataMigration:
+    def test_migration_converts_and_is_idempotent(self):
+        m = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Inception"}],
+                "duration": "148分钟",
+                "area": ["美国"],
+                "showtime": [{"time": "2010-07-16", "region": "美国"}],
+                "year": 2010,
+            }
+        )
+        a = Album.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "X"}],
+                "artist": ["Y"],
+                "duration": 2368000,
+                "media": "Audio CD",
+                "album_type": "专辑",
+            }
+        )
+        g = Game.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "G"}],
+                "release_year": 1995,
+            }
+        )
+        unify_metadata_20260715()
+        m.refresh_from_db()
+        a.refresh_from_db()
+        g.refresh_from_db()
+        assert m.metadata["duration"] == 8880
+        assert m.metadata["origin_country"] == ["US"]
+        assert m.metadata["release_date"] == "2010-07-16"
+        assert "area" not in m.metadata
+        assert "showtime" not in m.metadata
+        assert "year" not in m.metadata
+        assert a.metadata["duration"] == 2368
+        assert a.metadata["media_format"] == ["cd"]
+        assert a.metadata["album_type"] == ["album"]
+        assert "media" not in a.metadata
+        assert g.metadata["release_date"] == "1995"
+        assert "release_year" not in g.metadata
+
+        before = (dict(m.metadata), dict(a.metadata), dict(g.metadata))
+        unify_metadata_20260715()
+        m.refresh_from_db()
+        a.refresh_from_db()
+        g.refresh_from_db()
+        assert (dict(m.metadata), dict(a.metadata), dict(g.metadata)) == before

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -203,6 +203,42 @@ class TestDeprecatedApiAliases:
         assert o["media"] == "cd, vinyl"
         assert o["duration"] == 2368
 
+    def test_short_and_long_durations_not_recoerced_at_read_time(self):
+        # unit inference happens only on legacy ingest; stored seconds are
+        # trusted as-is by API/schema.org even near heuristic boundaries
+        m = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Short"}],
+                "duration": 480,  # 8-minute short film
+                "release_date": "2020",
+            }
+        )
+        assert m.ap_object["duration"] == 480
+        assert m.to_schema_org()["duration"] == "PT0H8M"
+        a = Album.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Box"}],
+                "artist": ["Y"],
+                "duration": 55200,  # 15h20m box set
+            }
+        )
+        assert a.ap_object["duration"] == 55200
+
+    def test_merge_preserves_legacy_year(self):
+        src = Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Src"}],
+                "year": 2010,
+            }
+        )
+        dst = Movie.objects.create(
+            metadata={"localized_title": [{"lang": "en", "text": "Dst"}]}
+        )
+        src.merge_to(dst)
+        dst.refresh_from_db()
+        assert dst.metadata["release_date"] == "2010"
+        assert dst.year == 2010
+
     def test_game_release_year_alias(self):
         g = Game.objects.create(
             metadata={

--- a/neodb/tests/catalog/test_music.py
+++ b/neodb/tests/catalog/test_music.py
@@ -312,7 +312,7 @@ class TestAppleMusic:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.genre == ["pop", "music"]
-        assert site.resource.item.duration == 2368000
+        assert site.resource.item.duration == 2368
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -341,12 +341,12 @@ class TestYouTubeMusic:
         assert site.resource is not None
         assert site.resource.metadata["title"] == "Synchronicity (Remastered 2003)"
         assert site.resource.metadata["artist"] == ["The Police"]
-        assert site.resource.metadata["release_date"] == "1983-01-01"
-        assert site.resource.metadata["album_type"] == "Album"
-        assert site.resource.metadata["duration"] == 2675000
+        assert site.resource.metadata["release_date"] == "1983"
+        assert site.resource.metadata["album_type"] == ["album"]
+        assert site.resource.metadata["duration"] == 2675
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
-        assert str(site.resource.item.release_date) == "1983-01-01"
+        assert site.resource.item.release_date == "1983"
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -389,7 +389,7 @@ class TestRateYourMusic:
         meta = site.resource.metadata
         assert meta["title"] == "OK Computer"
         assert meta["artist"] == ["Radiohead"]
-        assert meta["album_type"] == "Album"
+        assert meta["album_type"] == ["album"]
         assert meta["release_date"] == "1997-06-16"
         # Primary + secondary genres preserved in order
         assert meta["genre"][:2] == ["Alternative Rock", "Art Rock"]
@@ -400,7 +400,7 @@ class TestRateYourMusic:
         assert len(track_lines) == 12
         assert track_lines[0] == "1. Airbag (4:44)"
         assert track_lines[-1] == "12. The Tourist (5:24)"
-        assert meta["duration"] == 3201000
+        assert meta["duration"] == 3201
         # Primary label parsed out of og:description
         assert meta["company"] == ["Parlophone"]
         assert meta["cover_image_url"].startswith("https://cdn.sonemic.net/")

--- a/neodb/tests/catalog/test_music.py
+++ b/neodb/tests/catalog/test_music.py
@@ -312,7 +312,7 @@ class TestAppleMusic:
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.genre == ["pop", "music"]
-        assert site.resource.item.duration == 2368
+        assert site.resource.item.length == 2368
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -343,7 +343,7 @@ class TestYouTubeMusic:
         assert site.resource.metadata["artist"] == ["The Police"]
         assert site.resource.metadata["release_date"] == "1983"
         assert site.resource.metadata["album_type"] == ["album"]
-        assert site.resource.metadata["duration"] == 2675
+        assert site.resource.metadata["length"] == 2675
         assert site.resource.item is not None
         assert isinstance(site.resource.item, Album)
         assert site.resource.item.release_date == "1983"
@@ -400,7 +400,7 @@ class TestRateYourMusic:
         assert len(track_lines) == 12
         assert track_lines[0] == "1. Airbag (4:44)"
         assert track_lines[-1] == "12. The Tourist (5:24)"
-        assert meta["duration"] == 3201
+        assert meta["length"] == 3201
         # Primary label parsed out of og:description
         assert meta["company"] == ["Parlophone"]
         assert meta["cover_image_url"].startswith("https://cdn.sonemic.net/")

--- a/neodb/tests/catalog/test_musicbrainz.py
+++ b/neodb/tests/catalog/test_musicbrainz.py
@@ -7,6 +7,8 @@ from catalog.sites.musicbrainz import (
     MusicBrainzRelease,
     MusicBrainzReleaseGroup,
     _extract_first_isrc,
+    _extract_label_info,
+    _extract_track_info,
 )
 
 
@@ -134,13 +136,12 @@ class TestMusicBrainzReleaseGroup:
                 }
             ]
         }
-        track_info = site._extract_track_info(release_data)
+        track_info = _extract_track_info(release_data)
         assert track_info["track_list"] == "1. Airbag\n2. Paranoid Android"
         assert track_info["duration"] == 667
 
     def test_extract_track_info_multi_disc(self):
         """Test track extraction with multiple discs"""
-        site = MusicBrainzReleaseGroup()
 
         release_data = {
             "media": [
@@ -159,14 +160,13 @@ class TestMusicBrainzReleaseGroup:
             ]
         }
 
-        track_info = site._extract_track_info(release_data)
+        track_info = _extract_track_info(release_data)
         assert track_info["track_list"] == "1-1. Track 1\n2-1. Track 2"
         assert track_info["duration"] == 380
 
     def test_extract_track_info_null_length(self):
         """MB returns "length": null for tracks of unknown length; the key is
         present but the value is None, which int() can't take (EGGPLANT-1E4)."""
-        site = MusicBrainzReleaseGroup()
         release_data = {
             "media": [
                 {
@@ -179,13 +179,12 @@ class TestMusicBrainzReleaseGroup:
                 }
             ]
         }
-        track_info = site._extract_track_info(release_data)
+        track_info = _extract_track_info(release_data)
         assert track_info["track_list"] == "1. Known\n2. Unknown\n3. Missing"
         assert track_info["duration"] == 284
 
     def test_extract_label_info(self):
         """Test label information extraction"""
-        site = MusicBrainzReleaseGroup()
 
         release_data = {
             "label-info": [
@@ -194,7 +193,7 @@ class TestMusicBrainzReleaseGroup:
             ]
         }
 
-        labels = site._extract_label_info(release_data)
+        labels = _extract_label_info(release_data)
         assert labels == ["EMI", "Capitol Records"]
 
     def test_upc_to_gtin_conversion(self):
@@ -383,7 +382,6 @@ class TestMusicBrainzRelease:
 
     def test_track_extraction_from_release(self):
         """Test track extraction directly from release data"""
-        site = MusicBrainzRelease()
 
         release_data = {
             "media": [
@@ -397,14 +395,13 @@ class TestMusicBrainzRelease:
             ]
         }
 
-        track_info = site._extract_track_info(release_data)
+        track_info = _extract_track_info(release_data)
         assert track_info["track_list"] == "1. First Track\n2. Second Track"
         assert track_info["duration"] == 390
 
     def test_track_extraction_null_length(self):
         """A release whose tracks carry "length": null must not crash on
         int(None) while summing duration (EGGPLANT-1E4)."""
-        site = MusicBrainzRelease()
         release_data = {
             "media": [
                 {
@@ -416,7 +413,7 @@ class TestMusicBrainzRelease:
                 }
             ]
         }
-        track_info = site._extract_track_info(release_data)
+        track_info = _extract_track_info(release_data)
         assert track_info["track_list"] == "1. First Track\n2. Second Track"
         assert track_info["duration"] == 210
 

--- a/neodb/tests/catalog/test_musicbrainz.py
+++ b/neodb/tests/catalog/test_musicbrainz.py
@@ -90,8 +90,8 @@ class TestMusicBrainzReleaseGroup:
         assert "alternative rock" in metadata["genre"]
         assert "track_list" in metadata
         assert "1. Airbag" in metadata["track_list"]
-        assert "duration" in metadata
-        assert metadata["duration"] > 0
+        assert "length" in metadata
+        assert metadata["length"] > 0
         assert "company" in metadata
         assert "EMI" in metadata["company"]
 
@@ -302,8 +302,8 @@ class TestMusicBrainzRelease:
         assert "alternative rock" in metadata["genre"]
         assert "track_list" in metadata
         assert "1. Airbag" in metadata["track_list"]
-        assert "duration" in metadata
-        assert metadata["duration"] > 0
+        assert "length" in metadata
+        assert metadata["length"] > 0
         assert "company" in metadata
         assert "EMI" in metadata["company"]
 

--- a/neodb/tests/catalog/test_musicbrainz.py
+++ b/neodb/tests/catalog/test_musicbrainz.py
@@ -136,7 +136,7 @@ class TestMusicBrainzReleaseGroup:
         }
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1. Airbag\n2. Paranoid Android"
-        assert track_info["duration"] == 667000
+        assert track_info["duration"] == 667
 
     def test_extract_track_info_multi_disc(self):
         """Test track extraction with multiple discs"""
@@ -161,7 +161,7 @@ class TestMusicBrainzReleaseGroup:
 
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1-1. Track 1\n2-1. Track 2"
-        assert track_info["duration"] == 380000
+        assert track_info["duration"] == 380
 
     def test_extract_track_info_null_length(self):
         """MB returns "length": null for tracks of unknown length; the key is
@@ -181,7 +181,7 @@ class TestMusicBrainzReleaseGroup:
         }
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1. Known\n2. Unknown\n3. Missing"
-        assert track_info["duration"] == 284000
+        assert track_info["duration"] == 284
 
     def test_extract_label_info(self):
         """Test label information extraction"""
@@ -399,7 +399,7 @@ class TestMusicBrainzRelease:
 
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1. First Track\n2. Second Track"
-        assert track_info["duration"] == 390000
+        assert track_info["duration"] == 390
 
     def test_track_extraction_null_length(self):
         """A release whose tracks carry "length": null must not crash on
@@ -418,7 +418,7 @@ class TestMusicBrainzRelease:
         }
         track_info = site._extract_track_info(release_data)
         assert track_info["track_list"] == "1. First Track\n2. Second Track"
-        assert track_info["duration"] == 210000
+        assert track_info["duration"] == 210
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_wikidata.py
+++ b/neodb/tests/catalog/test_wikidata.py
@@ -738,8 +738,8 @@ class TestWikiData:
         # assert "Q1860" in content.metadata["language"]  # English
         # assert "Q80930" in content.metadata["genre"]  # Tragedy
         assert (
-            content.metadata["opening_date"] == "1602-01-01"
-        )  # convered from 1602-00-00
+            content.metadata["opening_date"] == "1602"
+        )  # 1602-00-00 keeps year precision
 
 
 def test_extract_openlibrary_ids():

--- a/neodb/tests/conftest.py
+++ b/neodb/tests/conftest.py
@@ -1,7 +1,20 @@
 import pytest
+from django.utils import translation
 
 # Marker for multi-database tests - equivalent to Django's databases = "__all__"
 pytest.mark.all_databases = pytest.mark.django_db(databases="__all__", transaction=True)  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def _reset_language():
+    """Reset the active language after each test.
+
+    Code paths like activate_language_for_user (middleware, crosspost
+    jobs) call translation.activate without restoring, which leaks the
+    language into later tests and makes failures depend on test order.
+    """
+    yield
+    translation.deactivate()
 
 
 @pytest.fixture(autouse=True)

--- a/neodb/tests/core/test_metadata_helpers.py
+++ b/neodb/tests/core/test_metadata_helpers.py
@@ -5,6 +5,11 @@ from common.models.country import (
     normalize_countries,
     normalize_country,
 )
+from common.models.game_platform import (
+    normalize_game_platform,
+    normalize_game_platforms,
+)
+
 from common.models.duration import (
     coerce_album_duration,
     coerce_video_duration,
@@ -165,6 +170,31 @@ class TestCountry:
         with translation.override("zh-hans"):
             assert country_display_name("US") == "美国"
             assert country_display_name("KR") == "韩国"
+
+
+class TestGamePlatform:
+    def test_single(self):
+        assert normalize_game_platform("PC") == "windows"
+        assert normalize_game_platform("PC (Microsoft Windows)") == "windows"
+        assert normalize_game_platform("Macintosh") == "mac"
+        assert normalize_game_platform("Nintendo Switch") == "switch"
+        assert normalize_game_platform("NS") == "switch"
+        assert normalize_game_platform("PlayStation 4") == "ps4"
+        assert normalize_game_platform("Xbox Series X|S") == "xbox-series"
+        assert normalize_game_platform("Boardgame") == "boardgame"
+        assert normalize_game_platform("桌游") == "boardgame"
+        assert normalize_game_platform("HTML5") == "web"
+        assert normalize_game_platform("Sinclair ZX81") == "Sinclair ZX81"
+
+    def test_list(self):
+        assert normalize_game_platforms(["PC", "PS5", "Nintendo Switch"]) == [
+            "windows",
+            "ps5",
+            "switch",
+        ]
+        assert normalize_game_platforms("PC / PS4") == ["windows", "ps4"]
+        assert normalize_game_platforms(["windows", "PC"]) == ["windows"]
+        assert normalize_game_platforms(None) == []
 
 
 class TestMusicFormat:

--- a/neodb/tests/core/test_metadata_helpers.py
+++ b/neodb/tests/core/test_metadata_helpers.py
@@ -17,10 +17,8 @@ from common.models.music_format import (
 )
 from common.models.partial_date import (
     earliest_partial_date,
-    pad_partial_date,
     parse_partial_date,
     partial_date_to_int,
-    unpad_partial_date,
     year_of_partial_date,
 )
 from common.models.price import normalize_price
@@ -69,19 +67,6 @@ class TestPartialDate:
         assert earliest_partial_date(["2010-09", "2010-09-10"]) == "2010-09-10"
         assert earliest_partial_date([None, "x"]) is None
         assert earliest_partial_date([]) is None
-
-    def test_pad_unpad(self):
-        assert pad_partial_date("2014") == ("2014-01-01", "year")
-        assert pad_partial_date("2014-05") == ("2014-05-01", "month")
-        assert pad_partial_date("2014-05-06") == ("2014-05-06", "day")
-        assert pad_partial_date(None) == (None, None)
-        assert pad_partial_date("garbage") == (None, None)
-        assert unpad_partial_date("2014-01-01", "year") == "2014"
-        assert unpad_partial_date("2014-05-01", "month") == "2014-05"
-        assert unpad_partial_date("2014-05-06", "day") == "2014-05-06"
-        assert unpad_partial_date("2014-05-06", None) == "2014-05-06"
-        for d in ("2014", "2014-05", "2014-05-06"):
-            assert unpad_partial_date(*pad_partial_date(d)) == d
 
 
 class TestDuration:

--- a/neodb/tests/core/test_metadata_helpers.py
+++ b/neodb/tests/core/test_metadata_helpers.py
@@ -17,8 +17,10 @@ from common.models.music_format import (
 )
 from common.models.partial_date import (
     earliest_partial_date,
+    pad_partial_date,
     parse_partial_date,
     partial_date_to_int,
+    unpad_partial_date,
     year_of_partial_date,
 )
 from common.models.price import normalize_price
@@ -67,6 +69,19 @@ class TestPartialDate:
         assert earliest_partial_date(["2010-09", "2010-09-10"]) == "2010-09-10"
         assert earliest_partial_date([None, "x"]) is None
         assert earliest_partial_date([]) is None
+
+    def test_pad_unpad(self):
+        assert pad_partial_date("2014") == ("2014-01-01", "year")
+        assert pad_partial_date("2014-05") == ("2014-05-01", "month")
+        assert pad_partial_date("2014-05-06") == ("2014-05-06", "day")
+        assert pad_partial_date(None) == (None, None)
+        assert pad_partial_date("garbage") == (None, None)
+        assert unpad_partial_date("2014-01-01", "year") == "2014"
+        assert unpad_partial_date("2014-05-01", "month") == "2014-05"
+        assert unpad_partial_date("2014-05-06", "day") == "2014-05-06"
+        assert unpad_partial_date("2014-05-06", None) == "2014-05-06"
+        for d in ("2014", "2014-05", "2014-05-06"):
+            assert unpad_partial_date(*pad_partial_date(d)) == d
 
 
 class TestDuration:

--- a/neodb/tests/core/test_metadata_helpers.py
+++ b/neodb/tests/core/test_metadata_helpers.py
@@ -1,0 +1,186 @@
+from django.utils import translation
+
+from common.models.country import (
+    country_display_name,
+    normalize_countries,
+    normalize_country,
+)
+from common.models.duration import (
+    coerce_album_duration,
+    coerce_video_duration,
+    format_duration,
+    parse_duration_text,
+)
+from common.models.music_format import (
+    normalize_album_types,
+    normalize_media_formats,
+)
+from common.models.partial_date import (
+    earliest_partial_date,
+    parse_partial_date,
+    partial_date_to_int,
+    year_of_partial_date,
+)
+from common.models.price import normalize_price
+
+
+class TestPartialDate:
+    def test_parse(self):
+        assert parse_partial_date("2014") == "2014"
+        assert parse_partial_date("2010-9") == "2010-09"
+        assert parse_partial_date("2010-9-5") == "2010-09-05"
+        assert parse_partial_date("2010-09-05") == "2010-09-05"
+        assert parse_partial_date("2025-01-25T00:36:35.000000000Z") == "2025-01-25"
+        assert parse_partial_date("2010/09/05") == "2010-09-05"
+        assert parse_partial_date(1995) == "1995"
+        assert parse_partial_date(None) is None
+        assert parse_partial_date("") is None
+        assert parse_partial_date("garbage") is None
+        assert parse_partial_date("18 kwietnia 2011") is None
+
+    def test_parse_invalid_parts_truncate(self):
+        assert parse_partial_date("2010-13") == "2010"
+        assert parse_partial_date("2010-02-31") == "2010-02"
+        assert parse_partial_date("2010-00-00") == "2010"
+
+    def test_dates(self):
+        from datetime import date, datetime
+
+        assert parse_partial_date(date(2010, 9, 5)) == "2010-09-05"
+        assert parse_partial_date(datetime(2010, 9, 5, 12, 0)) == "2010-09-05"
+
+    def test_to_int(self):
+        assert partial_date_to_int("2010") == 20100000
+        assert partial_date_to_int("2010-09") == 20100900
+        assert partial_date_to_int("2010-09-10") == 20100910
+        assert partial_date_to_int(None) == 0
+        assert partial_date_to_int("garbage") == 0
+
+    def test_year(self):
+        assert year_of_partial_date("2010-09-10") == 2010
+        assert year_of_partial_date("2010") == 2010
+        assert year_of_partial_date(None) is None
+
+    def test_earliest(self):
+        assert earliest_partial_date(["2010", "2010-09-10", None]) == "2010-09-10"
+        assert earliest_partial_date(["2009", "2010-09-10"]) == "2009"
+        assert earliest_partial_date(["2010-09", "2010-09-10"]) == "2010-09-10"
+        assert earliest_partial_date([None, "x"]) is None
+        assert earliest_partial_date([]) is None
+
+
+class TestDuration:
+    def test_parse_text(self):
+        assert parse_duration_text("148分钟") == 8880
+        assert parse_duration_text("2小时28分钟") == 8880
+        assert parse_duration_text("45分") == 2700
+        assert parse_duration_text("148 min") == 8880
+        assert parse_duration_text("2h 14m") == 8040
+        assert parse_duration_text("1:30:00") == 5400
+        assert parse_duration_text("4:44") == 284
+        assert parse_duration_text("PT2H28M") == 8880
+        assert parse_duration_text("148") == 8880  # bare digits = minutes
+        assert parse_duration_text("148分钟(导演剪辑版)") == 8880
+        assert parse_duration_text("") is None
+        assert parse_duration_text("garbage") is None
+
+    def test_coerce_video(self):
+        assert coerce_video_duration(148) == 8880  # legacy minutes
+        assert coerce_video_duration(8880) == 8880  # already seconds
+        assert coerce_video_duration("45分钟") == 2700
+        assert coerce_video_duration(None) is None
+        assert coerce_video_duration(0) is None
+
+    def test_coerce_album(self):
+        assert coerce_album_duration(2368000) == 2368  # legacy milliseconds
+        assert coerce_album_duration(2368) == 2368  # already seconds
+        assert coerce_album_duration("2368000") == 2368
+        assert coerce_album_duration(None) is None
+
+    def test_format(self):
+        assert format_duration(8040) == "2h 14m"
+        assert format_duration(7200) == "2h"
+        assert format_duration(2700) == "45m"
+        assert format_duration(58) == "58s"
+        assert format_duration(0) == ""
+        assert format_duration(None) == ""
+
+
+class TestPrice:
+    def test_canonical_unchanged(self):
+        assert normalize_price("CNY 26") == "CNY 26"
+        assert normalize_price("USD 10.99") == "USD 10.99"
+
+    def test_prefixed(self):
+        assert normalize_price("USD 26.00") == "USD 26.00"
+        assert normalize_price("￥484", "JPY") == "JPY 484"
+
+    def test_suffixed(self):
+        assert normalize_price("19.00元", "CNY") == "CNY 19.00"
+        assert normalize_price("450 NTD") == "TWD 450"
+        assert normalize_price("26.00 USD") == "USD 26.00"
+        assert normalize_price("1,299 JPY") == "JPY 1299"
+
+    def test_bare_number_needs_hint(self):
+        assert normalize_price("5.99", "CNY") == "CNY 5.99"
+        assert normalize_price("5.99") == "5.99"
+
+    def test_ambiguous_unchanged_without_hint(self):
+        assert normalize_price("￥484") == "￥484"
+        assert normalize_price("19.00元") == "19.00元"
+
+    def test_unparseable_unchanged(self):
+        assert normalize_price("48.00元（全二册）") == "48.00元（全二册）"
+        assert normalize_price("USD 26.00 / GBP 20") == "USD 26.00 / GBP 20"
+
+
+class TestCountry:
+    def test_codes(self):
+        assert normalize_country("US") == "US"
+        assert normalize_country("us") == "US"
+
+    def test_douban_aliases(self):
+        assert normalize_country("美国") == "US"
+        assert normalize_country("中国大陆") == "CN"
+        assert normalize_country("中国香港") == "HK"
+        assert normalize_country("英国") == "GB"
+
+    def test_english_names(self):
+        assert normalize_country("United States") == "US"
+        assert normalize_country("Japan") == "JP"
+
+    def test_passthrough(self):
+        assert normalize_country("西德") == "西德"
+        assert normalize_country("苏联") == "苏联"
+
+    def test_list(self):
+        assert normalize_countries(["美国", "英国", "美国"]) == ["US", "GB"]
+        assert normalize_countries("美国") == ["US"]
+        assert normalize_countries(None) == []
+
+    def test_display_name(self):
+        assert country_display_name("US") == "United States"
+        assert country_display_name("KR") == "South Korea"
+        assert country_display_name("西德") == "西德"
+        with translation.override("zh-hans"):
+            assert country_display_name("US") == "美国"
+            assert country_display_name("KR") == "韩国"
+
+
+class TestMusicFormat:
+    def test_album_types(self):
+        assert normalize_album_types("专辑") == ["album"]
+        assert normalize_album_types("EP") == ["ep"]
+        assert normalize_album_types("Album, EP") == ["album", "ep"]
+        assert normalize_album_types(["Mixtape/Street"]) == ["mixtape"]
+        assert normalize_album_types("Custom Thing") == ["Custom Thing"]
+        assert normalize_album_types(None) == []
+        assert normalize_album_types(["album"]) == ["album"]
+
+    def test_media_formats(self):
+        assert normalize_media_formats("Audio CD") == ["cd"]
+        assert normalize_media_formats("黑胶") == ["vinyl"]
+        assert normalize_media_formats(["Vinyl", "LP"]) == ["vinyl"]
+        assert normalize_media_formats("Digital Media") == ["digital"]
+        assert normalize_media_formats(["cd"]) == ["cd"]
+        assert normalize_media_formats(None) == []

--- a/neodb/tests/journal/test_csv.py
+++ b/neodb/tests/journal/test_csv.py
@@ -38,20 +38,20 @@ class TestCsvExportImport:
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt1375666",
             director=["Christopher Nolan"],
-            year=2010,
+            release_date="2010",
         )
         self.movie2 = Movie.objects.create(
             localized_title=[{"lang": "en", "text": "The Matrix"}],
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt0133093",
             director=["Lana Wachowski", "Lilly Wachowski"],
-            year=1999,
+            release_date="1999",
         )
         self.tvshow = TVShow.objects.create(
             localized_title=[{"lang": "en", "text": "Breaking Bad"}],
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt0903747",
-            year=2008,
+            release_date="2008",
         )
         self.tvseason = TVSeason.objects.create(
             localized_title=[{"lang": "en", "text": "Breaking Bad Season 1"}],

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -61,20 +61,20 @@ class TestNdjsonExportImport:
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt1375666",
             director=["Christopher Nolan"],
-            year=2010,
+            release_date="2010",
         )
         self.movie2 = Movie.objects.create(
             localized_title=[{"lang": "en", "text": "The Matrix"}],
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt0133093",
             director=["Lana Wachowski", "Lilly Wachowski"],
-            year=1999,
+            release_date="1999",
         )
         self.tvshow = TVShow.objects.create(
             localized_title=[{"lang": "en", "text": "Breaking Bad"}],
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt0903747",
-            year=2008,
+            release_date="2008",
         )
         self.tvseason = TVSeason.objects.create(
             localized_title=[{"lang": "en", "text": "Breaking Bad Season 1"}],

--- a/neodb/tests/journal/test_rating.py
+++ b/neodb/tests/journal/test_rating.py
@@ -38,7 +38,7 @@ class TestRating:
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt1234567",
             director=["Test Director"],
-            year=2020,
+            release_date="2020",
         )
 
         # Create a game (will have no ratings)

--- a/neodb/tests/journal/test_rating.py
+++ b/neodb/tests/journal/test_rating.py
@@ -48,7 +48,7 @@ class TestRating:
             primary_lookup_id_value="12345",
             developer=["Test Developer"],
             platform=["PC"],
-            release_year=2022,
+            release_date="2022",
         )
 
         # Create a TV show with a season and episode

--- a/neodb/tests/journal/test_shelf.py
+++ b/neodb/tests/journal/test_shelf.py
@@ -28,7 +28,7 @@ class TestShelfManager:
             primary_lookup_id_type=IdType.IMDB,
             primary_lookup_id_value="tt1234567",
             director=["Test Director"],
-            year=2020,
+            release_date="2020",
         )
 
         self.tvshow = TVShow.objects.create(


### PR DESCRIPTION
## Summary

Unifies inconsistent catalog metadata representations, per field:

| Field | Before | After |
|---|---|---|
| `Edition.price` | "19.00元", "450 NTD", "￥484" | `"<ISO4217> <amount>"` ("CNY 19.00", "TWD 450", "JPY 484") |
| duration (Movie/TV/Album) | free text "148分钟" / int minutes / milliseconds | new **`length`** field: int **seconds**, displayed as "2h 14m" |
| `Album.album_type` | free text ("专辑", "Album") | list of slugs (MusicBrainz release-group types), translated labels |
| `Album.media` | free text ("Audio CD") | renamed **`media_format`**, list of slugs (also fixes the Django `form.media` collision so the field becomes editable) |
| `Movie/TV.area` | free-text region names | **`origin_country`**: ISO 3166-1 alpha-2 list, localized display via pycountry's bundled translations |
| `Movie/TV.showtime` | list of {time, region} | single **`release_date`** (earliest entry) |
| `release_date` (all) | strict date, fabricated precision | partial ISO string: `YYYY` / `YYYY-MM` / `YYYY-MM-DD` |
| `Game.platform` | free text ("PC", "Boardgame", "PC (Microsoft Windows)") | canonical slugs based on [IGDB platforms](https://api-docs.igdb.com/#platform) (windows, ps5, switch, boardgame, ...) |
| `year` / `Game.release_year` | writable | read-only, derived from `release_date` |

New shared vocabularies/helpers follow the `common/models/genre.py` playbook: `partial_date.py`, `duration.py`, `price.py`, `country.py` (uses the already-declared `pycountry` dependency, incl. its gettext catalogs for localized country names — no new po entries needed), `music_format.py`, `game_platform.py` (alias tables for Douban Chinese terms, Spotify, Discogs, MusicBrainz, IGDB, Steam, itch.io, MobyGames, BGG). Unknown values always pass through as custom strings.

## API field changes

**New**

| Type | Field | Notes |
|---|---|---|
| Movie, TVShow, TVSeason | `origin_country` | `list[str]`, ISO 3166-1 alpha-2; unknown historic values (西德, 苏联) pass through |
| Movie, TVShow, TVSeason | `release_date` | `str`, partial ISO (earliest release) |
| Movie, TVShow, TVSeason, Album, PodcastEpisode | `length` | `int`, canonical duration in seconds |
| Album | `album_type` | `list[str]` of slugs; custom values pass through |
| Album | `media_format` | `list[str]` of slugs |
| Movie, TVShow, TVSeason | `official_site` | same value as `site`; naming now consistent with Game/Podcast/Performance |
| Edition | `format` | BookFormat enum (paperback/hardcover/ebook/...), previously model-only |

**Changed**

| Type | Field | Before -> After |
|---|---|---|
| Album, Game | `release_date` | strict full date -> partial ISO string (full dates unchanged; year-only items emit `"1997"`) |
| Edition | `price` | same str type; values normalized to `"<ISO4217> <amount>"` where unambiguous |
| Game | `platform` | same `list[str]` type; values normalized to IGDB-based slugs; unknown values pass through |

**Deprecated (still emitted for older peers/clients)**

| Type | Field | Emits |
|---|---|---|
| Movie, TVShow, TVSeason | `duration` | display string `"2h 28m"` (old free-text str type preserved) |
| Album | `duration` | `int` milliseconds (old semantic preserved; use `length`) |
| PodcastEpisode | `duration` | unchanged (seconds); use `length` |
| Movie, TVShow, TVSeason | `area` | ISO codes instead of free-text names (use `origin_country`) |
| Movie, TVShow, TVSeason | `showtime` | `[{"time": <release_date>, "region": ""}]` (use `release_date`) |
| Album | `media` | joined slug string `"cd, vinyl"` (use `media_format`) |
| Game | `release_year` | `int` derived from `release_date` |
| Movie, TVShow, TVSeason | `year` | `int` derived from `release_date` |
| Movie, TVShow, TVSeason | `site` | unchanged value; use `official_site` |
| Edition | `binding` | free text, duplicates the `format` enum |

**Removed**: `single_episode_length` is no longer displayed or exposed in the API (it was never public before this branch); still collected from scrapers and editable — fate undecided, likely to be deprecated.

Unchanged: `genre`/`language` (already canonical codes).

## Compatibility

- **Inbound (older peers / ndjson restores / stale ExternalResources)**: all legacy shapes are coerced in per-class `normalize_legacy_metadata` — the single ingest conversion point (AP fetch, merge, and the data migration all share it). Legacy unit inference (Album ms >= 50000; video int minutes) only fires on old-shaped payloads: pre-unification keys present and `length` absent, which only current servers emit — so re-conversion is a no-op and current-server federation is lossless with no heuristics.
- **Outbound (older peers / API clients)**: old keys keep their old shapes as deprecated aliases (see table above). `release_date` is the stored partial string ("1911" is acceptable — older peers typing it as a strict date will skip year-precision values).
- Tolerant `resolve_*` resolvers keep `ap_object` validation working on pre-migration rows during the deploy→migrate window.

## Data migration

```
neodb-manage catalog migrate --name unify_metadata [--start <pk>] [--batch-size N] [--dry-run]
```
Single pk-ordered polymorphic pass over Movie/TVShow/TVSeason/Album/Game/Edition; chunked `bulk_update` (no post_save signal storm), each batch reindexed immediately; restart-safe via `--start`; idempotent. Deploy code first, then run the migration.

## Scraper improvements bundled

- TMDB: captures `origin_country` and `episode_run_time` it previously discarded; runtime stored as seconds.
- Spotify: captures `album_type` (previously discarded); keeps year/month precision from `release_date`.
- Discogs: maps all `formats[].name` → media_format and format descriptions → album_type; Master year captured.
- MusicBrainz: captures release-group primary/secondary types and media formats.
- Steam: parses release dates (was stored raw localized text, e.g. "18 kwietnia 2011"); year-only values keep year precision.
- BGG/YouTube Music/IMDb: year-only data kept at year precision instead of fabricated dates.
- Wikidata: P2047 duration honors quantity units; partial dates keep true precision.
- All game scrapers emit canonical platform slugs.

## Search

`to_indexable_doc` emits `date` as YYYYMMDD ints padded with 00, so the `year:` filter keeps working for partial dates; Album `format` facet uses the slug lists; Game `format` facet gets consistent platform slugs.

## Tests

New unit tests for all helpers and per-class legacy coercion, migration idempotency test, deprecated-alias emission and lossless round-trip tests; existing scraper/journal tests updated to the new shapes. Also fixes a pre-existing test flake: an autouse fixture resets the active Django language after each test (activate_language_for_user leaks it otherwise). i18n: new pgettext contexts (`album_type`, `media_format`, `platform`) translated for zh_Hans.
