### PR TITLE
feat(journal): allow setting collection cover via API

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -403,6 +403,8 @@ MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    # populate request.FILES for non-POST (e.g. PUT with multipart) API requests
+    "ninja.compatibility.files.fix_request_files_middleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -1,15 +1,18 @@
 from datetime import datetime
 from typing import Any, List
 
+from django import forms
+from django.conf import settings
 from django.core.cache import cache
 from django.core.signing import b62_encode
 from django.db.models import Count, QuerySet, prefetch_related_objects
 from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
-from ninja import Field, Schema, Status
+from ninja import Field, File, Schema, Status
 from ninja.decorators import decorate_view
 from ninja.errors import HttpError
+from ninja.files import UploadedFile
 from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
@@ -21,6 +24,7 @@ from common.api import (
     api,
 )
 from common.sentry import record_activity
+from journal.models.collection import COVER_MAX_BYTES
 from journal.models.common import q_piece_visible_to_user
 
 from ..models import (
@@ -290,6 +294,72 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     c.brief = c_in.brief
     c.visibility = c_in.visibility
     c.query = q
+    c.application_id_when_save = getattr(request, "application_id", None)
+    c.save()
+    record_activity("collection", "api")
+    return c
+
+
+@api.put(
+    "/me/collection/{collection_uuid}/cover",
+    response={
+        200: CollectionSchema,
+        400: Result,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
+    tags=["collection"],
+)
+def collection_set_cover(request, collection_uuid: str, cover: File[UploadedFile]):
+    """
+    Set the cover image of a collection.
+
+    Send the image as `multipart/form-data` with a `cover` file field;
+    it must be a valid image no larger than 5MB.
+    """
+    c = Collection.get_by_url(collection_uuid)
+    if not c:
+        return Status(404, {"message": "Collection not found"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
+    if (cover.size or 0) > COVER_MAX_BYTES:
+        return Status(400, {"message": "Image file too large"})
+    try:
+        f = forms.ImageField().to_python(cover)
+    except forms.ValidationError:
+        return Status(400, {"message": "Invalid image file"})
+    if f is None:
+        return Status(400, {"message": "Invalid image file"})
+    # normalize the filename from the detected format so the stored path
+    # gets a meaningful extension even for extension-less uploads
+    image = getattr(f, "image", None)  # set by ImageField.to_python
+    fmt = (image.format or "").lower() if image else ""
+    ext = {"jpeg": "jpg"}.get(fmt, fmt)
+    if ext:
+        f.name = f"cover.{ext}"
+    c.cover = f
+    c.application_id_when_save = getattr(request, "application_id", None)
+    c.save()
+    record_activity("collection", "api")
+    return c
+
+
+@api.delete(
+    "/me/collection/{collection_uuid}/cover",
+    response={200: CollectionSchema, 401: Result, 403: Result, 404: Result},
+    tags=["collection"],
+)
+def collection_remove_cover(request, collection_uuid: str):
+    """
+    Reset the cover image of a collection to default.
+    """
+    c = Collection.get_by_url(collection_uuid)
+    if not c:
+        return Status(404, {"message": "Collection not found"})
+    if not c.is_editable_by(request.user):
+        return Status(403, {"message": "Permission denied"})
+    c.cover = settings.DEFAULT_ITEM_COVER
     c.application_id_when_save = getattr(request, "application_id", None)
     c.save()
     record_activity("collection", "api")

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
-_COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
+COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
 
 
 class CollectionMember(ListMember):
@@ -425,6 +425,7 @@ class Collection(List):
             if (
                 self.catalog_item.title != self.title
                 or self.catalog_item.brief != self.brief
+                or self.catalog_item.cover != self.cover
             ):
                 self.catalog_item.title = self.title
                 self.catalog_item.brief = self.brief
@@ -510,7 +511,7 @@ class Collection(List):
                     return existing
             except Exception:
                 pass
-        if cover_size is not None and cover_size > _COVER_MAX_BYTES:
+        if cover_size is not None and cover_size > COVER_MAX_BYTES:
             logger.warning(
                 f"collection cover too large to attach ({cover_size} bytes): {self.cover}"
             )

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1,10 +1,15 @@
 import json
+from io import BytesIO
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, override_settings
+from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.utils import timezone
+from PIL import Image
 
 from catalog.models import Edition, Game, Movie
 from journal.models import (
@@ -508,6 +513,89 @@ def test_collection_api_crud_and_items():
         HTTP_AUTHORIZATION=f"Bearer {token}",
     )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_collection_cover_api(tmp_path):
+    owner = User.register(email="cover@example.com", username="coverowner")
+    other = User.register(email="covop@example.com", username="coverother")
+    collection = Collection.objects.create(
+        owner=owner.identity,
+        title="Cover Collection",
+        brief="",
+        visibility=0,
+    )
+    app = Takahe.get_or_create_app(
+        "Collection Cover API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=owner.identity.pk,
+    )
+    token = Takahe.refresh_token(app, owner.identity.pk, owner.pk)
+    other_token = Takahe.refresh_token(app, other.identity.pk, other.pk)
+    client = Client()
+    url = f"/api/me/collection/{collection.uuid}/cover"
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    png = buf.getvalue()
+
+    def upload(path, content, auth_token, filename="cover.png"):
+        extra = {"HTTP_AUTHORIZATION": f"Bearer {auth_token}"} if auth_token else {}
+        return client.put(
+            path,
+            data=encode_multipart(
+                BOUNDARY,
+                {"cover": SimpleUploadedFile(filename, content, "image/png")},
+            ),
+            content_type=MULTIPART_CONTENT,
+            **extra,
+        )
+
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        response = upload(url, png, None)
+        assert response.status_code == 401
+
+        response = upload(url, png, other_token)
+        assert response.status_code == 403
+
+        missing = "7" * 22
+        response = upload(f"/api/me/collection/{missing}/cover", png, token)
+        assert response.status_code == 404
+
+        response = upload(url, b"not an image", token)
+        assert response.status_code == 400
+
+        response = upload(url, b"\0" * (5 * 1024 * 1024 + 1), token)
+        assert response.status_code == 400
+
+        collection.refresh_from_db()
+        assert str(collection.cover) == settings.DEFAULT_ITEM_COVER
+
+        response = upload(url, png, token)
+        assert response.status_code == 200
+        assert response.json()["cover_image_url"]
+
+        collection.refresh_from_db()
+        assert str(collection.cover) != settings.DEFAULT_ITEM_COVER
+        assert (collection.cover.name or "").endswith(".png")
+        assert collection.catalog_item.cover.name == collection.cover.name
+
+        # extension-less filename gets normalized from the detected format
+        response = upload(url, png, token, filename="blob")
+        assert response.status_code == 200
+        assert response.json()["cover_image_url"].endswith(".png")
+
+        response = client.delete(url, HTTP_AUTHORIZATION=f"Bearer {other_token}")
+        assert response.status_code == 403
+
+        response = client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        assert response.status_code == 200
+        assert response.json()["cover_image_url"] is None
+
+        collection.refresh_from_db()
+        assert str(collection.cover) == settings.DEFAULT_ITEM_COVER
+        assert str(collection.catalog_item.cover) == settings.DEFAULT_ITEM_COVER
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Closes #1681

## What

Adds a way to set a collection's cover image through the API, which previously could only be done in the web editor:

- `PUT /api/me/collection/{uuid}/cover` — upload as `multipart/form-data` with a `cover` file field; returns the updated collection (including the new `cover_image_url`)
- `DELETE /api/me/collection/{uuid}/cover` — reset the cover to default; also returns the updated collection

## API schema rationale

A dedicated cover sub-resource was chosen over accepting an image in `CollectionInSchema` (the other option suggested in the issue):

- keeps `POST`/`PUT /api/me/collection/` JSON-only, so existing clients are unaffected and payloads stay small (no base64)
- removing a cover has explicit semantics (`DELETE`) instead of null-vs-omitted ambiguity in the update schema
- both endpoints return `CollectionSchema` so clients immediately get the canonical state

## Implementation notes

- Uploads are verified with the same image validation the web form uses (`django.forms.ImageField`, PIL-based), capped at 5MB (the same limit used when attaching the cover to the fediverse post), and the stored filename extension is normalized from the detected image format so extension-less uploads still get a sensible extension.
- Permissions mirror the web editor: anyone the collection `is_editable_by` (owner, staff, or local mutuals when collaborative) can change the cover; remote mirrors stay read-only.
- Django only parses multipart bodies for POST, so django-ninja's `fix_request_files_middleware` is added to `MIDDLEWARE` to populate `request.FILES` for PUT (it is required by ninja at operation registration time; it is a no-op for JSON requests).
- Fixes a latent sync bug: `Collection.save()` only propagated the cover to the linked `CatalogCollection` when title or brief changed too, so a cover-only edit never updated the catalog item.

## Tests

`test_collection_cover_api` covers: 401 unauthenticated, 403 non-editor (upload and delete), 404 unknown collection, 400 non-image, 400 oversized, successful upload (including catalog item cover sync), extension normalization for extension-less filenames, and reset-to-default.