### PR TITLE
feat(journal): APIs to list a user's created and liked collections

### DIFF
--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -70,8 +70,9 @@ class CollectionPageNumberPagination(PageNumberPagination):
 
 
 def _prefetch_collection_owners(collections: List[Collection]) -> None:
-    """Batch-load takahe identities so ``CollectionOwnerSchema`` serialization
-    (display_name/avatar) does not fire a cross-db query per collection.
+    """Batch-load takahe identities so owner (``UserIdentitySchema``)
+    serialization (display_name/avatar) does not fire a cross-db query per
+    collection.
 
     Querysets feeding this should ``select_related("owner")``.
     """

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -29,6 +29,7 @@ from journal.models.common import (
     q_owned_piece_visible_to_user,
     q_piece_visible_to_user,
 )
+from takahe.utils import Takahe
 from users.models.apidentity import APIdentity
 
 from ..models import (
@@ -61,8 +62,26 @@ class CollectionPageNumberPagination(PageNumberPagination):
             return val
         data = val.get("data") if isinstance(val, dict) else None
         if data:
-            Collection.attach_item_count_by_category(list(data))
+            collections = list(data)
+            Collection.attach_item_count_by_category(collections)
+            _prefetch_collection_owners(collections)
         return val
+
+
+def _prefetch_collection_owners(collections: List[Collection]) -> None:
+    """Batch-load takahe identities so ``CollectionOwnerSchema`` serialization
+    (display_name/avatar) does not fire a cross-db query per collection.
+
+    Querysets feeding this should ``select_related("owner")``.
+    """
+    Takahe.prefetch_takahe_identities([c.owner for c in collections])
+
+
+class CollectionOwnerSchema(Schema):
+    username: str = Field(alias="handle")
+    url: str
+    display_name: str
+    avatar: str
 
 
 class CollectionSchema(Schema):
@@ -80,6 +99,7 @@ class CollectionSchema(Schema):
     is_dynamic: bool
     query: str | None = None
     item_count_by_category: dict[str, int]
+    owner: CollectionOwnerSchema
 
 
 class CollectionInSchema(Schema):
@@ -188,7 +208,9 @@ def list_user_collections(request):
     """
     Get collections created by current user
     """
-    queryset = Collection.objects.filter(owner=request.user.identity)
+    queryset = Collection.objects.filter(owner=request.user.identity).select_related(
+        "owner"
+    )
     return queryset
 
 
@@ -211,7 +233,46 @@ def list_collections_of_user(request, handle: str):
     except APIdentity.DoesNotExist:
         raise Http404("User not found")
     qv = q_owned_piece_visible_to_user(request.user, target, check_blocking=True)
-    return Collection.objects.filter(qv).order_by("-edited_time")
+    return (
+        Collection.objects.filter(qv).select_related("owner").order_by("-edited_time")
+    )
+
+
+@api.get(
+    "/user/{handle}/collection/liked/",
+    response={200: List[CollectionSchema], 401: Result, 404: Result},
+    tags=["collection"],
+    auth=OptionalOAuthAccessTokenAuth(),
+)
+@paginate(CollectionPageNumberPagination)
+def list_liked_collections_of_user(request, handle: str):
+    """
+    Get collections liked by a specific user
+
+    Only collections visible to the requesting identity are returned;
+    anonymous access is allowed if the user's profile is anonymous viewable.
+    """
+    try:
+        target = APIdentity.get_by_handle(handle)
+    except APIdentity.DoesNotExist:
+        raise Http404("User not found")
+    viewer = request.user.identity if request.user.is_authenticated else None
+    # gate on the target like the created-collections endpoint above:
+    # hide the list rather than 403, so it's indistinguishable from empty
+    if target.restricted:
+        return Collection.objects.none()
+    if viewer is None and not target.anonymous_viewable:
+        return Collection.objects.none()
+    if viewer and viewer != target and viewer.is_blocked_by(target):
+        return Collection.objects.none()
+    queryset = Collection.objects.filter(
+        interactions__identity=target,
+        interactions__interaction_type="like",
+        interactions__target_type="Collection",
+    )
+    if viewer != target:
+        queryset = queryset.filter(q_piece_visible_to_user(request.user))
+    return queryset.select_related("owner").order_by("-edited_time")
 
 
 @api.get(
@@ -589,7 +650,12 @@ def list_item_collections(request, item_uuid: str):
     if not item or item.is_deleted:
         raise Http404("Item not found")
     qv = q_piece_visible_to_user(request.user)
-    return Collection.objects.filter(items=item).filter(qv).order_by("-created_time")
+    return (
+        Collection.objects.filter(items=item)
+        .filter(qv)
+        .select_related("owner")
+        .order_by("-created_time")
+    )
 
 
 @api.post(
@@ -638,11 +704,12 @@ def list_featured_collections(request):
     List featured collections for current user.
     """
     collections = list(
-        Collection.objects.filter(featured_by=request.user.identity).filter(
-            q_piece_visible_to_user(request.user)
-        )
+        Collection.objects.filter(featured_by=request.user.identity)
+        .filter(q_piece_visible_to_user(request.user))
+        .select_related("owner")
     )
     Collection.attach_item_count_by_category(collections)
