### PR TITLE
fix(catalog): rate-limit and correctly handle IGDB 429s

### DIFF
--- a/neodb/catalog/sites/igdb.py
+++ b/neodb/catalog/sites/igdb.py
@@ -6,6 +6,7 @@ use (e.g. "portal-2") as id, which is different from real id in IGDB API
 
 import datetime
 import json
+import threading
 from urllib.parse import quote_plus
 
 import httpx
@@ -18,11 +19,32 @@ from loguru import logger
 from common.models import normalize_game_platforms
 
 from catalog.common import *
+from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import *
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import SiteConfig
 
 _cache_key = "igdb_access_token"
+
+# IGDB (Twitch-authenticated) documents a 4 requests/second cap per client ID:
+# https://api-docs.igdb.com/#rate-limits. Steam library imports can call
+# api_query several times per game, so throttle every caller through one
+# shared cursor rather than bursting past the cap and getting 429'd.
+_igdb_limiter: RedisRateLimiter | None = None
+_igdb_limiter_lock = threading.Lock()
+
+
+def igdb_limiter() -> RedisRateLimiter:
+    """Singleton limiter for api.igdb.com calls."""
+    global _igdb_limiter
+    if _igdb_limiter is None:
+        with _igdb_limiter_lock:
+            if _igdb_limiter is None:
+                _igdb_limiter = RedisRateLimiter(
+                    key="ratelimit:api.igdb.com",
+                    rate=4.0,
+                )
+    return _igdb_limiter
 
 
 def _igdb_access_token():
@@ -80,9 +102,12 @@ class IGDB(AbstractSite):
                 SiteConfig.system.igdb_client_id, _igdb_access_token()
             )
             try:
+                igdb_limiter().acquire(timeout=60.0)
                 r = json.loads(_wrapper.api_request(p, q))
-            except httpx.HTTPError as e:
-                logger.error(f"IGDB API: {e}", extra={"exception": e})
+            except requests.exceptions.RequestException as e:
+                # Transient third-party failure (rate limit, timeout, etc.) -> warn,
+                # not a Sentry error; IGDBWrapper raises requests' HTTPError, not httpx's.
+                logger.warning(f"IGDB API: {e}", extra={"exception": e})
                 return []
             if settings.DOWNLOADER_SAVEDIR:
                 with open(
@@ -206,13 +231,18 @@ class IGDB(AbstractSite):
         async with httpx.AsyncClient() as client:
             rs = []
             try:
+                # Shares the same 4 req/s IGDB quota as api_query, so a bulk
+                # import running concurrently doesn't push interactive
+                # searches (or itself) over the cap.
+                await igdb_limiter().acquire_async(timeout=15.0)
                 url = IGDBWrapper._build_url("games")
                 params = _wrapper._compose_request(q)
                 response = await client.post(url, **params)
                 if response.status_code == 200:
                     rs = json.loads(response.content)
             except httpx.HTTPError as e:
-                logger.error(f"IGDB API: {e}", extra={"exception": e})
+                # Transient third-party failure -> warn, not a Sentry error.
+                logger.warning(f"IGDB API: {e}", extra={"exception": e})
                 reason = "timeout" if isinstance(e, httpx.TimeoutException) else "error"
                 record_search_failure(SiteName.IGDB.value, reason)
         result = []

--- a/neodb/catalog/sites/igdb.py
+++ b/neodb/catalog/sites/igdb.py
@@ -7,6 +7,7 @@ use (e.g. "portal-2") as id, which is different from real id in IGDB API
 import datetime
 import json
 import threading
+import time
 from urllib.parse import quote_plus
 
 import httpx
@@ -45,6 +46,23 @@ def igdb_limiter() -> RedisRateLimiter:
                     rate=4.0,
                 )
     return _igdb_limiter
+
+
+# A 429 can still slip past the limiter (Redis unreachable, or the queue
+# exceeded acquire()'s timeout and fell open), so retry it a bounded number
+# of times before giving up -- otherwise a single rate-limit blip permanently
+# loses that item's IGDB metadata instead of just being slow.
+_IGDB_MAX_429_RETRIES = 2
+
+
+def _retry_after_seconds(response: requests.Response, default: float) -> float:
+    value = response.headers.get("Retry-After")
+    if value:
+        try:
+            return max(float(value), 0.0)
+        except ValueError:
+            pass
+    return default
 
 
 def _igdb_access_token():
@@ -102,8 +120,23 @@ class IGDB(AbstractSite):
                 SiteConfig.system.igdb_client_id, _igdb_access_token()
             )
             try:
