### PR TITLE
log collection add-item, import/export, register and account close

### DIFF
--- a/neodb/common/sentry.py
+++ b/neodb/common/sentry.py
@@ -47,6 +47,8 @@ def count(
 def record_activity(action: str, source: str) -> None:
     """Emit a `user.activity` counter for a user-initiated content action.
 
-    ``source`` is ``"api"`` or ``"web"``; importers should not call this.
+    ``source`` is ``"api"`` or ``"web"``. Call this at the view/API layer;
+    importer/exporter per-item processing should not call it (the import or
+    export *start* is recorded by the triggering view instead).
     """
     count("user.activity", attributes={"action": action, "source": source})

--- a/neodb/common/sentry.py
+++ b/neodb/common/sentry.py
@@ -45,7 +45,7 @@ def count(
 
 
 def record_activity(action: str, source: str) -> None:
-    """Emit a `user.activity` counter for a user-initiated content action.
+    """Emit a `user.activity` counter for a user-initiated action.
 
     ``source`` is ``"api"`` or ``"web"``. Call this at the view/API layer;
     importer/exporter per-item processing should not call it (the import or

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -523,6 +523,7 @@ def collection_add_item(
     if not item:
         return Status(404, {"message": "Item not found"})
     c.append_item(item, note=collection_item.note)
+    record_activity("collection", "api")
     return Status(200, {"message": "OK"})
 
 

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -57,6 +57,7 @@ def add_to_collection(request: AuthedHttpRequest, item_uuid):
             ).pk
         collection = Collection.objects.get(owner=request.user.identity, id=cid)
         collection.append_item(item, note=request.POST.get("note"))
+        record_activity("collection", "web")
         referer = request.META.get("HTTP_REFERER") or ""
         if not url_has_allowed_host_and_scheme(
             referer,
@@ -463,6 +464,7 @@ def collection_append_item(request: AuthedHttpRequest, collection_uuid):
     member = None
     if item:
         member, new = collection.append_item(item, note=note)
+        record_activity("collection", "web")
         # ``append_item`` fires the ``list_add`` signal, which the
         # ``_collection_member_changed`` receiver maps to
         # ``collection.save()`` (and federation re-post). No explicit save

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
 from common.models import SiteConfig
+from common.sentry import record_activity
 from common.utils import AuthedHttpRequest
 from common.validators import sanitize_next_url
 from mastodon.models import (
@@ -164,6 +165,7 @@ def _handle_new_user_registration(request, form, verified_account, email_readonl
         form.add_error("username", e.message)
         return None
     auth_login(request, new_user)
+    record_activity("register", "web")
 
     if not email_readonly and form.cleaned_data["email"]:
         # if new user wants to link email too
@@ -225,6 +227,7 @@ def register(request: AuthedHttpRequest):
                     },
                 )
             auth_login(request, new_user)
+            record_activity("register", "web")
             return render(request, "users/welcome.html")
         else:
             return redirect(request.session.get("next_url", reverse("common:home")))
@@ -319,6 +322,7 @@ def clear_data(request):
         for acct in request.user.social_accounts.all():
             if acct.handle == v:
                 initiate_user_deletion(request.user)
+                record_activity("leave", "web")
                 messages.add_message(
                     request, messages.INFO, _("Account is being deleted.")
                 )

--- a/neodb/users/views/data.py
+++ b/neodb/users/views/data.py
@@ -22,6 +22,7 @@ from catalog.common import SiteManager
 from catalog.models import Item, SiteName
 from catalog.sites import FediverseInstance
 from common.models import SiteConfig
+from common.sentry import record_activity
 from common.utils import GenerateDateUUIDMediaFilePath
 from journal.exporters import CsvExporter, DoufenExporter, NdjsonExporter
 from journal.importers import (
@@ -258,6 +259,7 @@ def export_marks(request):
     # TODO: deprecated
     if request.method == "POST":
         DoufenExporter.create(request.user).enqueue()
+        record_activity("export", "web")
         messages.add_message(request, messages.INFO, _("Generating exports."))
         return redirect(reverse("users:data"))
     else:
@@ -295,6 +297,7 @@ def export_csv(request):
             )
             return redirect(reverse("users:data"))
         CsvExporter.create(request.user).enqueue()
+        record_activity("export", "web")
         return redirect(
             reverse("users:user_task_status", args=("journal.csvexporter",))
         )
@@ -315,6 +318,7 @@ def export_ndjson(request):
             )
             return redirect(reverse("users:data"))
         NdjsonExporter.create(request.user).enqueue()
+        record_activity("export", "web")
         return redirect(
             reverse("users:user_task_status", args=("journal.ndjsonexporter",))
         )
@@ -451,6 +455,7 @@ def import_goodreads(request):
         file=f,
     )
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -469,6 +474,8 @@ def import_rym_upload(request):
         return redirect(reverse("users:data"))
     if not RymImporter.validate_file(request.FILES.get("file")):
         raise BadRequest(_("Invalid file."))
+    # record once at import start; the confirm step re-enqueues the same task.
+    record_activity("import", "web")
     f = (
         settings.MEDIA_ROOT
         + "/"
@@ -692,6 +699,8 @@ def import_storygraph(request):
         return redirect(reverse("users:data"))
     if not StoryGraphImporter.validate_file(request.FILES.get("file")):
         raise BadRequest(_("Invalid file."))
+    # record once at import start; the confirm step re-enqueues the same task.
+    record_activity("import", "web")
     f = (
         settings.MEDIA_ROOT
         + "/"
@@ -923,6 +932,7 @@ def import_douban(request):
         file=f,
     )
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -947,6 +957,7 @@ def import_letterboxd(request):
         file=f,
     )
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -971,6 +982,7 @@ def import_trakt(request):
         file=f,
     )
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -996,6 +1008,7 @@ def import_opml(request):
         file=f,
     )
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -1028,6 +1041,7 @@ def import_neodb(request):
             file=f,
         )
         task.enqueue()
