### PR TITLE
feat(journal): overlay reading progress bar on book covers

### DIFF
--- a/neodb/common/static/scss/_mark.scss
+++ b/neodb/common/static/scss/_mark.scss
@@ -43,6 +43,36 @@
   text-align: center;
 }
 
+// The cover wrapper anchors overlays (badge, progress bar) to the image edges.
+.shelf .progress-card .cover {
+  position: relative;
+  display: block;
+}
+
+.shelf .progress-card .cover > img {
+  display: block;
+}
+
+// Reading progress bar overlaid along the bottom of the book cover. Inset by
+// 2px to sit inside the cover's transparent border.
+.shelf .progress-card .cover > .progress-bar {
+  position: absolute;
+  inset-inline: 2px;
+  bottom: 2px;
+  z-index: 1;
+  height: 0.3rem;
+  border-radius: 0.15rem;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.shelf .progress-card .cover > .progress-bar > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--pico-primary-background);
+}
+
 #mark_date {
   width: unset !important;
 }

--- a/neodb/common/templates/_sidebar.html
+++ b/neodb/common/templates/_sidebar.html
@@ -170,9 +170,16 @@
               {% for item in books_in_progress %}
                 <li class="card progress-card">
                   <a href="{{ item.url }}" title="{{ item.display_title }}">
-                    <img src="{{ item.cover|thumb:'normal' }}"
-                         alt="{{ item.display_title }}"
-                         loading="lazy">
+                    <span class="cover">
+                      <img src="{{ item.cover|thumb:'normal' }}"
+                           alt="{{ item.display_title }}"
+                           loading="lazy">
+                      {% if item.reading_progress_percent %}
+                        <span class="progress-bar" title="{{ item.reading_progress_percent }}%">
+                          <span style="width:{{ item.reading_progress_percent }}%"></span>
+                        </span>
+                      {% endif %}
+                    </span>
                     <div class="card-title">{{ item.display_title }}</div>
                   </a>
                   <a href="#"

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -130,9 +130,14 @@ class Note(Content):
     ) -> int | None:
         """Return reading progress as an integer percent (0-100), if derivable.
 
-        Percentage-type progress is used directly; page-type is converted when
-        the total page count is known. Other types have no known total, so no
-        percentage can be computed and None is returned.
+        Percentage-type progress is used as-is; page-type is converted when a
+        positive total page count is known. Other types, and pages without a
+        usable total, have no derivable percentage and return None.
+
+        Inputs are coerced defensively so a bad value never raises: the value
+        is free-text, and ``total`` comes from an item's metadata JSON where a
+        page count may be stored as a non-int (or be negative/zero). Anything
+        that cannot be parsed into a positive total simply yields None.
         """
         if not progress_value or not _number.match(str(progress_value)):
             return None
@@ -142,8 +147,16 @@ class Note(Content):
             return None
         if progress_type == cls.ProgressType.PERCENTAGE:
             percent = value
-        elif progress_type == cls.ProgressType.PAGE and total:
-            percent = value / total * 100
+        elif progress_type == cls.ProgressType.PAGE:
+            if total is None:
+                return None
+            try:
+                total_pages = float(total)
+            except TypeError, ValueError:
+                return None
+            if total_pages <= 0:
+                return None
+            percent = value / total_pages * 100
         else:
             return None
         return max(0, min(100, round(percent)))

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -121,6 +121,33 @@ class Note(Content):
             return str(progress_value)
         return tpl.format(value=progress_value)
 