-                igdb_limiter().acquire(timeout=60.0)
-                r = json.loads(_wrapper.api_request(p, q))
+                for attempt in range(_IGDB_MAX_429_RETRIES + 1):
+                    igdb_limiter().acquire(timeout=60.0)
+                    try:
+                        r = json.loads(_wrapper.api_request(p, q))
+                        break
+                    except requests.exceptions.HTTPError as e:
+                        is_429 = (
+                            e.response is not None and e.response.status_code == 429
+                        )
+                        if not is_429 or attempt == _IGDB_MAX_429_RETRIES:
+                            raise
+                        wait = _retry_after_seconds(e.response, default=1.0)
+                        logger.warning(
+                            f"IGDB API rate limited, retrying in {wait:.1f}s",
+                            extra={"exception": e},
+                        )
+                        time.sleep(wait)
             except requests.exceptions.RequestException as e:
                 # Transient third-party failure (rate limit, timeout, etc.) -> warn,
                 # not a Sentry error; IGDBWrapper raises requests' HTTPError, not httpx's.
@@ -238,8 +271,8 @@ class IGDB(AbstractSite):
                 url = IGDBWrapper._build_url("games")
                 params = _wrapper._compose_request(q)
                 response = await client.post(url, **params)
-                if response.status_code == 200:
-                    rs = json.loads(response.content)
+                response.raise_for_status()
+                rs = json.loads(response.content)
             except httpx.HTTPError as e:
                 # Transient third-party failure -> warn, not a Sentry error.
                 logger.warning(f"IGDB API: {e}", extra={"exception": e})

--- a/neodb/tests/catalog/test_game.py
+++ b/neodb/tests/catalog/test_game.py
@@ -1,10 +1,14 @@
+import asyncio
+import time
+
+import httpx
 import pytest
 import requests
 from django.conf import settings
 from igdb.wrapper import IGDBWrapper
 
 from catalog.common import *
-from catalog.models import Game, IdType
+from catalog.models import Game, IdType, SiteName
 from catalog.sites.igdb import IGDB, igdb_limiter
 
 
@@ -70,6 +74,7 @@ class TestIGDB:
         # propagate and crash the caller (e.g. a Steam import job).
         # Regression for EGGPLANT-1GY / EGGPLANT-1GZ.
         monkeypatch.setattr(igdb_limiter(), "acquire", lambda timeout: None)
+        monkeypatch.setattr(time, "sleep", lambda s: None)
 
         def _raise_429(self, endpoint, query):
             response = requests.Response()
@@ -78,6 +83,58 @@ class TestIGDB:
 
         monkeypatch.setattr(IGDBWrapper, "api_request", _raise_429)
         assert IGDB.api_query("games", "fields *;") == []
+
+    def test_api_query_retries_429_then_succeeds(self, monkeypatch):
+        # A 429 can still slip past the limiter (Redis unreachable, or the
+        # queue exceeded acquire()'s timeout); a bounded retry that honors
+        # Retry-After should recover the item instead of losing its data.
+        monkeypatch.setattr(igdb_limiter(), "acquire", lambda timeout: None)
+        sleeps = []
+        monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+
+        calls = {"n": 0}
+
+        def _flaky(self, endpoint, query):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                response = requests.Response()
+                response.status_code = 429
+                response.headers["Retry-After"] = "2"
+                raise requests.exceptions.HTTPError(
+                    "429 Client Error", response=response
+                )
+            return b'[{"id": 1}]'
+
+        monkeypatch.setattr(IGDBWrapper, "api_request", _flaky)
+        assert IGDB.api_query("games", "fields *;") == [{"id": 1}]
+        assert sleeps == [2.0]
+
+    def test_search_task_429_records_failure(self, monkeypatch):
+        # search_task never called raise_for_status(), so a 429 silently
+        # fell through to a cacheable empty result with no failure
+        # telemetry. It must now be caught and recorded like any other
+        # transient IGDB failure.
+        async def _noop_acquire(timeout=15.0):
+            return None
+
+        monkeypatch.setattr(igdb_limiter(), "acquire_async", _noop_acquire)
+
+        async def _fake_post(self, url, **kwargs):
+            return httpx.Response(429, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+
+        failures = []
+        monkeypatch.setattr(
+            "catalog.sites.igdb.record_search_failure",
+            lambda site, reason: failures.append((site, reason)),
+        )
+
+        results = asyncio.run(
+            IGDB.search_task("test", page=1, category="game", page_size=5)
+        )
+        assert results == []
+        assert failures == [(SiteName.IGDB.value, "error")]
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_game.py
+++ b/neodb/tests/catalog/test_game.py
@@ -1,8 +1,11 @@
 import pytest
+import requests
 from django.conf import settings
+from igdb.wrapper import IGDBWrapper
 
 from catalog.common import *
 from catalog.models import Game, IdType
+from catalog.sites.igdb import IGDB, igdb_limiter
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -60,6 +63,21 @@ class TestIGDB:
             site.resource.item.primary_lookup_id_value
             == "the-legend-of-zelda-breath-of-the-wild"
         )