+        record_activity("import", "web")
         return redirect(reverse("users:user_task_status", args=(task.type,)))
     return redirect(reverse("users:data"))
 
@@ -1086,6 +1100,7 @@ def import_steam(request):
 
     task = SteamImporter.create(user=request.user, **metadata)
     task.enqueue()
+    record_activity("import", "web")
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
@@ -1306,6 +1321,7 @@ def import_social_graph(request):
         messages.error(request, _("No valid entries found in the CSV file."))
         return redirect(reverse("users:info"))
 
+    record_activity("import", "web")
     django_rq.get_queue("mastodon").enqueue(
         _import_social_graph_task, identity.pk, import_type, entries
     )
@@ -1321,6 +1337,7 @@ def import_social_graph(request):
 @login_required
 def export_social_graph_csv(request, export_type: str):
     identity = request.user.identity
+    record_activity("export", "web")
 
     response = HttpResponse(content_type="text/csv")
 

--- a/takahe/api/views/statuses.py
+++ b/takahe/api/views/statuses.py
@@ -21,6 +21,7 @@ from activities.models.post_types import (
     POLL_MIN_EXPIRATION,
 )
 from activities.services import PostService
+from core import sentry
 from users.models import Identity
 from api import schemas
 from api.decorators import scope_required
@@ -248,6 +249,7 @@ def post_status(request, details: PostStatusSchema) -> schemas.Status:
     )
     # Add their own timeline event for immediate visibility
     TimelineEvent.add_post(request.identity, post)
+    sentry.record_activity("post", "api")
     return schemas.Status.from_post(post, identity=request.identity)
 
 

--- a/takahe/core/sentry.py
+++ b/takahe/core/sentry.py
@@ -45,6 +45,16 @@ def count(key: str, value: float = 1, attributes: dict[str, str] | None = None):
     _metrics_count(key, value, attributes=attributes or {})
 
 
+def record_activity(action: str, source: str) -> None:
+    """Emit a `user.activity` counter for a user-initiated action.
+
+    Mirror of neodb's ``common.sentry.record_activity`` for the takahe-served
+    Mastodon API; takahe is a separate project and cannot import the neodb
+    package, so the counter is re-emitted here with the same key/attributes.
+    """
+    count("user.activity", attributes={"action": action, "source": source})
+
+
 def distribution(
     key: str,
     value: float,


### PR DESCRIPTION
## What

Extend `record_activity()` (the `user.activity` Sentry counter) to user actions that previously emitted nothing.

### Added

- **Add item to collection** -- `record_activity("collection", ...)` in `add_to_collection` and `collection_append_item` (web) and the `collection_add_item` API, matching the existing `"collection"` action used for collection create/edit/cover.
- **Start import/export** -- `record_activity("import"|"export", "web")` at the triggering views in `users/views/data.py`: all importers (Goodreads, RYM, StoryGraph, Douban, Letterboxd, Trakt, OPML, NeoDB CSV/NDJSON, Steam) and exporters (marks/xlsx, CSV, NDJSON), plus social-graph import/export.
- **Register** -- `record_activity("register", "web")` at both web registration completion points in `users/views/account.py`, right after the new user is logged in.
- **Leave / close account** -- `record_activity("leave", "web")` in `clear_data`, once account deletion is initiated.
- **New post via the Mastodon API** -- `record_activity("post", "api")` in takahe's `post_status` (`POST /api/v1/statuses`). Takahe is a separate project and cannot import neodb's `common.sentry`, so a mirror `record_activity()` is added to `takahe/core/sentry.py` that re-emits the same `user.activity` counter. Only creation is recorded; edits are not.

## Notes

- **Progress** already records `"progress"` (mark/note views + shelf API) -- unchanged.
- **New post and article in the NeoDB layer already record** `"post"`/`"article"` (post compose/reply/quote, `article_edit`, and the article API), so no change was needed there.
- **No double-counting for multi-phase imports:** RYM and StoryGraph enqueue twice (upload then confirm); recording happens once at the upload start.
- **Programmatic `User.register` callers** (superuser/CLI bootstrap) stay uncounted -- recording is at the view layer, consistent with the existing convention that keeps importer per-item processing from inflating the counter.

## Testing

`ruff`, `ruff-format`, `djlint`, and `ty` all pass via `pre-commit run -a`.
