### PR TITLE
feat(journal): add idx-sync command to reconcile index with db

### DIFF
--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -17,7 +17,6 @@ from journal.models import (
     Content,
     Note,
     Piece,
-    PiecePost,
     Review,
     ShelfMember,
     update_journal_for_merged_item,
@@ -208,6 +207,8 @@ class Command(SiteCommand):
         for post_id in live_post_ids:
             expected[str(post_id)] = ("post", post_id)
         piece_ids: set[int] = set()
+        # piece_id -> (piece_post_pk, post_id) of the latest linked post
+        latest_pps: dict[int, tuple[int, int]] = {}
         for cls in _INDEXABLE_PIECE_CLASSES:
             pieces = cls.objects.filter(owner_id=identity_id, local=True)
             if cls is Comment:
@@ -217,18 +218,18 @@ class Command(SiteCommand):
                         "item_id"
                     )
                 )
-            piece_ids.update(pieces.values_list("pk", flat=True))
-        latest_post_ids: dict[int, int] = {}
-        pps = (
-            PiecePost.objects.filter(piece__owner_id=identity_id, piece__local=True)
-            .order_by("pk")
-            .values_list("piece_id", "post_id")
-        )
-        for piece_id, post_id in pps:
-            if piece_id in piece_ids:
-                latest_post_ids[piece_id] = post_id
+            # left join keeps pieces without any post
+            rows = pieces.values_list(
+                "pk", "post_relations__pk", "post_relations__post_id"
+            )
+            for piece_id, pp_pk, post_id in rows:
+                piece_ids.add(piece_id)
+                if pp_pk is not None and (
+                    piece_id not in latest_pps or pp_pk > latest_pps[piece_id][0]
+                ):
+                    latest_pps[piece_id] = (pp_pk, post_id)
         for piece_id in piece_ids:
-            post_id = latest_post_ids.get(piece_id)
+            post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
             if post_id is None:
                 expected["p" + str(piece_id)] = ("piece", piece_id)
             elif post_id not in live_post_ids:

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -214,9 +214,9 @@ class Command(SiteCommand):
             if cls is Comment:
                 # comment with a sibling mark is indexed within its ShelfMember doc
                 pieces = pieces.exclude(
-                    item_id__in=ShelfMember.objects.filter(owner_id=identity_id).values(
-                        "item_id"
-                    )
+                    item_id__in=ShelfMember.objects.filter(owner_id=identity_id)
+                    .values("item_id")
+                    .order_by()
                 )
             # left join keeps pieces without any post
             rows = pieces.values_list(

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -1,5 +1,6 @@
 from argparse import RawTextHelpFormatter
 from datetime import timedelta
+from itertools import batched
 
 from django.core.paginator import Paginator
 from django.db.models import Q
@@ -10,11 +11,13 @@ from catalog.models import Item
 from common.management.base import SiteCommand
 from journal.exporters.ndjson import NdjsonExporter
 from journal.models import (
+    Article,
     Collection,
     Comment,
     Content,
     Note,
     Piece,
+    PiecePost,
     Review,
     ShelfMember,
     update_journal_for_merged_item,
@@ -38,7 +41,25 @@ idx-alt:        update index schema
 idx-delete:     delete docs in index
 idx-reindex:    reindex docs
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
+idx-sync:       add missing docs and delete stale docs for each local identity,
+                purge docs of deactivated identities (use --dry-run to preview)
 """
+
+_DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
+
+# Piece classes whose to_indexable_doc() may produce a doc of its own; the
+# others (Rating, Tag, TagMember, Shelf, CollectionMember, FeaturedCollection,
+# Debris) always return {} and are never indexed individually.
+_INDEXABLE_PIECE_CLASSES: list[type[Piece]] = [
+    ShelfMember,
+    Comment,
+    Review,
+    Collection,
+    Note,
+    Article,
+]
+
+_SYNC_DELETE_CHUNK = 200
 
 
 class Command(SiteCommand):
@@ -64,6 +85,7 @@ class Command(SiteCommand):
                 "idx-delete",
                 "search",
                 "idx-catchup",
+                "idx-sync",
             ],
             help=_HELP_TEXT,
         )
@@ -112,6 +134,11 @@ class Command(SiteCommand):
             "--hour",
             type=int,
             help="Number of hours to look back for edited items (used with idx-catchup)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="report what idx-sync would change without writing to index",
         )
 
     def integrity(self):
@@ -166,6 +193,130 @@ class Command(SiteCommand):
                         )
                     pbar.update(1)
 
+    def expected_index_docs(self, identity_id: int) -> dict[str, tuple[str, int]]:
+        """Doc ids an active local identity should have in the index.
+
+        Returns a map of doc id -> ("post" | "piece", pk), mirroring how
+        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids.
+        """
+        expected: dict[str, tuple[str, int]] = {}
+        live_post_ids = set(
+            Post.objects.filter(local=True, author_id=identity_id)
+            .exclude(state__in=_DELETED_POST_STATES)
+            .values_list("pk", flat=True)
+        )
+        for post_id in live_post_ids:
+            expected[str(post_id)] = ("post", post_id)
+        piece_ids: set[int] = set()
+        for cls in _INDEXABLE_PIECE_CLASSES:
+            pieces = cls.objects.filter(owner_id=identity_id, local=True)
+            if cls is Comment:
+                # comment with a sibling mark is indexed within its ShelfMember doc
+                pieces = pieces.exclude(
+                    item_id__in=ShelfMember.objects.filter(owner_id=identity_id).values(
+                        "item_id"
+                    )
+                )
+            piece_ids.update(pieces.values_list("pk", flat=True))
+        latest_post_ids: dict[int, int] = {}
+        pps = (
+            PiecePost.objects.filter(piece__owner_id=identity_id, piece__local=True)
+            .order_by("pk")
+            .values_list("piece_id", "post_id")
+        )
+        for piece_id, post_id in pps:
+            if piece_id in piece_ids:
+                latest_post_ids[piece_id] = post_id
+        for piece_id in piece_ids:
+            post_id = latest_post_ids.get(piece_id)
+            if post_id is None:
+                expected["p" + str(piece_id)] = ("piece", piece_id)
+            elif post_id not in live_post_ids:
+                # piece_to_doc() keys the doc by the latest linked post id
+                # even if that post is gone from db
+                expected[str(post_id)] = ("piece", piece_id)
+            # otherwise the piece is covered by the doc of its live post
+        return expected
+
+    def sync_identity_index(
+        self, index: JournalIndex, identity_id: int
+    ) -> tuple[int, int] | None:
+        """Add missing docs and delete stale docs for one active identity.
+
+        Docs already in the index are left as is (no deep comparison).
+        Returns (added, deleted), or None on index error.
+        """
+        expected = self.expected_index_docs(identity_id)
+        indexed = index.get_doc_ids_by_owner(identity_id)
+        if indexed is None:
+            return None
+        extra = indexed - expected.keys()
+        missing = expected.keys() - indexed
+        if self.dry_run:
+            return len(missing), len(extra)
+        deleted = 0
+        for chunk in batched(extra, _SYNC_DELETE_CHUNK):
+            deleted += index.delete_docs("id", chunk)
+        added = 0
+        post_ids = [expected[i][1] for i in missing if expected[i][0] == "post"]
+        for chunk in batched(post_ids, self.batch_size):
+            posts = Post.objects.filter(pk__in=chunk)
+            added += index.replace_docs(index.posts_to_docs(posts))
+        piece_ids = [expected[i][1] for i in missing if expected[i][0] == "piece"]
+        for chunk in batched(piece_ids, self.batch_size):
+            pieces = Piece.objects.filter(pk__in=chunk)
+            added += index.replace_docs(index.pieces_to_docs(pieces))
+        return added, deleted
+
+    def idx_sync(self, index: JournalIndex, owners: list[int]):
+        identities = APIdentity.objects.filter(local=True)
+        if owners:
+            identities = identities.filter(pk__in=owners)
+        # mirror APIdentity.is_active
+        active_q = Q(user__isnull=False, user__is_active=True) | Q(
+            user__isnull=True, deleted__isnull=True
+        )
+        active_ids = list(
+            identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
+        )
+        inactive_ids = list(
+            identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
+        )
+        added = deleted = errors = 0
+        for identity_id in tqdm(active_ids, desc="Syncing active identities"):
+            r = self.sync_identity_index(index, identity_id)
+            if r is None:
+                errors += 1
+                continue
+            a, d = r
+            added += a
+            deleted += d
+            if self.verbose and (a or d):
+                self.stdout.write(f"identity {identity_id}: +{a} -{d}")
+        purged = 0
+        if self.dry_run:
+            for identity_id in tqdm(inactive_ids, desc="Checking deactivated"):
+                ids = index.get_doc_ids_by_owner(identity_id)
+                if ids is None:
+                    errors += 1
+                else:
+                    purged += len(ids)
+        else:
+            for chunk in batched(inactive_ids, 100):
+                purged += index.delete_by_owner(chunk)
+        w = "would be " if self.dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"idx-sync complete: {len(active_ids)} active identities, "
+                f"{added} docs {w}added, {deleted} docs {w}deleted; "
+                f"{len(inactive_ids)} deactivated identities, {purged} docs {w}purged."
+            )
+        )
+        if errors:
+            self.stdout.write(
+                self.style.WARNING(f"{errors} identities skipped due to index errors.")
+            )
+
     def handle(
         self,
         action,
@@ -184,7 +335,8 @@ class Command(SiteCommand):
     ):
         self.verbose = verbose
         self.fix = fix
-        self.batch_size = batch_size
+        self.batch_size = int(batch_size)
+        self.dry_run = kwargs.get("dry_run", False)
         index = JournalIndex.instance()
 
         if owner and not remote:
@@ -329,6 +481,9 @@ class Command(SiteCommand):
             case "idx-catchup":
                 hour = kwargs.get("hour")
                 self.idx_catchup(hour)
+
+            case "idx-sync":
+                self.idx_sync(index, owners)
 
             case _:
                 self.stdout.write(self.style.ERROR("action not found."))

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -1,3 +1,4 @@
+import json
 import re
 from datetime import datetime
 from functools import cached_property, reduce
@@ -6,10 +7,12 @@ from typing import TYPE_CHECKING, Iterable
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import QuerySet
+from loguru import logger
 
 from catalog.models import Item, item_categories
 from common.models import int_, uniq
 from common.search import Index, QueryParser, SearchResult
+from common.search.index import TYPESENSE_ERRORS
 from takahe.models import Identity as TakaheIdentity
 from takahe.models import Post
 from takahe.utils import Takahe
@@ -453,6 +456,17 @@ class JournalIndex(Index):
 
     def delete_all(self):
         return self.delete_docs("owner_id", ">0")
+
+    def get_doc_ids_by_owner(self, owner_id: int) -> set[str] | None:
+        """Return ids of all docs owned by the identity, or None on error."""
+        try:
+            r = self.write_collection.documents.export(
+                {"filter_by": f"owner_id:{owner_id}", "include_fields": "id"}
+            )
+        except TYPESENSE_ERRORS as e:
+            logger.error(f"Typesense: error {e}")
+            return None
+        return {json.loads(line)["id"] for line in r.splitlines() if line}
 
     def delete_by_owner(self, owner_ids):
         return self.delete_docs("owner_id", owner_ids)

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -463,10 +463,10 @@ class JournalIndex(Index):
             r = self.write_collection.documents.export(
                 {"filter_by": f"owner_id:{owner_id}", "include_fields": "id"}
             )
+            return {json.loads(line)["id"] for line in r.splitlines() if line}
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return None
-        return {json.loads(line)["id"] for line in r.splitlines() if line}
 
     def delete_by_owner(self, owner_ids):
         return self.delete_docs("owner_id", owner_ids)

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -31,6 +31,11 @@ class TestIdxSync:
         call_command("journal", "idx-sync", *args, stdout=out)
         return out.getvalue()
 
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
     def stale_docs(self, owner_id: int) -> list[dict]:
         return [
             {
@@ -54,15 +59,15 @@ class TestIdxSync:
         ]
 
     def test_noop_when_in_sync(self):
-        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        before = self.doc_ids(self.identity1.pk)
         assert before
         output = self.run_sync()
         assert "0 docs added, 0 docs deleted" in output
         assert "0 docs purged" in output
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before
+        assert self.doc_ids(self.identity1.pk) == before
 
     def test_add_missing_docs(self):
-        # a piece saved without post or index is missing until sync
+        # a review without post is indexed on save as a piece doc
         review = Review(
             owner=self.identity1,
             item=self.book1,
@@ -70,44 +75,43 @@ class TestIdxSync:
             body="review body",
         )
         review.save(post_when_save=False)
-        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
-        assert before and f"p{review.pk}" not in before
-        # docs wiped from index should also be restored by sync
+        before = self.doc_ids(self.identity1.pk)
+        assert f"p{review.pk}" in before
+        # docs wiped from index are restored by sync, as both post and piece docs
         self.index.delete_by_owner([self.identity1.pk])
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == set()
+        assert self.doc_ids(self.identity1.pk) == set()
         self.run_sync()
-        after = self.index.get_doc_ids_by_owner(self.identity1.pk)
-        assert after == before | {f"p{review.pk}"}
+        assert self.doc_ids(self.identity1.pk) == before
 
     def test_delete_stale_docs(self):
-        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        before = self.doc_ids(self.identity1.pk)
         assert self.index.insert_docs(self.stale_docs(self.identity1.pk)) == 2
         self.run_sync()
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before
+        assert self.doc_ids(self.identity1.pk) == before
 
     def test_purge_deactivated_identity(self):
-        assert self.index.get_doc_ids_by_owner(self.identity2.pk)
+        assert self.doc_ids(self.identity2.pk)
         self.user2.is_active = False
         self.user2.save()
         output = self.run_sync()
         assert "1 deactivated identities" in output
-        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == set()
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert self.doc_ids(self.identity2.pk) == set()
+        assert self.doc_ids(self.identity1.pk)
 
     def test_dry_run(self):
         assert self.index.insert_docs(self.stale_docs(self.identity1.pk)) == 2
         self.user2.is_active = False
         self.user2.save()
-        before1 = self.index.get_doc_ids_by_owner(self.identity1.pk)
-        before2 = self.index.get_doc_ids_by_owner(self.identity2.pk)
+        before1 = self.doc_ids(self.identity1.pk)
+        before2 = self.doc_ids(self.identity2.pk)
         assert before2
         output = self.run_sync("--dry-run")
         assert "would be" in output
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before1
-        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == before2
+        assert self.doc_ids(self.identity1.pk) == before1
+        assert self.doc_ids(self.identity2.pk) == before2
 
     def test_owner_scope(self):
         self.index.delete_by_owner([self.identity1.pk, self.identity2.pk])
         self.run_sync("--owner", "userx")
-        assert self.index.get_doc_ids_by_owner(self.identity1.pk)
-        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == set()
+        assert self.doc_ids(self.identity1.pk)
+        assert self.doc_ids(self.identity2.pk) == set()

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -1,0 +1,113 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from catalog.models import Edition
+from journal.models import Mark, Review, ShelfType
+from journal.search import JournalIndex
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestIdxSync:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book1 = Edition.objects.create(title="Hyperion")
+        self.book2 = Edition.objects.create(title="Andymion")
+        self.user1 = User.register(email="x@y.com", username="userx")
+        self.user2 = User.register(email="a@b.com", username="usery")
+        self.identity1 = self.user1.identity
+        self.identity2 = self.user2.identity
+        mark = Mark(self.identity1, self.book1)
+        mark.update(ShelfType.WISHLIST, "a gentle comment", 9, ["Sci-Fi"], 0)
+        mark = Mark(self.identity2, self.book2)
+        mark.update(ShelfType.COMPLETE, "another comment", 8, ["fic"], 1)
+
+    def run_sync(self, *args) -> str:
+        out = StringIO()
+        call_command("journal", "idx-sync", *args, stdout=out)
+        return out.getvalue()
+
+    def stale_docs(self, owner_id: int) -> list[dict]:
+        return [
+            {
+                "id": "99999999",
+                "post_id": [99999999],
+                "piece_class": ["Post"],
+                "content": ["stale post doc"],
+                "created": 1700000000,
+                "owner_id": owner_id,
+                "visibility": 0,
+            },
+            {
+                "id": "p99999999",
+                "piece_id": [99999999],
+                "piece_class": ["Comment"],
+                "content": ["stale piece doc"],
+                "created": 1700000000,
+                "owner_id": owner_id,
+                "visibility": 0,
+            },
+        ]
+
+    def test_noop_when_in_sync(self):
+        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert before
+        output = self.run_sync()
+        assert "0 docs added, 0 docs deleted" in output
+        assert "0 docs purged" in output
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before
+
+    def test_add_missing_docs(self):
+        # a piece saved without post or index is missing until sync
+        review = Review(
+            owner=self.identity1,
+            item=self.book1,
+            title="my review",
+            body="review body",
+        )
+        review.save(post_when_save=False)
+        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert before and f"p{review.pk}" not in before
+        # docs wiped from index should also be restored by sync
+        self.index.delete_by_owner([self.identity1.pk])
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == set()
+        self.run_sync()
+        after = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert after == before | {f"p{review.pk}"}
+
+    def test_delete_stale_docs(self):
+        before = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert self.index.insert_docs(self.stale_docs(self.identity1.pk)) == 2
+        self.run_sync()
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before
+
+    def test_purge_deactivated_identity(self):
+        assert self.index.get_doc_ids_by_owner(self.identity2.pk)
+        self.user2.is_active = False
+        self.user2.save()
+        output = self.run_sync()
+        assert "1 deactivated identities" in output
+        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == set()
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk)
+
+    def test_dry_run(self):
+        assert self.index.insert_docs(self.stale_docs(self.identity1.pk)) == 2
+        self.user2.is_active = False
+        self.user2.save()
+        before1 = self.index.get_doc_ids_by_owner(self.identity1.pk)
+        before2 = self.index.get_doc_ids_by_owner(self.identity2.pk)
+        assert before2
+        output = self.run_sync("--dry-run")
+        assert "would be" in output
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk) == before1
+        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == before2
+
+    def test_owner_scope(self):
+        self.index.delete_by_owner([self.identity1.pk, self.identity2.pk])
+        self.run_sync("--owner", "userx")
+        assert self.index.get_doc_ids_by_owner(self.identity1.pk)
+        assert self.index.get_doc_ids_by_owner(self.identity2.pk) == set()


### PR DESCRIPTION
## Summary

Adds `neodb-manage journal idx-sync`, a reconciliation command for the journal Typesense index:

- For each **active local identity**, compares doc ids in the index against post/piece ids in the db: deletes stale docs and adds missing ones. Docs whose ids already match are left untouched — no content comparison by design, keeping the sync cheap.
- Expected doc ids mirror `piece_to_doc()` / `post_to_doc()`: live local posts (`str(post_pk)`), indexable pieces without posts (`p{piece_pk}`), and pieces whose latest linked post is gone keep the post-keyed doc id. Never-indexed piece classes (Rating, Tag, TagMember, Shelf, CollectionMember, FeaturedCollection, Debris) and comments folded into their sibling mark's doc are excluded.
- For each **deactivated local identity** (inactive user or deleted identity), all their docs are purged from the index.
- Options: `--owner` to limit scope, `--dry-run` to preview, `--batch-size`, `--verbose`.

Also adds `JournalIndex.get_doc_ids_by_owner()` using the Typesense export endpoint to pull doc ids per owner cheaply.

## Test plan

- New `tests/journal/test_idx_sync.py`: no-op on a synced index, restoring wiped docs (post and piece docs), deleting stale docs, purging deactivated identities, dry-run makes no changes, `--owner` scoping.
- Full suite green on GH Actions (unit test + code check).