### PR TITLE
fix(journal): keep book reading progress private on profiles

### DIFF
--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -580,7 +580,7 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
                 Item.external_resources_prefetch(lookup="item__external_resources"),
             )
         )
-        is_owner = request.user.is_authenticated and request.user.identity == target
+        is_owner = request.user.is_authenticated and target.user == request.user
         # Reading progress is private; only show the badge to the shelf owner.
         show_progress_badges = (
             is_owner

--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -580,14 +580,16 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
                 Item.external_resources_prefetch(lookup="item__external_resources"),
             )
         )
+        is_owner = request.user.is_authenticated and request.user.identity == target
+        # Reading progress is private; only show the badge to the shelf owner.
         show_progress_badges = (
-            item_category == ItemCategory.Book and shelf_type_enum == ShelfType.PROGRESS
+            is_owner
+            and item_category == ItemCategory.Book
+            and shelf_type_enum == ShelfType.PROGRESS
         )
         if show_progress_badges:
             members_queryset = members_queryset.select_related("current_progress")
-            can_update_progress = (
-                request.user.is_authenticated and request.user.identity == target
-            )
+            can_update_progress = True
         if people_type:
             members_queryset = members_queryset.filter(
                 item__people__people_type=people_type

--- a/neodb/tests/journal/test_mark.py
+++ b/neodb/tests/journal/test_mark.py
@@ -365,6 +365,33 @@ def test_edition_and_profile_show_and_update_book_progress(client):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_profile_book_progress_badge_hidden_from_non_owner(client):
+    owner = User.register(email="progress-owner@example.com", username="progressowner")
+    book = Edition.objects.create(title="Private Progress Book")
+    mark = Mark(owner.identity, book)
+    mark.update(ShelfType.PROGRESS, visibility=0)
+    mark.set_progress(Note.ProgressType.CHAPTER, "7")
+
+    viewer = User.register(
+        email="progress-viewer@example.com", username="progressviewer"
+    )
+    client.force_login(viewer, backend="mastodon.auth.OAuth2Backend")
+
+    response = client.get(
+        f"/users/{owner.username}/profile/book/progress/items",
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    # The public shelf still lists the book, but the private reading
+    # progress must not leak to anyone other than the owner.
+    assert 'class="card progress-card"' in content
+    assert book.display_title in content
+    assert 'class="progress-badge"' not in content
+    assert "ch7" not in content
+    assert "Chapter 7" not in content
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_note_and_progress_dialog_modes(client):
     user = User.register(email="note-progress@example.com", username="noteprogress")
     book = Edition.objects.create(title="Note Progress Book")


### PR DESCRIPTION
## Problem

The reading progress badge added in "Add current reading progress" is rendered on the book **Reading** shelf of a user's profile for **any** viewer. This exposes the owner's private page/chapter position: `profile_shelf_items` set `show_progress_badges` based only on category/shelf type, and attached `reading_progress` / `reading_progress_short` to the items whenever badges were shown. The owner check only governed whether the badge was *editable*, not whether the value was *visible*.

Note the mark's shelf visibility governs whether the book appears on the shelf at all; the progress value is a separate detail that should stay private regardless.

## Fix

In `profile_shelf_items`, gate `show_progress_badges` on the viewer being the shelf owner. Because the progress data is only attached inside that block, non-owners now receive neither the badge nor the underlying value.

The `_sidebar.html` "Currently reading" section is unaffected: it is only populated for the logged-in user's own home/feed, never for another user's profile.

## Tests

- Added `test_profile_book_progress_badge_hidden_from_non_owner`: a non-owner viewing a public reading shelf still sees the book card but not the `progress-badge` nor the progress value.
- Existing owner test `test_edition_and_profile_show_and_update_book_progress` still passes (owner keeps the editable badge).
- Ran `tests/journal/test_mark.py`, `tests/social/test_pages.py`, `tests/journal/test_n_plus_one.py`: 75 passed.