### PR TITLE
fix(takahe): coerce relationship notify/boosts to bool

### DIFF
--- a/takahe/tests/api/test_new_endpoints.py
+++ b/takahe/tests/api/test_new_endpoints.py
@@ -140,3 +140,36 @@ def test_account_note_in_relationship(api_client, identity, other_identity):
     data = response.json()
     assert len(data) == 1
     assert data[0]["note"] == "My note"
+
+
+@pytest.mark.django_db
+def test_relationship_null_boolean_columns(identity, other_identity):
+    """
+    Legacy/imported follow rows can hold NULL in the notify/boosts columns.
+    The relationship JSON must coerce these to real booleans so the Mastodon
+    Relationship schema validation does not fail (NEODB-SOCIAL-7RP).
+    """
+    from api.schemas import Relationship
+    from users.models.follow import Follow, FollowStates
+    from users.services import IdentityService
+
+    follow = Follow.create_local(source=identity, target=other_identity)
+    follow.state = FollowStates.accepted
+    # Simulate NULL columns from imported data.
+    follow.notify = None
+    follow.boosts = None
+
+    relationships = {
+        "outbound_follow": follow,
+        "inbound_follow": None,
+        "outbound_block": None,
+        "inbound_block": None,
+        "outbound_mute": None,
+    }
+    data = IdentityService(other_identity)._build_relationship_json(
+        relationships, identity
+    )
+    assert data["notifying"] is False
+    assert data["showing_reblogs"] is False
+    # Must not raise pydantic ValidationError.
+    Relationship(**data)

--- a/takahe/users/services/identity.py
+++ b/takahe/users/services/identity.py
@@ -308,11 +308,11 @@ class IdentityService:
                 relationships["inbound_follow"] is not None
                 and relationships["inbound_follow"].accepted
             ),
-            "showing_reblogs": (
+            "showing_reblogs": bool(
                 relationships["outbound_follow"] is not None
                 and relationships["outbound_follow"].boosts
             ),
-            "notifying": (
+            "notifying": bool(
                 relationships["outbound_follow"] is not None
                 and relationships["outbound_follow"].notify
             ),


### PR DESCRIPTION
## Problem

The Mastodon API endpoint `GET /api/v1/accounts/relationships` intermittently returns a 500 with:

```
ValidationError: 1 validation error for account_relationships_output
value.N.notifying
  Input should be a valid boolean [type=bool_type, input_value=None, input_type=NoneType]
```

(Sentry NEODB-SOCIAL-7RP)

## Root cause

`IdentityService._build_relationship_json` builds `notifying` and `showing_reblogs` from the raw `Follow.notify` / `Follow.boosts` columns:

```python
"notifying": relationships["outbound_follow"] is not None
             and relationships["outbound_follow"].notify,
```

Some follow rows (legacy / federated-imported data) hold `NULL` in these columns. Due to Python's `and` short-circuit, `True and None` evaluates to `None`, which then fails the `Relationship` Pydantic schema's `notifying: bool` validation and 500s the request. The other boolean fields are unaffected because they derive from state comparisons that always return real bools.

## Fix

Wrap both expressions in `bool(...)` so a `NULL` column value coerces to `False`.

## Test

Adds `test_relationship_null_boolean_columns`, which simulates a follow with `notify=None`/`boosts=None`, asserts the JSON yields real `False` booleans, and validates the result against the `Relationship` schema so the error cannot recur.

Fixes NEODB-SOCIAL-7RP