### PR TITLE
fix(activities): correct domain lookup in identity handle search

### DIFF
--- a/takahe/activities/services/search.py
+++ b/takahe/activities/services/search.py
@@ -64,7 +64,9 @@ class SearchService:
             for identity in Identity.objects.filter(username__istartswith=handle)[:20]:
                 results.add(identity)
             if "." in handle:
-                for identity in Identity.objects.filter(domain__iexact=handle)[:20]:
+                for identity in Identity.objects.filter(domain__domain__iexact=handle)[
+                    :20
+                ]:
                     results.add(identity)
 
         if prio_result:

--- a/takahe/tests/activities/services/test_search.py
+++ b/takahe/tests/activities/services/test_search.py
@@ -74,6 +74,20 @@ def test_search_url_follows_ap_alternate(monkeypatch, config_system):
 
 
 @pytest.mark.django_db
+def test_search_identities_by_domain(identity, identity2):
+    """Searching a bare domain name should return identities on that
+    domain, matched case-insensitively.
+
+    Regression: EGGPLANT-1GW - ``domain__iexact`` raised FieldError as
+    ``iexact`` cannot be applied directly to the ForeignKey.
+    """
+    results = SearchService("Example.COM", None).search_identities_handle()
+
+    assert identity in results
+    assert identity2 not in results
+
+
+@pytest.mark.django_db
 def test_search_url_gives_up_when_no_alternate(monkeypatch, config_system):
     """If the response is HTML without an AP alternate hint, search_url
     must give up rather than loop or raise."""


### PR DESCRIPTION
## Summary

Searching a bare domain name (e.g. `bridge.neodb.net`) via `/api/v2/search` crashed with:

```
FieldError: Unsupported lookup 'iexact' for ForeignKey or join on the field not permitted, perhaps you meant exact?
```

`Identity.domain` is a ForeignKey, so `domain__iexact` is not a valid lookup. This traverses to the `Domain` primary key (`domain__domain__iexact`) instead, matching the pattern already used in the admin identities view (`domain__domain__istartswith`).

## Changes
- `takahe/activities/services/search.py`: fix the lookup in `search_identities_handle`
- `takahe/tests/activities/services/test_search.py`: regression test - searching a bare/mixed-case domain returns identities on that domain

## Testing
- `tests/activities/services/test_search.py`: 4 passed (docker dev-shell)
- Verified the old lookup reproduces the exact FieldError and the new lookup does not

Fixes EGGPLANT-1GW