+
+    def test_api_query_handles_429_without_crashing(self, monkeypatch):
+        # IGDBWrapper raises requests' HTTPError (not httpx's) on a 429;
+        # api_query must catch it and degrade to [] rather than let it
+        # propagate and crash the caller (e.g. a Steam import job).
+        # Regression for EGGPLANT-1GY / EGGPLANT-1GZ.
+        monkeypatch.setattr(igdb_limiter(), "acquire", lambda timeout: None)
+
+        def _raise_429(self, endpoint, query):
+            response = requests.Response()
+            response.status_code = 429
+            raise requests.exceptions.HTTPError("429 Client Error", response=response)
+
+        monkeypatch.setattr(IGDBWrapper, "api_request", _raise_429)
+        assert IGDB.api_query("games", "fields *;") == []
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_rate_limit.py
+++ b/neodb/tests/catalog/test_rate_limit.py
@@ -9,6 +9,7 @@ import uuid
 import pytest
 
 from catalog.common.rate_limit import RedisRateLimiter
+from catalog.sites.igdb import igdb_limiter
 from catalog.sites.musicbrainz import musicbrainz_limiter
 
 
@@ -83,3 +84,12 @@ def test_musicbrainz_limiter_is_singleton() -> None:
     assert a.key == "ratelimit:musicbrainz.org"
     # MusicBrainz' documented 1 req/s/IP ceiling.
     assert 1.0 / a.interval <= 1.0
+
+
+def test_igdb_limiter_is_singleton() -> None:
+    a = igdb_limiter()
+    b = igdb_limiter()
+    assert a is b
+    assert a.key == "ratelimit:api.igdb.com"
+    # IGDB's documented 4 req/s/client-ID ceiling.
+    assert 1.0 / a.interval <= 4.0


### PR DESCRIPTION
## Summary

- Steam library imports call `IGDB.api_query` 2-3 times per game with no throttling, blowing past IGDB's documented 4 req/s cap per client ID (https://api-docs.igdb.com/#rate-limits).
- Worse, the resulting 429 is `requests.exceptions.HTTPError` (`IGDBWrapper` uses `requests`, not `httpx`), which `api_query`'s `except httpx.HTTPError` never caught. The exception propagated unhandled through `Steam.scrape()` (no try/except there) into the importer's generic exception handler, killing that item's import and logging a full traceback to Sentry on every occurrence.
- This is what produced Sentry issues EGGPLANT-1GY (526 occurrences) and EGGPLANT-1GZ (1440 occurrences) during a single Steam library import.

Fix, mirroring the `RedisRateLimiter` pattern already used for MusicBrainz (`catalog/sites/musicbrainz.py`):
- Throttle every `IGDB.api_query` call (sync) and `IGDB.search_task` call (async) through one shared Redis-backed cursor at 4 req/s.
- Fix the exception type so a 429 (or other request failure) degrades to `[]` gracefully instead of crashing the caller.
- Downgrade the log level from `error` to `warning` for these transient third-party failures, matching the convention already established for MusicBrainz/OpenLibrary/Bandcamp (see 6fd1c1ba "stop logging transient external failures as errors").

## Test plan

- [x] `uv run pre-commit run -a` passes
- [x] Added a regression test (`TestIGDB::test_api_query_handles_429_without_crashing`) that monkeypatches `IGDBWrapper.api_request` to raise `requests.exceptions.HTTPError` and asserts `api_query` returns `[]` instead of raising
- [x] Added `test_igdb_limiter_is_singleton` alongside the existing MusicBrainz limiter test
- [x] Ran `tests/catalog/test_game.py` and `tests/catalog/test_rate_limit.py` against throwaway Postgres/Redis/Typesense containers -- all pass (pre-existing minio-dependent tests unrelated to this change still fail the same way on `main`)
- [x] Full `tests/catalog` suite still collects cleanly (653 tests, no import errors)