### PR TITLE
fix(journal): tolerate duplicate Comment/Review rows on AP update and NDJSON import

### DIFF
--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -229,13 +229,22 @@ class NdjsonImporter(BaseImporter):
             existing_review = Review.objects.filter(
                 owner=owner, item=item, title=name
             ).first()
-            if (
-                existing_review
-                and existing_review.created_time
-                and published_dt
-                and existing_review.created_time >= published_dt
-            ):
-                return "skipped"
+            if existing_review:
+                if (
+                    existing_review.created_time
+                    and published_dt
+                    and existing_review.created_time >= published_dt
+                ):
+                    return "skipped"
+                # a newer export updates the existing review in place;
+                # creating another row would duplicate (owner, item, title)
+                existing_review.body = content
+                if published_dt:
+                    existing_review.created_time = published_dt
+                existing_review.visibility = visibility
+                existing_review.metadata = metadata
+                existing_review.save()
+                return "imported"
             Review.objects.create(
                 owner=owner,
                 item=item,
@@ -334,13 +343,23 @@ class NdjsonImporter(BaseImporter):
                 raise KeyError(f"Could not find item: {data.get('item', '')}")
             content = content_data.get("content", "")
             existing_comment = Comment.objects.filter(owner=owner, item=item).first()
-            if (
-                existing_comment
-                and existing_comment.created_time
-                and published_dt
-                and existing_comment.created_time >= published_dt
-            ):
-                return "skipped"
+            if existing_comment:
+                if (
+                    existing_comment.created_time
+                    and published_dt
+                    and existing_comment.created_time >= published_dt
+                ):
+                    return "skipped"
+                # a newer export updates the existing comment in place;
+                # creating another row would duplicate (owner, item),
+                # the same corruption behind EGGPLANT-1GP
+                existing_comment.text = content
+                if published_dt:
+                    existing_comment.created_time = published_dt
+                existing_comment.visibility = visibility
+                existing_comment.metadata = metadata
+                existing_comment.save()
+                return "imported"
             Comment.objects.create(
                 owner=owner,
                 item=item,

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -18,6 +18,7 @@ from .shelf import ShelfManager, ShelfType
 
 
 class Comment(Content):
+    dedupe_content_fields = ("text",)
     text = models.TextField(blank=False, null=False)
 
     class Meta:

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -46,7 +46,7 @@ class Comment(Content):
     def update_by_ap_object(cls, owner, item, obj, post, crosspost=None):
         if post.local:  # ignore local user updating their post via Mastodon API
             return
-        p = cls.objects.filter(owner=owner, item=item).first()
+        p = cls.dedupe_newest(owner, item)
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
             return p  # incoming ap object is older than what we have, no update needed
@@ -64,7 +64,14 @@ class Comment(Content):
         }
         if obj.get("relatedWithItemPosition"):
             d["metadata"] = {"position": obj["relatedWithItemPosition"]}
-        p, _ = cls.objects.update_or_create(owner=owner, item=item, defaults=d)
+        # update the fetched row directly; a second lookup via update_or_create
+        # can hit raced duplicates (no unique constraint on owner+item)
+        if p:
+            for k, v in d.items():
+                setattr(p, k, v)
+            p.save()
+        else:
+            p = cls.objects.create(owner=owner, item=item, **d)
         p.link_post_id(post.id)
         return p
 

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -65,14 +65,7 @@ class Comment(Content):
         }
         if obj.get("relatedWithItemPosition"):
             d["metadata"] = {"position": obj["relatedWithItemPosition"]}
-        # update the fetched row directly; a second lookup via update_or_create
-        # can hit raced duplicates (no unique constraint on owner+item)
-        if p:
-            for k, v in d.items():
-                setattr(p, k, v)
-            p.save()
-        else:
-            p = cls.objects.create(owner=owner, item=item, **d)
+        p = cls.apply_ap_update(p, owner, item, d)
         p.link_post_id(post.id)
         return p
 

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -1036,6 +1036,24 @@ class Content(Piece):
     def __str__(self):
         return f"{self.__class__.__name__}:{self.uuid}@{self.item}"
 