+    _prefetch_collection_owners(collections)
     return collections
 
 
@@ -731,7 +798,7 @@ def trending_collection(request):
     # made them non-public after the discover job cached them
     qs = Collection.objects.filter(
         pk__in=collection_ids, visibility=0, owner__anonymous_viewable=True
-    )
+    ).select_related("owner")
     if restricted_owner_ids:
         qs = qs.exclude(owner_id__in=restricted_owner_ids)
     # pk__in does not preserve list order; reapply the rotation
@@ -739,4 +806,5 @@ def trending_collection(request):
     collections = [by_pk[pk] for pk in collection_ids if pk in by_pk]
     prefetch_latest_posts(collections)
     Collection.attach_item_count_by_category(collections)
+    _prefetch_collection_owners(collections)
     return collections

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -25,7 +25,11 @@ from common.api import (
 )
 from common.sentry import record_activity
 from journal.models.collection import COVER_MAX_BYTES
-from journal.models.common import q_piece_visible_to_user
+from journal.models.common import (
+    q_owned_piece_visible_to_user,
+    q_piece_visible_to_user,
+)
+from users.models.apidentity import APIdentity
 
 from ..models import (
     Collection,
@@ -186,6 +190,28 @@ def list_user_collections(request):
     """
     queryset = Collection.objects.filter(owner=request.user.identity)
     return queryset
+
+
+@api.get(
+    "/user/{handle}/collection/",
+    response={200: List[CollectionSchema], 401: Result, 404: Result},
+    tags=["collection"],
+    auth=OptionalOAuthAccessTokenAuth(),
+)
+@paginate(CollectionPageNumberPagination)
+def list_collections_of_user(request, handle: str):
+    """
+    Get collections created by a specific user
+
+    Only collections visible to the requesting identity are returned;
+    anonymous access is allowed if the user's profile is anonymous viewable.
+    """
+    try:
+        target = APIdentity.get_by_handle(handle)
+    except APIdentity.DoesNotExist:
+        raise Http404("User not found")
+    qv = q_owned_piece_visible_to_user(request.user, target, check_blocking=True)
+    return Collection.objects.filter(qv).order_by("-edited_time")
 
 
 @api.get(

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -30,6 +30,7 @@ from journal.models.common import (
     q_piece_visible_to_user,
 )
 from takahe.utils import Takahe
+from users.apis import UserIdentitySchema
 from users.models.apidentity import APIdentity
 
 from ..models import (
@@ -77,13 +78,6 @@ def _prefetch_collection_owners(collections: List[Collection]) -> None:
     Takahe.prefetch_takahe_identities([c.owner for c in collections])
 
 
-class CollectionOwnerSchema(Schema):
-    username: str = Field(alias="handle")
-    url: str
-    display_name: str
-    avatar: str
-
-
 class CollectionSchema(Schema):
     uuid: str
     url: str
@@ -99,7 +93,7 @@ class CollectionSchema(Schema):
     is_dynamic: bool
     query: str | None = None
     item_count_by_category: dict[str, int]
-    owner: CollectionOwnerSchema
+    owner: UserIdentitySchema
 
 
 class CollectionInSchema(Schema):

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -279,7 +279,7 @@ def test_user_collections_api_visibility():
     ]
     owner_info = payload["data"][0]["owner"]
     assert owner_info["username"] == "collowner"
-    assert owner_info["url"] == "/users/collowner/"
+    assert owner_info["url"] == settings.SITE_INFO["site_url"] + "/users/collowner/"
     assert owner_info["display_name"]
     assert owner_info["avatar"]
 

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -3,7 +3,6 @@ from io import BytesIO
 from unittest.mock import patch
 
 import pytest
-from django.conf import settings
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, override_settings
@@ -279,7 +278,7 @@ def test_user_collections_api_visibility():
     ]
     owner_info = payload["data"][0]["owner"]
     assert owner_info["username"] == "collowner"
-    assert owner_info["url"] == settings.SITE_INFO["site_url"] + "/users/collowner/"
+    assert owner_info["url"] == "/users/collowner/"
     assert owner_info["display_name"]
     assert owner_info["avatar"]
 

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -280,7 +280,7 @@ def test_user_collections_api_visibility():
     assert owner_info["username"] == "collowner"
     assert owner_info["url"] == "/users/collowner/"
     assert owner_info["display_name"]
-    assert owner_info["avatar"]
+    assert owner_info["avatar"].startswith("http")
 
     payload = get_collections(follower)
     assert {c["uuid"] for c in payload["data"]} == {public.uuid, follower_only.uuid}

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -18,6 +18,7 @@ from journal.models import (
     FeaturedCollection,
     Mark,
     Note,
+    PieceInteraction,
     Review,
     Tag,
 )
@@ -276,6 +277,11 @@ def test_user_collections_api_visibility():
         follower_only.uuid,
         public.uuid,
     ]
+    owner_info = payload["data"][0]["owner"]
+    assert owner_info["username"] == "collowner"
+    assert owner_info["url"] == "/users/collowner/"
+    assert owner_info["display_name"]
+    assert owner_info["avatar"]
 
     payload = get_collections(follower)
     assert {c["uuid"] for c in payload["data"]} == {public.uuid, follower_only.uuid}
@@ -292,6 +298,95 @@ def test_user_collections_api_visibility():
     assert payload["count"] == 0
 
     response = Client().get("/api/user/nosuchuser/collection/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_user_liked_collections_api():
+    with (
+        patch("journal.models.collection.Collection.sync_to_timeline"),
+        patch("journal.models.collection.Collection.update_index"),
+    ):
+        owner = User.register(email="lkowner@example.com", username="lkowner")
+        liker = User.register(email="lkliker@example.com", username="lkliker")
+        stranger = User.register(email="lkstranger@example.com", username="lkstranger")
+        ofollower = User.register(
+            email="lkofollower@example.com", username="lkofollower"
+        )
+        public = Collection.objects.create(
+            owner=owner.identity, title="Public Collection", brief="", visibility=0
+        )
+        follower_only = Collection.objects.create(
+            owner=owner.identity, title="Follower Collection", brief="", visibility=1
+        )
+        private = Collection.objects.create(
+            owner=owner.identity, title="Private Collection", brief="", visibility=2
+        )
+        unliked = Collection.objects.create(
+            owner=owner.identity, title="Unliked Collection", brief="", visibility=0
+        )
+    for c in (public, follower_only, private):
+        PieceInteraction.objects.create(
+            target=c,
+            identity=liker.identity,
+            interaction_type="like",
+            target_type="Collection",
+        )
+    ofollower.identity.follow(owner.identity, True)
+
+    app = Takahe.get_or_create_app(
+        "Liked Collection API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=liker.identity.pk,
+    )
+
+    def get_liked(user=None):
+        headers = {}
+        if user:
+            token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+            headers["Authorization"] = f"Bearer {token}"
+        response = Client().get(
+            f"/api/user/{liker.username}/collection/liked/", headers=headers
+        )
+        assert response.status_code == 200
+        return response.json()
+
+    # the liker sees everything they liked, but not what they didn't
+    payload = get_liked(liker)
+    assert {c["uuid"] for c in payload["data"]} == {
+        public.uuid,
+        follower_only.uuid,
+        private.uuid,
+    }
+    assert unliked.uuid not in {c["uuid"] for c in payload["data"]}
+    liked_owner = payload["data"][0]["owner"]
+    assert liked_owner["username"] == "lkowner"
+
+    # others see liked collections gated by their own visibility to each
+    # collection's owner, not their relation to the liker
+    payload = get_liked(stranger)
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+
+    payload = get_liked(ofollower)
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid, follower_only.uuid}
+
+    payload = get_liked(owner)
+    assert {c["uuid"] for c in payload["data"]} == {
+        public.uuid,
+        follower_only.uuid,
+        private.uuid,
+    }
+
+    payload = get_liked()
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+
+    liker.identity.anonymous_viewable = False
+    liker.identity.save(update_fields=["anonymous_viewable"])
+    payload = get_liked()
+    assert payload["count"] == 0
+
+    response = Client().get("/api/user/nosuchuser/collection/liked/")
     assert response.status_code == 404
 
 

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, override_settings

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -227,6 +227,75 @@ def test_item_collections_visibility():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_user_collections_api_visibility():
+    with (
+        patch("journal.models.collection.Collection.sync_to_timeline"),
+        patch("journal.models.collection.Collection.update_index"),
+    ):
+        owner = User.register(email="collowner@example.com", username="collowner")
+        follower = User.register(
+            email="collfollower@example.com", username="collfollower"
+        )
+        stranger = User.register(
+            email="collstranger@example.com", username="collstranger"
+        )
+        public = Collection.objects.create(
+            owner=owner.identity, title="Public Collection", brief="", visibility=0
+        )
+        follower_only = Collection.objects.create(
+            owner=owner.identity, title="Follower Collection", brief="", visibility=1
+        )
+        private = Collection.objects.create(
+            owner=owner.identity, title="Private Collection", brief="", visibility=2
+        )
+    follower.identity.follow(owner.identity, True)
+
+    app = Takahe.get_or_create_app(
+        "User Collection API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=owner.identity.pk,
+    )
+
+    def get_collections(user=None):
+        headers = {}
+        if user:
+            token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+            headers["Authorization"] = f"Bearer {token}"
+        response = Client().get(
+            f"/api/user/{owner.username}/collection/", headers=headers
+        )
+        assert response.status_code == 200
+        return response.json()
+
+    payload = get_collections(owner)
+    assert payload["count"] == 3
+    # most recently edited first, same order as the web page
+    assert [c["uuid"] for c in payload["data"]] == [
+        private.uuid,
+        follower_only.uuid,
+        public.uuid,
+    ]
+
+    payload = get_collections(follower)
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid, follower_only.uuid}
+
+    payload = get_collections(stranger)
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+
+    payload = get_collections()
+    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+
+    owner.identity.anonymous_viewable = False
+    owner.identity.save(update_fields=["anonymous_viewable"])
+    payload = get_collections()
+    assert payload["count"] == 0
+
+    response = Client().get("/api/user/nosuchuser/collection/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_tag_api_lifecycle():
     user = User.register(email="tagger@example.com", username="tagger")
     item = Edition.objects.create(title="Tagged Book")

--- a/neodb/users/apis.py
+++ b/neodb/users/apis.py
@@ -1,5 +1,6 @@
 from typing import Any, Literal
 
+from django.conf import settings
 from ninja import Schema, Status
 from ninja.schema import Field
 
@@ -34,6 +35,17 @@ class UserIdentitySchema(Schema):
             username = obj.get("username")
             return username if isinstance(username, str) else ""
         return obj.handle
+
+    @staticmethod
+    def resolve_avatar(obj: "APIdentity | dict[str, Any]") -> str:
+        avatar = obj.get("avatar") if isinstance(obj, dict) else obj.avatar
+        if not isinstance(avatar, str):
+            return ""
+        # image assets are absolute in the API (like cover_image_url), while
+        # in-site page urls stay relative
+        if avatar.startswith("/"):
+            return settings.SITE_INFO["site_url"] + avatar
+        return avatar
 
 
 class UserSchema(UserIdentitySchema):

--- a/neodb/users/apis.py
+++ b/neodb/users/apis.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from django.conf import settings
 from ninja import Schema, Status
@@ -19,13 +19,27 @@ class ExternalAccountSchema(Schema):
     url: str | None
 
 
-class UserSchema(Schema):
+class UserIdentitySchema(Schema):
+    """Public info of an identity, embeddable in other schemas (e.g. as owner)."""
+
+    username: str
     url: str
-    external_acct: str | None = Field(deprecated=True)
-    external_accounts: list[ExternalAccountSchema]
     display_name: str
     avatar: str
-    username: str
+
+    @staticmethod
+    def resolve_username(obj: "APIdentity | dict[str, Any]") -> str:
+        # serialized either from an APIdentity ("user" local / "user@site"
+        # remote, same form /api/user/{handle} accepts) or a prebuilt dict
+        if isinstance(obj, dict):
+            username = obj.get("username")
+            return username if isinstance(username, str) else ""
+        return obj.handle
+
+
+class UserSchema(UserIdentitySchema):
+    external_acct: str | None = Field(deprecated=True)
+    external_accounts: list[ExternalAccountSchema]
     roles: list[Literal["admin", "staff"]]
 
 

--- a/neodb/users/apis.py
+++ b/neodb/users/apis.py
@@ -1,6 +1,5 @@
 from typing import Any, Literal
 
-from django.conf import settings
 from ninja import Schema, Status
 from ninja.schema import Field
 
@@ -35,16 +34,6 @@ class UserIdentitySchema(Schema):
             username = obj.get("username")
             return username if isinstance(username, str) else ""
         return obj.handle
-
-    @staticmethod
-    def resolve_url(obj: "APIdentity | dict[str, Any]") -> str:
-        url = obj.get("url") if isinstance(obj, dict) else obj.url
-        if not isinstance(url, str):
-            return ""
-        # APIdentity.url is site-relative; return absolute urls in the API
-        if url.startswith("/"):
-            return settings.SITE_INFO["site_url"] + url
-        return url
 
 
 class UserSchema(UserIdentitySchema):
@@ -83,7 +72,8 @@ def me(request):
         {
             # "id": str(request.user.identity.pk),
             "username": request.user.username,
-            "url": settings.SITE_INFO["site_url"] + request.user.url,
+            # site-relative, like identity urls elsewhere in the API
+            "url": request.user.url,
             "external_acct": (
                 request.user.mastodon.handle if request.user.mastodon else None
             ),

--- a/neodb/users/apis.py
+++ b/neodb/users/apis.py
@@ -36,6 +36,16 @@ class UserIdentitySchema(Schema):
             return username if isinstance(username, str) else ""
         return obj.handle
 
+    @staticmethod
+    def resolve_url(obj: "APIdentity | dict[str, Any]") -> str:
+        url = obj.get("url") if isinstance(obj, dict) else obj.url
+        if not isinstance(url, str):
+            return ""
+        # APIdentity.url is site-relative; return absolute urls in the API
+        if url.startswith("/"):
+            return settings.SITE_INFO["site_url"] + url
+        return url
+
 
 class UserSchema(UserIdentitySchema):
     external_acct: str | None = Field(deprecated=True)


### PR DESCRIPTION
## Summary

Implements #1678 and #1310: APIs to list the collections a user has created and the collections a user has liked, plus creator attribution in the collection schema.

### `GET /api/user/{handle}/collection/` (closes #1678)

Paginated list of collections created by a user:

- Same visibility rules as the web page at `/users/{name}/collections/`: owner sees all, followers see public + followers-only, others see public only; blocked viewers and restricted owners get nothing (`q_owned_piece_visible_to_user(..., check_blocking=True)`, matching `GET /api/user/{handle}/shelf/{type}`).
- Anonymous access allowed (`OptionalOAuthAccessTokenAuth`) when the profile is anonymous viewable, consistent with `GET /api/collection/{uuid}` and the public web page.
- Ordered by `-edited_time`, same as the web page; 404 for unknown handle.

### `GET /api/user/{handle}/collection/liked/` (closes #1310)

Paginated list of collections a user liked (distinct from featured collections), mirroring the web page at `/users/{name}/collections/liked/`:

- Gated on the target user the same way as the created-collections endpoint (restricted/blocked/anonymous-not-viewable yield an empty list rather than 403, indistinguishable from "no likes").
- Each liked collection is filtered by the viewer's visibility to that collection's own creator (`q_piece_visible_to_user`), so liking something never leaks it.

### `owner` field on `CollectionSchema`

All collection endpoints now embed the creator as `owner: {username, url, display_name, avatar}` (`username` is the same handle accepted by `/api/user/{handle}`). The embedded shape is a new `UserIdentitySchema` — the reusable public-identity core that `UserSchema` now extends — so user profile and embedded-owner representations cannot drift apart. Identity `url`s are consistently site-relative, matching item and collection `url` fields elsewhere in the API; this changes `GET /api/me`, whose `url` was previously absolute — a small behavior change for existing clients of that endpoint. `avatar` is absolutized instead (image asset, like `cover_image_url`); it was previously a relative media/static path in most configurations. Previously clients of `GET /api/item/{uuid}/collection/`, `GET /api/trending/collection/`, and the new liked endpoint had no way to attribute a collection to its creator. Owners are batch-prefetched (`select_related` + `Takahe.prefetch_takahe_identities`) so list endpoints do not gain per-row cross-db queries.

## Test plan

- `test_user_collections_api_visibility`: owner / follower / stranger / anonymous tiers, `-edited_time` ordering, `anonymous_viewable=False`, unknown-handle 404, and owner field shape.
- `test_user_liked_collections_api`: liker sees all likes; stranger / owner's-follower / collection-owner / anonymous each see likes gated by their own visibility to the collection creator; `anonymous_viewable=False`; unknown-handle 404.
- `pre-commit run -a` clean; full CI green.
