### PR TITLE
feat(journal): API to update the note of an existing collection item

### DIFF
--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -154,6 +154,10 @@ class CollectionItemInSchema(Schema):
     note: str
 
 
+class CollectionItemNoteInSchema(Schema):
+    note: str
+
+
 class CollectionItemReorderInSchema(Schema):
     item_uuids: list[str]
 
@@ -347,6 +351,10 @@ def collection_add_item(
 ):
     """
     Add an item to collection
+
+    If the item is already in the collection this is a no-op and its note is
+    kept; use `PUT /me/collection/{collection_uuid}/item/{item_uuid}` to
+    update the note of an existing item.
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
@@ -364,6 +372,44 @@ def collection_add_item(
         return Status(404, {"message": "Item not found"})
     c.append_item(item, note=collection_item.note)
     return Status(200, {"message": "OK"})
+
+
+@api.put(
+    "/me/collection/{collection_uuid}/item/{item_uuid}",
+    response={200: CollectionItemSchema, 401: Result, 403: Result, 404: Result},
+    tags=["collection"],
+)
+def collection_update_item(
+    request,
+    collection_uuid: str,
+    item_uuid: str,
+    collection_item: CollectionItemNoteInSchema,
+):
+    """
+    Update the note of an item in the collection.
+
+    The item must already be in the collection; 404 is returned otherwise
+    (position is preserved, unlike remove + re-add). Set `note` to an empty
+    string to clear it. Returns the updated member.
+    """
+    c = Collection.get_by_url(collection_uuid)
+    if not c:
+        return Status(404, {"message": "Collection not found"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
+    if c.is_dynamic:
+        return Status(
+            403, {"message": "Item list of dynamic collection cannot be updated"}
+        )
+    item = Item.get_by_url(item_uuid)
+    if not item:
+        return Status(404, {"message": "Item not found"})
+    member = c.update_item_note(item, collection_item.note)
+    if not member:
+        return Status(404, {"message": "Item not in collection"})
+    # reuse the already-resolved polymorphic item for serialization
+    member.item = item
+    return member
 
 
 @api.post(

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -407,8 +407,6 @@ def collection_update_item(
     member = c.update_item_note(item, collection_item.note)
     if not member:
         return Status(404, {"message": "Item not in collection"})
-    # reuse the already-resolved polymorphic item for serialization
-    member.item = item
     return member
 
 

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -178,6 +178,18 @@ class Collection(List):
         # Collaborators may edit content but only owner/staff may delete.
         return super().is_editable_by(viewing_user)
 
+    def update_item_note(self, item: Item, note: str) -> CollectionMember | None:
+        """Update the note of an existing member, or return None if item is not in the collection."""
+        member = self.members.filter(item=item).first()
+        if member is None:
+            return None
+        member.note = note
+        member.save()
+        # Re-emit list_add so the Collection receiver bumps edited_time
+        # and federates the updated member state.
+        list_add.send(sender=self.__class__, instance=self, item=item, member=member)
+        return member
+
     def get_query(self, viewer, **kwargs):
         if not self.is_dynamic:
             return None

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -183,6 +183,8 @@ class Collection(List):
         member = self.members.filter(item=item).first()
         if member is None:
             return None
+        # reuse the resolved item so save()'s index update doesn't re-fetch it
+        member.item = item
         member.note = note
         member.save()
         # Re-emit list_add so the Collection receiver bumps edited_time

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -23,7 +23,6 @@ from users.models import User
 
 from ..forms import *
 from ..models import *
-from ..models.itemlist import list_add
 from ..models.renderers import sanitize_md_images
 from .common import (
     conditional_get_for_anonymous,
@@ -538,12 +537,7 @@ def collection_update_item_note(request: AuthedHttpRequest, collection_uuid, ite
     note = request.POST.get("note", default="")
     cancel = request.GET.get("cancel")
     if request.method == "POST" and member:
-        member.note = note
-        member.save()
-        # Re-emit list_add so the Collection receiver bumps edited_time
-        # and federates the updated member-state — the receiver gates on
-        # is_dynamic itself.
-        list_add.send(sender=Collection, instance=collection, item=item, member=member)
+        member = collection.update_item_note(item, note)
         return render(
             request,
             "collection_update_item_note_ok.html",

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -548,6 +548,100 @@ def test_collection_reorder_items():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_collection_api_update_item_note():
+    user = User.register(email="noteedit@example.com", username="noteeditor")
+    book1 = Edition.objects.create(title="Note Book 1")
+    book2 = Edition.objects.create(title="Note Book 2")
+    outside = Edition.objects.create(title="Note Book Outside")
+    collection = Collection.objects.create(
+        owner=user.identity, title="Note Collection", brief="", visibility=0
+    )
+    collection.append_item(book1, note="original")
+    collection.append_item(book2)
+
+    app = Takahe.get_or_create_app(
+        "Collection Note API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/{book1.uuid}",
+        data=json.dumps({"note": "updated"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["item"]["uuid"] == book1.uuid
+    assert payload["note"] == "updated"
+    # position is preserved
+    members = list(collection.ordered_members)
+    assert [m.item.uuid for m in members] == [book1.uuid, book2.uuid]
+    assert members[0].note == "updated"
+
+    # empty string clears the note
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/{book1.uuid}",
+        data=json.dumps({"note": ""}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 200
+    assert response.json()["note"] == ""
+
+    # item not in the collection -> 404
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/{outside.uuid}",
+        data=json.dumps({"note": "nope"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 404
+
+    # unknown item uuid -> 404
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/nonexistent",
+        data=json.dumps({"note": "nope"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 404
+
+    # another user's collection -> 403
+    other = User.register(email="notother@example.com", username="noteother")
+    other_app = Takahe.get_or_create_app(
+        "Collection Note API Tests 2",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=other.identity.pk,
+    )
+    other_token = Takahe.refresh_token(other_app, other.identity.pk, other.pk)
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/{book1.uuid}",
+        data=json.dumps({"note": "hijack"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {other_token}",
+    )
+    assert response.status_code == 403
+
+    # dynamic collection -> 403
+    dynamic = Collection.objects.create(
+        owner=user.identity, title="Dynamic", brief="", visibility=0, query="q"
+    )
+    response = client.put(
+        f"/api/me/collection/{dynamic.uuid}/item/{book1.uuid}",
+        data=json.dumps({"note": "nope"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_collection_reorder_items_validation():
     user = User.register(email="reorder2@example.com", username="reorderer2")
     book1 = Edition.objects.create(title="Reorder2 Book 1")

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -611,6 +611,15 @@ def test_collection_api_update_item_note():
     )
     assert response.status_code == 404
 
+    # unknown collection uuid -> 404
+    response = client.put(
+        f"/api/me/collection/nonexistent/item/{book1.uuid}",
+        data=json.dumps({"note": "nope"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert response.status_code == 404
+
     # another user's collection -> 403
     other = User.register(email="notother@example.com", username="noteother")
     other_app = Takahe.get_or_create_app(

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -176,6 +176,24 @@ class TestCollectionListOperations:
         # Should not raise when item is not in collection
         self.collection.update_item_metadata(self.book1, {"note": "test"})
 
+    def test_update_item_note(self):
+        self.collection.append_item(self.book1, note="old")
+        member = self.collection.get_member_for_item(self.book1)
+        member.metadata["extra"] = 1
+        member.save()
+
+        member = self.collection.update_item_note(self.book1, "new")
+
+        assert member is not None
+        assert member.note == "new"
+        member = self.collection.get_member_for_item(self.book1)
+        assert member.note == "new"
+        # unlike update_item_metadata, other metadata keys are preserved
+        assert member.metadata.get("extra") == 1
+
+    def test_update_item_note_nonexistent(self):
+        assert self.collection.update_item_note(self.book1, "note") is None
+
     def test_get_summary(self):
         self.collection.append_item(self.book1)
         self.collection.append_item(self.book2)

--- a/neodb/tests/journal/test_conditional_get.py
+++ b/neodb/tests/journal/test_conditional_get.py
@@ -252,6 +252,12 @@ class TestCollectionMemberEditBumpsEditedTime:
         self.collection.update_item_metadata(self.book1, {"note": "new note"})
         assert self._refetch_edited_time() > before
 
+    def test_update_item_note_bumps_edited_time(self):
+        self.collection.append_item(self.book1, note="old")
+        before = self._refetch_edited_time()
+        self.collection.update_item_note(self.book1, "new note")
+        assert self._refetch_edited_time() > before
+
     def test_view_update_item_note_bumps_edited_time(self):
         self.collection.append_item(self.book1, note="old")
         before = self._refetch_edited_time()


### PR DESCRIPTION
Closes #1682

## What

Adds `PUT /api/me/collection/{collection_uuid}/item/{item_uuid}` accepting `{"note": "..."}` to update the note of an item already in a collection. Previously a note could only be set at add time; changing it via the API required remove + re-add, which loses the item's position.

## API design notes

Went with the `PUT` variant suggested in the issue rather than making `POST .../item/` upsert, refined as follows:

- **Strict update, no upsert**: returns `404 Item not in collection` when the item is not a member, so existing `POST` add semantics stay untouched and a typo'd uuid can't silently append. The `POST` docstring now cross-references the new endpoint.
- **Returns the updated member** (`CollectionItemSchema`) instead of a bare `{"message": "OK"}` — mirrors how `PUT /me/collection/{uuid}` returns the updated `CollectionSchema`, so clients get the canonical state back in one round trip.
- **Empty string clears the note**, matching the web behavior and the existing API contract where `note` is a non-null `str`.
- `403` for dynamic collections and non-editors, consistent with the sibling add/delete/reorder endpoints; collaborators on collaborative collections can edit notes, same as on the web.

## Implementation

- New `Collection.update_item_note()` model method holding the logic previously inlined in the web view (`collection_update_item_note`), which now uses it too — the `list_add` re-emit that bumps `edited_time` and re-federates member state lives in one place. Unlike `List.update_item_metadata` it preserves other metadata keys.
- Tests: API endpoint coverage (update / clear / not-in-collection / unknown item / other user / dynamic collection), model-level tests, and an `edited_time` bump test alongside the existing conditional-GET ones.

## Test

- `uv run pre-commit run -a` passes (ruff, djLint, ty)
- `pytest tests/journal/` in the dev-shell container: 630 passed