+    @classmethod
+    def dedupe_newest(cls, owner: APIdentity, item: Item) -> Self | None:
+        """Return the newest piece for (owner, item), deleting older duplicates.
+
+        Only for types where (owner, item) is logically unique but not
+        DB-enforced (Comment, Review — unlike Rating/ShelfMember there is no
+        unique constraint, so concurrent inbound fetch workers can race
+        duplicate rows in). Never use for Note, which allows multiple pieces
+        per (owner, item) by design.
+        """
+        pieces = list(
+            cls.objects.filter(owner=owner, item=item).order_by("-edited_time", "-pk")
+        )
+        for dup in pieces[1:]:
+            logger.warning(f"deleting duplicate {dup!r} of {pieces[0]!r}")
+            dup.delete()
+        return pieces[0] if pieces else None
+
     @property
     def display_title(self) -> str:
         raise NotImplementedError("subclass should override this")

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -1064,6 +1064,24 @@ class Content(Piece):
                     dup.delete()
         return newest
 
+    @classmethod
+    def apply_ap_update(
+        cls, p: Self | None, owner: APIdentity, item: Item, d: dict[str, Any]
+    ) -> Self:
+        """Save inbound AP fields onto the already-fetched piece, or create one.
+
+        Updates the fetched row directly; a second lookup via
+        update_or_create can hit raced duplicates (no unique constraint on
+        owner+item for Comment/Review).
+        """
+        if p:
+            for k, v in d.items():
+                setattr(p, k, v)
+            p.save()
+        else:
+            p = cls.objects.create(owner=owner, item=item, **d)
+        return p
+
     @property
     def display_title(self) -> str:
         raise NotImplementedError("subclass should override this")

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -1036,9 +1036,15 @@ class Content(Piece):
     def __str__(self):
         return f"{self.__class__.__name__}:{self.uuid}@{self.item}"
 
+    # content fields compared by dedupe_newest; only types where (owner,
+    # item) is logically unique should set this (Comment, Review). The
+    # empty default means nothing is ever deleted by accident.
+    dedupe_content_fields: tuple[str, ...] = ()
+
     @classmethod
     def dedupe_newest(cls, owner: APIdentity, item: Item) -> Self | None:
-        """Return the newest piece for (owner, item), deleting older duplicates.
+        """Return the newest piece for (owner, item), deleting older
+        duplicates whose dedupe_content_fields all match it.
 
         Only for types where (owner, item) is logically unique but not
         DB-enforced (Comment, Review — unlike Rating/ShelfMember there is no
@@ -1049,10 +1055,14 @@ class Content(Piece):
         pieces = list(
             cls.objects.filter(owner=owner, item=item).order_by("-edited_time", "-pk")
         )
-        for dup in pieces[1:]:
-            logger.warning(f"deleting duplicate {dup!r} of {pieces[0]!r}")
-            dup.delete()
-        return pieces[0] if pieces else None
+        newest = pieces[0] if pieces else None
+        fields = cls.dedupe_content_fields
+        if newest and fields:
+            for dup in pieces[1:]:
+                if all(getattr(dup, f) == getattr(newest, f) for f in fields):
+                    logger.warning(f"deleting duplicate {dup!r} of {newest!r}")
+                    dup.delete()
+        return newest
 
     @property
     def display_title(self) -> str:

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -135,14 +135,7 @@ class Review(Content):
             "created_time": datetime.fromisoformat(obj["published"]),
             "edited_time": datetime.fromisoformat(updated),
         }
-        # update the fetched row directly; a second lookup via update_or_create
-        # can hit raced duplicates (no unique constraint on owner+item)
-        if p:
-            for k, v in d.items():
-                setattr(p, k, v)
-            p.save()
-        else:
-            p = cls.objects.create(owner=owner, item=item, **d)
+        p = cls.apply_ap_update(p, owner, item, d)
         p.link_post_id(post.id)
         return p
 

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -116,7 +116,7 @@ class Review(Content):
     def update_by_ap_object(cls, owner, item, obj, post, crosspost=None):
         if post.local:  # ignore local user updating their post via Mastodon API
             return
-        p = cls.objects.filter(owner=owner, item=item).first()
+        p = cls.dedupe_newest(owner, item)
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
             return p  # incoming ap object is older than what we have, no update needed
@@ -134,7 +134,14 @@ class Review(Content):
             "created_time": datetime.fromisoformat(obj["published"]),
             "edited_time": datetime.fromisoformat(updated),
         }
