### PR TITLE
Assume CNY for legacy yuan-suffixed edition prices

### DIFF
--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -15,6 +15,7 @@ from rq.job import Job
 from tqdm import tqdm
 
 from common.models.site_config import SiteConfig
+from common.sentry import count as sentry_count
 
 _CHAIN_KEY = "neodb:migration_enqueue:last_job_id"
 _CHAIN_TTL = 7 * 24 * 3600
@@ -901,8 +902,13 @@ def unify_metadata_20260715(
             if index:
                 items = Item.objects.filter(pk__in=[i.pk for i in pending])
                 reindexed += index.replace_docs(index.items_to_docs(items))
+            sentry_count(
+                "migration", len(pending), attributes={"name": "catalog.unify_metadata"}
+            )
         pending.clear()
 
+    if not dry_run:
+        sentry_count("migration", attributes={"name": "catalog.unify_metadata.start"})
     with tqdm(total=total, desc="unify_metadata") as pbar:
         for pk, ctype_id, metadata in qs.values_list(
             "pk", "polymorphic_ctype_id", "metadata"
@@ -941,6 +947,7 @@ def unify_metadata_20260715(
             f"unify_metadata dry run complete; {updated} of {total} items would be updated."
         )
     else:
+        sentry_count("migration", attributes={"name": "catalog.unify_metadata.end"})
         logger.warning(
             f"unify_metadata complete: {updated} of {total} items updated, "
             f"{reindexed} docs reindexed, last pk {last_pk}."

--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -840,6 +840,7 @@ def unify_metadata_20260715(
       album_type -> slug list; release_date canonicalized
     - Game: release_year -> release_date; localized release_date text -> ISO
     - Edition: price -> "<ISO4217> <amount>" where unambiguous
+      (suffixed 元 is assumed CNY)
 
     Restart-safe: one pk-ordered pass over all items (resume with --start),
     and idempotent because legacy keys are removed on first conversion (the

--- a/neodb/catalog/migrations/0026_unify_metadata.py
+++ b/neodb/catalog/migrations/0026_unify_metadata.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+from catalog.common.migrations import enqueue_migration_job
+
+
+def queue_unify_metadata(apps, schema_editor):
+    enqueue_migration_job("unify_metadata_20260715")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("catalog", "0025_podcastepisode_covering_index"),
+    ]
+
+    operations = [
+        migrations.RunPython(queue_unify_metadata),
+    ]

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -204,10 +204,13 @@ class Edition(Item):
                 metadata["imprint"] = "/".join(coerced)
             else:
                 metadata.pop("imprint", None)
-        # normalize price to "<ISO4217> <amount>" where unambiguous
+        # normalize price to "<ISO4217> <amount>" where unambiguous;
+        # legacy 元 prices are overwhelmingly douban-sourced, so assume CNY
+        # (¥/￥ and bare numbers stay as-is without a source hint)
         price = metadata.get("price")
         if isinstance(price, str) and price:
-            metadata["price"] = normalize_price(price)
+            hint = "CNY" if price.strip().endswith("元") else None
+            metadata["price"] = normalize_price(price, hint)
 
     available_roles = [
         PeopleRole.AUTHOR,

--- a/neodb/common/models/price.py
+++ b/neodb/common/models/price.py
@@ -2,9 +2,10 @@
 Price normalization
 
 Canonical price form is "<ISO 4217 code> <amount>", e.g. "CNY 26" or
-"USD 10.99". Values that cannot be normalized unambiguously (ranges,
-multiple prices, bare numbers or ¥/元 without a source hint) are kept
-as-is rather than guessed.
+"USD 10.99". Unambiguous Chinese currency names ("99 美元", "66日元")
+normalize as well. Values that cannot be normalized unambiguously
+(ranges, multiple prices, bare numbers or ¥/元 without a source hint)
+are kept as-is rather than guessed.
 """
 
 import re
@@ -13,7 +14,11 @@ _RE_CANONICAL = re.compile(r"^[A-Z]{3} \d+(\.\d+)?$")
 _RE_PREFIXED = re.compile(
     r"^([A-Za-z]{2,4}|US\$|NT\$|HK\$|[$€£¥￥])\s*([\d,]+(?:\.\d+)?)$"
 )
-_RE_SUFFIXED = re.compile(r"^([\d,]+(?:\.\d+)?)\s*([A-Za-z]{2,4}|元|円)$")
+# suffix accepts short CJK currency words (元, 円, 美元, 人民币, ...);
+# unrecognized words resolve to no currency and the value is kept
+_RE_SUFFIXED = re.compile(
+    r"^([\d,]+(?:\.\d+)?)\s*([A-Za-z]{2,4}|[\u4e00-\u9fff]{1,4})$"
+)
 _RE_BARE = re.compile(r"^([\d,]+(?:\.\d+)?)$")
 
 # non-ISO codes and symbols that map to one currency unambiguously
@@ -30,6 +35,19 @@ _CURRENCY_ALIASES = {
     "円": "JPY",
     "YEN": "JPY",
     "WON": "KRW",
+    # Chinese currency names (suffix form, e.g. "99 美元")
+    "美元": "USD",
+    "美金": "USD",
+    "日元": "JPY",
+    "日圆": "JPY",
+    "港元": "HKD",
+    "港币": "HKD",
+    "人民币": "CNY",
+    "欧元": "EUR",
+    "英镑": "GBP",
+    "新台币": "TWD",
+    "台币": "TWD",
+    "韩元": "KRW",
 }
 # symbols/words that are ambiguous without knowing the source site
 _HINT_ONLY = {"¥", "￥", "元"}

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -135,10 +135,24 @@ class TestNormalizeLegacyEditionMetadata:
         Edition.normalize_legacy_metadata(md)
         assert md["price"] == "TWD 450"
 
-    def test_ambiguous_price_kept(self):
+    def test_yuan_suffix_assumed_cny(self):
         md = {"price": "19.00元"}
         Edition.normalize_legacy_metadata(md)
-        assert md["price"] == "19.00元"
+        assert md["price"] == "CNY 19.00"
+        md = {"price": "1,299 元"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "CNY 1299"
+        # annotated values still do not parse and are kept verbatim
+        md = {"price": "48.00元（全二册）"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "48.00元（全二册）"
+
+    def test_ambiguous_price_kept(self):
+        # ¥ could be JPY or CNY; bare numbers have no currency at all
+        for price in ("¥19.00", "￥484", "19.00"):
+            md = {"price": price}
+            Edition.normalize_legacy_metadata(md)
+            assert md["price"] == price
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -134,6 +134,13 @@ class TestNormalizeLegacyEditionMetadata:
         md = {"price": "450 NTD"}
         Edition.normalize_legacy_metadata(md)
         assert md["price"] == "TWD 450"
+        md = {"price": "99 美元"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "USD 99"
+        # ends with 元 so the CNY hint fires, but the 日元 alias wins
+        md = {"price": "66日元"}
+        Edition.normalize_legacy_metadata(md)
+        assert md["price"] == "JPY 66"
 
     def test_yuan_suffix_assumed_cny(self):
         md = {"price": "19.00元"}

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -381,37 +381,3 @@ class TestUnifyMetadataMigration:
         a.refresh_from_db()
         g.refresh_from_db()
         assert (dict(m.metadata), dict(a.metadata), dict(g.metadata)) == before
-
-    def test_migration_emits_sentry_metrics(self, monkeypatch):
-        calls = []
-        monkeypatch.setattr(
-            "catalog.common.migrations.sentry_count",
-            lambda key, value=1, attributes=None: calls.append(
-                (key, value, attributes)
-            ),
-        )
-        Movie.objects.create(
-            metadata={
-                "localized_title": [{"lang": "en", "text": "Inception"}],
-                "duration": "148分钟",
-                "year": 2010,
-            }
-        )
-        unify_metadata_20260715()
-        assert all(key == "migration" for key, _, _ in calls)
-        names = [attributes["name"] for _, _, attributes in calls]
-        assert names[0] == "catalog.unify_metadata.start"
-        assert names[-1] == "catalog.unify_metadata.end"
-        steps = [v for _, v, a in calls if a["name"] == "catalog.unify_metadata"]
-        assert sum(steps) == 1
-        # a no-op re-run emits only the start/end markers
-        calls.clear()
-        unify_metadata_20260715()
-        assert [a["name"] for _, _, a in calls] == [
-            "catalog.unify_metadata.start",
-            "catalog.unify_metadata.end",
-        ]
-        # dry run emits nothing
-        calls.clear()
-        unify_metadata_20260715(dry_run=True)
-        assert calls == []

--- a/neodb/tests/catalog/test_metadata_unification.py
+++ b/neodb/tests/catalog/test_metadata_unification.py
@@ -381,3 +381,37 @@ class TestUnifyMetadataMigration:
         a.refresh_from_db()
         g.refresh_from_db()
         assert (dict(m.metadata), dict(a.metadata), dict(g.metadata)) == before
+
+    def test_migration_emits_sentry_metrics(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "catalog.common.migrations.sentry_count",
+            lambda key, value=1, attributes=None: calls.append(
+                (key, value, attributes)
+            ),
+        )
+        Movie.objects.create(
+            metadata={
+                "localized_title": [{"lang": "en", "text": "Inception"}],
+                "duration": "148分钟",
+                "year": 2010,
+            }
+        )
+        unify_metadata_20260715()
+        assert all(key == "migration" for key, _, _ in calls)
+        names = [attributes["name"] for _, _, attributes in calls]
+        assert names[0] == "catalog.unify_metadata.start"
+        assert names[-1] == "catalog.unify_metadata.end"
+        steps = [v for _, v, a in calls if a["name"] == "catalog.unify_metadata"]
+        assert sum(steps) == 1
+        # a no-op re-run emits only the start/end markers
+        calls.clear()
+        unify_metadata_20260715()
+        assert [a["name"] for _, _, a in calls] == [
+            "catalog.unify_metadata.start",
+            "catalog.unify_metadata.end",
+        ]
+        # dry run emits nothing
+        calls.clear()
+        unify_metadata_20260715(dry_run=True)
+        assert calls == []

--- a/neodb/tests/core/test_metadata_helpers.py
+++ b/neodb/tests/core/test_metadata_helpers.py
@@ -126,6 +126,18 @@ class TestPrice:
         assert normalize_price("26.00 USD") == "USD 26.00"
         assert normalize_price("1,299 JPY") == "JPY 1299"
 
+    def test_chinese_currency_names(self):
+        assert normalize_price("99 美元") == "USD 99"
+        assert normalize_price("66日元") == "JPY 66"
+        assert normalize_price("30 港币") == "HKD 30"
+        assert normalize_price("9.9人民币") == "CNY 9.9"
+        assert normalize_price("120 新台币") == "TWD 120"
+        assert normalize_price("484円") == "JPY 484"
+        # unknown CJK words resolve to no currency and are kept,
+        # even when a source hint is present
+        assert normalize_price("99 金币") == "99 金币"
+        assert normalize_price("99 金币", "CNY") == "99 金币"
+
     def test_bare_number_needs_hint(self):
         assert normalize_price("5.99", "CNY") == "CNY 5.99"
         assert normalize_price("5.99") == "5.99"


### PR DESCRIPTION
Improvements to legacy `Edition.price` normalization, plus operational wiring for the `unify_metadata` migration:

**1. Assume CNY for 元-suffixed prices.** Stored legacy values like `26.50元` are overwhelmingly douban-sourced, so `Edition.normalize_legacy_metadata` now passes a `CNY` hint to `normalize_price` when the value has a `元` suffix. This applies both to the `unify_metadata` catalog migration and to legacy metadata ingest.

**2. Normalize unambiguous Chinese currency names.** The `normalize_price` suffix pattern now accepts short CJK currency words, with the common Chinese names mapped to ISO 4217: 美元/美金→USD, 日元/日圆→JPY, 港元/港币→HKD, 人民币→CNY, 欧元→EUR, 英镑→GBP, 新台币/台币→TWD, 韩元→KRW.

**3. Sentry metrics for the migration.** `unify_metadata_20260715` emits counter `migration` with `name=catalog.unify_metadata` and the number of items updated per flushed batch, plus `name=catalog.unify_metadata.start`/`.end` markers around the run. Real runs only; dry runs emit nothing; no-op when Sentry is not configured.

**4. Auto-run on deploy.** Catalog migration `0026_unify_metadata` enqueues `unify_metadata_20260715` as a chained background job on `migrate`, skippable at dequeue time via SiteConfig `skip_migrations`.

Examples:
- `"26.50元"` → `"CNY 26.50"`, `"1,299 元"` → `"CNY 1299"`
- `"99 美元"` → `"USD 99"`, `"66日元"` → `"JPY 66"` (the 日元 alias wins over the 元-suffix CNY hint)
- `¥`/`￥` and bare numbers remain ambiguous and are kept as-is
- unrecognized CJK words (`"99 金币"`), ranges, and annotated values (`"48.00元（全二册）"`) are kept verbatim
- scrape-time site hints (douban=CNY, bangumi=JPY, bookstw=TWD) behave as before