### PR TITLE
feat(takahe): full support for polls (Question)

### DIFF
--- a/takahe/activities/migrations/0026_alter_timelineevent_type.py
+++ b/takahe/activities/migrations/0026_alter_timelineevent_type.py
@@ -24,6 +24,7 @@ class Migration(migrations.Migration):
                     ("quoted", "Quoted"),
                     ("announcement", "Announcement"),
                     ("identity_created", "Identity Created"),
+                    ("poll", "Poll"),
                 ],
                 max_length=100,
             ),

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -335,9 +335,7 @@ class PostStates(StateGraph):
                     TimelineEvent.add_poll_ended(voter, post)
                 return cls.fanned_out
         # Remote poll: refresh final tallies outside the row lock
-        try:
-            instance.refresh_question_from_remote()
-        except Exception:
+        if not instance.refresh_question_from_remote():
             logger.warning(
                 "Could not refresh final poll tallies for %s",
                 instance.object_uri,
@@ -1052,11 +1050,15 @@ class Post(StatorModel):
             json_data = json_from_response(response)
             ap_data = canonicalise(json_data, include_security=True, outbound=False)
             post = Post.by_ap(ap_data, create=False, update=True)
-        except json.JSONDecodeError, ValueError, JsonLdError, Post.DoesNotExist:
+        except (
+            json.JSONDecodeError,
+            ValueError,
+            JsonLdError,
+            ActivityPubFormatError,
+            Post.DoesNotExist,
+        ):
             return None
-        if isinstance(post.type_data, QuestionData):
-            post.type_data.last_fetched = timezone.now()
-            post.save()
+        # by_ap stamped type_data.last_fetched while applying the update
         return post
 
     def refresh_question_if_stale(self) -> "Post":
@@ -1464,6 +1466,10 @@ class Post(StatorModel):
             post.url = data.get("url", data["id"])
             if post.type == cls.Types.question:
                 post.type_data = PostTypeData(root=data).root
+                if not post.local and isinstance(post.type_data, QuestionData):
+                    # Fresh data from the origin counts as a fetch, so
+                    # a first API view doesn't immediately re-fetch it
+                    post.type_data.last_fetched = timezone.now()
             elif post.type == cls.Types.article or "relatedWith" in data:
                 # Preserve the full AS Article (name, summary, source, url,
                 # tags, etc.) so the NeoDB Post-only renderer can show a

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -54,6 +54,7 @@ from activities.models.post_types import (
     PostTypeDataDecoder,
     PostTypeDataEncoder,
     QuestionData,
+    vote_value,
 )
 from activities.models.quote_authorization import QuoteAuthorization
 
@@ -304,36 +305,43 @@ class PostStates(StateGraph):
         """
         from activities.models.timeline_event import TimelineEvent
 
-        if instance.type != Post.Types.question or not isinstance(
-            instance.type_data, QuestionData
-        ):
-            return cls.fanned_out
-        question = instance.type_data
-        if not question.is_expired:
-            if (
-                instance.local
-                and not question.hide_totals
-                and question.last_distributed_tally != question.tally
+        with transaction.atomic():
+            # Lock the row so concurrent vote handling can't clobber the
+            # type_data we are about to save
+            post = Post.objects.select_for_update().get(pk=instance.pk)
+            if post.type != Post.Types.question or not isinstance(
+                post.type_data, QuestionData
             ):
-                cls.targets_fan_out(instance, FanOut.Types.post_edited)
+                return cls.fanned_out
+            question = post.type_data
+            if not question.is_expired:
+                if (
+                    post.local
+                    and not question.hide_totals
+                    and question.last_distributed_tally != question.tally
+                ):
+                    cls.targets_fan_out(post, FanOut.Types.post_edited)
+                    question.last_distributed_tally = question.tally
+                    post.save()
+                return None
+            # The poll has ended
+            if post.local:
+                # Final Update reveals hidden totals and carries `closed`
+                cls.targets_fan_out(post, FanOut.Types.post_edited)
                 question.last_distributed_tally = question.tally
-                instance.save()
-            return None
-        # The poll has ended
-        if instance.local:
-            # Final Update reveals hidden totals and carries `closed`
-            cls.targets_fan_out(instance, FanOut.Types.post_edited)
-            question.last_distributed_tally = question.tally
-            instance.save()
-            TimelineEvent.add_poll_ended(instance.author, instance)
-        else:
-            try:
-                instance.refresh_question_from_remote()
-            except Exception:
-                logger.warning(
-                    "Could not refresh final poll tallies for %s",
-                    instance.object_uri,
-                )
+                post.save()
+                TimelineEvent.add_poll_ended(post.author, post)
+                for voter in post.question_local_voters():
+                    TimelineEvent.add_poll_ended(voter, post)
+                return cls.fanned_out
+        # Remote poll: refresh final tallies outside the row lock
+        try:
+            instance.refresh_question_from_remote()
+        except Exception:
+            logger.warning(
+                "Could not refresh final poll tallies for %s",
+                instance.object_uri,
+            )
         for voter in instance.question_local_voters():
             TimelineEvent.add_poll_ended(voter, instance)
         return cls.fanned_out
@@ -861,6 +869,9 @@ class Post(StatorModel):
         question: dict | None = None,
     ):
         with transaction.atomic():
+            # Serialize against concurrent vote handling, which also
+            # rewrites type_data
+            Post.objects.select_for_update().get(pk=self.pk)
             # Strip all HTML and apply linebreaks filter
             parser = FediverseHtmlParser(linebreaks_filter(content), find_hashtags=True)
             self.content = parser.html
@@ -991,22 +1002,20 @@ class Post(StatorModel):
         """
         Recalculate type_data (used mostly for poll votes)
         """
-        from activities.models import PostInteraction
+        from activities.models import PostInteraction, PostInteractionStates
 
         if self.local and isinstance(self.type_data, QuestionData):
+            active_votes = self.interactions.filter(
+                type=PostInteraction.Types.vote,
+                state__in=PostInteractionStates.group_active(),
+            )
             self.type_data.voter_count = (
-                self.interactions.filter(
-                    type=PostInteraction.Types.vote,
-                )
-                .values("identity")
-                .distinct()
-                .count()
+                active_votes.values("identity").distinct().count()
             )
 
             for option in self.type_data.options:
-                option.votes = self.interactions.filter(
-                    type=PostInteraction.Types.vote,
-                    value=option.name,
+                option.votes = active_votes.filter(
+                    value=vote_value(option.name),
                 ).count()
         if save:
             self.save()
@@ -1015,12 +1024,13 @@ class Post(StatorModel):
         """
         Local identities that voted on this poll (for end-of-poll notifications)
         """
-        from activities.models import PostInteraction
+        from activities.models import PostInteraction, PostInteractionStates
 
         return list(
             Identity.objects.filter(
                 interactions__post=self,
                 interactions__type=PostInteraction.Types.vote,
+                interactions__state__in=PostInteractionStates.group_active(),
                 local=True,
             ).distinct()
         )
@@ -1222,11 +1232,18 @@ class Post(StatorModel):
         Returns the AP JSON to update this object
         """
         object = self.to_ap()
+        # Each revision needs its own activity ID - some servers (e.g.
+        # Pleroma) deduplicate activities by ID, and polls now send
+        # several Updates (tallies, closing) over their lifetime.
+        if self.updated:
+            update_id = f"{self.object_uri}#updates/{int(self.updated.timestamp())}"
+        else:
+            update_id = self.object_uri + "#update"
         return {
             "to": object.get("to", []),
             "cc": object.get("cc", []),
             "type": "Update",
-            "id": self.object_uri + "#update",
+            "id": update_id,
             "actor": self.author.actor_uri,
             "object": object,
         }

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -110,16 +110,27 @@ class PostStates(StateGraph):
 
     edited = State(try_interval=300)
     edited_fanned_out = State(externally_progressed=True)
+    # Open polls: local ones federate throttled tally Updates and close at
+    # expiry; remote ones with local voters get end-of-poll notifications.
+    question_open = State(try_interval=300, attempt_immediately=False)
 
     new.transitions_to(fanned_out)
+    new.transitions_to(question_open)
     fanned_out.transitions_to(deleted_fanned_out)
     fanned_out.transitions_to(deleted)
     fanned_out.transitions_to(edited)
+    fanned_out.transitions_to(question_open)
 
     deleted.transitions_to(deleted_fanned_out)
     edited.transitions_to(edited_fanned_out)
+    edited.transitions_to(question_open)
     edited_fanned_out.transitions_to(edited)
     edited_fanned_out.transitions_to(deleted)
+    edited_fanned_out.transitions_to(question_open)
+    question_open.transitions_to(fanned_out)
+    question_open.transitions_to(edited)
+    question_open.transitions_to(deleted)
+    question_open.transitions_to(deleted_fanned_out)
 
     @classmethod
     def targets_fan_out(cls, post: "Post", type_: str) -> None:
@@ -175,6 +186,8 @@ class PostStates(StateGraph):
             cls.targets_fan_out(instance, FanOut.Types.post)
         instance.ensure_hashtags()
         _attach_preview_card(instance.pk, instance.content)
+        if cls.needs_question_tracking(instance):
+            return cls.question_open
         return cls.fanned_out
 
     @classmethod
@@ -250,7 +263,80 @@ class PostStates(StateGraph):
         cls.targets_fan_out(instance, FanOut.Types.post_edited)
         instance.ensure_hashtags()
         _attach_preview_card(instance.pk, instance.content)
+        if cls.needs_question_tracking(instance):
+            question = instance.type_data
+            if instance.local and question.last_distributed_tally != question.tally:
+                # The Update we just fanned out carries the current tallies
+                question.last_distributed_tally = question.tally
+                instance.save()
+            return cls.question_open
         return cls.edited_fanned_out
+
+    @classmethod
+    def needs_question_tracking(cls, instance: "Post") -> bool:
+        """
+        Whether this post should sit in question_open: an unexpired poll
+        that is either local or has local voters to notify at expiry.
+        """
+        from activities.models.post_interaction import PostInteraction
+
+        if instance.type != Post.Types.question or not isinstance(
+            instance.type_data, QuestionData
+        ):
+            return False
+        if instance.type_data.is_expired:
+            return False
+        if instance.local:
+            return True
+        if not instance.type_data.effective_end_time:
+            # A remote poll that never ends has no expiry to track
+            return False
+        return instance.interactions.filter(
+            type=PostInteraction.Types.vote, identity__local=True
+        ).exists()
+
+    @classmethod
+    def handle_question_open(cls, instance: "Post"):
+        """
+        Watches an open poll: federates throttled tally Updates for local
+        polls, and at expiry sends the final Update (now carrying `closed`)
+        and notifies the author and local voters.
+        """
+        from activities.models.timeline_event import TimelineEvent
+
+        if instance.type != Post.Types.question or not isinstance(
+            instance.type_data, QuestionData
+        ):
+            return cls.fanned_out
+        question = instance.type_data
+        if not question.is_expired:
+            if (
+                instance.local
+                and not question.hide_totals
+                and question.last_distributed_tally != question.tally
+            ):
+                cls.targets_fan_out(instance, FanOut.Types.post_edited)
+                question.last_distributed_tally = question.tally
+                instance.save()
+            return None
+        # The poll has ended
+        if instance.local:
+            # Final Update reveals hidden totals and carries `closed`
+            cls.targets_fan_out(instance, FanOut.Types.post_edited)
+            question.last_distributed_tally = question.tally
+            instance.save()
+            TimelineEvent.add_poll_ended(instance.author, instance)
+        else:
+            try:
+                instance.refresh_question_from_remote()
+            except Exception:
+                logger.warning(
+                    "Could not refresh final poll tallies for %s",
+                    instance.object_uri,
+                )
+        for voter in instance.question_local_voters():
+            TimelineEvent.add_poll_ended(voter, instance)
+        return cls.fanned_out
 
 
 class PostQuerySet(models.QuerySet):
@@ -749,6 +835,9 @@ class Post(StatorModel):
             if question:
                 post.type = question["type"]
                 post.type_data = PostTypeData(root=question).root
+                if isinstance(post.type_data, QuestionData):
+                    # Baseline for detecting when a tally Update is due
+                    post.type_data.last_distributed_tally = post.type_data.tally
             post.save()
             # Assign to conversation if this is a direct message
             if visibility == cls.Visibilities.mentioned:
@@ -769,6 +858,7 @@ class Post(StatorModel):
         attachments: list | None = None,
         attachment_attributes: list | None = None,
         language: str | None = None,
+        question: dict | None = None,
     ):
         with transaction.atomic():
             # Strip all HTML and apply linebreaks filter
