### PR TITLE
Progressively reveal profile shelves during load

### DIFF
--- a/neodb/journal/templates/profile.html
+++ b/neodb/journal/templates/profile.html
@@ -237,6 +237,33 @@
           $('.unsorted .entity-sort').each((i, elem) => {
               $('.sortable').append(elem);
           });
+          // Progressively reveal shelves: show only the first section's loading
+          // state and keep the rest hidden until the preceding one has finished
+          // loading, so the page fills top-to-bottom instead of showing a stack
+          // of placeholders that then grow or get removed. Lazy (intersect)
+          // loading is preserved: a revealed section still waits until scrolled
+          // into view before it loads.
+          (function () {
+              const sections = Array.prototype.slice
+                  .call(document.querySelectorAll('.sortable > .entity-sort'))
+                  .filter((el) => el.style.display !== 'none');
+              if (sections.length <= 1) return;
+              for (let i = 1; i < sections.length; i++) {
+                  sections[i].style.display = 'none';
+              }
+              let active = 0;
+              const advance = (section) => {
+                  if (sections.indexOf(section) !== active) return;
+                  active += 1;
+                  if (active < sections.length) sections[active].style.display = '';
+              };
+              const onLoaded = (e) => {
+                  const section = e.target.closest && e.target.closest('.entity-sort');
+                  if (section) advance(section);
+              };
+              document.body.addEventListener('htmx:afterSettle', onLoaded);
+              document.body.addEventListener('htmx:afterRequest', onLoaded);
+          })();
           </script>
           {% if identity.user == request.user %}
             <div class="entity-sort-control">


### PR DESCRIPTION
## What

The user profile page lazy-loads many shelf sections via htmx (`hx-trigger="intersect once"`). Previously, every section within the initial viewport rendered its placeholder at the same time, and then each one either grew to fit its content or was removed when empty. The result was a stack of placeholders that visibly shifted, grew, and collapsed while the page loaded.

## Change

Show only the **first** section's loading state and keep the rest hidden until the preceding section has finished loading, so the page fills top-to-bottom without the layout shift.

- Implemented in the existing inline layout script in `journal/templates/profile.html`, right after sections are arranged into `.sortable`.
- At parse time, all shelves except the first are set to `display:none`. htmx's `IntersectionObserver` is still attached to each (it only fires on `isIntersecting`, and never consumes the `once` budget while hidden), so revealing a section later triggers its lazy load exactly once.
- On each section's `htmx:afterSettle` / `htmx:afterRequest`, the next section is revealed. `afterRequest` is also handled so a failed request does not stall the chain.

## Preserved behavior

- **Lazy loading is preserved**: a revealed section still waits until it is scrolled into view before loading, so below-the-fold shelves are not eagerly fetched.
- **Layout editor is untouched**: entering edit mode reveals all sections (`.show()`), which overrides the inline `display`, and the post-load DOM state (visible vs. empty-hidden vs. layout-hidden shelves) is identical to before. Only layout-visible shelves participate in the reveal chain.

## Testing

Reviewed against htmx 2.0.8's `intersect` implementation to confirm a `display:none` element reveals-and-loads correctly. `pre-commit` (djLint etc.) passes. Recommend a visual confirmation in Chrome, including the layout editor.