-        p, _ = cls.objects.update_or_create(owner=owner, item=item, defaults=d)
+        # update the fetched row directly; a second lookup via update_or_create
+        # can hit raced duplicates (no unique constraint on owner+item)
+        if p:
+            for k, v in d.items():
+                setattr(p, k, v)
+            p.save()
+        else:
+            p = cls.objects.create(owner=owner, item=item, **d)
         p.link_post_id(post.id)
         return p
 

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -39,6 +39,7 @@ class Review(Content):
     url_path = "review"
     post_when_save = True
     index_when_save = True
+    dedupe_content_fields = ("title", "body")
     title = models.CharField(max_length=500, blank=False, null=False)
     body = models.TextField()
 

--- a/neodb/tests/journal/test_ap_object.py
+++ b/neodb/tests/journal/test_ap_object.py
@@ -648,7 +648,8 @@ class TestUpdateByApObjectDuplicateRows:
     Comment and Review have no unique constraint on (owner, item), so
     concurrent fetch workers can race duplicate rows in; a later update
     then crashed update_or_create with MultipleObjectsReturned (Sentry
-    EGGPLANT-1GP). The update must consolidate onto the newest row.
+    EGGPLANT-1GP). The update must target the newest row and delete older
+    duplicates only when their content matches it.
     """
 
     @pytest.fixture(autouse=True)
@@ -669,11 +670,13 @@ class TestUpdateByApObjectDuplicateRows:
             "href": "https://example.com/comment/1",
         }
 
-    def _make_duplicate_comments(self) -> tuple[Comment, Comment]:
+    def _make_duplicate_comments(
+        self, older_text: str = "duplicate text", newer_text: str = "duplicate text"
+    ) -> tuple[Comment, Comment]:
         older = Comment.objects.create(
             item=self.book,
             owner=self.identity,
-            text="older duplicate",
+            text=older_text,
             local=False,
             remote_id="https://example.com/comment/1",
             visibility=0,
@@ -681,7 +684,7 @@ class TestUpdateByApObjectDuplicateRows:
         newer = Comment.objects.create(
             item=self.book,
             owner=self.identity,
-            text="newer duplicate",
+            text=newer_text,
             local=False,
             remote_id="https://example.com/comment/1",
             visibility=0,
@@ -722,21 +725,39 @@ class TestUpdateByApObjectDuplicateRows:
         )
         assert result is not None
         assert result.pk == newer.pk
-        assert result.text == "newer duplicate"
+        assert result.text == "duplicate text"
         remaining = Comment.objects.filter(owner=self.identity, item=self.book)
         assert remaining.count() == 1
         assert not Comment.objects.filter(pk=older.pk).exists()
 
+    def test_comment_divergent_duplicate_is_kept(self):
+        """A duplicate whose content differs from the newest row must not be
+        deleted; the update still lands on the newest row without crashing."""
+        older, newer = self._make_duplicate_comments(older_text="different text")
+        post = _make_remote_post(self.identity.pk, post_id=66664)
+        result = Comment.update_by_ap_object(
+            self.identity,
+            self.book,
+            self._comment_ap_obj("final text", "2023-01-01T00:00:00+00:00"),
+            post,
+        )
+        assert result is not None
+        assert result.pk == newer.pk
+        assert result.text == "final text"
+        remaining = Comment.objects.filter(owner=self.identity, item=self.book)
+        assert remaining.count() == 2
+        assert Comment.objects.get(pk=older.pk).text == "different text"
+
     def test_review_update_consolidates_duplicates(self):
         reviews = []
-        for title, edited in [
-            ("older duplicate", "2021-06-01T00:00:00+00:00"),
-            ("newer duplicate", "2022-06-01T00:00:00+00:00"),
+        for edited in [
+            "2021-06-01T00:00:00+00:00",
+            "2022-06-01T00:00:00+00:00",
         ]:
             review = Review.objects.create(
                 item=self.book,
                 owner=self.identity,
-                title=title,
+                title="duplicate title",
                 body="body",
                 local=False,
                 remote_id="https://example.com/review/1",

--- a/neodb/tests/journal/test_ap_object.py
+++ b/neodb/tests/journal/test_ap_object.py
@@ -642,6 +642,133 @@ class TestUpdateByApObject:
 
 
 @pytest.mark.django_db(databases="__all__")
+class TestUpdateByApObjectDuplicateRows:
+    """Duplicate (owner, item) rows must not crash update_by_ap_object.
+
+    Comment and Review have no unique constraint on (owner, item), so
+    concurrent fetch workers can race duplicate rows in; a later update
+    then crashed update_or_create with MultipleObjectsReturned (Sentry
+    EGGPLANT-1GP). The update must consolidate onto the newest row.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.book = Edition.objects.create(title="Test Book")
+        self.user = User.register(email="dupap@test.com", username="dupap_user")
+        self.identity = self.user.identity
+
+    def _comment_ap_obj(self, content: str, updated: str) -> dict:
+        return {
+            "id": "https://example.com/comment/1",
+            "type": "Comment",
+            "content": content,
+            "published": "2021-01-01T00:00:00+00:00",
+            "updated": updated,
+            "attributedTo": self.identity.actor_uri,
+            "withRegardTo": self.book.absolute_url,
+            "href": "https://example.com/comment/1",
+        }
+
+    def _make_duplicate_comments(self) -> tuple[Comment, Comment]:
+        older = Comment.objects.create(
+            item=self.book,
+            owner=self.identity,
+            text="older duplicate",
+            local=False,
+            remote_id="https://example.com/comment/1",
+            visibility=0,
+        )
+        newer = Comment.objects.create(
+            item=self.book,
+            owner=self.identity,
+            text="newer duplicate",
+            local=False,
+            remote_id="https://example.com/comment/1",
+            visibility=0,
+        )
+        # edited_time is auto_now; backdate via update() to control ordering
+        Comment.objects.filter(pk=older.pk).update(
+            edited_time="2021-06-01T00:00:00+00:00"
+        )
+        Comment.objects.filter(pk=newer.pk).update(
+            edited_time="2022-06-01T00:00:00+00:00"
+        )
+        return older, newer
+
+    def test_comment_update_consolidates_duplicates(self):
+        older, newer = self._make_duplicate_comments()
+        post = _make_remote_post(self.identity.pk, post_id=66661)
+        result = Comment.update_by_ap_object(
+            self.identity,
+            self.book,
+            self._comment_ap_obj("final text", "2023-01-01T00:00:00+00:00"),
+            post,
+        )
+        assert result is not None
+        assert result.pk == newer.pk
+        assert result.text == "final text"
+        remaining = Comment.objects.filter(owner=self.identity, item=self.book)
+        assert remaining.count() == 1
+        assert not Comment.objects.filter(pk=older.pk).exists()
+
+    def test_comment_stale_update_still_dedupes(self):
+        older, newer = self._make_duplicate_comments()
+        post = _make_remote_post(self.identity.pk, post_id=66662)
+        result = Comment.update_by_ap_object(
+            self.identity,
+            self.book,
+            self._comment_ap_obj("stale text", "2022-01-01T00:00:00+00:00"),
+            post,
+        )
+        assert result is not None
+        assert result.pk == newer.pk
+        assert result.text == "newer duplicate"
+        remaining = Comment.objects.filter(owner=self.identity, item=self.book)
+        assert remaining.count() == 1
+        assert not Comment.objects.filter(pk=older.pk).exists()
+
+    def test_review_update_consolidates_duplicates(self):
+        reviews = []
+        for title, edited in [
+            ("older duplicate", "2021-06-01T00:00:00+00:00"),
+            ("newer duplicate", "2022-06-01T00:00:00+00:00"),
+        ]:
+            review = Review.objects.create(
+                item=self.book,
+                owner=self.identity,
+                title=title,
+                body="body",
+                local=False,
+                remote_id="https://example.com/review/1",
+                visibility=0,
+            )
+            # edited_time is auto_now; backdate via update() so the incoming
+            # object below is newer than both rows
+            Review.objects.filter(pk=review.pk).update(edited_time=edited)
+            reviews.append(review)
+        post = _make_remote_post(self.identity.pk, post_id=66663)
+        ap_obj = {
+            "id": "https://example.com/review/1",
+            "type": "Review",
+            "name": "final title",
+            "content": "final body",
+            "mediaType": "text/markdown",
+            "published": "2021-01-01T00:00:00+00:00",
+            "updated": "2023-01-01T00:00:00+00:00",
+            "attributedTo": self.identity.actor_uri,
+            "withRegardTo": self.book.absolute_url,
+            "href": "https://example.com/review/1",
+        }
+        result = Review.update_by_ap_object(self.identity, self.book, ap_obj, post)
+        assert result is not None
+        assert result.pk == reviews[1].pk
+        assert result.title == "final title"
+        assert result.body == "final body"
+        remaining = Review.objects.filter(owner=self.identity, item=self.book)
+        assert remaining.count() == 1
+
+
+@pytest.mark.django_db(databases="__all__")
 class TestUpdateByApObjectMissingUpdated:
     """Verify update_by_ap_object handles AP objects that omit the 'updated' field.
 

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -555,6 +555,60 @@ class TestNdjsonExportImport:
             == 1
         )
 
+    def test_ndjson_newer_import_updates_instead_of_duplicating(self):
+        """Importing newer data updates existing Comment/Review rows in place;
+        creating another row would duplicate (owner, item) — the same
+        corruption behind Sentry EGGPLANT-1GP."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        owner = self.user2.identity
+
+        Comment.objects.create(
+            item=self.book1,
+            owner=owner,
+            text="old comment",
+            visibility=0,
+            created_time=self.dt,
+        )
+        result = importer.import_comment(
+            {
+                "visibility": 0,
+                "content": {
+                    "withRegardTo": self.book1.absolute_url,
+                    "content": "newer comment",
+                    "published": "2021-02-01T00:00:00Z",
+                },
+            }
+        )
+        assert result == "imported"
+        comment = Comment.objects.get(owner=owner, item=self.book1)
+        assert comment.text == "newer comment"
+        assert comment.created_time == self.dt2
+
+        Review.objects.create(
+            item=self.book1,
+            owner=owner,
+            title="My Review",
+            body="old body",
+            visibility=0,
+            created_time=self.dt,
+        )
+        result = importer.import_review(
+            {
+                "visibility": 0,
+                "content": {
+                    "withRegardTo": self.book1.absolute_url,
+                    "name": "My Review",
+                    "content": "newer body",
+                    "published": "2021-02-01T00:00:00Z",
+                },
+            }
+        )
+        assert result == "imported"
+        review = Review.objects.get(owner=owner, item=self.book1)
+        assert review.body == "newer body"
+        assert review.created_time == self.dt2
+
     def test_ndjson_article_round_trip(self):
         """Standalone Articles round-trip through export and import."""
         Article.update_local_article(


### PR DESCRIPTION
## Summary

Sentry [EGGPLANT-1GP](https://neodb.sentry.io/issues/EGGPLANT-1GP): `Comment.MultipleObjectsReturned: get() returned more than one Comment -- it returned 2!` in `takahe.ap_handlers.post_fetched`.

Comment and Review have no unique constraint on `(owner, item)` (unlike Rating and ShelfMember), so duplicate rows can appear — from concurrent fetch workers racing on the same remote piece, and from NDJSON re-imports (see below). Every later inbound AP update then crashes in `update_or_create`, whose internal `get()` finds both rows.

## Changes

- `Content.dedupe_newest(owner, item)` returns the newest-edited row and deletes older duplicates, but only when all `dedupe_content_fields` match the kept row (`text` for Comment, `title`+`body` for Review) — rows with divergent content are never destroyed. The empty default on other types means nothing is deleted by accident.
- `Comment.update_by_ap_object` and `Review.update_by_ap_object` update the fetched row in place instead of doing a second lookup via `update_or_create`, making the `MultipleObjectsReturned` crash structurally impossible even when divergent duplicates remain.
- NDJSON importer: importing newer data now updates the existing Comment/Review in place; previously it created a second `(owner, item)` row — a direct source of the duplicates behind this crash (the douban importer already recovers from this; csv/goodreads/letterboxd/rym/storygraph go through `update_item_review` and are safe).
- Regression tests for all three behaviors, including divergent-content duplicates being preserved.

## Notes

A DB unique constraint on `(owner, item)` matching Rating/ShelfMember would be the deeper fix, but needs a dedupe data migration plus a blocking unique-index build on large tables, and would surface `IntegrityError` in local double-submit paths that currently rely on the constraint's absence. Left out of scope; can follow up if wanted.

## Testing

- `tests/journal/test_ap_object.py` + `tests/journal/test_ndjson.py`: 53 passed (5 new) via dockerized pytest; the one failure (`test_import_collection_cover_inside_temp_dir`) also fails on the base commit in this environment.
- Full `tests/journal` and fork CI (code check + unit test) green on the first commit; fork CI running on the follow-up.
- `uv run pre-commit run -a` clean.

Fixes EGGPLANT-1GP