### PR TITLE
perf(catalog): bulk-load viewer marks on person works page

### DIFF
--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -243,6 +243,8 @@ def people_works(request, item_path, item_uuid, role):
         )
         Item.prefetch_parent_items(works_items)
         Rating.attach_to_items(works_items)
+        if request.user.is_authenticated:
+            Mark.attach_to_items(request.user.identity, works_items, request.user)
     return render(
         request,
         "people_works.html",

--- a/neodb/tests/catalog/test_people_works_view.py
+++ b/neodb/tests/catalog/test_people_works_view.py
@@ -4,6 +4,7 @@ from django.test import Client
 from catalog.models import (
     Edition,
     ItemPeopleRelation,
+    Movie,
     People,
     PeopleRole,
     PeopleType,
@@ -212,3 +213,42 @@ class TestPeopleWorksMergedAndDeleted:
 
         response = Client().get(f"{person1.url}/works/not_a_role")
         assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPeopleWorksMarks:
+    """The works page shows the viewer's shelf status on each listed work."""
+
+    def _setup_marked_work(self) -> tuple[People, Movie, Movie, User]:
+        person = _director()
+        watched = Movie.objects.create(title="Watched Movie")
+        unwatched = Movie.objects.create(title="Unwatched Movie")
+        for movie in (watched, unwatched):
+            ItemPeopleRelation.objects.create(
+                item=movie, people=person, role=PeopleRole.DIRECTOR
+            )
+        user = User.register(email="viewer@example.com", username="viewer")
+        shelf = user.identity.shelf_manager.get_shelf(ShelfType.COMPLETE)
+        ShelfMember.objects.create(
+            owner=user.identity,
+            item=watched,
+            parent=shelf,
+            visibility=0,
+            position=0,
+        )
+        return person, watched, unwatched, user
+
+    def test_people_works_attaches_marks_in_bulk(self):
+        person, watched, unwatched, user = self._setup_marked_work()
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+        response = client.get(f"{person.url}/works/{PeopleRole.DIRECTOR.value}")
+        assert response.status_code == 200
+        marks = {w.pk: getattr(w, "mark", None) for w in response.context["works"]}
+        watched_mark = marks[watched.pk]
+        unwatched_mark = marks[unwatched.pk]
+        assert watched_mark is not None
+        assert watched_mark.shelf_type == ShelfType.COMPLETE
+        assert unwatched_mark is not None
+        assert unwatched_mark.shelf_type is None


### PR DESCRIPTION
## Summary

On the person works page (`/person/<uid>/works/<role>`), each work card is rendered via `_list_item.html`, which shows the viewer's shelf status. Since marks were never attached in bulk, the `get_mark_for_item` template tag fell back to constructing a lazy `Mark` per card, causing N+1 queries (shelf member, comment, rating, review, tags per work).

This attaches the viewer's marks with `Mark.attach_to_items` alongside the existing `Rating.attach_to_items`, matching the pattern used by search results and collection lists.


## Tests

- New test in `tests/catalog/test_people_works_view.py` asserting marks are attached in bulk with the correct shelf status.
- Full file passes (12 tests); `pre-commit run -a` green.