+    @classmethod
+    def get_progress_percentage(
+        cls,
+        progress_type: str | None,
+        progress_value: str | None,
+        total: int | None = None,
+    ) -> int | None:
+        """Return reading progress as an integer percent (0-100), if derivable.
+
+        Percentage-type progress is used directly; page-type is converted when
+        the total page count is known. Other types have no known total, so no
+        percentage can be computed and None is returned.
+        """
+        if not progress_value or not _number.match(str(progress_value)):
+            return None
+        try:
+            value = float(str(progress_value))
+        except TypeError, ValueError:
+            return None
+        if progress_type == cls.ProgressType.PERCENTAGE:
+            percent = value
+        elif progress_type == cls.ProgressType.PAGE and total:
+            percent = value / total * 100
+        else:
+            return None
+        return max(0, min(100, round(percent)))
+
     @property
     def ap_object(self):
         d = {

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -644,6 +644,13 @@ class ShelfMemberProgress(models.Model):
 
         return Note.format_progress_short(self.progress_type, self.progress_value)
 
+    def progress_percentage(self, total: int | None = None) -> int | None:
+        from .note import Note
+
+        return Note.get_progress_percentage(
+            self.progress_type, self.progress_value, total
+        )
+
 
 class Shelf(List):
     """

--- a/neodb/journal/templates/profile_items.html
+++ b/neodb/journal/templates/profile_items.html
@@ -24,9 +24,16 @@
   {% for item in items %}
     <li class="card progress-card">
       <a href="{{ item.url }}" title="{{ item.display_title }}">
-        <img src="{{ item.cover|thumb:'normal' }}"
-             alt="{{ item.display_title }}"
-             loading="lazy">
+        <span class="cover">
+          <img src="{{ item.cover|thumb:'normal' }}"
+               alt="{{ item.display_title }}"
+               loading="lazy">
+          {% if item.reading_progress_percent %}
+            <span class="progress-bar" title="{{ item.reading_progress_percent }}%">
+              <span style="width:{{ item.reading_progress_percent }}%"></span>
+            </span>
+          {% endif %}
+        </span>
         <div>{{ item.display_title }}</div>
       </a>
       {% if show_progress_badges %}

--- a/neodb/journal/views/profile.py
+++ b/neodb/journal/views/profile.py
@@ -610,6 +610,11 @@ def profile_shelf_items(request: AuthedHttpRequest, user_name, category, shelf_t
                     member.item.reading_progress_short = (
                         current_progress.progress_short_display
                     )
+                    member.item.reading_progress_percent = (
+                        current_progress.progress_percentage(
+                            getattr(member.item, "pages", None)
+                        )
+                    )
     if items:
         Item.prefetch_parent_items(items)
         Rating.attach_to_items(items)

--- a/neodb/social/views.py
+++ b/neodb/social/views.py
@@ -62,6 +62,9 @@ def _sidebar_context(user):
             rendered_book.reading_progress_short = (
                 current_progress.progress_short_display
             )
+            rendered_book.reading_progress_percent = (
+                current_progress.progress_percentage(book.pages)
+            )
         books_in_progress.append(book)
     tvshows_in_progress = Item.objects.filter(
         id__in=[

--- a/neodb/tests/journal/test_mark.py
+++ b/neodb/tests/journal/test_mark.py
@@ -181,6 +181,36 @@ def test_set_book_progress_logs_change_without_new_post():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_progress_shelf_renders_progress_bar(client):
+    user = User.register(email="progressbar@example.com", username="progressbar")
+    book = Edition.objects.create(title="Bar Book")
+    book.pages = 400
+    book.save()
+    mark = Mark(user.identity, book)
+    mark.update(ShelfType.PROGRESS, visibility=0)
+    mark.set_progress(Note.ProgressType.PAGE, "100")
+
+    url = reverse(
+        "journal:profile_shelf_items", args=[user.username, "book", "progress"]
+    )
+
+    # Owner sees the progress bar; page 100 of 400 converts to 25%.
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    response = client.get(url)
+    assert response.status_code == 200
+    owner_content = response.content.decode()
+    assert "progress-bar" in owner_content
+    assert "width:25%" in owner_content
+
+    # Reading progress is private: another viewer never sees the bar.
+    other = User.register(email="progressbar-other@example.com", username="pbother")
+    client.force_login(other, backend="mastodon.auth.OAuth2Backend")
+    response = client.get(url)
+    assert response.status_code == 200
+    assert "progress-bar" not in response.content.decode()
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_set_book_progress_retries_log_timestamp_collision(monkeypatch):
     user = User.register(email="progress-collision@example.com", username="progressdup")
     book = Edition.objects.create(title="Progress Collision Book")

--- a/neodb/tests/journal/test_note_coverage.py
+++ b/neodb/tests/journal/test_note_coverage.py
@@ -59,6 +59,39 @@ class TestNoteProgressDisplay:
         assert Note.format_progress_short("unknown", "42") == "42"
 
 
+class TestNoteProgressPercentage:
+    def test_percentage_type_used_directly(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "50") == 50
+
+    def test_percentage_type_ignores_total(self):
+        assert (
+            Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "30", 400) == 30
+        )
+
+    def test_percentage_clamped_to_max(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "150") == 100
+
+    def test_page_type_converted_with_total(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100", 400) == 25
+
+    def test_page_type_rounds(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PAGE, "1", 3) == 33
+
+    def test_page_type_without_total(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100") is None
+        assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100", 0) is None
+
+    def test_chapter_type_has_no_percentage(self):
+        assert Note.get_progress_percentage(Note.ProgressType.CHAPTER, "3", 10) is None
+
+    def test_empty_or_non_numeric_value(self):
+        assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, None) is None
+        assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "") is None
+        assert (
+            Note.get_progress_percentage(Note.ProgressType.PAGE, "12-15", 100) is None
+        )
+
+
 class TestNoteExtractProgress:
     def test_track_prefix(self):
         typ, val = Note.extract_progress("trk 5")

--- a/neodb/tests/journal/test_note_coverage.py
+++ b/neodb/tests/journal/test_note_coverage.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 
 from catalog.models import (
@@ -77,9 +79,27 @@ class TestNoteProgressPercentage:
     def test_page_type_rounds(self):
         assert Note.get_progress_percentage(Note.ProgressType.PAGE, "1", 3) == 33
 
-    def test_page_type_without_total(self):
+    def test_page_type_without_usable_total(self):
         assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100") is None
         assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100", 0) is None
+        assert Note.get_progress_percentage(Note.ProgressType.PAGE, "100", -10) is None
+
+    def test_page_type_non_numeric_total(self):
+        # Edition.pages comes from item metadata JSON and may arrive as a
+        # non-int; a total that cannot be parsed must not raise.
+        assert (
+            Note.get_progress_percentage(
+                Note.ProgressType.PAGE, "100", cast(Any, "many")
+            )
+            is None
+        )
+        # A numeric string total is still usable.
+        assert (
+            Note.get_progress_percentage(
+                Note.ProgressType.PAGE, "100", cast(Any, "400")
+            )
+            == 25
+        )
 
     def test_chapter_type_has_no_percentage(self):
         assert Note.get_progress_percentage(Note.ProgressType.CHAPTER, "3", 10) is None
@@ -87,6 +107,10 @@ class TestNoteProgressPercentage:
     def test_empty_or_non_numeric_value(self):
         assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, None) is None
         assert Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "") is None
+        # passes the numeric-ish guard but is not a real number -> no crash
+        assert (
+            Note.get_progress_percentage(Note.ProgressType.PERCENTAGE, "12:30") is None
+        )
         assert (
             Note.get_progress_percentage(Note.ProgressType.PAGE, "12-15", 100) is None
         )


### PR DESCRIPTION
## What

Adds a thin reading-progress bar along the bottom of book covers, complementing the existing top-right progress badge. It appears in two places (owner-only):

- The profile **reading** shelf (`profile_items.html`)
- The sidebar **Currently reading** section (`_sidebar.html`)

## How the percentage is derived

The bar needs a percentage to size its fill:

- **Percentage** progress → used directly (clamped to 0-100)
- **Page** progress → converted to a percentage when the edition's total page count (`Edition.pages`) is known
- **Chapter** progress, or page progress without a known total → no derivable percentage, so no bar is shown

The textual badge (e.g. `p42`) is unchanged; the bar is purely the visual percentage.

## Privacy

Reading progress is private. The percentage is only attached to items for the shelf owner (mirroring the existing badge logic), so other viewers never receive the value and never see the bar. Covered by a regression test.

## Implementation notes

- `Note.get_progress_percentage(progress_type, progress_value, total)` centralizes the conversion; `ShelfMemberProgress.progress_percentage(total)` is a thin wrapper used by the two views.
- Covers are wrapped in a `.cover` positioning context so the bar can anchor to the image's bottom edge; the badge continues to anchor to the card.

## Tests

- `TestNoteProgressPercentage` unit tests for the conversion (percentage passthrough, page→percent, rounding, clamping, no-total, chapter, non-numeric).
- `test_progress_shelf_renders_progress_bar` integration test: renders the reading shelf, asserts a page-100-of-400 book shows `width:25%`, and asserts a different viewer does not see the bar.

All targeted suites pass and `pre-commit run` is clean.