@@ -787,6 +877,8 @@ class Post(StatorModel):
             self.mentions.set(self.mentions_from_content(content, self.author))
             self.emojis.set(Emoji.emojis_from_content(content, None))
             self.attachments.set(attachments or [])
+            if question is not None or self.type == Post.Types.question:
+                self.apply_question_edit(question)
             self.save()
 
             for attrs in attachment_attributes or []:
@@ -800,6 +892,34 @@ class Post(StatorModel):
 
             self.transition_perform(PostStates.edited)
         self.neodb_sync_local(self.in_reply_to_post(), content, False)
+
+    def apply_question_edit(self, question: dict | None) -> None:
+        """
+        Applies a poll change during a local post edit: adds, replaces or
+        removes the poll. Changing the options or the mode invalidates all
+        previous votes (matching Mastodon).
+        """
+        from activities.models.post_interaction import PostInteraction
+
+        if question is None:
+            # The poll was removed by the edit
+            self.type = Post.Types.note
+            self.type_data = None
+            self.interactions.filter(type=PostInteraction.Types.vote).delete()
+            return
+        old = self.type_data if isinstance(self.type_data, QuestionData) else None
+        new_data = PostTypeData(root=question).root
+        significantly_changed = (
+            old is None
+            or old.mode != new_data.mode
+            or [option.name for option in (old.options or [])]
+            != [option.name for option in (new_data.options or [])]
+        )
+        if significantly_changed:
+            self.interactions.filter(type=PostInteraction.Types.vote).delete()
+        self.type = Post.Types.question
+        self.type_data = new_data
+        self.calculate_type_data(save=False)
 
     @classmethod
     def mentions_from_content(cls, content, author) -> set[Identity]:
@@ -891,6 +1011,61 @@ class Post(StatorModel):
         if save:
             self.save()
 
+    def question_local_voters(self) -> list[Identity]:
+        """
+        Local identities that voted on this poll (for end-of-poll notifications)
+        """
+        from activities.models import PostInteraction
+
+        return list(
+            Identity.objects.filter(
+                interactions__post=self,
+                interactions__type=PostInteraction.Types.vote,
+                local=True,
+            ).distinct()
+        )
+
+    def refresh_question_from_remote(self) -> "Post | None":
+        """
+        Re-fetches a remote poll from its origin to pick up fresh tallies.
+        Returns the updated Post, or None if it could not be refreshed.
+        """
+        if self.local or self.type != Post.Types.question:
+            return None
+        try:
+            response = SystemActor().signed_request(method="get", uri=self.object_uri)
+        except httpx.HTTPError, ssl.SSLCertVerificationError, ValueError, TypeError:
+            return None
+        if response.status_code >= 400:
+            return None
+        try:
+            json_data = json_from_response(response)
+            ap_data = canonicalise(json_data, include_security=True, outbound=False)
+            post = Post.by_ap(ap_data, create=False, update=True)
+        except json.JSONDecodeError, ValueError, JsonLdError, Post.DoesNotExist:
+            return None
+        if isinstance(post.type_data, QuestionData):
+            post.type_data.last_fetched = timezone.now()
+            post.save()
+        return post
+
+    def refresh_question_if_stale(self) -> "Post":
+        """
+        Re-fetches a remote poll when its tallies may be out of date:
+        more than a minute since the last fetch, and not yet fetched
+        after the poll ended (final results).
+        """
+        question = self.type_data
+        if self.local or not isinstance(question, QuestionData):
+            return self
+        if question.last_fetched:
+            if (timezone.now() - question.last_fetched).total_seconds() < 60:
+                return self
+            end_time = question.effective_end_time
+            if end_time and question.last_fetched >= end_time:
+                return self
+        return self.refresh_question_from_remote() or self
+
     ### ActivityPub (outbound) ###
 
     def to_ap(self) -> dict:
@@ -916,17 +1091,25 @@ class Post(StatorModel):
                 self.language: value["content"],
             }
         if self.type == Post.Types.question and self.type_data:
-            value[self.type_data.mode] = [
+            question = self.type_data
+            expired = question.is_expired
+            totals_hidden = question.hide_totals and not expired
+            value[question.mode] = [
                 {
                     "name": option.name,
                     "type": option.type,
-                    "replies": {"type": "Collection", "totalItems": option.votes},
+                    "replies": {
+                        "type": "Collection",
+                        "totalItems": 0 if totals_hidden else option.votes,
+                    },
                 }
-                for option in self.type_data.options
+                for option in question.options or []
             ]
-            value["toot:votersCount"] = self.type_data.voter_count
-            if self.type_data.end_time:
-                value["endTime"] = format_ld_date(self.type_data.end_time)
+            value["toot:votersCount"] = question.voter_count
+            if question.end_time:
+                value["endTime"] = format_ld_date(question.end_time)
+            if expired and question.effective_end_time:
+                value["closed"] = format_ld_date(question.effective_end_time)
         if self.summary:
             value["summary"] = self.summary
         if self.in_reply_to:

--- a/takahe/activities/models/post_interaction.py
+++ b/takahe/activities/models/post_interaction.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from stator.models import State, StateField, StateGraph, StatorModel
 
 from activities.models.fan_out import FanOut
-from activities.models.post import Post
+from activities.models.post import Post, PostStates
 from activities.models.post_types import QuestionData
 from activities.models.timeline_event import TimelineEvent
 from users.models import Block, Identity
@@ -287,6 +287,10 @@ class PostInteraction(StatorModel):
     @classmethod
     def create_votes(cls, post, identity, choices) -> list["PostInteraction"]:
         question = post.type_data
+        if not isinstance(question, QuestionData):
+            raise ValueError("Validation failed: Post is not a poll")
+        if post.author_id == identity.pk:
+            raise ValueError("Validation failed: You can't vote in your own poll")
         if (
             Block.objects.filter(
                 source=post.author, target=identity, mute=False
@@ -297,32 +301,61 @@ class PostInteraction(StatorModel):
         ):
             raise ValueError("Validation failed: blocked")
 
-        if question.end_time and timezone.now() > question.end_time:
+        if question.is_expired:
             raise ValueError("Validation failed: The poll has already ended")
 
-        if post.interactions.filter(identity=identity, type=cls.Types.vote).exists():
-            raise ValueError("Validation failed: You have already voted on this poll")
+        options = question.options or []
+        choices = set(choices)
+        if not choices:
+            raise ValueError("Validation failed: No poll options chosen")
+        if any(choice < 0 or choice >= len(options) for choice in choices):
+            raise ValueError("Validation failed: The chosen vote option does not exist")
+        existing_votes = post.interactions.filter(
+            identity=identity, type=cls.Types.vote
+        )
+        if question.mode == "anyOf":
+            # Multiple-choice polls accept additional, not-yet-voted options
+            voted_values = set(existing_votes.values_list("value", flat=True))
+            if any(options[choice].name in voted_values for choice in choices):
+                raise ValueError(
+                    "Validation failed: You have already voted on this poll"
+                )
+            already_voted = bool(voted_values)
+        else:
+            if len(choices) > 1 or existing_votes.exists():
+                raise ValueError(
+                    "Validation failed: You have already voted on this poll"
+                )
+            already_voted = False
 
         votes = []
         with transaction.atomic():
-            for choice in set(choices):
+            for choice in choices:
                 vote = cls.objects.create(
                     identity=identity,
                     post=post,
                     type=PostInteraction.Types.vote,
-                    value=question.options[choice].name,
+                    value=options[choice].name,
                 )
                 vote.object_uri = f"{identity.actor_uri}#votes/{vote.id}"
                 vote.save()
                 votes.append(vote)
 
                 if not post.local:
-                    question.options[choice].votes += 1
+                    options[choice].votes += 1
 
-            if not post.local:
+            if not post.local and not already_voted:
                 question.voter_count += 1
 
             post.calculate_type_data()
+
+        # Track remote polls so local voters get notified when they end
+        if (
+            not post.local
+            and question.effective_end_time
+            and post.state in [PostStates.fanned_out, PostStates.edited_fanned_out]
+        ):
+            post.transition_perform(PostStates.question_open)
 
         return votes
 
@@ -451,19 +484,25 @@ class PostInteraction(StatorModel):
                 ):
                     type = cls.Types.vote
                     question = post.type_data
-                    value = object["name"]
-                    if question.end_time and timezone.now() > question.end_time:
+                    value = object.get("name")
+                    option_names = {option.name for option in (question.options or [])}
+                    if not isinstance(value, str) or value not in option_names:
+                        raise cls.DoesNotExist(
+                            f"Invalid vote option {value!r} for question {post.id}"
+                        )
+                    if question.is_expired:
                         # TODO: Maybe create an expecific expired exception?
                         raise cls.DoesNotExist(
                             f"Cannot create a vote to the expired question {post.id}"
                         )
 
-                    already_voted = (
-                        post.type_data.mode == "oneOf"
-                        and post.interactions.filter(
-                            type=cls.Types.vote, identity=identity
-                        ).exists()
+                    existing_votes = post.interactions.filter(
+                        type=cls.Types.vote, identity=identity
                     )
+                    if question.mode == "oneOf":
+                        already_voted = existing_votes.exists()
+                    else:
+                        already_voted = existing_votes.filter(value=value).exists()
                     if already_voted:
                         raise cls.DoesNotExist(
                             f"The identity {identity.handle} already voted in question {post.id}"

--- a/takahe/activities/models/post_interaction.py
+++ b/takahe/activities/models/post_interaction.py
@@ -10,7 +10,7 @@ from stator.models import State, StateField, StateGraph, StatorModel
 
 from activities.models.fan_out import FanOut
 from activities.models.post import Post, PostStates
-from activities.models.post_types import QuestionData
+from activities.models.post_types import QuestionData, vote_value
 from activities.models.timeline_event import TimelineEvent
 from users.models import Block, Identity
 
@@ -286,56 +286,64 @@ class PostInteraction(StatorModel):
 
     @classmethod
     def create_votes(cls, post, identity, choices) -> list["PostInteraction"]:
-        question = post.type_data
-        if not isinstance(question, QuestionData):
-            raise ValueError("Validation failed: Post is not a poll")
-        if post.author_id == identity.pk:
-            raise ValueError("Validation failed: You can't vote in your own poll")
-        if (
-            Block.objects.filter(
-                source=post.author, target=identity, mute=False
-            ).exists()
-            or Block.objects.filter(
-                source=identity, target=post.author, mute=False
-            ).exists()
-        ):
-            raise ValueError("Validation failed: blocked")
-
-        if question.is_expired:
-            raise ValueError("Validation failed: The poll has already ended")
-
-        options = question.options or []
-        choices = set(choices)
-        if not choices:
-            raise ValueError("Validation failed: No poll options chosen")
-        if any(choice < 0 or choice >= len(options) for choice in choices):
-            raise ValueError("Validation failed: The chosen vote option does not exist")
-        existing_votes = post.interactions.filter(
-            identity=identity, type=cls.Types.vote
-        )
-        if question.mode == "anyOf":
-            # Multiple-choice polls accept additional, not-yet-voted options
-            voted_values = set(existing_votes.values_list("value", flat=True))
-            if any(options[choice].name in voted_values for choice in choices):
-                raise ValueError(
-                    "Validation failed: You have already voted on this poll"
-                )
-            already_voted = bool(voted_values)
-        else:
-            if len(choices) > 1 or existing_votes.exists():
-                raise ValueError(
-                    "Validation failed: You have already voted on this poll"
-                )
-            already_voted = False
-
         votes = []
         with transaction.atomic():
+            # Lock the post row so concurrent votes on the same poll
+            # can't slip past the duplicate checks or clobber tallies
+            post = Post.objects.select_for_update().get(pk=post.pk)
+            question = post.type_data
+            if not isinstance(question, QuestionData):
+                raise ValueError("Validation failed: Post is not a poll")
+            if post.author_id == identity.pk:
+                raise ValueError("Validation failed: You can't vote in your own poll")
+            if (
+                Block.objects.filter(
+                    source=post.author, target=identity, mute=False
+                ).exists()
+                or Block.objects.filter(
+                    source=identity, target=post.author, mute=False
+                ).exists()
+            ):
+                raise ValueError("Validation failed: blocked")
+
+            if question.is_expired:
+                raise ValueError("Validation failed: The poll has already ended")
+
+            options = question.options or []
+            choices = set(choices)
+            if not choices:
+                raise ValueError("Validation failed: No poll options chosen")
+            if any(choice < 0 or choice >= len(options) for choice in choices):
+                raise ValueError(
+                    "Validation failed: The chosen vote option does not exist"
+                )
+            existing_votes = post.interactions.filter(
+                identity=identity, type=cls.Types.vote
+            )
+            if question.mode == "anyOf":
+                # Multiple-choice polls accept additional, not-yet-voted options
+                voted_values = set(existing_votes.values_list("value", flat=True))
+                if any(
+                    vote_value(options[choice].name) in voted_values
+                    for choice in choices
+                ):
+                    raise ValueError(
+                        "Validation failed: You have already voted on this poll"
+                    )
+                already_voted = bool(voted_values)
+            else:
+                if len(choices) > 1 or existing_votes.exists():
+                    raise ValueError(
+                        "Validation failed: You have already voted on this poll"
+                    )
+                already_voted = False
+
             for choice in choices:
                 vote = cls.objects.create(
                     identity=identity,
                     post=post,
                     type=PostInteraction.Types.vote,
-                    value=options[choice].name,
+                    value=vote_value(options[choice].name),
                 )
                 vote.object_uri = f"{identity.actor_uri}#votes/{vote.id}"
                 vote.save()
@@ -483,6 +491,10 @@ class PostInteraction(StatorModel):
                     and isinstance(post.type_data, QuestionData)
                 ):
                     type = cls.Types.vote
+                    # Lock the post row so concurrent inbound votes can't
+                    # slip past the duplicate checks (we are always inside
+                    # a transaction here via handle_ap)
+                    post = Post.objects.select_for_update().get(pk=post.pk)
                     question = post.type_data
                     value = object.get("name")
                     option_names = {option.name for option in (question.options or [])}
@@ -490,6 +502,7 @@ class PostInteraction(StatorModel):
                         raise cls.DoesNotExist(
                             f"Invalid vote option {value!r} for question {post.id}"
                         )
+                    value = vote_value(value)
                     if question.is_expired:
                         # TODO: Maybe create an expecific expired exception?
                         raise cls.DoesNotExist(

--- a/takahe/activities/models/post_types.py
+++ b/takahe/activities/models/post_types.py
@@ -16,6 +16,14 @@ POLL_MIN_EXPIRATION = 300
 POLL_MAX_EXPIRATION = 2629746
 
 
+def vote_value(option_name: str) -> str:
+    """
+    The stored form of a voted option: remote polls may have names longer
+    than local limits allow, but PostInteraction.value is a 50-char column.
+    """
+    return option_name[:POLL_MAX_OPTION_CHARS]
+
+
 class BasePostDataType(BaseModel):
     pass
 
@@ -129,7 +137,7 @@ class QuestionData(BasePostDataType):
                 }
             )
             value["votes_count"] += option.votes
-            option_map[option.name] = index
+            option_map[vote_value(option.name)] = index
 
         if identity:
             votes = post.interactions.filter(

--- a/takahe/activities/models/post_types.py
+++ b/takahe/activities/models/post_types.py
@@ -5,7 +5,15 @@ from typing import Literal
 from django.utils import timezone
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from core.ld import format_ld_date
+from core.ld import format_ld_date, parse_ld_date
+
+
+# Poll composition limits, advertised via /api/v1/instance and enforced
+# when creating or editing a poll through the client API.
+POLL_MAX_OPTIONS = 42
+POLL_MAX_OPTION_CHARS = 50
+POLL_MIN_EXPIRATION = 300
+POLL_MAX_EXPIRATION = 2629746
 
 
 class BasePostDataType(BaseModel):
@@ -36,6 +44,13 @@ class QuestionData(BasePostDataType):
     options: list[QuestionOption] | None = None
     voter_count: int = Field(0, alias="http://joinmastodon.org/ns#votersCount")
     end_time: datetime | None = Field(None, alias="endTime")
+    closed: datetime | None = None
+    hide_totals: bool = False
+    # Internal bookkeeping, never sent over AP or the client API:
+    # tally snapshot at last federated Update, and when a remote poll
+    # was last re-fetched from its origin.
+    last_distributed_tally: str | None = None
+    last_fetched: datetime | None = None
 
     def __init__(self, **data) -> None:
         data["voter_count"] = data.get(
@@ -48,16 +63,47 @@ class QuestionData(BasePostDataType):
             if not options:
                 options = data.pop("oneOf", None)
             data["options"] = options
+        # Some servers signal a finished poll with a boolean `closed`
+        # rather than a datetime (Mastodon treats any truthy value as
+        # "closed now"), and invalid datetimes (e.g. hour 26) have been
+        # seen in the wild - drop those rather than failing the post.
+        closed = data.get("closed")
+        if isinstance(closed, bool):
+            data["closed"] = timezone.now() if closed else None
+        elif isinstance(closed, str):
+            try:
+                data["closed"] = parse_ld_date(closed)
+            except ValueError, OverflowError:
+                data["closed"] = None
         super().__init__(**data)
+
+    @property
+    def effective_end_time(self) -> datetime | None:
+        return self.closed or self.end_time
+
+    @property
+    def is_expired(self) -> bool:
+        end_time = self.effective_end_time
+        return bool(end_time and timezone.now() >= end_time)
+
+    @property
+    def tally(self) -> str:
+        """
+        Snapshot of the current vote counts, used to detect when a new
+        federated Update is due.
+        """
+        votes = ":".join(str(option.votes) for option in self.options or [])
+        return f"{self.voter_count}:{votes}"
 
     def to_mastodon_json(self, post, identity=None):
         from activities.models import PostInteraction
 
         multiple = self.mode == "anyOf"
+        expired = self.is_expired
         value = {
             "id": str(post.pk),
             "expires_at": None,
-            "expired": False,
+            "expired": expired,
             "multiple": multiple,
             "votes_count": 0,
             "voters_count": self.voter_count,
@@ -67,17 +113,19 @@ class QuestionData(BasePostDataType):
             "emojis": [],
         }
 
-        if self.end_time:
-            value["expires_at"] = format_ld_date(self.end_time)
-            value["expired"] = timezone.now() >= self.end_time
+        if self.effective_end_time:
+            value["expires_at"] = format_ld_date(self.effective_end_time)
 
+        # Per-option tallies stay hidden until the poll ends when the
+        # author asked for hidden totals.
+        totals_hidden = self.hide_totals and not expired
         options = self.options or []
         option_map = {}
         for index, option in enumerate(options):
             value["options"].append(
                 {
                     "title": option.name,
-                    "votes_count": option.votes,
+                    "votes_count": None if totals_hidden else option.votes,
                 }
             )
             value["votes_count"] += option.votes

--- a/takahe/activities/models/timeline_event.py
+++ b/takahe/activities/models/timeline_event.py
@@ -24,6 +24,7 @@ class TimelineEvent(models.Model):
         quoted = "quoted"  # Someone quoting one of our posts
         announcement = "announcement"  # Server announcement
         identity_created = "identity_created"  # New identity created
+        poll = "poll"  # A poll we created or voted in has ended
 
     NOTIFICATION_NAMES = {
         Types.post: "status",
@@ -34,6 +35,7 @@ class TimelineEvent(models.Model):
         Types.follow_requested: "follow_request",
         Types.quoted: "quote",
         Types.identity_created: "admin.sign_up",
+        Types.poll: "poll",
     }
 
     # The user this event is for
@@ -181,6 +183,28 @@ class TimelineEvent(models.Model):
         )
         if created:
             identity.notify(PushType.quote, post.author, body=post.content_preview())
+        return event
+
+    @classmethod
+    def add_poll_ended(cls, identity, post):
+        """
+        Notifies identity that a poll they created or voted in has ended
+        """
+        event, created = cls.objects.get_or_create(
+            identity=identity,
+            type=cls.Types.poll,
+            subject_post=post,
+            subject_identity=post.author,
+        )
+        if created:
+            title = (
+                "Your poll has ended"
+                if identity == post.author
+                else "A poll you voted in has ended"
+            )
+            identity.notify(
+                PushType.poll, post.author, title=title, body=post.content_preview()
+            )
         return event
 
     @classmethod

--- a/takahe/api/models/push.py
+++ b/takahe/api/models/push.py
@@ -42,7 +42,7 @@ class PushType(models.TextChoices):
             "follow": "{name} is now following you",
             "follow_request": "Follow request from {name}",
             "favourite": "{name} favorited your post",
-            "poll": "{name} posted a new poll",
+            "poll": "A poll by {name} has ended",
             "update": "Update",
             "quote": "{name} quoted your post",
             "admin.sign_up": "{name} signed up for an account",

--- a/takahe/api/views/instance.py
+++ b/takahe/api/views/instance.py
@@ -7,6 +7,12 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from activities.models import Post
+from activities.models.post_types import (
+    POLL_MAX_EXPIRATION,
+    POLL_MAX_OPTION_CHARS,
+    POLL_MAX_OPTIONS,
+    POLL_MIN_EXPIRATION,
+)
 from api import schemas
 from core.models import Config
 from hatchway import api_view
@@ -79,10 +85,10 @@ def instance_info_v1(request) -> dict:
                 "video_matrix_limit": 2000 * 2000,
             },
             "polls": {
-                "max_options": 4,
-                "max_characters_per_option": 50,
-                "min_expiration": 300,
-                "max_expiration": 2629746,
+                "max_options": POLL_MAX_OPTIONS,
+                "max_characters_per_option": POLL_MAX_OPTION_CHARS,
+                "min_expiration": POLL_MIN_EXPIRATION,
+                "max_expiration": POLL_MAX_EXPIRATION,
             },
         },
         "contact_account": (
@@ -157,10 +163,10 @@ def instance_info_v2(request) -> dict:
                 "video_matrix_limit": 2000 * 2000,
             },
             "polls": {
-                "max_options": 4,
-                "max_characters_per_option": 50,
-                "min_expiration": 300,
-                "max_expiration": 2629746,
+                "max_options": POLL_MAX_OPTIONS,
+                "max_characters_per_option": POLL_MAX_OPTION_CHARS,
+                "min_expiration": POLL_MIN_EXPIRATION,
+                "max_expiration": POLL_MAX_EXPIRATION,
             },
             "translation": {"enabled": False},
         },

--- a/takahe/api/views/notifications.py
+++ b/takahe/api/views/notifications.py
@@ -20,6 +20,7 @@ NOTIFICATION_TYPES = {
     "follow_request": TimelineEvent.Types.follow_requested,
     "quote": TimelineEvent.Types.quoted,
     "admin.sign_up": TimelineEvent.Types.identity_created,
+    "poll": TimelineEvent.Types.poll,
 }
 
 

--- a/takahe/api/views/polls.py
+++ b/takahe/api/views/polls.py
@@ -1,6 +1,6 @@
 from django.http import Http404
 from api.views import get_object_or_404
-from hatchway import api_view, QueryOrBody
+from hatchway import ApiError, api_view, QueryOrBody
 
 from activities.models import Post, PostInteraction
 from users.models import Block
@@ -16,6 +16,7 @@ def get_poll(request, id: str) -> schemas.Poll:
         source=post.author, target=request.identity, require_active=True
     ):
         raise Http404
+    post = post.refresh_question_if_stale()
     return schemas.Poll.from_post(post, identity=request.identity)
 
 
@@ -23,6 +24,9 @@ def get_poll(request, id: str) -> schemas.Poll:
 @api_view.post
 def vote_poll(request, id: str, choices: QueryOrBody[list[int]]) -> schemas.Poll:
     post = get_object_or_404(Post, pk=id, type=Post.Types.question)
-    PostInteraction.create_votes(post, request.identity, choices)
+    try:
+        PostInteraction.create_votes(post, request.identity, choices)
+    except ValueError as e:
+        raise ApiError(422, str(e)) from e
     post.refresh_from_db()
     return schemas.Poll.from_post(post, identity=request.identity)

--- a/takahe/api/views/polls.py
+++ b/takahe/api/views/polls.py
@@ -1,17 +1,27 @@
 from django.http import Http404
-from api.views import get_object_or_404
 from hatchway import ApiError, api_view, QueryOrBody
 
 from activities.models import Post, PostInteraction
 from users.models import Block
 from api import schemas
 from api.decorators import scope_required
+from api.views.statuses import post_for_id
+
+
+def poll_for_id(request, id: str) -> Post:
+    """
+    Returns the poll post for an ID, respecting visibility and deletion.
+    """
+    post = post_for_id(request, id)
+    if post.type != Post.Types.question:
+        raise Http404
+    return post
 
 
 @scope_required("read:statuses")
 @api_view.get
 def get_poll(request, id: str) -> schemas.Poll:
-    post = get_object_or_404(Post, pk=id, type=Post.Types.question)
+    post = poll_for_id(request, id)
     if Block.maybe_get(
         source=post.author, target=request.identity, require_active=True
     ):
@@ -23,7 +33,7 @@ def get_poll(request, id: str) -> schemas.Poll:
 @scope_required("write:statuses")
 @api_view.post
 def vote_poll(request, id: str, choices: QueryOrBody[list[int]]) -> schemas.Poll:
-    post = get_object_or_404(Post, pk=id, type=Post.Types.question)
+    post = poll_for_id(request, id)
     try:
         PostInteraction.create_votes(post, request.identity, choices)
     except ValueError as e:

--- a/takahe/api/views/statuses.py
+++ b/takahe/api/views/statuses.py
@@ -14,6 +14,12 @@ from activities.models import (
     PostInteractionStates,
     TimelineEvent,
 )
+from activities.models.post_types import (
+    POLL_MAX_EXPIRATION,
+    POLL_MAX_OPTION_CHARS,
+    POLL_MAX_OPTIONS,
+    POLL_MIN_EXPIRATION,
+)
 from activities.services import PostService
 from users.models import Identity
 from api import schemas
@@ -28,6 +34,30 @@ class PostPollSchema(Schema):
     multiple: bool = False
     hide_totals: bool = False
 
+    def validate_limits(self) -> None:
+        if len(self.options) < 2:
+            raise ApiError(
+                422, "Validation failed: Options must have more than one item"
+            )
+        if len(self.options) > POLL_MAX_OPTIONS:
+            raise ApiError(
+                422,
+                f"Validation failed: Options can't contain more than {POLL_MAX_OPTIONS} items",
+            )
+        if any(len(option) > POLL_MAX_OPTION_CHARS for option in self.options):
+            raise ApiError(
+                422,
+                f"Validation failed: Options can't be longer than {POLL_MAX_OPTION_CHARS} characters each",
+            )
+        if len(set(self.options)) != len(self.options):
+            raise ApiError(422, "Validation failed: Options contain duplicate items")
+        if self.expires_in < POLL_MIN_EXPIRATION:
+            raise ApiError(422, "Validation failed: Expiration is too soon")
+        if self.expires_in > POLL_MAX_EXPIRATION:
+            raise ApiError(
+                422, "Validation failed: Expiration is too far into the future"
+            )
+
     def dict(self):
         return {
             "type": "Question",
@@ -36,6 +66,7 @@ class PostPollSchema(Schema):
                 {"name": name, "type": "Note", "votes": 0} for name in self.options
             ],
             "voter_count": 0,
+            "hide_totals": self.hide_totals,
             "end_time": timezone.now() + timedelta(seconds=self.expires_in),
         }
 
@@ -68,6 +99,7 @@ class EditStatusSchema(Schema):
     language: str | None = None
     media_ids: list[str] = []
     media_attributes: list[MediaAttributesSchema] = []
+    poll: PostPollSchema | None = None
 
 
 def post_for_id(request: HttpRequest, id: str) -> Post:
@@ -159,6 +191,12 @@ def post_status(request, details: PostStatusSchema) -> schemas.Status:
         raise ApiError(400, "Status is too long")
     if not details.status and not details.media_ids:
         raise ApiError(400, "Status is empty")
+    if details.poll:
+        if details.media_ids:
+            raise ApiError(
+                422, "Validation failed: Poll can't be attached to a post with media"
+            )
+        details.poll.validate_limits()
     # Grab attachments
     attachments = _resolve_owned_attachments(request, details.media_ids)
     # Create the Post
@@ -229,13 +267,22 @@ def edit_status(request, id: str, details: EditStatusSchema) -> schemas.Status:
         raise ApiError(401, "Not the author of this status")
     if post.in_reply_to is None and (
         post.type == "Article"
-        or (post.type_data and post.type_data.get("object", {}).get("relatedWith"))
+        or (
+            isinstance(post.type_data, dict)
+            and post.type_data.get("object", {}).get("relatedWith")
+        )
     ):
         # NeoDB-managed structured posts (Reviews via relatedWith, and
         # standalone Articles) cannot be edited via Mastodon API without
         # corrupting the source markdown / metadata; users must edit them
         # in NeoDB.
         raise ApiError(422, "This post must be edited in NeoDB")
+    if details.poll:
+        if details.media_ids:
+            raise ApiError(
+                422, "Validation failed: Poll can't be attached to a post with media"
+            )
+        details.poll.validate_limits()
     # Grab attachments
     attachments = _resolve_owned_attachments(request, details.media_ids)
     # Update all details, as the client must provide them all
@@ -246,8 +293,9 @@ def edit_status(request, id: str, details: EditStatusSchema) -> schemas.Status:
         attachments=attachments,
         attachment_attributes=details.media_attributes,
         language=details.language,
+        question=details.poll.dict() if details.poll else None,
     )
-    return schemas.Status.from_post(post)
+    return schemas.Status.from_post(post, identity=request.identity)
 
 
 @scope_required("write:statuses")

--- a/takahe/api/views/statuses.py
+++ b/takahe/api/views/statuses.py
@@ -39,6 +39,8 @@ class PostPollSchema(Schema):
             raise ApiError(
                 422, "Validation failed: Options must have more than one item"
             )
+        if any(not option.strip() for option in self.options):
+            raise ApiError(422, "Validation failed: Options can't be blank")
         if len(self.options) > POLL_MAX_OPTIONS:
             raise ApiError(
                 422,

--- a/takahe/tests/activities/models/test_post_interaction.py
+++ b/takahe/tests/activities/models/test_post_interaction.py
@@ -433,3 +433,48 @@ def test_handle_remove_ap(remote_identity: Identity, config_system):
 
     # Remove activity on unknown post is a no-op
     PostInteraction.handle_remove_ap(data=remove_ap | {"object": "unknown-post"})
+
+
+@pytest.mark.django_db
+def test_vote_with_invalid_option_ignored(
+    identity: Identity, remote_identity: Identity, config_system
+):
+    post = Post.create_local(
+        author=identity,
+        content="<p>Test Question</p>",
+        question={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 0},
+                {"name": "Option 2", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+
+    def vote_payload(vote_id, note):
+        return {
+            "id": f"https://remote.test/test-actor#votes/{vote_id}/activity",
+            "to": "https://example.com/@test@example.com/",
+            "type": "Create",
+            "actor": "https://remote.test/test-actor/",
+            "object": {
+                "id": f"https://remote.test/users/test-actor#votes/{vote_id}",
+                "to": "https://example.com/@test@example.com/",
+                "type": "Note",
+                "inReplyTo": post.object_uri,
+                "attributedTo": "https://remote.test/test-actor/",
+                **note,
+            },
+        }
+
+    # A vote for an option that does not exist is dropped, not an error
+    PostInteraction.handle_ap(vote_payload(21, {"name": "Nonexistent Option"}))
+    # A bare Note without a name is dropped too
+    PostInteraction.handle_ap(vote_payload(22, {}))
+
+    post.refresh_from_db()
+    assert post.type_data.voter_count == 0
+    assert not post.interactions.filter(type=PostInteraction.Types.vote).exists()

--- a/takahe/tests/activities/models/test_post_types.py
+++ b/takahe/tests/activities/models/test_post_types.py
@@ -1,7 +1,11 @@
 import pytest
 
 from activities.models import Post
-from activities.models.post_types import QuestionData, QuestionOption
+from activities.models.post_types import (
+    PostTypeData,
+    QuestionData,
+    QuestionOption,
+)
 from core.ld import canonicalise
 
 
@@ -76,3 +80,28 @@ def test_question_post(config_system, identity, remote_identity, httpx_mock):
     assert len(question_data.options) == 2
     assert question_data.options[0].votes == 2
     assert question_data.options[1].votes == 1
+
+
+def test_question_closed_datetime_marks_expired():
+    question = PostTypeData(
+        root={
+            "type": "Question",
+            "oneOf": [{"name": "A"}, {"name": "B"}],
+            "closed": "2022-01-01T00:00:00Z",
+        }
+    ).root
+    assert isinstance(question, QuestionData)
+    assert question.is_expired
+    assert question.effective_end_time is not None
+
+
+def test_question_closed_boolean_marks_expired():
+    question = PostTypeData(
+        root={
+            "type": "Question",
+            "oneOf": [{"name": "A"}, {"name": "B"}],
+            "closed": True,
+        }
+    ).root
+    assert isinstance(question, QuestionData)
+    assert question.is_expired

--- a/takahe/tests/activities/models/test_question_lifecycle.py
+++ b/takahe/tests/activities/models/test_question_lifecycle.py
@@ -86,6 +86,7 @@ def test_question_open_distributes_tally_updates(
     post.refresh_from_db()
     assert PostStates.handle_question_open(post) is None
     assert edited_fan_outs(post).filter(identity=identity2).exists()
+    post.refresh_from_db()
     assert post.type_data.last_distributed_tally == "1:1:0"
 
     # Unchanged tallies do not fan out again
@@ -245,3 +246,61 @@ def test_refresh_question_from_remote(
     assert refreshed.type_data.last_fetched is not None
     # A fresh fetch within a minute is skipped (no second request mocked)
     assert refreshed.refresh_question_if_stale().type_data.voter_count == 12
+
+
+@pytest.mark.django_db
+def test_vote_on_remote_poll_with_long_option(
+    identity: Identity, remote_identity: Identity, config_system
+):
+    long_name = "A" * 80
+    post = Post.objects.create(
+        author=remote_identity,
+        local=False,
+        content="<p>Test Question</p>",
+        object_uri="https://remote.test/status/poll-long",
+        state=PostStates.fanned_out,
+        type=Post.Types.question,
+        type_data={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": long_name, "type": "Note", "votes": 0},
+                {"name": "Short", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+    post.refresh_from_db()
+    vote = PostInteraction.create_votes(post, identity, [0])[0]
+    # The stored value fits the 50-char column, and own_votes still resolve
+    assert vote.value == long_name[:50]
+    json = post.type_data.to_mastodon_json(post, identity=identity)
+    assert json["own_votes"] == [0]
+
+
+@pytest.mark.django_db
+def test_undone_votes_are_not_counted(
+    identity: Identity, identity2: Identity, config_system
+):
+    from activities.models import PostInteractionStates
+
+    post = make_local_poll(identity)
+    vote = PostInteraction.create_votes(post, identity2, [0])[0]
+    post.refresh_from_db()
+    assert post.type_data.options[0].votes == 1
+
+    # e.g. a block or an AP Undo forces the vote out of the active states
+    vote.transition_perform(PostInteractionStates.undone_fanned_out)
+    post.calculate_type_data()
+    post.refresh_from_db()
+    assert post.type_data.options[0].votes == 0
+    assert post.type_data.voter_count == 0
+    assert post.question_local_voters() == []
+
+
+@pytest.mark.django_db
+def test_update_ap_ids_are_unique_per_revision(identity: Identity, config_system):
+    post = make_local_poll(identity)
+    first = post.to_update_ap()["id"]
+    assert "#updates/" in first

--- a/takahe/tests/activities/models/test_question_lifecycle.py
+++ b/takahe/tests/activities/models/test_question_lifecycle.py
@@ -1,0 +1,247 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from pytest_httpx import HTTPXMock
+
+from activities.models import (
+    FanOut,
+    Post,
+    PostInteraction,
+    PostStates,
+    TimelineEvent,
+)
+from activities.models.post_types import QuestionData
+from core.ld import format_ld_date
+from users.models import Identity
+
+
+def make_local_poll(author, mode="oneOf", expires=timedelta(days=1), hide_totals=False):
+    return Post.create_local(
+        author=author,
+        content="<p>Test Question</p>",
+        question={
+            "type": "Question",
+            "mode": mode,
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 0},
+                {"name": "Option 2", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "hide_totals": hide_totals,
+            "end_time": format_ld_date(timezone.now() + expires),
+        },
+    )
+
+
+def expire_poll(post):
+    post.type_data.end_time = timezone.now() - timedelta(hours=1)
+    post.save()
+
+
+def edited_fan_outs(post):
+    return FanOut.objects.filter(subject_post=post, type=FanOut.Types.post_edited)
+
+
+@pytest.mark.django_db
+def test_new_local_poll_enters_question_open(identity: Identity, config_system):
+    post = make_local_poll(identity)
+    assert post.type_data.last_distributed_tally == "0:0:0"
+    assert PostStates.handle_new(post) == PostStates.question_open
+
+
+@pytest.mark.django_db
+def test_new_remote_question_stays_fanned_out(remote_identity: Identity, config_system):
+    post = Post.objects.create(
+        author=remote_identity,
+        local=False,
+        content="<p>Test Question</p>",
+        object_uri="https://remote.test/status/poll-new",
+        type=Post.Types.question,
+        type_data={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 0},
+                {"name": "Option 2", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+    post.refresh_from_db()
+    assert PostStates.handle_new(post) == PostStates.fanned_out
+
+
+@pytest.mark.django_db
+def test_question_open_distributes_tally_updates(
+    identity: Identity, identity2: Identity, config_system
+):
+    post = make_local_poll(identity)
+    # No votes yet: nothing to distribute, stays in question_open
+    assert PostStates.handle_question_open(post) is None
+    assert not edited_fan_outs(post).exists()
+
+    PostInteraction.create_votes(post, identity2, [0])
+    post.refresh_from_db()
+    assert PostStates.handle_question_open(post) is None
+    assert edited_fan_outs(post).filter(identity=identity2).exists()
+    assert post.type_data.last_distributed_tally == "1:1:0"
+
+    # Unchanged tallies do not fan out again
+    edited_fan_outs(post).delete()
+    post.refresh_from_db()
+    assert PostStates.handle_question_open(post) is None
+    assert not edited_fan_outs(post).exists()
+
+
+@pytest.mark.django_db
+def test_question_open_hide_totals(
+    identity: Identity, identity2: Identity, config_system
+):
+    post = make_local_poll(identity, hide_totals=True)
+    PostInteraction.create_votes(post, identity2, [0])
+    post.refresh_from_db()
+    # Hidden totals: no tally Updates while the poll is running
+    assert PostStates.handle_question_open(post) is None
+    assert not edited_fan_outs(post).exists()
+    # Per-option tallies are hidden in the API and over AP
+    assert post.type_data.to_mastodon_json(post)["options"][0]["votes_count"] is None
+    ap = post.to_ap()
+    assert ap["oneOf"][0]["replies"]["totalItems"] == 0
+
+    # The final Update after expiry reveals the tallies
+    expire_poll(post)
+    post.refresh_from_db()
+    assert PostStates.handle_question_open(post) == PostStates.fanned_out
+    assert edited_fan_outs(post).exists()
+    post.refresh_from_db()
+    assert post.type_data.to_mastodon_json(post)["options"][0]["votes_count"] == 1
+    assert post.to_ap()["oneOf"][0]["replies"]["totalItems"] == 1
+
+
+@pytest.mark.django_db
+def test_question_open_expiry_notifies_and_closes(
+    identity: Identity, identity2: Identity, config_system
+):
+    post = make_local_poll(identity)
+    PostInteraction.create_votes(post, identity2, [1])
+    post.refresh_from_db()
+    expire_poll(post)
+    post.refresh_from_db()
+
+    assert PostStates.handle_question_open(post) == PostStates.fanned_out
+    assert edited_fan_outs(post).exists()
+    # Both the author and the local voter get a poll-ended notification
+    assert TimelineEvent.objects.filter(
+        identity=identity, type=TimelineEvent.Types.poll, subject_post=post
+    ).exists()
+    assert TimelineEvent.objects.filter(
+        identity=identity2, type=TimelineEvent.Types.poll, subject_post=post
+    ).exists()
+    # The final AP representation carries `closed`
+    ap = post.to_ap()
+    assert ap["closed"] == ap["endTime"]
+
+
+@pytest.mark.django_db
+def test_remote_poll_vote_tracks_expiry(
+    identity: Identity, remote_identity: Identity, config_system
+):
+    post = Post.objects.create(
+        author=remote_identity,
+        local=False,
+        content="<p>Test Question</p>",
+        object_uri="https://remote.test/status/poll-track",
+        state=PostStates.fanned_out,
+        type=Post.Types.question,
+        type_data={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 3},
+                {"name": "Option 2", "type": "Note", "votes": 4},
+            ],
+            "voter_count": 7,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+    post.refresh_from_db()
+    PostInteraction.create_votes(post, identity, [0])
+    post.refresh_from_db()
+    # Voting on a remote poll starts expiry tracking
+    assert post.state == str(PostStates.question_open)
+
+    # Not expired yet: stays put and does not notify
+    assert PostStates.handle_question_open(post) is None
+
+    expire_poll(post)
+    post.refresh_from_db()
+    assert PostStates.handle_question_open(post) == PostStates.fanned_out
+    assert TimelineEvent.objects.filter(
+        identity=identity, type=TimelineEvent.Types.poll, subject_post=post
+    ).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_refresh_question_from_remote(
+    httpx_mock: HTTPXMock, identity: Identity, remote_identity: Identity, config_system
+):
+    post = Post.objects.create(
+        author=remote_identity,
+        local=False,
+        content="<p>Test Question</p>",
+        object_uri="https://remote.test/status/poll-refresh",
+        state=PostStates.fanned_out,
+        type=Post.Types.question,
+        type_data={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 3},
+                {"name": "Option 2", "type": "Note", "votes": 4},
+            ],
+            "voter_count": 7,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+    post.refresh_from_db()
+    httpx_mock.add_response(
+        url="https://remote.test/status/poll-refresh",
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                {
+                    "toot": "http://joinmastodon.org/ns#",
+                    "votersCount": "toot:votersCount",
+                },
+            ],
+            "id": "https://remote.test/status/poll-refresh",
+            "type": "Question",
+            "attributedTo": remote_identity.actor_uri,
+            "content": "<p>Test Question</p>",
+            "endTime": format_ld_date(timezone.now() + timedelta(1)),
+            "votersCount": 12,
+            "oneOf": [
+                {
+                    "name": "Option 1",
+                    "type": "Note",
+                    "replies": {"type": "Collection", "totalItems": 5},
+                },
+                {
+                    "name": "Option 2",
+                    "type": "Note",
+                    "replies": {"type": "Collection", "totalItems": 7},
+                },
+            ],
+        },
+    )
+    refreshed = post.refresh_question_if_stale()
+    assert isinstance(refreshed.type_data, QuestionData)
+    assert refreshed.type_data.voter_count == 12
+    assert refreshed.type_data.options[0].votes == 5
+    assert refreshed.type_data.last_fetched is not None
+    # A fresh fetch within a minute is skipped (no second request mocked)
+    assert refreshed.refresh_question_if_stale().type_data.voter_count == 12

--- a/takahe/tests/api/test_polls.py
+++ b/takahe/tests/api/test_polls.py
@@ -161,6 +161,7 @@ def test_poll_hide_totals(api_client, identity2):
             "can't contain more than",
         ),
         ({"options": ["A", "A"], "expires_in": 300}, "duplicate"),
+        ({"options": ["A", "  "], "expires_in": 300}, "blank"),
         ({"options": ["A", "B" * 51], "expires_in": 300}, "characters each"),
         ({"options": ["A", "B"], "expires_in": 60}, "too soon"),
         ({"options": ["A", "B"], "expires_in": 3000000}, "too far into the future"),
@@ -271,3 +272,25 @@ def test_poll_notification(api_client, identity, identity2):
     assert response[0]["type"] == "poll"
     assert response[0]["status"]["id"] == str(post.id)
     assert response[0]["account"]["id"] == str(identity2.id)
+
+
+@pytest.mark.django_db
+def test_poll_visibility_respected(api_client, identity2):
+    post = Post.create_local(
+        author=identity2,
+        content="<p>Followers only poll</p>",
+        visibility=Post.Visibilities.followers,
+        question={
+            "type": "Question",
+            "mode": "oneOf",
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 0},
+                {"name": "Option 2", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "end_time": format_ld_date(timezone.now() + timedelta(1)),
+        },
+    )
+    # The API identity does not follow identity2, so the poll is invisible
+    assert api_client.get(f"/api/v1/polls/{post.id}").status_code == 404
+    assert vote(api_client, post.id, [0]).status_code == 404

--- a/takahe/tests/api/test_polls.py
+++ b/takahe/tests/api/test_polls.py
@@ -3,8 +3,36 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
-from activities.models import Post
+from activities.models import Post, PostInteraction, TimelineEvent
+from activities.models.post_types import POLL_MAX_OPTIONS
 from core.ld import format_ld_date
+
+
+def make_poll_post(author, mode="oneOf", hide_totals=False, expires=timedelta(1)):
+    return Post.create_local(
+        author=author,
+        content="<p>Test Question</p>",
+        question={
+            "type": "Question",
+            "mode": mode,
+            "options": [
+                {"name": "Option 1", "type": "Note", "votes": 0},
+                {"name": "Option 2", "type": "Note", "votes": 0},
+                {"name": "Option 3", "type": "Note", "votes": 0},
+            ],
+            "voter_count": 0,
+            "hide_totals": hide_totals,
+            "end_time": format_ld_date(timezone.now() + expires),
+        },
+    )
+
+
+def vote(api_client, post_id, choices):
+    return api_client.post(
+        f"/api/v1/polls/{post_id}/votes",
+        content_type="application/json",
+        data={"choices": choices},
+    )
 
 
 @pytest.mark.django_db
@@ -33,30 +61,213 @@ def test_get_poll(api_client):
 
 @pytest.mark.django_db
 def test_vote_poll(api_client, identity2):
-    post = Post.create_local(
-        author=identity2,
-        content="<p>Test Question</p>",
-        question={
-            "type": "Question",
-            "mode": "oneOf",
-            "options": [
-                {"name": "Option 1", "type": "Note", "votes": 0},
-                {"name": "Option 2", "type": "Note", "votes": 0},
-            ],
-            "voter_count": 0,
-            "end_time": format_ld_date(timezone.now() + timedelta(1)),
-        },
-    )
+    post = make_poll_post(identity2)
 
-    response = api_client.post(
-        f"/api/v1/polls/{post.id}/votes",
-        content_type="application/json",
-        data={
-            "choices": [0],
-        },
-    ).json()
+    response = vote(api_client, post.id, [0]).json()
 
     assert response["id"] == str(post.id)
     assert response["voted"]
     assert response["votes_count"] == 1
     assert response["own_votes"] == [0]
+
+
+@pytest.mark.django_db
+def test_vote_poll_own_poll_rejected(api_client, identity):
+    post = make_poll_post(identity)
+    response = vote(api_client, post.id, [0])
+    assert response.status_code == 422
+    assert "own poll" in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_vote_poll_invalid_choice(api_client, identity2):
+    post = make_poll_post(identity2)
+    response = vote(api_client, post.id, [3])
+    assert response.status_code == 422
+    assert "does not exist" in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_vote_poll_no_choices(api_client, identity2):
+    post = make_poll_post(identity2)
+    response = vote(api_client, post.id, [])
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_vote_poll_twice_rejected(api_client, identity2):
+    post = make_poll_post(identity2)
+    assert vote(api_client, post.id, [0]).status_code == 200
+    response = vote(api_client, post.id, [1])
+    assert response.status_code == 422
+    assert "already voted" in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_vote_poll_single_choice_multiple_votes_rejected(api_client, identity2):
+    post = make_poll_post(identity2)
+    response = vote(api_client, post.id, [0, 1])
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_vote_poll_multiple_additive(api_client, identity2):
+    post = make_poll_post(identity2, mode="anyOf")
+    assert vote(api_client, post.id, [0]).status_code == 200
+    # Adding a different choice later is allowed on multiple-choice polls
+    response = vote(api_client, post.id, [1]).json()
+    assert sorted(response["own_votes"]) == [0, 1]
+    assert response["votes_count"] == 2
+    assert response["voters_count"] == 1
+    # Re-voting an already chosen option is not
+    assert vote(api_client, post.id, [1]).status_code == 422
+
+
+@pytest.mark.django_db
+def test_vote_poll_expired(api_client, identity2):
+    post = make_poll_post(identity2, expires=timedelta(hours=-1))
+    response = vote(api_client, post.id, [0])
+    assert response.status_code == 422
+    assert "already ended" in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_poll_hide_totals(api_client, identity2):
+    post = make_poll_post(identity2, hide_totals=True)
+    response = vote(api_client, post.id, [0]).json()
+    assert response["options"][0]["votes_count"] is None
+    assert response["votes_count"] == 1
+    assert response["own_votes"] == [0]
+
+    # Once the poll ends, the tallies are revealed
+    post.refresh_from_db()
+    post.type_data.end_time = timezone.now() - timedelta(hours=1)
+    post.save()
+    response = api_client.get(f"/api/v1/polls/{post.id}").json()
+    assert response["expired"]
+    assert response["options"][0]["votes_count"] == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "poll,error",
+    [
+        ({"options": ["A"], "expires_in": 300}, "more than one item"),
+        (
+            {
+                "options": [f"O{i}" for i in range(POLL_MAX_OPTIONS + 1)],
+                "expires_in": 300,
+            },
+            "can't contain more than",
+        ),
+        ({"options": ["A", "A"], "expires_in": 300}, "duplicate"),
+        ({"options": ["A", "B" * 51], "expires_in": 300}, "characters each"),
+        ({"options": ["A", "B"], "expires_in": 60}, "too soon"),
+        ({"options": ["A", "B"], "expires_in": 3000000}, "too far into the future"),
+    ],
+)
+def test_create_poll_validation(api_client, poll, error):
+    response = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={"status": "Poll!", "poll": poll},
+    )
+    assert response.status_code == 422
+    assert error in response.json()["error"]
+
+
+@pytest.mark.django_db
+def test_create_poll_max_options_allowed(api_client):
+    response = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={
+            "status": "Poll!",
+            "poll": {
+                "options": [f"O{i}" for i in range(POLL_MAX_OPTIONS)],
+                "expires_in": 300,
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert len(response.json()["poll"]["options"]) == POLL_MAX_OPTIONS
+
+
+@pytest.mark.django_db
+def test_create_poll_with_media_rejected(api_client):
+    response = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={
+            "status": "Poll!",
+            "media_ids": ["12345"],
+            "poll": {"options": ["A", "B"], "expires_in": 300},
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.django_db
+def test_edit_poll(api_client, identity, identity2):
+    response = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={
+            "status": "Poll!",
+            "poll": {"options": ["A", "B"], "expires_in": 3600},
+        },
+    ).json()
+    post = Post.objects.get(pk=response["id"])
+    PostInteraction.create_votes(post, identity2, [0])
+    post.refresh_from_db()
+    assert post.type_data.options[0].votes == 1
+
+    # Editing without changing the options keeps the votes
+    response = api_client.put(
+        f"/api/v1/statuses/{post.id}",
+        content_type="application/json",
+        data={
+            "status": "Poll! (edited)",
+            "poll": {"options": ["A", "B"], "expires_in": 3600},
+        },
+    ).json()
+    assert response["poll"]["votes_count"] == 1
+
+    # Changing the options resets all votes
+    response = api_client.put(
+        f"/api/v1/statuses/{post.id}",
+        content_type="application/json",
+        data={
+            "status": "Poll! (edited again)",
+            "poll": {"options": ["X", "Y", "Z"], "expires_in": 3600},
+        },
+    ).json()
+    assert response["poll"]["votes_count"] == 0
+    assert [o["title"] for o in response["poll"]["options"]] == ["X", "Y", "Z"]
+    post.refresh_from_db()
+    assert not post.interactions.filter(type=PostInteraction.Types.vote).exists()
+
+    # Removing the poll turns the post back into a plain note
+    response = api_client.put(
+        f"/api/v1/statuses/{post.id}",
+        content_type="application/json",
+        data={"status": "No poll anymore"},
+    ).json()
+    assert response["poll"] is None
+    post.refresh_from_db()
+    assert post.type == Post.Types.note
+
+
+@pytest.mark.django_db
+def test_poll_notification(api_client, identity, identity2):
+    post = make_poll_post(identity2)
+    TimelineEvent.add_poll_ended(identity, post)
+
+    response = api_client.get(
+        "/api/v1/notifications",
+        data={"types[]": ["poll"]},
+    ).json()
+    assert len(response) == 1
+    assert response[0]["type"] == "poll"
+    assert response[0]["status"]["id"] == str(post.id)
+    assert response[0]["account"]["id"] == str(identity2.id)


### PR DESCRIPTION
## Summary

Completes poll (ActivityPub `Question`) support in takahe, closing the gaps against Mastodon's implementation (researched against mastodon/mastodon main).

### Federation
- **Tally Updates for local polls**: a new `question_open` stator state watches open polls and federates throttled `Update` activities (~5 min cadence, analogous to Mastodon's 3-minute throttle) to followers and voters whenever tallies change, so remote instances no longer show stale/zero results for local polls.
- **Poll closing**: when a local poll expires, a final `Update` carrying `closed` is federated (revealing hidden totals if any).
- **Inbound `closed` parsing**: polls from servers that send only `closed` (datetime or boolean, including invalid datetimes seen in the wild like hour 26) now expire correctly.
- **Malformed inbound votes** (missing/unknown option name) are dropped instead of erroring the inbox message.
- **Stale remote poll refresh**: `GET /api/v1/polls/:id` re-fetches a remote poll from origin if last fetched over a minute ago, and once more after expiry for final tallies (mirrors Mastodon's `possibly_stale?` logic).

### Notifications
- New `poll` notification type (timeline event, Mastodon API `type: "poll"`, web push) sent to the author and local voters when a poll ends — including remote polls a local user voted on, which are now tracked for expiry.

### Client API
- Poll composition limits enforced, matching what `/api/v1/instance` advertises: 2–42 options (max raised from Mastodon's default 4), 50 chars per option, no duplicates, expiry 5 minutes–1 month.
- Poll editing via `PUT /api/v1/statuses/:id`: add, change, or remove a poll; changing options/mode resets votes (Mastodon behavior). Also fixes a pre-existing 500 when editing any poll post (`type_data` guard assumed a dict).
- `hide_totals` honored: per-option tallies hidden until expiry (API returns `votes_count: null`, AP emits 0), no tally Updates while hidden.
- Vote validation parity: self-votes rejected, out-of-range/empty choices rejected, additive voting allowed on multiple-choice polls (re-voting the same option rejected), expired-poll votes rejected — all as 422 with Mastodon-style messages instead of 500s.

### Notes
- The `TimelineEvent.type` choices change is folded into the existing migration `0026_alter_timelineevent_type` (choices-only, no schema change); `makemigrations --check` is clean.
- Pre-existing open polls (created before deploy) remain in `fanned_out` and won't distribute tally Updates; polls created after deploy get the full lifecycle.
- NeoDB's own web UI intentionally untouched: its notification page uses an explicit type whitelist, and poll rendering there is out of scope. Polls are fully served via the Mastodon API.

## Test plan
- 402 takahe tests pass locally (postgres+redis), including ~25 new ones covering: creation validation (incl. 42-option boundary), vote validation (self-vote, bounds, double-vote, additive anyOf), hide_totals (API+AP), `closed` parsing (datetime/boolean/invalid), question_open lifecycle (tally fan-out, throttling, expiry notifications, remote tracking), remote refresh via mocked HTTP, poll editing (keep/reset/remove), and poll notifications API.
- `uv run pre-commit run -a` clean.