### PR TITLE
Replace Bluesky app-password login with ATProto OAuth

### DIFF
--- a/docs/internals/atproto.md
+++ b/docs/internals/atproto.md
@@ -9,6 +9,23 @@ The lexicon is project-owned under the `net.neodb.*` namespace (reverse of
 `neodb.net`), so it is shared by every NeoDB instance. The schema files live in
 [`docs/lexicons/net/neodb/`](../lexicons/net/neodb).
 
+## Authentication
+
+Users link their ATProto identity via [OAuth](https://atproto.com/specs/oauth)
+(`mastodon/models/bluesky_oauth.py`): the login form takes only a handle, which
+is resolved handle -> DID -> PDS -> authorization server; the authorization
+request is pushed via PAR with PKCE and the user is redirected to their server
+to approve the `atproto transition:generic` scope. NeoDB acts as a confidential
+client: the client metadata document is served at
+`/account/bluesky/client-metadata.json` (its URL is the `client_id`) and token
+requests carry a `private_key_jwt` assertion signed with an auto-generated
+ES256 key persisted in SiteConfig. Access tokens are DPoP-bound; a custom
+transport for the atproto SDK client signs every XRPC call and transparently
+handles server nonce rotation and token refresh. Tokens, the per-session DPoP
+key and nonces are stored encrypted on the account. Accounts created before
+the OAuth flow keep working through their stored app-password session until
+they re-authorize.
+
 ## Record types
 
 | Collection (NSID)   | Written from         | Purpose                                   |

--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -133,6 +133,9 @@ class SiteConfig(models.Model):
         task_cleanup_days: int = 28
 
         # Advanced / Operational
+        # auto-generated ES256 key (JWK) for the ATProto OAuth client;
+        # managed by mastodon.models.bluesky_oauth, not exposed in the UI
+        atproto_client_jwk: str = ""
         alternative_domains: list[str] = []
         mastodon_client_scope: str = (
             "read:accounts read:follows read:search"

--- a/neodb/common/views_manage.py
+++ b/neodb/common/views_manage.py
@@ -815,6 +815,14 @@ class AdvancedSettings(SiteConfigSettingsPage):
                 "skipped jobs log a warning and notify the Discord system channel."
             ),
         },
+        "atproto_client_jwk": {
+            "title": _("ATProto OAuth Client Key"),
+            "help_text": _(
+                "Private key (JWK) identifying this site to ATProto "
+                "authorization servers. Auto-generated on first Bluesky "
+                "login; clear to regenerate."
+            ),
+        },
     }
     layout = {
         _("Domains"): [
@@ -827,6 +835,7 @@ class AdvancedSettings(SiteConfigSettingsPage):
             "index_aliases",
             "task_cleanup_days",
             "skip_migrations",
+            "atproto_client_jwk",
         ],
     }
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 02:03+0000\n"
+"POT-Creation-Date: 2026-07-22 00:05-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,44 +18,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: boofilsic/settings.py:465 common/models/lang.py:223
+#: boofilsic/settings.py:472 common/models/lang.py:223
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:466 common/models/lang.py:70
+#: boofilsic/settings.py:473 common/models/lang.py:70
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:467 common/models/lang.py:71
+#: boofilsic/settings.py:474 common/models/lang.py:71
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:468 common/models/lang.py:176
+#: boofilsic/settings.py:475 common/models/lang.py:176
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:469 common/models/lang.py:80
+#: boofilsic/settings.py:476 common/models/lang.py:80
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:470 common/models/lang.py:105
+#: boofilsic/settings.py:477 common/models/lang.py:105
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:471 common/models/lang.py:159
+#: boofilsic/settings.py:478 common/models/lang.py:159
 #: common/models/lang.py:298
 msgid "Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:472
+#: boofilsic/settings.py:479
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:473 common/models/lang.py:309
+#: boofilsic/settings.py:480 common/models/lang.py:309
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:474 common/models/lang.py:310
+#: boofilsic/settings.py:481 common/models/lang.py:310
 msgid "Traditional Chinese"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgid "Add note"
 msgstr ""
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:184 journal/templates/profile_items.html:39
+#: common/templates/_sidebar.html:191 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 #: journal/templates/mark.html:157 journal/templates/note.html:84
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
-#: users/templates/users/account.html:263
+#: users/templates/users/account.html:254
 msgid "Delete"
 msgstr ""
 
@@ -1775,23 +1775,23 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: catalog/templates/discover.html:153 journal/templates/profile.html:244
+#: catalog/templates/discover.html:153 journal/templates/profile.html:271
 msgid "edit layout"
 msgstr ""
 
-#: catalog/templates/discover.html:156 journal/templates/profile.html:247
+#: catalog/templates/discover.html:156 journal/templates/profile.html:274
 msgid "save"
 msgstr ""
 
-#: catalog/templates/discover.html:167 journal/templates/profile.html:258
+#: catalog/templates/discover.html:167 journal/templates/profile.html:285
 msgid "cancel"
 msgstr ""
 
-#: catalog/templates/discover.html:173 journal/templates/profile.html:264
+#: catalog/templates/discover.html:173 journal/templates/profile.html:291
 msgid "show"
 msgstr ""
 
-#: catalog/templates/discover.html:174 journal/templates/profile.html:265
+#: catalog/templates/discover.html:174 journal/templates/profile.html:292
 msgid "hide"
 msgstr ""
 
@@ -1821,7 +1821,7 @@ msgstr ""
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
-#: journal/templates/profile_items.html:58
+#: journal/templates/profile_items.html:65
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_article_list.html:58
 #: journal/templates/user_collection_list.html:52
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "nothing so far."
 msgstr ""
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:257
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:264
 msgid "Recent Posts"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgid "Logged in user may see search results from other sites."
 msgstr ""
 
 #: catalog/templates/search_results_people.html:12
-#: journal/templates/profile.html:196 journal/views/profile.py:596
+#: journal/templates/profile.html:196 journal/views/profile.py:598
 msgid "People"
 msgstr ""
 
@@ -2134,11 +2134,11 @@ msgstr ""
 #: catalog/views/edit.py:511 catalog/views/verify.py:156
 #: catalog/views/verify.py:203 journal/views/article.py:39
 #: journal/views/article.py:121 journal/views/article.py:141
-#: journal/views/collection.py:237 journal/views/collection.py:298
-#: journal/views/collection.py:317 journal/views/collection.py:341
-#: journal/views/collection.py:414 journal/views/collection.py:457
-#: journal/views/collection.py:495 journal/views/collection.py:507
-#: journal/views/collection.py:532 journal/views/collection.py:569
+#: journal/views/collection.py:238 journal/views/collection.py:299
+#: journal/views/collection.py:318 journal/views/collection.py:342
+#: journal/views/collection.py:415 journal/views/collection.py:458
+#: journal/views/collection.py:497 journal/views/collection.py:509
+#: journal/views/collection.py:534 journal/views/collection.py:571
 #: journal/views/common.py:272 journal/views/mark.py:264
 #: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
 #: journal/views/post.py:165 journal/views/post.py:194
@@ -2150,9 +2150,9 @@ msgid "Insufficient permission"
 msgstr ""
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
-#: catalog/views/verify.py:194 journal/views/collection.py:74
-#: journal/views/collection.py:99 journal/views/collection.py:512
-#: journal/views/collection.py:607 journal/views/common.py:193
+#: catalog/views/verify.py:194 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:514
+#: journal/views/collection.py:609 journal/views/common.py:193
 #: journal/views/mark.py:190 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:274
+#: common/templates/_footer.html:12 users/templates/users/login.html:265
 #, python-format
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr ""
@@ -3720,7 +3720,7 @@ msgid "Notification"
 msgstr ""
 
 #: common/templates/_header.html:122 users/models/task.py:21
-#: users/templates/users/account.html:228
+#: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr ""
@@ -3789,31 +3789,31 @@ msgstr ""
 msgid "Currently reading"
 msgstr ""
 
-#: common/templates/_sidebar.html:203
+#: common/templates/_sidebar.html:210
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:226 journal/forms.py:197
+#: common/templates/_sidebar.html:233 journal/forms.py:197
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: common/templates/_sidebar.html:232 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:239 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:235 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:242 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr ""
 
-#: common/templates/_sidebar.html:242 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:249 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr ""
 
-#: common/templates/_sidebar.html:246 common/templates/_sidebar.html:259
+#: common/templates/_sidebar.html:253 common/templates/_sidebar.html:266
 msgid "show all"
 msgstr ""
 
@@ -4635,63 +4635,71 @@ msgstr ""
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:820
+#: common/views_manage.py:819
+msgid "ATProto OAuth Client Key"
+msgstr ""
+
+#: common/views_manage.py:821
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
+msgstr ""
+
+#: common/views_manage.py:828
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:823
+#: common/views_manage.py:831
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:838
+#: common/views_manage.py:847
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:840
+#: common/views_manage.py:849
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:845
+#: common/views_manage.py:854
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:856
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:852
+#: common/views_manage.py:861
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:854
+#: common/views_manage.py:863
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:859
+#: common/views_manage.py:868
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:861
+#: common/views_manage.py:870
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:866
+#: common/views_manage.py:875
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:877
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:873
+#: common/views_manage.py:882
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:875
+#: common/views_manage.py:884
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:881
+#: common/views_manage.py:890
 msgid "Genres by Category"
 msgstr ""
 
@@ -5474,7 +5482,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:893
+#: journal/models/shelf.py:900
 msgid "removed mark"
 msgstr ""
 
@@ -5963,7 +5971,7 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
-#: journal/templates/profile.html:162 journal/views/collection.py:384
+#: journal/templates/profile.html:162 journal/views/collection.py:385
 #: journal/views/profile.py:385
 msgid "collection"
 msgstr ""
@@ -5972,7 +5980,7 @@ msgstr ""
 msgid "liked collection"
 msgstr ""
 
-#: journal/templates/profile.html:213 journal/views/profile.py:598
+#: journal/templates/profile.html:213 journal/views/profile.py:600
 msgid "Organizations"
 msgstr ""
 
@@ -6014,12 +6022,12 @@ msgid "Liked Collections"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:491
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:443
 msgid "Following"
 msgstr ""
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:495
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:452
 msgid "Followers"
 msgstr ""
 
@@ -6066,34 +6074,34 @@ msgstr ""
 msgid "Link invalid"
 msgstr ""
 
-#: journal/views/collection.py:56 journal/views/collection.py:93
+#: journal/views/collection.py:56 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr ""
 
-#: journal/views/collection.py:389
+#: journal/views/collection.py:390
 msgid "shared my collection"
 msgstr ""
 
-#: journal/views/collection.py:392
+#: journal/views/collection.py:393
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr ""
 
-#: journal/views/collection.py:459 journal/views/collection.py:497
-#: journal/views/collection.py:509 journal/views/collection.py:535
+#: journal/views/collection.py:460 journal/views/collection.py:499
+#: journal/views/collection.py:511 journal/views/collection.py:537
 msgid "Dynamic collection is not editable"
 msgstr ""
 
-#: journal/views/collection.py:474
+#: journal/views/collection.py:476
 msgid "The item is already in the collection."
 msgstr ""
 
-#: journal/views/collection.py:476
+#: journal/views/collection.py:478
 msgid "Unable to find the item, please use item url from this site."
 msgstr ""
 
-#: journal/views/collection.py:522
+#: journal/views/collection.py:524
 msgid "Saved."
 msgstr ""
 
@@ -6307,31 +6315,44 @@ msgstr ""
 msgid "New Post"
 msgstr ""
 
-#: mastodon/views/bluesky.py:23 mastodon/views/email.py:35
+#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+msgid "Bluesky login is disabled."
+msgstr ""
+
+#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
 #: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
 #: users/templates/users/login.html:6 users/views/webauthn.py:133
 msgid "Security check failed. Please try again."
 msgstr ""
 
-#: mastodon/views/bluesky.py:29 mastodon/views/bluesky.py:37
-#: mastodon/views/bluesky.py:47 mastodon/views/common.py:40
+#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
+#: mastodon/views/bluesky.py:78 mastodon/views/common.py:40
 #: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:187
+#: users/views/account.py:189
 msgid "Authentication failed"
 msgstr ""
 
-#: mastodon/views/bluesky.py:30 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr ""
 
-#: mastodon/views/bluesky.py:38
-msgid "Username and app password is required."
+#: mastodon/views/bluesky.py:40
+msgid "ATProto handle is required."
 msgstr ""
 
-#: mastodon/views/bluesky.py:47
+#: mastodon/views/bluesky.py:50
+msgid "Error connecting to your ATProto server"
+msgstr ""
+
+#: mastodon/views/bluesky.py:73
+msgid "Invalid response from ATProto authorization server."
+msgstr ""
+
+#: mastodon/views/bluesky.py:78
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
@@ -6339,7 +6360,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:56 users/views/account.py:223
+#: mastodon/views/common.py:56 users/views/account.py:225
 msgid "Registration failed"
 msgstr ""
 
@@ -6495,7 +6516,8 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: social/templates/_remote_article_teaser.html:5
+#: social/templates/_remote_article_teaser.html:11
+#: social/templates/_remote_article_teaser.html:30
 msgid "Untitled article"
 msgstr ""
 
@@ -6992,7 +7014,7 @@ msgstr ""
 
 #: users/templates/users/account.html:86 users/templates/users/account.html:148
 #: users/templates/users/account.html:186
-#: users/templates/users/account.html:317
+#: users/templates/users/account.html:308
 msgid "Last updated"
 msgstr ""
 
@@ -7026,7 +7048,7 @@ msgstr ""
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
-#: users/templates/users/account.html:215
+#: users/templates/users/account.html:206
 msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr ""
 
@@ -7062,185 +7084,177 @@ msgstr ""
 msgid "Verified ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:194
-msgid "Bluesky Login ID"
+#: users/templates/users/account.html:194 users/templates/users/login.html:216
+msgid "ATProto handle"
 msgstr ""
 
-#: users/templates/users/account.html:202 users/templates/users/login.html:225
-msgid "Bluesky app password"
-msgstr ""
-
-#: users/templates/users/account.html:208
+#: users/templates/users/account.html:200
 msgid "Link with a different ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:208
+#: users/templates/users/account.html:200
 msgid "Link with an ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:209 users/templates/users/login.html:230
-msgid "App password can be created on <a href=\"https://bsky.app/settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-msgstr ""
-
-#: users/templates/users/account.html:218
+#: users/templates/users/account.html:209
 msgid "Disconnect with ATProto identity"
 msgstr ""
 
-#: users/templates/users/account.html:233
+#: users/templates/users/account.html:224
 msgid "Passkeys"
 msgstr ""
 
-#: users/templates/users/account.html:235 users/templates/users/welcome.html:32
+#: users/templates/users/account.html:226 users/templates/users/welcome.html:32
 msgid "Name this passkey:"
 msgstr ""
 
-#: users/templates/users/account.html:236 users/templates/users/login.html:69
+#: users/templates/users/account.html:227 users/templates/users/login.html:69
 #: users/templates/users/welcome.html:33 users/views/webauthn.py:106
 msgid "Passkey"
 msgstr ""
 
-#: users/templates/users/account.html:242
+#: users/templates/users/account.html:233
 #: users/templates/users/authorized_app_create.html:24
 msgid "Name"
 msgstr ""
 
-#: users/templates/users/account.html:243
-#: users/templates/users/account.html:394
+#: users/templates/users/account.html:234
+#: users/templates/users/account.html:385
 msgid "Created"
 msgstr ""
 
-#: users/templates/users/account.html:244
+#: users/templates/users/account.html:235
 msgid "Last Used"
 msgstr ""
 
-#: users/templates/users/account.html:270
+#: users/templates/users/account.html:261
 msgid "No passkeys registered."
 msgstr ""
 
-#: users/templates/users/account.html:275
+#: users/templates/users/account.html:266
 msgid "Add Passkey"
 msgstr ""
 
-#: users/templates/users/account.html:283
+#: users/templates/users/account.html:274
 msgid "Sync and import social account"
 msgstr ""
 
-#: users/templates/users/account.html:293
+#: users/templates/users/account.html:284
 msgid "Sync display name, bio and avatar"
 msgstr ""
 
-#: users/templates/users/account.html:301
+#: users/templates/users/account.html:292
 msgid "Sync follow, mute and block"
 msgstr ""
 
-#: users/templates/users/account.html:304
+#: users/templates/users/account.html:295
 msgid "Save sync settings"
 msgstr ""
 
-#: users/templates/users/account.html:306
+#: users/templates/users/account.html:297
 msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr ""
 
-#: users/templates/users/account.html:313
+#: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
 msgstr ""
 
-#: users/templates/users/account.html:314
+#: users/templates/users/account.html:305
 msgid "Sync now"
 msgstr ""
 
-#: users/templates/users/account.html:326
+#: users/templates/users/account.html:317
 msgid "Users you are following"
 msgstr ""
 
-#: users/templates/users/account.html:335
+#: users/templates/users/account.html:326
 msgid "Users who follow you"
 msgstr ""
 
-#: users/templates/users/account.html:344
+#: users/templates/users/account.html:335
 msgid "Users who request to follow you"
 msgstr ""
 
-#: users/templates/users/account.html:353
+#: users/templates/users/account.html:344
 msgid "Users you are muting"
 msgstr ""
 
-#: users/templates/users/account.html:362
+#: users/templates/users/account.html:353
 msgid "Users you are blocking"
 msgstr ""
 
+#: users/templates/users/account.html:362
 #: users/templates/users/account.html:371
-#: users/templates/users/account.html:380
 msgid "Log out everywhere"
 msgstr ""
 
-#: users/templates/users/account.html:374
+#: users/templates/users/account.html:365
 msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr ""
 
-#: users/templates/users/account.html:377
+#: users/templates/users/account.html:368
 msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr ""
 
-#: users/templates/users/account.html:387
+#: users/templates/users/account.html:378
 msgid "Authorized Apps"
 msgstr ""
 
-#: users/templates/users/account.html:392
+#: users/templates/users/account.html:383
 msgid "Application"
 msgstr ""
 
-#: users/templates/users/account.html:393
+#: users/templates/users/account.html:384
 msgid "Scopes"
 msgstr ""
 
-#: users/templates/users/account.html:407
+#: users/templates/users/account.html:398
 msgid "Revoke access for this application?"
 msgstr ""
 
-#: users/templates/users/account.html:410
+#: users/templates/users/account.html:401
 msgid "Revoke"
 msgstr ""
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:409
 msgid "No authorized applications."
 msgstr ""
 
-#: users/templates/users/account.html:421
+#: users/templates/users/account.html:412
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr ""
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:418
 msgid "Import/Export Social Graph"
 msgstr ""
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:419
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr ""
 
-#: users/templates/users/account.html:434
+#: users/templates/users/account.html:425
 msgid "Import type"
 msgstr ""
 
-#: users/templates/users/account.html:436
+#: users/templates/users/account.html:427
 msgid "Following list"
 msgstr ""
 
-#: users/templates/users/account.html:437
+#: users/templates/users/account.html:428
 msgid "Block list"
 msgstr ""
 
-#: users/templates/users/account.html:438
+#: users/templates/users/account.html:429
 msgid "Mute list"
 msgstr ""
 
-#: users/templates/users/account.html:442
+#: users/templates/users/account.html:433
 msgid "CSV file"
 msgstr ""
 
-#: users/templates/users/account.html:445 users/templates/users/data.html:74
+#: users/templates/users/account.html:436 users/templates/users/data.html:74
 #: users/templates/users/data.html:126 users/templates/users/data.html:183
 #: users/templates/users/data.html:234 users/templates/users/data.html:298
 #: users/templates/users/data.html:358
@@ -7248,66 +7262,66 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
+#: users/templates/users/account.html:447
 #: users/templates/users/account.html:456
 #: users/templates/users/account.html:465
 #: users/templates/users/account.html:474
-#: users/templates/users/account.html:483
 msgid "Download CSV"
 msgstr ""
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:461
 msgid "Blocks"
 msgstr ""
 
-#: users/templates/users/account.html:479
+#: users/templates/users/account.html:470
 msgid "Mutes"
 msgstr ""
 
-#: users/templates/users/account.html:493
+#: users/templates/users/account.html:484
 msgid "Migrate Account"
 msgstr ""
 
-#: users/templates/users/account.html:497
+#: users/templates/users/account.html:488
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr ""
 
-#: users/templates/users/account.html:500
+#: users/templates/users/account.html:491
 msgid "Migrate another account here"
 msgstr ""
 
-#: users/templates/users/account.html:503
+#: users/templates/users/account.html:494
 msgid "Migrate to another account"
 msgstr ""
 
-#: users/templates/users/account.html:510
+#: users/templates/users/account.html:501
 msgid "Delete Account"
 msgstr ""
 
-#: users/templates/users/account.html:513
+#: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr ""
 
-#: users/templates/users/account.html:516
+#: users/templates/users/account.html:507
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr ""
 
-#: users/templates/users/account.html:526
+#: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
 msgstr ""
 
-#: users/templates/users/account.html:529
+#: users/templates/users/account.html:520
 msgid "Task in progress, can't delete now."
 msgstr ""
 
-#: users/templates/users/account.html:533
+#: users/templates/users/account.html:524
 msgid "Permanently Delete"
 msgstr ""
 
-#: users/templates/users/account.html:574
+#: users/templates/users/account.html:565
 msgid "Delete this passkey?"
 msgstr ""
 
-#: users/templates/users/account.html:594
+#: users/templates/users/account.html:585
 msgid "Rename passkey:"
 msgstr ""
 
@@ -7595,7 +7609,7 @@ msgstr ""
 msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr ""
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:255
+#: users/templates/users/login.html:182 users/templates/users/login.html:246
 msgid "Authorize via Fediverse instance"
 msgstr ""
 
@@ -7607,44 +7621,40 @@ msgstr ""
 msgid "Authorize via Threads"
 msgstr ""
 
-#: users/templates/users/login.html:216
-msgid "ATProto handle"
-msgstr ""
-
 #: users/templates/users/login.html:221
 msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr ""
 
-#: users/templates/users/login.html:233
-msgid "Authorize via bsky.app"
+#: users/templates/users/login.html:224
+msgid "Authorize via ATProto server"
 msgstr ""
 
-#: users/templates/users/login.html:240
+#: users/templates/users/login.html:231
 #, python-format
 msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr ""
 
-#: users/templates/users/login.html:264
+#: users/templates/users/login.html:255
 msgid "Valid invitation code, please login or register."
 msgstr ""
 
-#: users/templates/users/login.html:266
+#: users/templates/users/login.html:257
 msgid "Please use invitation link to register a new account; existing user may login."
 msgstr ""
 
-#: users/templates/users/login.html:268
+#: users/templates/users/login.html:259
 msgid "Invitation code invalid or expired."
 msgstr ""
 
-#: users/templates/users/login.html:276
+#: users/templates/users/login.html:267
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr ""
 
-#: users/templates/users/login.html:282
+#: users/templates/users/login.html:273
 msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr ""
 
-#: users/templates/users/login.html:296
+#: users/templates/users/login.html:287
 msgid "Domain of your instance (excl. @)"
 msgstr ""
 
@@ -8182,169 +8192,169 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:121
+#: users/views/account.py:122
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:132
+#: users/views/account.py:133
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:188
+#: users/views/account.py:190
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:224
+#: users/views/account.py:226
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:253
+#: users/views/account.py:256
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:323
+#: users/views/account.py:327
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:326
+#: users/views/account.py:330
 msgid "Account mismatch."
 msgstr ""
 
-#: users/views/data.py:238 users/views/data.py:267
+#: users/views/data.py:239 users/views/data.py:269
 msgid "Export file not available."
 msgstr ""
 
-#: users/views/data.py:261
+#: users/views/data.py:263
 msgid "Generating exports."
 msgstr ""
 
-#: users/views/data.py:279
+#: users/views/data.py:281
 msgid "Export file expired. Please export again."
 msgstr ""
 
-#: users/views/data.py:294 users/views/data.py:314
+#: users/views/data.py:296 users/views/data.py:317
 msgid "Recent export still in progress."
 msgstr ""
 
-#: users/views/data.py:328
+#: users/views/data.py:332
 msgid "Sync in progress."
 msgstr ""
 
-#: users/views/data.py:342
+#: users/views/data.py:346
 msgid "Settings saved."
 msgstr ""
 
-#: users/views/data.py:397
+#: users/views/data.py:401
 msgid "Account no longer linked."
 msgstr ""
 
-#: users/views/data.py:400
+#: users/views/data.py:404
 msgid "Content is no longer public."
 msgstr ""
 
-#: users/views/data.py:428
+#: users/views/data.py:432
 msgid "Retry did not complete, please try again."
 msgstr ""
 
-#: users/views/data.py:438 users/views/data.py:471 users/views/data.py:694
-#: users/views/data.py:909 users/views/data.py:934 users/views/data.py:958
-#: users/views/data.py:982
+#: users/views/data.py:442 users/views/data.py:476 users/views/data.py:701
+#: users/views/data.py:918 users/views/data.py:944 users/views/data.py:969
+#: users/views/data.py:994
 msgid "Invalid file."
 msgstr ""
 
-#: users/views/data.py:505 users/views/data.py:728
+#: users/views/data.py:512 users/views/data.py:737
 msgid "Loaded from uploaded matched file."
 msgstr ""
 
-#: users/views/data.py:530 users/views/data.py:757
+#: users/views/data.py:537 users/views/data.py:766
 msgid "Cancelled."
 msgstr ""
 
-#: users/views/data.py:550
+#: users/views/data.py:557
 msgid "No RateYourMusic import to preview."
 msgstr ""
 
-#: users/views/data.py:558 users/views/data.py:668 users/views/data.py:787
-#: users/views/data.py:892
+#: users/views/data.py:565 users/views/data.py:675 users/views/data.py:796
+#: users/views/data.py:901
 msgid "Matched file missing."
 msgstr ""
 
-#: users/views/data.py:654 users/views/data.py:878
+#: users/views/data.py:661 users/views/data.py:887
 msgid "Starting import..."
 msgstr ""
 
-#: users/views/data.py:664 users/views/data.py:888
+#: users/views/data.py:671 users/views/data.py:897
 msgid "No matched file available."
 msgstr ""
 
-#: users/views/data.py:779
+#: users/views/data.py:788
 msgid "No StoryGraph import to preview."
 msgstr ""
 
-#: users/views/data.py:1102
+#: users/views/data.py:1117
 msgid "Name is required."
 msgstr ""
 
-#: users/views/data.py:1124
+#: users/views/data.py:1139
 msgid "Application access has been revoked."
 msgstr ""
 
-#: users/views/data.py:1140
+#: users/views/data.py:1155
 msgid "Alias update not allowed for a moved account."
 msgstr ""
 
-#: users/views/data.py:1145
+#: users/views/data.py:1160
 msgid "No alias specified."
 msgstr ""
 
-#: users/views/data.py:1155 users/views/data.py:1206
+#: users/views/data.py:1170 users/views/data.py:1221
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr ""
 
-#: users/views/data.py:1162
+#: users/views/data.py:1177
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr ""
 
-#: users/views/data.py:1167
+#: users/views/data.py:1182
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr ""
 
-#: users/views/data.py:1193
+#: users/views/data.py:1208
 msgid "Migration cancelled."
 msgstr ""
 
-#: users/views/data.py:1198
+#: users/views/data.py:1213
 msgid "No target account specified."
 msgstr ""
 
-#: users/views/data.py:1211
+#: users/views/data.py:1226
 msgid "Cannot migrate to a local account."
 msgstr ""
 
-#: users/views/data.py:1222
+#: users/views/data.py:1237
 msgid "You must set up an alias in the target account first."
 msgstr ""
 
-#: users/views/data.py:1228
+#: users/views/data.py:1243
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr ""
 
-#: users/views/data.py:1286
+#: users/views/data.py:1301
 msgid "No file uploaded."
 msgstr ""
 
-#: users/views/data.py:1302
+#: users/views/data.py:1317
 msgid "The uploaded file is not a valid CSV."
 msgstr ""
 
-#: users/views/data.py:1306
+#: users/views/data.py:1321
 msgid "No valid entries found in the CSV file."
 msgstr ""
 
-#: users/views/data.py:1315
+#: users/views/data.py:1331
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 02:03+0000\n"
+"POT-Creation-Date: 2026-07-22 00:05-0400\n"
 "PO-Revision-Date: 2026-07-02 15:01+0000\n"
 "Last-Translator: Hosted Weblate user 54392 <hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -17,44 +17,44 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: boofilsic/settings.py:465 common/models/lang.py:223
+#: boofilsic/settings.py:472 common/models/lang.py:223
 msgid "English"
 msgstr "英语"
 
-#: boofilsic/settings.py:466 common/models/lang.py:70
+#: boofilsic/settings.py:473 common/models/lang.py:70
 msgid "Danish"
 msgstr "丹麦语"
 
-#: boofilsic/settings.py:467 common/models/lang.py:71
+#: boofilsic/settings.py:474 common/models/lang.py:71
 msgid "German"
 msgstr "德语"
 
-#: boofilsic/settings.py:468 common/models/lang.py:176
+#: boofilsic/settings.py:475 common/models/lang.py:176
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: boofilsic/settings.py:469 common/models/lang.py:80
+#: boofilsic/settings.py:476 common/models/lang.py:80
 msgid "French"
 msgstr "法语"
 
-#: boofilsic/settings.py:470 common/models/lang.py:105
+#: boofilsic/settings.py:477 common/models/lang.py:105
 msgid "Italian"
 msgstr "意大利语"
 
-#: boofilsic/settings.py:471 common/models/lang.py:159
+#: boofilsic/settings.py:478 common/models/lang.py:159
 #: common/models/lang.py:298
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: boofilsic/settings.py:472
+#: boofilsic/settings.py:479
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: boofilsic/settings.py:473 common/models/lang.py:309
+#: boofilsic/settings.py:480 common/models/lang.py:309
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: boofilsic/settings.py:474 common/models/lang.py:310
+#: boofilsic/settings.py:481 common/models/lang.py:310
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
@@ -1179,7 +1179,7 @@ msgid "Add note"
 msgstr "添加笔记"
 
 #: catalog/templates/_item_user_pieces.html:83
-#: common/templates/_sidebar.html:184 journal/templates/profile_items.html:39
+#: common/templates/_sidebar.html:191 journal/templates/profile_items.html:46
 msgid "Set progress"
 msgstr "设置进度"
 
@@ -1386,7 +1386,7 @@ msgstr "合并到另一条目"
 #: journal/templates/mark.html:157 journal/templates/note.html:84
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
-#: users/templates/users/account.html:263
+#: users/templates/users/account.html:254
 msgid "Delete"
 msgstr "删除"
 
@@ -1774,23 +1774,23 @@ msgstr "联邦宇宙原创"
 msgid "Collections"
 msgstr "收藏单"
 
-#: catalog/templates/discover.html:153 journal/templates/profile.html:244
+#: catalog/templates/discover.html:153 journal/templates/profile.html:271
 msgid "edit layout"
 msgstr "编辑布局"
 
-#: catalog/templates/discover.html:156 journal/templates/profile.html:247
+#: catalog/templates/discover.html:156 journal/templates/profile.html:274
 msgid "save"
 msgstr "保存"
 
-#: catalog/templates/discover.html:167 journal/templates/profile.html:258
+#: catalog/templates/discover.html:167 journal/templates/profile.html:285
 msgid "cancel"
 msgstr "取消"
 
-#: catalog/templates/discover.html:173 journal/templates/profile.html:264
+#: catalog/templates/discover.html:173 journal/templates/profile.html:291
 msgid "show"
 msgstr "显示"
 
-#: catalog/templates/discover.html:174 journal/templates/profile.html:265
+#: catalog/templates/discover.html:174 journal/templates/profile.html:292
 msgid "hide"
 msgstr "隐藏"
 
@@ -1820,7 +1820,7 @@ msgstr "热门标签"
 #: common/templates/_sidebar_anonymous.html:62 journal/templates/posts.html:8
 #: journal/templates/profile_articles.html:24
 #: journal/templates/profile_articles.html:26
-#: journal/templates/profile_items.html:58
+#: journal/templates/profile_items.html:65
 #: journal/templates/profile_posts.html:23
 #: journal/templates/user_article_list.html:58
 #: journal/templates/user_collection_list.html:52
@@ -1833,7 +1833,7 @@ msgstr "热门标签"
 msgid "nothing so far."
 msgstr "暂无内容。"
 
-#: catalog/templates/discover.html:239 common/templates/_sidebar.html:257
+#: catalog/templates/discover.html:239 common/templates/_sidebar.html:264
 msgid "Recent Posts"
 msgstr "近期帖文"
 
@@ -2095,7 +2095,7 @@ msgid "Logged in user may see search results from other sites."
 msgstr "登录用户可看到来自其它网站的搜索结果。"
 
 #: catalog/templates/search_results_people.html:12
-#: journal/templates/profile.html:196 journal/views/profile.py:596
+#: journal/templates/profile.html:196 journal/views/profile.py:598
 msgid "People"
 msgstr "人物"
 
@@ -2133,11 +2133,11 @@ msgstr "条目不可被删除。"
 #: catalog/views/edit.py:511 catalog/views/verify.py:156
 #: catalog/views/verify.py:203 journal/views/article.py:39
 #: journal/views/article.py:121 journal/views/article.py:141
-#: journal/views/collection.py:237 journal/views/collection.py:298
-#: journal/views/collection.py:317 journal/views/collection.py:341
-#: journal/views/collection.py:414 journal/views/collection.py:457
-#: journal/views/collection.py:495 journal/views/collection.py:507
-#: journal/views/collection.py:532 journal/views/collection.py:569
+#: journal/views/collection.py:238 journal/views/collection.py:299
+#: journal/views/collection.py:318 journal/views/collection.py:342
+#: journal/views/collection.py:415 journal/views/collection.py:458
+#: journal/views/collection.py:497 journal/views/collection.py:509
+#: journal/views/collection.py:534 journal/views/collection.py:571
 #: journal/views/common.py:272 journal/views/mark.py:264
 #: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
 #: journal/views/post.py:165 journal/views/post.py:194
@@ -2149,9 +2149,9 @@ msgid "Insufficient permission"
 msgstr "权限不足"
 
 #: catalog/views/edit.py:275 catalog/views/edit.py:278
-#: catalog/views/verify.py:194 journal/views/collection.py:74
-#: journal/views/collection.py:99 journal/views/collection.py:512
-#: journal/views/collection.py:607 journal/views/common.py:193
+#: catalog/views/verify.py:194 journal/views/collection.py:75
+#: journal/views/collection.py:100 journal/views/collection.py:514
+#: journal/views/collection.py:609 journal/views/common.py:193
 #: journal/views/mark.py:190 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
@@ -3665,7 +3665,7 @@ msgstr "服务协议"
 msgid "About"
 msgstr "关于"
 
-#: common/templates/_footer.html:12 users/templates/users/login.html:274
+#: common/templates/_footer.html:12 users/templates/users/login.html:265
 #, python-format
 msgid "You are visiting an alternative domain for %(site_name)s, please always use <a href=\"%(site_url)s%(request.get_full_path)s\">original version</a> if possible."
 msgstr "这是%(site_name)s的临时镜像，请尽可能使用<a href=\"%(site_url)s%(request.get_full_path)s\">原始站点</a>。"
@@ -3719,7 +3719,7 @@ msgid "Notification"
 msgstr "通知"
 
 #: common/templates/_header.html:122 users/models/task.py:21
-#: users/templates/users/account.html:228
+#: users/templates/users/account.html:219
 #: users/templates/users/crossposts.html:9
 msgid "Pending"
 msgstr "等待"
@@ -3788,31 +3788,31 @@ msgstr "近期播客节目"
 msgid "Currently reading"
 msgstr "正在阅读"
 
-#: common/templates/_sidebar.html:203
+#: common/templates/_sidebar.html:210
 msgid "Currently watching"
 msgstr "正在追看"
 
-#: common/templates/_sidebar.html:226 journal/forms.py:197
+#: common/templates/_sidebar.html:233 journal/forms.py:197
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
 msgstr "标签"
 
-#: common/templates/_sidebar.html:232 journal/templates/user_tag_list.html:28
+#: common/templates/_sidebar.html:239 journal/templates/user_tag_list.html:28
 #: journal/templates/user_tagmember_list.html:10
 msgid "featured tag"
 msgstr "置顶标签"
 
-#: common/templates/_sidebar.html:235 journal/templates/user_tag_list.html:31
+#: common/templates/_sidebar.html:242 journal/templates/user_tag_list.html:31
 #: journal/templates/user_tagmember_list.html:15
 msgid "personal tag"
 msgstr "个人标签"
 
-#: common/templates/_sidebar.html:242 journal/templates/user_tag_list.html:39
+#: common/templates/_sidebar.html:249 journal/templates/user_tag_list.html:39
 msgid "no tags so far."
 msgstr "暂无标签。"
 
-#: common/templates/_sidebar.html:246 common/templates/_sidebar.html:259
+#: common/templates/_sidebar.html:253 common/templates/_sidebar.html:266
 msgid "show all"
 msgstr "显示全部"
 
@@ -4655,63 +4655,71 @@ msgstr "跳过迁移任务"
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr "要跳过的迁移后任务键，每行一个（如 normalize_genre）。worker 在出队时检查；被跳过的任务会记录警告并通知 Discord system 频道。"
 
-#: common/views_manage.py:820
+#: common/views_manage.py:819
+msgid "ATProto OAuth Client Key"
+msgstr "ATProto OAuth 客户端密钥"
+
+#: common/views_manage.py:821
+msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
+msgstr "用于向 ATProto 授权服务器标识本站点的私钥（JWK 格式）。首次 Bluesky 登录时自动生成；清空后将重新生成。"
+
+#: common/views_manage.py:828
 msgid "Domains"
 msgstr "域名"
 
-#: common/views_manage.py:823
+#: common/views_manage.py:831
 msgid "Operational"
 msgstr "运维"
 
-#: common/views_manage.py:838
+#: common/views_manage.py:847
 msgid "Movie Genres"
 msgstr "电影类型"
 
-#: common/views_manage.py:840
+#: common/views_manage.py:849
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "电影编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:845
+#: common/views_manage.py:854
 msgid "TV Genres"
 msgstr "剧集类型"
 
-#: common/views_manage.py:847
+#: common/views_manage.py:856
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "剧集编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:852
+#: common/views_manage.py:861
 msgid "Music Genres"
 msgstr "音乐类型"
 
-#: common/views_manage.py:854
+#: common/views_manage.py:863
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "音乐编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:859
+#: common/views_manage.py:868
 msgid "Game Genres"
 msgstr "游戏类型"
 
-#: common/views_manage.py:861
+#: common/views_manage.py:870
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "游戏编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:866
+#: common/views_manage.py:875
 msgid "Podcast Genres"
 msgstr "播客类型"
 
-#: common/views_manage.py:868
+#: common/views_manage.py:877
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "播客编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:873
+#: common/views_manage.py:882
 msgid "Performance Genres"
 msgstr "演出类型"
 
-#: common/views_manage.py:875
+#: common/views_manage.py:884
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:881
+#: common/views_manage.py:890
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
@@ -5494,7 +5502,7 @@ msgstr "关注的人"
 msgid "started following {item}"
 msgstr "关注了{item}"
 
-#: journal/models/shelf.py:893
+#: journal/models/shelf.py:900
 msgid "removed mark"
 msgstr "移除标记"
 
@@ -6028,7 +6036,7 @@ msgstr "年度小结"
 msgid "Articles"
 msgstr "文章"
 
-#: journal/templates/profile.html:162 journal/views/collection.py:384
+#: journal/templates/profile.html:162 journal/views/collection.py:385
 #: journal/views/profile.py:385
 msgid "collection"
 msgstr "收藏单"
@@ -6037,7 +6045,7 @@ msgstr "收藏单"
 msgid "liked collection"
 msgstr "喜欢的收藏单"
 
-#: journal/templates/profile.html:213 journal/views/profile.py:598
+#: journal/templates/profile.html:213 journal/views/profile.py:600
 msgid "Organizations"
 msgstr "团体"
 
@@ -6079,12 +6087,12 @@ msgid "Liked Collections"
 msgstr "喜欢的收藏单"
 
 #: journal/templates/user_follow_list.html:23 journal/views/profile.py:491
-#: users/templates/users/account.html:452
+#: users/templates/users/account.html:443
 msgid "Following"
 msgstr "正在关注"
 
 #: journal/templates/user_follow_list.html:28 journal/views/profile.py:495
-#: users/templates/users/account.html:461
+#: users/templates/users/account.html:452
 msgid "Followers"
 msgstr "关注者"
 
@@ -6131,34 +6139,34 @@ msgstr "{0} 的文章"
 msgid "Link invalid"
 msgstr "链接无效"
 
-#: journal/views/collection.py:56 journal/views/collection.py:93
+#: journal/views/collection.py:56 journal/views/collection.py:94
 #, python-brace-format
 msgid "Collection by {0}"
 msgstr "{0} 的收藏单"
 
-#: journal/views/collection.py:389
+#: journal/views/collection.py:390
 msgid "shared my collection"
 msgstr "分享我的收藏单"
 
-#: journal/views/collection.py:392
+#: journal/views/collection.py:393
 #, python-brace-format
 msgid "shared {username}'s collection"
 msgstr "分享 {username} 的收藏单"
 
-#: journal/views/collection.py:459 journal/views/collection.py:497
-#: journal/views/collection.py:509 journal/views/collection.py:535
+#: journal/views/collection.py:460 journal/views/collection.py:499
+#: journal/views/collection.py:511 journal/views/collection.py:537
 msgid "Dynamic collection is not editable"
 msgstr "不能修改动态收藏单中的条目"
 
-#: journal/views/collection.py:474
+#: journal/views/collection.py:476
 msgid "The item is already in the collection."
 msgstr "条目已在收藏单中。"
 
-#: journal/views/collection.py:476
+#: journal/views/collection.py:478
 msgid "Unable to find the item, please use item url from this site."
 msgstr "找不到条目，请使用本站条目网址。"
 
-#: journal/views/collection.py:522
+#: journal/views/collection.py:524
 msgid "Saved."
 msgstr "已保存"
 
@@ -6389,31 +6397,44 @@ msgstr "帖文长度限制"
 msgid "New Post"
 msgstr "新帖文"
 
-#: mastodon/views/bluesky.py:23 mastodon/views/email.py:35
+#: mastodon/views/bluesky.py:26 mastodon/views/bluesky.py:59
+msgid "Bluesky login is disabled."
+msgstr "Bluesky 登录已禁用。"
+
+#: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
 #: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
 #: users/templates/users/login.html:6 users/views/webauthn.py:133
 msgid "Security check failed. Please try again."
 msgstr "安全检查失败，请重试。"
 
-#: mastodon/views/bluesky.py:29 mastodon/views/bluesky.py:37
-#: mastodon/views/bluesky.py:47 mastodon/views/common.py:40
+#: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
+#: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
+#: mastodon/views/bluesky.py:78 mastodon/views/common.py:40
 #: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:187
+#: users/views/account.py:189
 msgid "Authentication failed"
 msgstr "认证失败"
 
-#: mastodon/views/bluesky.py:30 mastodon/views/email.py:66
+#: mastodon/views/bluesky.py:35 mastodon/views/email.py:66
 msgid "Too many attempts, please try again later."
 msgstr "尝试次数过多，请稍后再试。"
 
-#: mastodon/views/bluesky.py:38
-msgid "Username and app password is required."
-msgstr "请输入用户名和密码。"
+#: mastodon/views/bluesky.py:40
+msgid "ATProto handle is required."
+msgstr "请输入 ATProto 用户标识。"
 
-#: mastodon/views/bluesky.py:47
+#: mastodon/views/bluesky.py:50
+msgid "Error connecting to your ATProto server"
+msgstr "无法连接 ATProto 服务器"
+
+#: mastodon/views/bluesky.py:73
+msgid "Invalid response from ATProto authorization server."
+msgstr "ATProto 授权服务器返回信息无效"
+
+#: mastodon/views/bluesky.py:78
 msgid "Invalid account data from Bluesky."
 msgstr "Bluesky返回了无效的账号数据。"
 
@@ -6421,7 +6442,7 @@ msgstr "Bluesky返回了无效的账号数据。"
 msgid "Invalid user."
 msgstr "无效用户。"
 
-#: mastodon/views/common.py:56 users/views/account.py:223
+#: mastodon/views/common.py:56 users/views/account.py:225
 msgid "Registration failed"
 msgstr "注册失败"
 
@@ -6577,7 +6598,8 @@ msgstr "回应"
 msgid "More"
 msgstr "更多"
 
-#: social/templates/_remote_article_teaser.html:5
+#: social/templates/_remote_article_teaser.html:11
+#: social/templates/_remote_article_teaser.html:30
 msgid "Untitled article"
 msgstr "无标题文章"
 
@@ -7116,7 +7138,7 @@ msgstr "已验证的身份"
 
 #: users/templates/users/account.html:86 users/templates/users/account.html:148
 #: users/templates/users/account.html:186
-#: users/templates/users/account.html:317
+#: users/templates/users/account.html:308
 msgid "Last updated"
 msgstr "最近更新"
 
@@ -7150,7 +7172,7 @@ msgstr "关联联邦宇宙身份后可发现更多用户，并使用本站完整
 
 #: users/templates/users/account.html:123
 #: users/templates/users/account.html:160
-#: users/templates/users/account.html:215
+#: users/templates/users/account.html:206
 msgid "Once disconnected, you will no longer be able login with this identity. Are you sure to continue?"
 msgstr "取消关联后将无法使用这个身份登录本站，确认继续吗？"
 
@@ -7186,185 +7208,177 @@ msgstr "Bluesky (ATProto)"
 msgid "Verified ATProto identity"
 msgstr "已验证的ATProto身份"
 
-#: users/templates/users/account.html:194
-msgid "Bluesky Login ID"
-msgstr "Bluesky 登录名"
+#: users/templates/users/account.html:194 users/templates/users/login.html:216
+msgid "ATProto handle"
+msgstr "ATProto 用户标识"
 
-#: users/templates/users/account.html:202 users/templates/users/login.html:225
-msgid "Bluesky app password"
-msgstr "Bluesky 应用密码"
-
-#: users/templates/users/account.html:208
+#: users/templates/users/account.html:200
 msgid "Link with a different ATProto identity"
 msgstr "关联另一个ATProto身份"
 
-#: users/templates/users/account.html:208
+#: users/templates/users/account.html:200
 msgid "Link with an ATProto identity"
 msgstr "关联ATProto身份"
 
-#: users/templates/users/account.html:209 users/templates/users/login.html:230
-msgid "App password can be created on <a href=\"https://bsky.app/settings/app-passwords\" target=\"_blank\">bsky.app</a>."
-msgstr "应用密码可在 <a href=\"https://bsky.app/settings/app-passwords\" target=\"_blank\">bsky.app</a> 创建管理。"
-
-#: users/templates/users/account.html:218
+#: users/templates/users/account.html:209
 msgid "Disconnect with ATProto identity"
 msgstr "取消关联"
 
-#: users/templates/users/account.html:233
+#: users/templates/users/account.html:224
 msgid "Passkeys"
 msgstr "通行密钥"
 
-#: users/templates/users/account.html:235 users/templates/users/welcome.html:32
+#: users/templates/users/account.html:226 users/templates/users/welcome.html:32
 msgid "Name this passkey:"
 msgstr "为通行密钥命名:"
 
-#: users/templates/users/account.html:236 users/templates/users/login.html:69
+#: users/templates/users/account.html:227 users/templates/users/login.html:69
 #: users/templates/users/welcome.html:33 users/views/webauthn.py:106
 msgid "Passkey"
 msgstr "通行密钥"
 
-#: users/templates/users/account.html:242
+#: users/templates/users/account.html:233
 #: users/templates/users/authorized_app_create.html:24
 msgid "Name"
 msgstr "名称"
 
-#: users/templates/users/account.html:243
-#: users/templates/users/account.html:394
+#: users/templates/users/account.html:234
+#: users/templates/users/account.html:385
 msgid "Created"
 msgstr "创建时间"
 
-#: users/templates/users/account.html:244
+#: users/templates/users/account.html:235
 msgid "Last Used"
 msgstr "最近使用"
 
-#: users/templates/users/account.html:270
+#: users/templates/users/account.html:261
 msgid "No passkeys registered."
 msgstr "尚未注册通行密钥。"
 
-#: users/templates/users/account.html:275
+#: users/templates/users/account.html:266
 msgid "Add Passkey"
 msgstr "添加通行密钥"
 
-#: users/templates/users/account.html:283
+#: users/templates/users/account.html:274
 msgid "Sync and import social account"
 msgstr "同步第三方社交网络上的个人信息和社交数据"
 
-#: users/templates/users/account.html:293
+#: users/templates/users/account.html:284
 msgid "Sync display name, bio and avatar"
 msgstr "自动同步用户昵称等基本信息"
 
-#: users/templates/users/account.html:301
+#: users/templates/users/account.html:292
 msgid "Sync follow, mute and block"
 msgstr "自动导入新增的关注、屏蔽和隐藏列表"
 
-#: users/templates/users/account.html:304
+#: users/templates/users/account.html:295
 msgid "Save sync settings"
 msgstr "保存同步设置"
 
-#: users/templates/users/account.html:306
+#: users/templates/users/account.html:297
 msgid "New follow, mute and blocks in the associated identity may be automatically imported; removal has to be done manually."
 msgstr "本站会按照以上设置每天自动导入你在联邦宇宙实例等社交网络中新增的关注、屏蔽和隐藏列表；如果你在联邦宇宙实例中关注的用户加入了本站，你会自动关注她；如果你在联邦宇宙实例中取消了关注、屏蔽或隐藏，本站不会自动取消，但你可以手动移除。"
 
-#: users/templates/users/account.html:313
+#: users/templates/users/account.html:304
 msgid "Click button below to start sync now."
 msgstr "如果希望立即开始同步，可以点击下方按钮。"
 
-#: users/templates/users/account.html:314
+#: users/templates/users/account.html:305
 msgid "Sync now"
 msgstr "立即同步"
 
-#: users/templates/users/account.html:326
+#: users/templates/users/account.html:317
 msgid "Users you are following"
 msgstr "正在关注的用户"
 
-#: users/templates/users/account.html:335
+#: users/templates/users/account.html:326
 msgid "Users who follow you"
 msgstr "关注了你的用户"
 
-#: users/templates/users/account.html:344
+#: users/templates/users/account.html:335
 msgid "Users who request to follow you"
 msgstr "请求关注你的用户"
 
-#: users/templates/users/account.html:353
+#: users/templates/users/account.html:344
 msgid "Users you are muting"
 msgstr "已隐藏的用户"
 
-#: users/templates/users/account.html:362
+#: users/templates/users/account.html:353
 msgid "Users you are blocking"
 msgstr "已屏蔽的用户"
 
+#: users/templates/users/account.html:362
 #: users/templates/users/account.html:371
-#: users/templates/users/account.html:380
 msgid "Log out everywhere"
 msgstr "在所有设备上登出"
 
-#: users/templates/users/account.html:374
+#: users/templates/users/account.html:365
 msgid "This will log you out of all browsers and devices (including the current one), and revoke all API tokens. Continue?"
 msgstr "这将使你在所有浏览器和设备（包括当前设备）上登出，并撤销所有API令牌。继续吗？"
 
-#: users/templates/users/account.html:377
+#: users/templates/users/account.html:368
 msgid "If you notice any suspicious activity or have logged in on a shared computer, you can log out of all sessions and revoke all API tokens."
 msgstr "如果你留意到任何可疑活动，或者曾在公共电脑上登录过，可以选择在所有设备上登出并撤销所有API令牌。"
 
-#: users/templates/users/account.html:387
+#: users/templates/users/account.html:378
 msgid "Authorized Apps"
 msgstr "已授权的应用"
 
-#: users/templates/users/account.html:392
+#: users/templates/users/account.html:383
 msgid "Application"
 msgstr "应用"
 
-#: users/templates/users/account.html:393
+#: users/templates/users/account.html:384
 msgid "Scopes"
 msgstr "权限范围"
 
-#: users/templates/users/account.html:407
+#: users/templates/users/account.html:398
 msgid "Revoke access for this application?"
 msgstr "撤销此应用的访问权限？"
 
-#: users/templates/users/account.html:410
+#: users/templates/users/account.html:401
 msgid "Revoke"
 msgstr "撤销"
 
-#: users/templates/users/account.html:418
+#: users/templates/users/account.html:409
 msgid "No authorized applications."
 msgstr "没有已授权的应用。"
 
-#: users/templates/users/account.html:421
+#: users/templates/users/account.html:412
 #: users/templates/users/authorized_app_create.html:9
 #: users/templates/users/authorized_app_create.html:19
 msgid "Create Personal Token"
 msgstr "创建个人令牌"
 
-#: users/templates/users/account.html:427
+#: users/templates/users/account.html:418
 msgid "Import/Export Social Graph"
 msgstr "导入/导出社交关系"
 
-#: users/templates/users/account.html:428
+#: users/templates/users/account.html:419
 msgid "Upload a CSV file exported from Mastodon or compatible services."
 msgstr "上传从 Mastodon 或兼容服务导出的 CSV 文件。"
 
-#: users/templates/users/account.html:434
+#: users/templates/users/account.html:425
 msgid "Import type"
 msgstr "导入类型"
 
-#: users/templates/users/account.html:436
+#: users/templates/users/account.html:427
 msgid "Following list"
 msgstr "关注列表"
 
-#: users/templates/users/account.html:437
+#: users/templates/users/account.html:428
 msgid "Block list"
 msgstr "屏蔽列表"
 
-#: users/templates/users/account.html:438
+#: users/templates/users/account.html:429
 msgid "Mute list"
 msgstr "静音列表"
 
-#: users/templates/users/account.html:442
+#: users/templates/users/account.html:433
 msgid "CSV file"
 msgstr "CSV 文件"
 
-#: users/templates/users/account.html:445 users/templates/users/data.html:74
+#: users/templates/users/account.html:436 users/templates/users/data.html:74
 #: users/templates/users/data.html:126 users/templates/users/data.html:183
 #: users/templates/users/data.html:234 users/templates/users/data.html:298
 #: users/templates/users/data.html:358
@@ -7372,66 +7386,66 @@ msgstr "CSV 文件"
 msgid "Import"
 msgstr "导入"
 
+#: users/templates/users/account.html:447
 #: users/templates/users/account.html:456
 #: users/templates/users/account.html:465
 #: users/templates/users/account.html:474
-#: users/templates/users/account.html:483
 msgid "Download CSV"
 msgstr "下载 CSV"
 
-#: users/templates/users/account.html:470
+#: users/templates/users/account.html:461
 msgid "Blocks"
 msgstr "屏蔽"
 
-#: users/templates/users/account.html:479
+#: users/templates/users/account.html:470
 msgid "Mutes"
 msgstr "静音"
 
-#: users/templates/users/account.html:493
+#: users/templates/users/account.html:484
 msgid "Migrate Account"
 msgstr "迁移账号"
 
-#: users/templates/users/account.html:497
+#: users/templates/users/account.html:488
 msgid "Linking an email to your account is highly recommended before migrating from another Fediverse instance."
 msgstr "建议关联电子邮件后再从其他实例迁入。"
 
-#: users/templates/users/account.html:500
+#: users/templates/users/account.html:491
 msgid "Migrate another account here"
 msgstr "将其他账号迁入此处"
 
-#: users/templates/users/account.html:503
+#: users/templates/users/account.html:494
 msgid "Migrate to another account"
 msgstr "迁移到其他账号"
 
-#: users/templates/users/account.html:510
+#: users/templates/users/account.html:501
 msgid "Delete Account"
 msgstr "删除账号"
 
-#: users/templates/users/account.html:513
+#: users/templates/users/account.html:504
 msgid "Once deleted, account data cannot be recovered. Sure to proceed?"
 msgstr "账号数据一旦删除后将无法恢复，确定继续吗？"
 
-#: users/templates/users/account.html:516
+#: users/templates/users/account.html:507
 msgid "Enter full <code>username@instance.social</code> or <code>email@domain.com</code> to confirm deletion."
 msgstr "输入完整的登录用 <code>用户名@实例名</code> 或 <code>电子邮件地址</code> 以确认删除"
 
-#: users/templates/users/account.html:526
+#: users/templates/users/account.html:517
 msgid "Once deleted, account data cannot be recovered."
 msgstr "账号数据一旦删除后将无法恢复"
 
-#: users/templates/users/account.html:529
+#: users/templates/users/account.html:520
 msgid "Task in progress, can't delete now."
 msgstr "暂时无法删除，因为有导入或导出任务正在进行"
 
-#: users/templates/users/account.html:533
+#: users/templates/users/account.html:524
 msgid "Permanently Delete"
 msgstr "永久删除"
 
-#: users/templates/users/account.html:574
+#: users/templates/users/account.html:565
 msgid "Delete this passkey?"
 msgstr "确定删除这个通行密钥吗?"
 
-#: users/templates/users/account.html:594
+#: users/templates/users/account.html:585
 msgid "Rename passkey:"
 msgstr "重命名通行密钥:"
 
@@ -7719,7 +7733,7 @@ msgstr "实例域名(不含@和@之前的部分)，如mastodon.social"
 msgid "Please enter domain of your instance; e.g. if your id is <i>@neodb@mastodon.social</i>, only enter <i>mastodon.social</i>."
 msgstr "请输入你的实例域名(不含@和@之前的部分)；如果你的联邦账号是<i>@neodb@mastodon.social</i>，只需要在此输入<i>mastodon.social</i>。"
 
-#: users/templates/users/login.html:182 users/templates/users/login.html:255
+#: users/templates/users/login.html:182 users/templates/users/login.html:246
 msgid "Authorize via Fediverse instance"
 msgstr "去联邦实例授权注册或登录"
 
@@ -7731,44 +7745,40 @@ msgstr "如果你还没有或不便注册<a href=\"https://joinmastodon.org/serv
 msgid "Authorize via Threads"
 msgstr "去Threads授权注册或登录"
 
-#: users/templates/users/login.html:216
-msgid "ATProto handle"
-msgstr "ATProto 用户标识"
-
 #: users/templates/users/login.html:221
 msgid "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one."
 msgstr "请输入你的ATProto用户标识（例如neodb.bsky.social，不包含开头的@），不要输入电子邮件地址。如果你最近更改过标识，请使用最新的那一个。"
 
-#: users/templates/users/login.html:233
-msgid "Authorize via bsky.app"
-msgstr "使用Bluesky账号信息注册或登录"
+#: users/templates/users/login.html:224
+msgid "Authorize via ATProto server"
+msgstr "去 ATProto 服务器授权注册或登录"
 
-#: users/templates/users/login.html:240
+#: users/templates/users/login.html:231
 #, python-format
 msgid "Please choose one to register or login %(site_name)s. Have more than one of these identities? Don't worry, you may link them in account settings once logged in."
 msgstr "请选择一种方式注册或登录 %(site_name)s。如果你有多个社交身份，登录后可在账号设置中添加绑定。"
 
-#: users/templates/users/login.html:264
+#: users/templates/users/login.html:255
 msgid "Valid invitation code, please login or register."
 msgstr "邀请链接有效，可注册新用户"
 
-#: users/templates/users/login.html:266
+#: users/templates/users/login.html:257
 msgid "Please use invitation link to register a new account; existing user may login."
 msgstr "本站目前为邀请注册，已有账户可直接登入，新用户请使用有效邀请链接注册"
 
-#: users/templates/users/login.html:268
+#: users/templates/users/login.html:259
 msgid "Invitation code invalid or expired."
 msgstr "邀请链接无效，已有账户可直接登入，新用户请使用有效邀请链接注册"
 
-#: users/templates/users/login.html:276
+#: users/templates/users/login.html:267
 msgid "Loading timed out, please check your network (VPN) settings."
 msgstr "部分模块加载超时，请检查网络（翻墙）设置。"
 
-#: users/templates/users/login.html:282
+#: users/templates/users/login.html:273
 msgid "Continue using this site implies consent to our <a href=\"/pages/rules/\">rules</a> and <a href=\"/pages/terms/\">terms</a>, including using cookies to provide necessary functionality."
 msgstr "继续访问或注册视为同意<a href=\"/pages/rules/\">站规</a>与<a href=\"/pages/terms/\">协议</a>，及使用cookie提供必要功能"
 
-#: users/templates/users/login.html:296
+#: users/templates/users/login.html:287
 msgid "Domain of your instance (excl. @)"
 msgstr "实例域名(不含@和@之前的部分)"
 
@@ -8312,169 +8322,169 @@ msgstr "以后再说"
 msgid "Passkey created"
 msgstr "通行密钥已创建"
 
-#: users/views/account.py:121
+#: users/views/account.py:122
 msgid "This username is already in use."
 msgstr "用户名已被使用"
 
-#: users/views/account.py:132
+#: users/views/account.py:133
 msgid "This email address is already in use."
 msgstr "此电子邮件地址已被使用"
 
-#: users/views/account.py:188
+#: users/views/account.py:190
 msgid "Registration is for invitation only"
 msgstr "本站仅限邀请注册"
 
-#: users/views/account.py:224
+#: users/views/account.py:226
 msgid "Username already taken. Please try again."
 msgstr "用户名已被使用，请重试。"
 
-#: users/views/account.py:253
+#: users/views/account.py:256
 msgid "Valid username required"
 msgstr "请输入有效的用户名"
 
-#: users/views/account.py:323
+#: users/views/account.py:327
 msgid "Account is being deleted."
 msgstr "账户删除进行中。"
 
-#: users/views/account.py:326
+#: users/views/account.py:330
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 
-#: users/views/data.py:238 users/views/data.py:267
+#: users/views/data.py:239 users/views/data.py:269
 msgid "Export file not available."
 msgstr "导出文件不可用。"
 
-#: users/views/data.py:261
+#: users/views/data.py:263
 msgid "Generating exports."
 msgstr "正在生成导出文件。"
 
-#: users/views/data.py:279
+#: users/views/data.py:281
 msgid "Export file expired. Please export again."
 msgstr "导出文件已失效，请重新导出"
 
-#: users/views/data.py:294 users/views/data.py:314
+#: users/views/data.py:296 users/views/data.py:317
 msgid "Recent export still in progress."
 msgstr "正在导出"
 
-#: users/views/data.py:328
+#: users/views/data.py:332
 msgid "Sync in progress."
 msgstr "正在同步。"
 
-#: users/views/data.py:342
+#: users/views/data.py:346
 msgid "Settings saved."
 msgstr "设置已保存"
 
-#: users/views/data.py:397
+#: users/views/data.py:401
 msgid "Account no longer linked."
 msgstr "账户已不再关联。"
 
-#: users/views/data.py:400
+#: users/views/data.py:404
 msgid "Content is no longer public."
 msgstr "内容已不再公开。"
 
-#: users/views/data.py:428
+#: users/views/data.py:432
 msgid "Retry did not complete, please try again."
 msgstr "重试未完成，请再试一次。"
 
-#: users/views/data.py:438 users/views/data.py:471 users/views/data.py:694
-#: users/views/data.py:909 users/views/data.py:934 users/views/data.py:958
-#: users/views/data.py:982
+#: users/views/data.py:442 users/views/data.py:476 users/views/data.py:701
+#: users/views/data.py:918 users/views/data.py:944 users/views/data.py:969
+#: users/views/data.py:994
 msgid "Invalid file."
 msgstr "无效文件。"
 
-#: users/views/data.py:505 users/views/data.py:728
+#: users/views/data.py:512 users/views/data.py:737
 msgid "Loaded from uploaded matched file."
 msgstr "已从上传的匹配文件中加载。"
 
-#: users/views/data.py:530 users/views/data.py:757
+#: users/views/data.py:537 users/views/data.py:766
 msgid "Cancelled."
 msgstr "已取消。"
 
-#: users/views/data.py:550
+#: users/views/data.py:557
 msgid "No RateYourMusic import to preview."
 msgstr "暂无可预览的 RateYourMusic 导入任务。"
 
-#: users/views/data.py:558 users/views/data.py:668 users/views/data.py:787
-#: users/views/data.py:892
+#: users/views/data.py:565 users/views/data.py:675 users/views/data.py:796
+#: users/views/data.py:901
 msgid "Matched file missing."
 msgstr "匹配文件丢失。"
 
-#: users/views/data.py:654 users/views/data.py:878
+#: users/views/data.py:661 users/views/data.py:887
 msgid "Starting import..."
 msgstr "开始导入..."
 
-#: users/views/data.py:664 users/views/data.py:888
+#: users/views/data.py:671 users/views/data.py:897
 msgid "No matched file available."
 msgstr "没有可用的匹配文件。"
 
-#: users/views/data.py:779
+#: users/views/data.py:788
 msgid "No StoryGraph import to preview."
 msgstr "暂无可预览的 StoryGraph 导入任务。"
 
-#: users/views/data.py:1102
+#: users/views/data.py:1117
 msgid "Name is required."
 msgstr "名称不能为空。"
 
-#: users/views/data.py:1124
+#: users/views/data.py:1139
 msgid "Application access has been revoked."
 msgstr "应用访问权限已被撤销。"
 
-#: users/views/data.py:1140
+#: users/views/data.py:1155
 msgid "Alias update not allowed for a moved account."
 msgstr "已迁移的账号不允许更新别名。"
 
-#: users/views/data.py:1145
+#: users/views/data.py:1160
 msgid "No alias specified."
 msgstr "未指定别名。"
 
-#: users/views/data.py:1155 users/views/data.py:1206
+#: users/views/data.py:1170 users/views/data.py:1221
 msgid "Looking up the account. Please try again in a few seconds."
 msgstr "正在查找账号，请稍后重试。"
 
-#: users/views/data.py:1162
+#: users/views/data.py:1177
 #, python-brace-format
 msgid "Alias to {handle} removed."
 msgstr "已移除 {handle} 的别名。"
 
-#: users/views/data.py:1167
+#: users/views/data.py:1182
 #, python-brace-format
 msgid "Alias to {handle} added."
 msgstr "已添加 {handle} 的别名。"
 
-#: users/views/data.py:1193
+#: users/views/data.py:1208
 msgid "Migration cancelled."
 msgstr "迁移已取消。"
 
-#: users/views/data.py:1198
+#: users/views/data.py:1213
 msgid "No target account specified."
 msgstr "未指定目标账号。"
 
-#: users/views/data.py:1211
+#: users/views/data.py:1226
 msgid "Cannot migrate to a local account."
 msgstr "无法迁移到本站账号。"
 
-#: users/views/data.py:1222
+#: users/views/data.py:1237
 msgid "You must set up an alias in the target account first."
 msgstr "请先在目标账号上设置别名。"
 
-#: users/views/data.py:1228
+#: users/views/data.py:1243
 #, python-brace-format
 msgid "Start moving to {handle}."
 msgstr "开始迁移到 {handle}。"
 
-#: users/views/data.py:1286
+#: users/views/data.py:1301
 msgid "No file uploaded."
 msgstr "未上传文件。"
 
-#: users/views/data.py:1302
+#: users/views/data.py:1317
 msgid "The uploaded file is not a valid CSV."
 msgstr "上传的文件不是有效的 CSV 文件。"
 
-#: users/views/data.py:1306
+#: users/views/data.py:1321
 msgid "No valid entries found in the CSV file."
 msgstr "CSV 文件中未找到有效条目。"
 
-#: users/views/data.py:1315
+#: users/views/data.py:1331
 #, python-brace-format
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -163,6 +163,10 @@ class Bluesky:
             }
         )
         if account.pk:
+            # persist the exchanged credentials before the profile refresh:
+            # the old tokens are already invalid, so a transient PDS failure
+            # during refresh() must not leave them in the database
+            account.save(update_fields=["access_data", "handle"])
             account.refresh(save=True, did_check=False)
         else:
             account.refresh(save=False, did_check=False)
@@ -227,13 +231,14 @@ class BlueskyAccount(SocialAccount):
             force_refresh
             or int(session.get("expires_at") or 0) < time.time() + _TOKEN_EXPIRY_MARGIN
         ):
-            self._refresh_oauth_token()
+            self._refresh_oauth_token(force=force_refresh)
             session = self._get_oauth()
         return session["access_token"]
 
-    def _refresh_oauth_token(self) -> None:
+    def _refresh_oauth_token(self, force: bool = False) -> None:
         # refresh tokens are single-use, so serialize refreshes across
         # workers and pick up tokens another worker may have just rotated
+        rejected_token = self._get_oauth().get("access_token")
         lock_key = f"bluesky_oauth_refresh_{self.uid}"
         acquired = cache.add(lock_key, 1, timeout=60)
         try:
@@ -249,7 +254,13 @@ class BlueskyAccount(SocialAccount):
                     self._oauth_cache = None
             session = self._get_oauth()
             expires_at = int(session.get("expires_at") or 0)
-            if expires_at > time.time() + _TOKEN_EXPIRY_MARGIN:
+            rotated = session.get("access_token") != rejected_token
+            # a forced refresh means the server rejected the current token,
+            # so its recorded expiry cannot be trusted; only skip if another
+            # worker has already rotated it away
+            if expires_at > time.time() + _TOKEN_EXPIRY_MARGIN and (
+                not force or rotated
+            ):
                 return  # already refreshed by another worker
             if not session.get("refresh_token"):
                 raise OAuthError("OAuth session expired, re-authorization needed")

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -2,9 +2,11 @@ import base64
 import hashlib
 import json
 import re
+import secrets
+import time
 import typing
 from functools import cached_property
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from atproto import Client, SessionEvent, client_utils
 from atproto_client import models
@@ -14,6 +16,8 @@ from atproto_identity.handle.resolver import HandleResolver
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from django.conf import settings
+from django.core.cache import cache
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import timezone
 from loguru import logger
@@ -21,6 +25,17 @@ from loguru import logger
 from common.models import jsondata
 from takahe.utils import Takahe
 
+from .bluesky_oauth import (
+    DpopRequest,
+    OAuthError,
+    fetch_authserver_metadata,
+    fetch_pds_authserver,
+    generate_dpop_jwk,
+    get_client_id,
+    initial_token_request,
+    refresh_token_request,
+    send_par,
+)
 from .common import SocialAccount
 
 if typing.TYPE_CHECKING:
@@ -29,6 +44,10 @@ if typing.TYPE_CHECKING:
 
 
 PROFILE_NSID = "net.neodb.profile"
+
+_OAUTH_SESSION_KEY = "atproto_oauth"
+# refresh the access token when it expires within this margin
+_TOKEN_EXPIRY_MARGIN = 60
 
 
 class Bluesky:
@@ -42,46 +61,107 @@ class Bluesky:
     # handle and base_url may change in BlueskyAccount.refresh()
 
     @staticmethod
-    def authenticate(handle: str, password: str) -> "BlueskyAccount | None":
+    def _resolve_identity(handle: str) -> tuple[str, str]:
+        """handle -> (did, pds endpoint), with bidirectional verification."""
+        handle_r = HandleResolver(timeout=5)
+        did = handle_r.resolve(handle)
+        if not did:
+            raise OAuthError(f"handle {handle} not found")
+        did_r = DidResolver()
+        did_doc = did_r.resolve(did)
+        if not did_doc:
+            raise OAuthError(f"DID document for {did} not found")
+        resolved_handle = did_doc.get_handle()
+        if resolved_handle != handle:
+            raise OAuthError(f"handle {handle} does not match its DID document")
+        pds_url = did_doc.get_pds_endpoint()
+        if not pds_url:
+            raise OAuthError(f"no PDS endpoint for {did}")
+        return did, pds_url
+
+    @staticmethod
+    def generate_auth_url(handle: str, request: HttpRequest) -> str:
+        """Resolve the handle, push an authorization request to its auth
+        server and return the URL to redirect the user to; the pending
+        authorization state is kept in the django session."""
+        handle = handle.strip().lstrip("@").lower()
         if not Bluesky._RE_HANDLE.match(handle) or len(handle) > 500:
-            logger.warning(f"ATProto login failed: handle {handle} is invalid")
+            raise OAuthError("invalid handle")
+        did, pds_url = Bluesky._resolve_identity(handle)
+        issuer = fetch_pds_authserver(pds_url)
+        meta = fetch_authserver_metadata(issuer)
+        state = secrets.token_urlsafe(32)
+        code_verifier = secrets.token_urlsafe(48)
+        dpop_jwk = generate_dpop_jwk()
+        request_uri, nonce = send_par(
+            meta, dpop_jwk, handle=handle, state=state, code_verifier=code_verifier
+        )
+        request.session[_OAUTH_SESSION_KEY] = {
+            "state": state,
+            "did": did,
+            "handle": handle,
+            "pds_url": pds_url,
+            "issuer": meta["issuer"],
+            "token_endpoint": meta["token_endpoint"],
+            "code_verifier": code_verifier,
+            "dpop_jwk": dpop_jwk,
+            "authserver_nonce": nonce,
+        }
+        query = urlencode({"client_id": get_client_id(), "request_uri": request_uri})
+        return f"{meta['authorization_endpoint']}?{query}"
+
+    @staticmethod
+    def receive_oauth_code(
+        request: HttpRequest, code: str, state: str, iss: str | None
+    ) -> "BlueskyAccount | None":
+        """Complete the authorization code flow and return the account."""
+        pending = request.session.pop(_OAUTH_SESSION_KEY, None)
+        if not pending or not secrets.compare_digest(
+            pending["state"].encode(), state.encode()
+        ):
+            logger.warning("ATProto OAuth failed: state mismatch")
+            return None
+        if iss and iss.rstrip("/") != pending["issuer"].rstrip("/"):
+            logger.warning(f"ATProto OAuth failed: iss mismatch {iss}")
             return None
         try:
-            handle_r = HandleResolver(timeout=5)
-            did = handle_r.resolve(handle)
-            if not did:
-                logger.warning(
-                    f"ATProto login failed: handle {handle} -> <missing did>"
-                )
-                return
-            did_r = DidResolver()
-            did_doc = did_r.resolve(did)
-            if not did_doc:
-                logger.warning(
-                    f"ATProto login failed: handle {handle} -> did {did} -> <missing doc>"
-                )
-                return
-            resolved_handle = did_doc.get_handle()
-            if resolved_handle != handle:
-                logger.warning(
-                    f"ATProto login failed: handle {handle} -> did {did} -> handle {resolved_handle}"
-                )
-                return
-            base_url = did_doc.get_pds_endpoint()
-            client = Client(base_url)
-            profile = client.login(handle, password)
-            session_string = client.export_session_string()
-        except Exception as e:
-            logger.warning(f"Bluesky login {handle} exception {e}")
-            return
-        account = BlueskyAccount.objects.filter(
-            uid=profile.did, domain=Bluesky._DOMAIN
-        ).first()
+            tokens, nonce = initial_token_request(
+                pending["token_endpoint"],
+                pending["issuer"],
+                code,
+                pending["code_verifier"],
+                pending["dpop_jwk"],
+                pending["authserver_nonce"],
+            )
+        except OAuthError as e:
+            logger.warning(f"ATProto OAuth token exchange failed: {e}")
+            return None
+        did = tokens.get("sub")
+        if did != pending["did"]:
+            logger.warning(f"ATProto OAuth failed: sub {did} != {pending['did']}")
+            return None
+        if "atproto" not in (tokens.get("scope") or "").split():
+            logger.warning("ATProto OAuth failed: atproto scope not granted")
+            return None
+        account = BlueskyAccount.objects.filter(uid=did, domain=Bluesky._DOMAIN).first()
         if not account:
-            account = BlueskyAccount(uid=profile.did, domain=Bluesky._DOMAIN)
-        account._client = client
-        account.session_string = session_string
-        account.base_url = base_url
+            account = BlueskyAccount(uid=did, domain=Bluesky._DOMAIN)
+        account.handle = pending["handle"]
+        account.base_url = pending["pds_url"]
+        account.session_string = ""  # drop legacy app-password session if any
+        account._set_oauth(
+            {
+                "issuer": pending["issuer"],
+                "token_endpoint": pending["token_endpoint"],
+                "dpop_jwk": pending["dpop_jwk"],
+                "access_token": tokens["access_token"],
+                "refresh_token": tokens.get("refresh_token", ""),
+                "expires_at": int(time.time()) + int(tokens.get("expires_in") or 300),
+                "scope": tokens.get("scope", ""),
+                "authserver_nonce": nonce,
+                "pds_nonce": "",
+            }
+        )
         if account.pk:
             account.refresh(save=True, did_check=False)
         else:
@@ -90,23 +170,106 @@ class Bluesky:
 
 
 class BlueskyAccount(SocialAccount):
-    # app_username = jsondata.CharField(json_field_name="access_data", default="")
-    # app_password = jsondata.EncryptedTextField(
-    #     json_field_name="access_data", default=""
-    # )
     base_url = jsondata.CharField(json_field_name="access_data", default=None)
+    # legacy app-password session; still used by accounts that have not
+    # re-authorized via OAuth yet
     session_string = jsondata.EncryptedTextField(
+        json_field_name="access_data", default=""
+    )
+    # JSON-encoded OAuth session: tokens, DPoP key and server nonces
+    oauth_session = jsondata.EncryptedTextField(
         json_field_name="access_data", default=""
     )
     display_name = jsondata.CharField(json_field_name="account_data", default="")
     description = jsondata.CharField(json_field_name="account_data", default="")
     avatar = jsondata.CharField(json_field_name="account_data", default="")
 
+    _oauth_cache: dict | None = None
+
     def get_reauthorize_url(self) -> str:
         url = reverse("users:login") + "?method=bluesky"
         if self.handle:
             url += "&username=" + quote(self.handle)
         return url
+
+    def _get_oauth(self) -> dict:
+        if self._oauth_cache is None:
+            try:
+                self._oauth_cache = (
+                    json.loads(self.oauth_session) if self.oauth_session else {}
+                )
+            except json.JSONDecodeError:
+                self._oauth_cache = {}
+        return self._oauth_cache
+
+    def _set_oauth(self, session: dict, save: bool = False) -> None:
+        self._oauth_cache = session
+        self.oauth_session = json.dumps(session)
+        if save and self.pk:
+            self.save(update_fields=["access_data"])
+
+    def get_dpop_jwk(self) -> dict:
+        return self._get_oauth().get("dpop_jwk") or {}
+
+    def get_pds_nonce(self) -> str:
+        return self._get_oauth().get("pds_nonce") or ""
+
+    def save_pds_nonce(self, nonce: str) -> None:
+        session = self._get_oauth()
+        session["pds_nonce"] = nonce
+        self._set_oauth(session, save=True)
+
+    def get_access_token(self, force_refresh: bool = False) -> str:
+        session = self._get_oauth()
+        if not session.get("access_token"):
+            raise OAuthError("no OAuth session for this account")
+        if (
+            force_refresh
+            or int(session.get("expires_at") or 0) < time.time() + _TOKEN_EXPIRY_MARGIN
+        ):
+            self._refresh_oauth_token()
+            session = self._get_oauth()
+        return session["access_token"]
+
+    def _refresh_oauth_token(self) -> None:
+        # refresh tokens are single-use, so serialize refreshes across
+        # workers and pick up tokens another worker may have just rotated
+        lock_key = f"bluesky_oauth_refresh_{self.uid}"
+        acquired = cache.add(lock_key, 1, timeout=60)
+        try:
+            if not acquired:
+                for _ in range(20):
+                    time.sleep(0.5)
+                    if not cache.get(lock_key):
+                        break
+            if self.pk:
+                fresh = BlueskyAccount.objects.filter(pk=self.pk).first()
+                if fresh and fresh.access_data != self.access_data:
+                    self.access_data = fresh.access_data
+                    self._oauth_cache = None
+            session = self._get_oauth()
+            expires_at = int(session.get("expires_at") or 0)
+            if expires_at > time.time() + _TOKEN_EXPIRY_MARGIN:
+                return  # already refreshed by another worker
+            if not session.get("refresh_token"):
+                raise OAuthError("OAuth session expired, re-authorization needed")
+            tokens, nonce = refresh_token_request(
+                session["token_endpoint"],
+                session["issuer"],
+                session["refresh_token"],
+                session["dpop_jwk"],
+                session.get("authserver_nonce", ""),
+            )
+            session.update(
+                access_token=tokens["access_token"],
+                refresh_token=tokens.get("refresh_token", session["refresh_token"]),
+                expires_at=int(time.time()) + int(tokens.get("expires_in") or 300),
+                authserver_nonce=nonce,
+            )
+            self._set_oauth(session, save=True)
+        finally:
+            if acquired:
+                cache.delete(lock_key)
 
     def on_session_change(self, event, session) -> None:
         if event in (SessionEvent.CREATE, SessionEvent.REFRESH):
@@ -118,6 +281,13 @@ class BlueskyAccount(SocialAccount):
 
     @cached_property
     def _client(self):
+        if self._get_oauth().get("access_token"):
+            client = Client(self.base_url, request=DpopRequest(self))
+            self._profile = client.app.bsky.actor.get_profile(
+                models.AppBskyActorGetProfile.Params(actor=self.uid)
+            )
+            client.me = self._profile
+            return client
         client = Client()
         client.on_session_change(self.on_session_change)
         self._profile = client.login(session_string=self.session_string)

--- a/neodb/mastodon/models/bluesky_oauth.py
+++ b/neodb/mastodon/models/bluesky_oauth.py
@@ -169,8 +169,12 @@ def fetch_authserver_metadata(issuer: str) -> dict:
         "token_endpoint",
         "pushed_authorization_request_endpoint",
     ):
-        if not meta.get(key):
+        endpoint = meta.get(key)
+        if not endpoint or not isinstance(endpoint, str):
             raise OAuthError(f"authorization server metadata missing {key}")
+        # server-side requests (PAR/token) and the user redirect must never
+        # be sent to a non-https endpoint smuggled via compliant metadata
+        _require_https(endpoint, key)
     return meta
 
 

--- a/neodb/mastodon/models/bluesky_oauth.py
+++ b/neodb/mastodon/models/bluesky_oauth.py
@@ -1,0 +1,382 @@
+"""
+ATProto OAuth client, per https://atproto.com/specs/oauth
+
+NeoDB acts as a confidential OAuth client: the client metadata document is
+served under /account/bluesky/client-metadata.json (its public URL is the
+client_id), token requests are authenticated with a private_key_jwt assertion
+signed by an auto-generated ES256 key persisted in SiteConfig, and all access
+tokens are DPoP-bound as the spec requires.
+"""
+
+import base64
+import hashlib
+import json
+import secrets
+import time
+import typing
+from urllib.parse import urlsplit
+
+import httpx
+from atproto_client.request import Request, _handle_request_errors, _handle_response
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+from django.conf import settings
+from django.db import transaction
+from django.urls import reverse
+
+from common.models import SiteConfig
+
+SCOPE = "atproto transition:generic"
+CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+_TIMEOUT = 10
+
+
+class OAuthError(Exception):
+    pass
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+
+
+def _json_b64(obj: dict) -> str:
+    return _b64url(json.dumps(obj, separators=(",", ":")).encode())
+
+
+def generate_dpop_jwk() -> dict[str, str]:
+    """Generate an ES256 (P-256) private key as a JWK dict."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    private = key.private_numbers()
+    public = private.public_numbers
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _b64url(public.x.to_bytes(32, "big")),
+        "y": _b64url(public.y.to_bytes(32, "big")),
+        "d": _b64url(private.private_value.to_bytes(32, "big")),
+    }
+
+
+def public_jwk(jwk: dict) -> dict:
+    return {
+        k: jwk[k] for k in ("kty", "crv", "x", "y", "kid", "alg", "use") if k in jwk
+    }
+
+
+def _private_key(jwk: dict) -> ec.EllipticCurvePrivateKey:
+    public = ec.EllipticCurvePublicNumbers(
+        int.from_bytes(_b64url_decode(jwk["x"]), "big"),
+        int.from_bytes(_b64url_decode(jwk["y"]), "big"),
+        ec.SECP256R1(),
+    )
+    private_value = int.from_bytes(_b64url_decode(jwk["d"]), "big")
+    return ec.EllipticCurvePrivateNumbers(private_value, public).private_key()
+
+
+def sign_jwt(private_jwk: dict, header: dict, claims: dict) -> str:
+    signing_input = f"{_json_b64(header)}.{_json_b64(claims)}"
+    der = _private_key(private_jwk).sign(
+        signing_input.encode(), ec.ECDSA(hashes.SHA256())
+    )
+    r, s = decode_dss_signature(der)
+    signature = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+def get_client_private_jwk() -> dict:
+    """The instance-wide ES256 client key, generated and persisted on first use."""
+    SiteConfig.ensure_loaded()
+    raw = SiteConfig.system.atproto_client_jwk
+    if not raw:
+        with transaction.atomic():
+            obj, _ = SiteConfig.objects.select_for_update().get_or_create(
+                pk=1, defaults={"data": {}}
+            )
+            raw = obj.data.get("atproto_client_jwk", "")
+            if not raw:
+                jwk = generate_dpop_jwk()
+                jwk["kid"] = f"neodb-{secrets.token_hex(8)}"
+                raw = json.dumps(jwk)
+                obj.data = {**obj.data, "atproto_client_jwk": raw}
+                obj.save(update_fields=["data"])
+        SiteConfig.reload()
+    return json.loads(raw)
+
+
+def get_client_id() -> str:
+    return settings.SITE_INFO["site_url"] + reverse("mastodon:bluesky_client_metadata")
+
+
+def get_redirect_uri() -> str:
+    return settings.SITE_INFO["site_url"] + reverse("mastodon:bluesky_oauth")
+
+
+def get_client_metadata() -> dict:
+    return {
+        "client_id": get_client_id(),
+        "client_name": settings.SITE_INFO["site_name"],
+        "client_uri": settings.SITE_INFO["site_url"],
+        "redirect_uris": [get_redirect_uri()],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "scope": SCOPE,
+        "application_type": "web",
+        "dpop_bound_access_tokens": True,
+        "token_endpoint_auth_method": "private_key_jwt",
+        "token_endpoint_auth_signing_alg": "ES256",
+        "jwks": {"keys": [public_jwk(get_client_private_jwk())]},
+    }
+
+
+def _require_https(url: str, what: str) -> None:
+    if urlsplit(url).scheme != "https" and not settings.DEBUG:
+        raise OAuthError(f"{what} is not https: {url}")
+
+
+def fetch_pds_authserver(pds_url: str) -> str:
+    """Resolve the authorization server issuer for a PDS."""
+    _require_https(pds_url, "PDS endpoint")
+    url = f"{pds_url.rstrip('/')}/.well-known/oauth-protected-resource"
+    try:
+        r = httpx.get(url, timeout=_TIMEOUT)
+        r.raise_for_status()
+        servers = r.json().get("authorization_servers")
+    except Exception as e:
+        raise OAuthError(f"error fetching PDS resource metadata: {e}") from e
+    if not isinstance(servers, list) or not servers or not isinstance(servers[0], str):
+        raise OAuthError("PDS lists no authorization server")
+    return servers[0]
+
+
+def fetch_authserver_metadata(issuer: str) -> dict:
+    _require_https(issuer, "authorization server")
+    url = f"{issuer.rstrip('/')}/.well-known/oauth-authorization-server"
+    try:
+        r = httpx.get(url, timeout=_TIMEOUT)
+        r.raise_for_status()
+        meta = r.json()
+    except Exception as e:
+        raise OAuthError(f"error fetching authorization server metadata: {e}") from e
+    if meta.get("issuer", "").rstrip("/") != issuer.rstrip("/"):
+        raise OAuthError("issuer mismatch in authorization server metadata")
+    for key in (
+        "authorization_endpoint",
+        "token_endpoint",
+        "pushed_authorization_request_endpoint",
+    ):
+        if not meta.get(key):
+            raise OAuthError(f"authorization server metadata missing {key}")
+    return meta
+
+
+def dpop_proof(
+    dpop_jwk: dict, method: str, url: str, *, nonce: str = "", access_token: str = ""
+) -> str:
+    parts = urlsplit(url)
+    now = int(time.time())
+    claims: dict[str, typing.Any] = {
+        "jti": secrets.token_urlsafe(16),
+        "htm": method.upper(),
+        "htu": f"{parts.scheme}://{parts.netloc}{parts.path}",
+        "iat": now,
+        "exp": now + 60,
+    }
+    if nonce:
+        claims["nonce"] = nonce
+    if access_token:
+        claims["ath"] = _b64url(hashlib.sha256(access_token.encode()).digest())
+    header = {
+        "typ": "dpop+jwt",
+        "alg": "ES256",
+        "jwk": {k: dpop_jwk[k] for k in ("kty", "crv", "x", "y")},
+    }
+    return sign_jwt(dpop_jwk, header, claims)
+
+
+def client_assertion(audience: str) -> str:
+    jwk = get_client_private_jwk()
+    client_id = get_client_id()
+    now = int(time.time())
+    return sign_jwt(
+        jwk,
+        {"alg": "ES256", "kid": jwk["kid"]},
+        {
+            "iss": client_id,
+            "sub": client_id,
+            "aud": audience,
+            "jti": secrets.token_urlsafe(16),
+            "iat": now,
+            "exp": now + 300,
+        },
+    )
+
+
+def _authserver_post(
+    url: str, data: dict, dpop_jwk: dict, nonce: str
+) -> tuple[dict, str]:
+    """POST to an auth server endpoint with DPoP, retrying once when the
+    server demands a (new) nonce. Returns (json body, latest DPoP nonce)."""
+    for _ in range(2):
+        headers = {"DPoP": dpop_proof(dpop_jwk, "POST", url, nonce=nonce)}
+        try:
+            r = httpx.post(url, data=data, headers=headers, timeout=_TIMEOUT)
+        except Exception as e:
+            raise OAuthError(f"error requesting {url}: {e}") from e
+        nonce = r.headers.get("DPoP-Nonce", nonce)
+        if r.status_code in (400, 401):
+            try:
+                error = r.json().get("error")
+            except Exception:
+                error = None
+            if error == "use_dpop_nonce":
+                continue
+        break
+    if r.status_code not in (200, 201):
+        raise OAuthError(f"{url} returned {r.status_code}: {r.text[:200]}")
+    return r.json(), nonce
+
+
+def send_par(
+    authserver_meta: dict,
+    dpop_jwk: dict,
+    *,
+    handle: str,
+    state: str,
+    code_verifier: str,
+) -> tuple[str, str]:
+    """Pushed Authorization Request; returns (request_uri, DPoP nonce)."""
+    challenge = _b64url(hashlib.sha256(code_verifier.encode()).digest())
+    data = {
+        "response_type": "code",
+        "client_id": get_client_id(),
+        "redirect_uri": get_redirect_uri(),
+        "scope": SCOPE,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "login_hint": handle,
+        "client_assertion_type": CLIENT_ASSERTION_TYPE,
+        "client_assertion": client_assertion(authserver_meta["issuer"]),
+    }
+    body, nonce = _authserver_post(
+        authserver_meta["pushed_authorization_request_endpoint"], data, dpop_jwk, ""
+    )
+    request_uri = body.get("request_uri")
+    if not request_uri:
+        raise OAuthError("PAR response missing request_uri")
+    return request_uri, nonce
+
+
+def initial_token_request(
+    token_endpoint: str,
+    issuer: str,
+    code: str,
+    code_verifier: str,
+    dpop_jwk: dict,
+    nonce: str,
+) -> tuple[dict, str]:
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": get_client_id(),
+        "redirect_uri": get_redirect_uri(),
+        "code": code,
+        "code_verifier": code_verifier,
+        "client_assertion_type": CLIENT_ASSERTION_TYPE,
+        "client_assertion": client_assertion(issuer),
+    }
+    return _authserver_post(token_endpoint, data, dpop_jwk, nonce)
+
+
+def refresh_token_request(
+    token_endpoint: str, issuer: str, refresh_token: str, dpop_jwk: dict, nonce: str
+) -> tuple[dict, str]:
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": get_client_id(),
+        "refresh_token": refresh_token,
+        "client_assertion_type": CLIENT_ASSERTION_TYPE,
+        "client_assertion": client_assertion(issuer),
+    }
+    return _authserver_post(token_endpoint, data, dpop_jwk, nonce)
+
+
+def _is_use_dpop_nonce(response: httpx.Response) -> bool:
+    if "use_dpop_nonce" in response.headers.get("WWW-Authenticate", ""):
+        return True
+    try:
+        return response.json().get("error") == "use_dpop_nonce"
+    except Exception:
+        return False
+
+
+class OAuthSessionProvider(typing.Protocol):
+    """What DpopRequest needs from an account holding an OAuth session."""
+
+    def get_dpop_jwk(self) -> dict: ...
+
+    def get_pds_nonce(self) -> str: ...
+
+    def save_pds_nonce(self, nonce: str) -> None: ...
+
+    def get_access_token(self, force_refresh: bool = False) -> str: ...
+
+
+class DpopRequest(Request):
+    """atproto SDK transport that signs every XRPC call with the account's
+    DPoP key and OAuth access token, transparently handling server nonce
+    rotation and expired-token refresh."""
+
+    _MAX_ATTEMPTS = 4
+
+    def __init__(self, session: OAuthSessionProvider | None = None) -> None:
+        super().__init__()
+        self._oauth = session
+
+    def clone(self):
+        # Request.clone() constructs type(self)() with no arguments
+        cloned = super().clone()
+        cloned._oauth = self._oauth
+        return cloned
+
+    def _send_request(self, method: str, url: str, **kwargs: typing.Any):
+        if self._oauth is None:
+            raise OAuthError("no OAuth session bound to this client")
+        base_headers = self.get_headers(kwargs.pop("headers", None))
+        refreshed = False
+        for attempt in range(self._MAX_ATTEMPTS):
+            token = self._oauth.get_access_token()
+            headers = dict(base_headers)
+            headers["Authorization"] = f"DPoP {token}"
+            headers["DPoP"] = dpop_proof(
+                self._oauth.get_dpop_jwk(),
+                method,
+                url,
+                nonce=self._oauth.get_pds_nonce(),
+                access_token=token,
+            )
+            try:
+                response = self._client.request(
+                    method=method, url=url, headers=headers, **kwargs
+                )
+            except Exception as e:
+                _handle_request_errors(e)
+                raise e
+            nonce = response.headers.get("DPoP-Nonce", "")
+            if nonce and nonce != self._oauth.get_pds_nonce():
+                self._oauth.save_pds_nonce(nonce)
+            retriable = attempt < self._MAX_ATTEMPTS - 1
+            if response.status_code in (400, 401) and _is_use_dpop_nonce(response):
+                if nonce and retriable:
+                    continue
+            elif response.status_code == 401 and not refreshed and retriable:
+                # server rejected the token before its recorded expiry
+                refreshed = True
+                self._oauth.get_access_token(force_refresh=True)
+                continue
+            break
+        return _handle_response(response)

--- a/neodb/mastodon/urls.py
+++ b/neodb/mastodon/urls.py
@@ -23,6 +23,12 @@ urlpatterns = [
     path("threads/delete/status", threads_delete_status, name="threads_delete_status"),
     # Bluesky
     path("bluesky/login", bluesky_login, name="bluesky_login"),
+    path("bluesky/oauth", bluesky_oauth, name="bluesky_oauth"),
+    path(
+        "bluesky/client-metadata.json",
+        bluesky_client_metadata,
+        name="bluesky_client_metadata",
+    ),
     path("bluesky/reconnect", bluesky_reconnect, name="bluesky_reconnect"),
     path("bluesky/disconnect", bluesky_disconnect, name="bluesky_disconnect"),
 ]

--- a/neodb/mastodon/views/bluesky.py
+++ b/neodb/mastodon/views/bluesky.py
@@ -1,24 +1,29 @@
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.http import HttpRequest
+from django.http import HttpRequest, JsonResponse
+from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.models import SiteConfig
 from common.sentry import count as sentry_count
 from common.views import render_error
 from users.login_proof import verify_login_proof
 
 from ..models import Bluesky
+from ..models.bluesky_oauth import get_client_metadata
 from .common import client_ip, disconnect_identity, process_verified_account
 
-# Cap failed app-password logins per client IP so the server cannot be used
-# to relay credential stuffing against Bluesky accounts.
+# Cap failed authorization starts per client IP so the server cannot be
+# used to relay identity probing against ATProto handles.
 _MAX_AUTH_FAILS = 10
 _AUTH_FAIL_TTL = 60 * 60
 
 
 @require_http_methods(["POST"])
 def bluesky_login(request: HttpRequest):
+    if not request.user.is_authenticated and not SiteConfig.system.enable_login_bluesky:
+        return render_error(request, _("Bluesky login is disabled."))
     if not verify_login_proof(request, "bluesky"):
         return render_error(request, _("Security check failed. Please try again."))
     sentry_count("login.attempt", attributes={"type": "bluesky"})
@@ -30,23 +35,55 @@ def bluesky_login(request: HttpRequest):
             _("Too many attempts, please try again later."),
         )
     username = request.POST.get("username", "").strip().lstrip("@")
-    password = request.POST.get("password", "").strip()
-    if not username or not password:
+    if not username:
         return render_error(
-            request,
-            _("Authentication failed"),
-            _("Username and app password is required."),
+            request, _("Authentication failed"), _("ATProto handle is required.")
         )
-    account = Bluesky.authenticate(username, password)
-    if not account:
+    try:
+        login_url = Bluesky.generate_auth_url(username, request)
+    except Exception as e:
         try:
             cache.incr(fail_key)
         except ValueError:
             cache.set(fail_key, 1, timeout=_AUTH_FAIL_TTL)
         return render_error(
+            request, _("Error connecting to your ATProto server"), f"{username}: {e}"
+        )
+    return redirect(login_url)
+
+
+@require_http_methods(["GET"])
+def bluesky_oauth(request: HttpRequest):
+    """handle redirect back from the ATProto authorization server"""
+    if not request.user.is_authenticated and not SiteConfig.system.enable_login_bluesky:
+        return render_error(request, _("Bluesky login is disabled."))
+    if request.GET.get("error"):
+        request.session.pop("atproto_oauth", None)
+        return render_error(
+            request,
+            _("Authentication failed"),
+            request.GET.get("error_description") or request.GET["error"],
+        )
+    code = request.GET.get("code")
+    state = request.GET.get("state")
+    if not code or not state:
+        return render_error(
+            request,
+            _("Authentication failed"),
+            _("Invalid response from ATProto authorization server."),
+        )
+    account = Bluesky.receive_oauth_code(request, code, state, request.GET.get("iss"))
+    if not account:
+        return render_error(
             request, _("Authentication failed"), _("Invalid account data from Bluesky.")
         )
     return process_verified_account(request, account)
+
+
+@require_http_methods(["GET"])
+def bluesky_client_metadata(request: HttpRequest):
+    """OAuth client metadata document; its public URL is the client_id"""
+    return JsonResponse(get_client_metadata())
 
 
 @require_http_methods(["POST"])

--- a/neodb/tests/mastodon/test_bluesky_oauth.py
+++ b/neodb/tests/mastodon/test_bluesky_oauth.py
@@ -1,0 +1,481 @@
+import base64
+import hashlib
+import json
+import time
+from importlib import import_module
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from django.conf import settings
+from django.test import RequestFactory
+from django.urls import reverse
+
+from common.models import SiteConfig
+from mastodon.models import bluesky as bluesky_module
+from mastodon.models import bluesky_oauth
+from mastodon.models.bluesky import Bluesky, BlueskyAccount
+from mastodon.models.bluesky_oauth import (
+    SCOPE,
+    DpopRequest,
+    OAuthError,
+    dpop_proof,
+    generate_dpop_jwk,
+    public_jwk,
+    sign_jwt,
+)
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+
+
+def _decode_segment(segment: str) -> dict:
+    return json.loads(_b64url_decode(segment))
+
+
+def _verify_es256(jwk: dict, token: str) -> tuple[dict, dict]:
+    """Verify signature with plain cryptography, return (header, claims)."""
+    header_b64, claims_b64, sig_b64 = token.split(".")
+    signature = _b64url_decode(sig_b64)
+    der = encode_dss_signature(
+        int.from_bytes(signature[:32], "big"), int.from_bytes(signature[32:], "big")
+    )
+    public_key = ec.EllipticCurvePublicNumbers(
+        int.from_bytes(_b64url_decode(jwk["x"]), "big"),
+        int.from_bytes(_b64url_decode(jwk["y"]), "big"),
+        ec.SECP256R1(),
+    ).public_key()
+    public_key.verify(
+        der, f"{header_b64}.{claims_b64}".encode(), ec.ECDSA(hashes.SHA256())
+    )
+    return _decode_segment(header_b64), _decode_segment(claims_b64)
+
+
+def test_sign_jwt_roundtrip():
+    jwk = generate_dpop_jwk()
+    token = sign_jwt(jwk, {"alg": "ES256"}, {"iss": "me", "aud": "you"})
+    header, claims = _verify_es256(jwk, token)
+    assert header == {"alg": "ES256"}
+    assert claims == {"iss": "me", "aud": "you"}
+
+
+def test_public_jwk_has_no_private_part():
+    jwk = generate_dpop_jwk()
+    jwk["kid"] = "k1"
+    pub = public_jwk(jwk)
+    assert "d" not in pub
+    assert pub["kid"] == "k1"
+    assert pub["kty"] == "EC"
+
+
+def test_dpop_proof_claims():
+    jwk = generate_dpop_jwk()
+    proof = dpop_proof(
+        jwk,
+        "get",
+        "https://pds.example/xrpc/com.atproto.repo.getRecord?repo=x&rkey=y",
+        nonce="n1",
+        access_token="tok",
+    )
+    header, claims = _verify_es256(jwk, proof)
+    assert header["typ"] == "dpop+jwt"
+    assert header["alg"] == "ES256"
+    assert "d" not in header["jwk"]
+    assert claims["htm"] == "GET"
+    # htu must not carry query or fragment
+    assert claims["htu"] == "https://pds.example/xrpc/com.atproto.repo.getRecord"
+    assert claims["nonce"] == "n1"
+    assert claims["ath"] == (
+        base64.urlsafe_b64encode(hashlib.sha256(b"tok").digest()).rstrip(b"=").decode()
+    )
+
+
+def test_authserver_post_retries_with_server_nonce(monkeypatch):
+    jwk = generate_dpop_jwk()
+    posts = []
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        posts.append((url, dict(data or {}), dict(headers or {})))
+        if len(posts) == 1:
+            return httpx.Response(
+                400,
+                json={"error": "use_dpop_nonce"},
+                headers={"DPoP-Nonce": "server-nonce"},
+            )
+        return httpx.Response(
+            200, json={"request_uri": "urn:x"}, headers={"DPoP-Nonce": "server-nonce"}
+        )
+
+    monkeypatch.setattr(bluesky_oauth.httpx, "post", fake_post)
+
+    body, nonce = bluesky_oauth._authserver_post(
+        "https://auth.example/par", {"a": "b"}, jwk, ""
+    )
+
+    assert body == {"request_uri": "urn:x"}
+    assert nonce == "server-nonce"
+    assert len(posts) == 2
+    # second attempt carries the server-provided nonce in its proof
+    _, claims = _verify_es256(jwk, posts[1][2]["DPoP"])
+    assert claims["nonce"] == "server-nonce"
+    _, first_claims = _verify_es256(jwk, posts[0][2]["DPoP"])
+    assert "nonce" not in first_claims
+
+
+def test_authserver_post_error_raises(monkeypatch):
+    monkeypatch.setattr(
+        bluesky_oauth.httpx,
+        "post",
+        lambda url, data=None, headers=None, timeout=None: httpx.Response(
+            400, json={"error": "invalid_grant"}
+        ),
+    )
+    with pytest.raises(OAuthError):
+        bluesky_oauth._authserver_post(
+            "https://auth.example/token", {}, generate_dpop_jwk(), ""
+        )
+
+
+@pytest.fixture
+def _restore_site_config():
+    # get_client_private_jwk() persists the generated key via
+    # SiteConfig.reload(), which survives the test transaction rollback
+    original = SiteConfig.system
+    yield
+    SiteConfig.system = original
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_client_metadata_document(client, _restore_site_config):
+    response = client.get(reverse("mastodon:bluesky_client_metadata"))
+    assert response.status_code == 200
+    meta = response.json()
+    site_url = settings.SITE_INFO["site_url"]
+    assert meta["client_id"] == site_url + reverse("mastodon:bluesky_client_metadata")
+    assert meta["redirect_uris"] == [site_url + reverse("mastodon:bluesky_oauth")]
+    assert meta["scope"] == SCOPE
+    assert meta["dpop_bound_access_tokens"] is True
+    assert meta["token_endpoint_auth_method"] == "private_key_jwt"
+    keys = meta["jwks"]["keys"]
+    assert len(keys) == 1
+    assert keys[0]["kid"].startswith("neodb-")
+    assert "d" not in keys[0]
+    # the key is persisted, so a second read serves the same key
+    response2 = client.get(reverse("mastodon:bluesky_client_metadata"))
+    assert response2.json()["jwks"]["keys"][0] == keys[0]
+
+
+class _StubHttpClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def request(self, method, url, headers=None, **kwargs):
+        self.requests.append((method, url, dict(headers or {})))
+        return self.responses.pop(0)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.dpop_jwk = generate_dpop_jwk()
+        self.pds_nonce = ""
+        self.tokens = ["tok1"]
+        self.refreshes = 0
+
+    def get_dpop_jwk(self):
+        return self.dpop_jwk
+
+    def get_pds_nonce(self):
+        return self.pds_nonce
+
+    def save_pds_nonce(self, nonce):
+        self.pds_nonce = nonce
+
+    def get_access_token(self, force_refresh=False):
+        if force_refresh:
+            self.refreshes += 1
+            self.tokens.append(f"tok{len(self.tokens) + 1}")
+        return self.tokens[-1]
+
+
+def test_dpop_request_signs_and_rotates_nonce():
+    session = _FakeSession()
+    request = DpopRequest(session)
+    stub = _StubHttpClient(
+        [
+            httpx.Response(
+                401,
+                json={"error": "use_dpop_nonce"},
+                headers={"DPoP-Nonce": "pds-nonce"},
+            ),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    request._client = stub  # ty: ignore[invalid-assignment]  # stub transport
+
+    response = request.get("https://pds.example/xrpc/app.bsky.actor.getProfile")
+
+    assert response.success
+    assert session.pds_nonce == "pds-nonce"
+    assert len(stub.requests) == 2
+    first_headers = stub.requests[0][2]
+    assert first_headers["Authorization"] == "DPoP tok1"
+    _, claims = _verify_es256(session.dpop_jwk, first_headers["DPoP"])
+    assert claims["htm"] == "GET"
+    assert claims["ath"]
+    _, retry_claims = _verify_es256(session.dpop_jwk, stub.requests[1][2]["DPoP"])
+    assert retry_claims["nonce"] == "pds-nonce"
+    assert session.refreshes == 0
+
+
+def test_dpop_request_refreshes_on_unexpected_401():
+    session = _FakeSession()
+    request = DpopRequest(session)
+    stub = _StubHttpClient(
+        [
+            httpx.Response(401, json={"error": "invalid_token"}),
+            httpx.Response(200, json={"ok": True}),
+        ]
+    )
+    request._client = stub  # ty: ignore[invalid-assignment]  # stub transport
+
+    response = request.get("https://pds.example/xrpc/app.bsky.actor.getProfile")
+
+    assert response.success
+    assert session.refreshes == 1
+    assert stub.requests[1][2]["Authorization"] == "DPoP tok2"
+
+
+def _oauth_session(**over):
+    return {
+        "issuer": "https://auth.example",
+        "token_endpoint": "https://auth.example/token",
+        "dpop_jwk": generate_dpop_jwk(),
+        "access_token": "old-token",
+        "refresh_token": "refresh-1",
+        "expires_at": int(time.time()) - 1,
+        "scope": SCOPE,
+        "authserver_nonce": "",
+        "pds_nonce": "",
+    } | over
+
+
+def test_account_access_token_refreshes_when_expired(monkeypatch):
+    account = BlueskyAccount(uid="did:plc:alice", domain="-")
+    account.access_data = {}
+    account._set_oauth(_oauth_session())
+    calls = []
+
+    def fake_refresh(token_endpoint, issuer, refresh_token, dpop_jwk, nonce):
+        calls.append((token_endpoint, issuer, refresh_token))
+        return (
+            {
+                "access_token": "new-token",
+                "refresh_token": "refresh-2",
+                "expires_in": 600,
+            },
+            "nonce-2",
+        )
+
+    monkeypatch.setattr(bluesky_module, "refresh_token_request", fake_refresh)
+
+    assert account.get_access_token() == "new-token"
+
+    assert calls == [
+        ("https://auth.example/token", "https://auth.example", "refresh-1")
+    ]
+    stored = json.loads(account.oauth_session or "")
+    assert stored["refresh_token"] == "refresh-2"
+    assert stored["authserver_nonce"] == "nonce-2"
+    assert stored["expires_at"] > time.time() + 500
+    # fresh token is served without another refresh round-trip
+    assert account.get_access_token() == "new-token"
+    assert len(calls) == 1
+
+
+def test_account_without_oauth_session_raises():
+    account = BlueskyAccount(uid="did:plc:alice", domain="-")
+    account.access_data = {}
+    with pytest.raises(OAuthError):
+        account.get_access_token()
+
+
+def test_account_refresh_without_refresh_token_raises():
+    account = BlueskyAccount(uid="did:plc:alice", domain="-")
+    account.access_data = {}
+    account._set_oauth(_oauth_session(refresh_token=""))
+    with pytest.raises(OAuthError):
+        account.get_access_token()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_generate_auth_url_pushes_request_and_saves_state(monkeypatch):
+    monkeypatch.setattr(
+        Bluesky,
+        "_resolve_identity",
+        lambda handle: ("did:plc:alice", "https://pds.example"),
+    )
+    monkeypatch.setattr(
+        bluesky_module, "fetch_pds_authserver", lambda pds: "https://auth.example"
+    )
+    monkeypatch.setattr(
+        bluesky_module,
+        "fetch_authserver_metadata",
+        lambda issuer: {
+            "issuer": issuer,
+            "authorization_endpoint": "https://auth.example/authorize",
+            "token_endpoint": "https://auth.example/token",
+            "pushed_authorization_request_endpoint": "https://auth.example/par",
+        },
+    )
+    par_calls = []
+
+    def fake_send_par(meta, dpop_jwk, *, handle, state, code_verifier):
+        par_calls.append((meta["issuer"], handle, state, code_verifier))
+        return "urn:ietf:params:oauth:request_uri:req-1", "par-nonce"
+
+    monkeypatch.setattr(bluesky_module, "send_par", fake_send_par)
+
+    request = RequestFactory().post("/account/bluesky/login")
+    engine = import_module(settings.SESSION_ENGINE)
+    request.session = engine.SessionStore()
+
+    url = Bluesky.generate_auth_url("@Alice.Test", request)
+
+    parts = urlsplit(url)
+    assert url.startswith("https://auth.example/authorize?")
+    query = parse_qs(parts.query)
+    assert query["request_uri"] == ["urn:ietf:params:oauth:request_uri:req-1"]
+    assert query["client_id"] == [bluesky_oauth.get_client_id()]
+    pending = request.session["atproto_oauth"]
+    assert pending["did"] == "did:plc:alice"
+    assert pending["handle"] == "alice.test"  # normalized
+    assert pending["issuer"] == "https://auth.example"
+    assert pending["authserver_nonce"] == "par-nonce"
+    assert pending["state"] == par_calls[0][2]
+    assert pending["code_verifier"] == par_calls[0][3]
+    assert "d" in pending["dpop_jwk"]
+
+
+def test_generate_auth_url_rejects_invalid_handle():
+    request = RequestFactory().post("/account/bluesky/login")
+    with pytest.raises(OAuthError):
+        Bluesky.generate_auth_url("not a handle", request)
+
+
+@pytest.fixture
+def bluesky_enabled(monkeypatch):
+    enabled = SiteConfig.system.model_copy(update={"enable_login_bluesky": True})
+    monkeypatch.setattr(SiteConfig, "system", enabled)
+    monkeypatch.setattr(SiteConfig, "__forced__", True, raising=False)
+
+
+def _prime_pending(client, **over):
+    pending = {
+        "state": "state-1",
+        "did": "did:plc:alice",
+        "handle": "alice.test",
+        "pds_url": "https://pds.example",
+        "issuer": "https://auth.example",
+        "token_endpoint": "https://auth.example/token",
+        "code_verifier": "v" * 43,
+        "dpop_jwk": generate_dpop_jwk(),
+        "authserver_nonce": "",
+    } | over
+    session = client.session
+    session["atproto_oauth"] = pending
+    session.save()
+    return pending
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_registers_new_user(client, monkeypatch, bluesky_enabled):
+    _prime_pending(client)
+    monkeypatch.setattr(
+        bluesky_module,
+        "initial_token_request",
+        lambda token_endpoint, issuer, code, verifier, jwk, nonce: (
+            {
+                "sub": "did:plc:alice",
+                "access_token": "at-1",
+                "refresh_token": "rt-1",
+                "expires_in": 300,
+                "scope": SCOPE,
+            },
+            "nonce-1",
+        ),
+    )
+    monkeypatch.setattr(
+        BlueskyAccount, "refresh", lambda self, save=True, did_check=True: True
+    )
+
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"),
+        {"code": "code-1", "state": "state-1", "iss": "https://auth.example"},
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("users:register")
+    verified = client.session["verified_account"]
+    assert verified["uid"] == "did:plc:alice"
+    account = BlueskyAccount.from_dict(verified)
+    stored = account._get_oauth()
+    assert stored["access_token"] == "at-1"
+    assert stored["refresh_token"] == "rt-1"
+    assert stored["authserver_nonce"] == "nonce-1"
+    assert not account.session_string
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_rejects_state_mismatch(client, bluesky_enabled):
+    _prime_pending(client)
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"), {"code": "c", "state": "wrong"}
+    )
+    assert response.status_code == 200
+    assert b"Authentication failed" in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_rejects_sub_mismatch(client, monkeypatch, bluesky_enabled):
+    _prime_pending(client)
+    monkeypatch.setattr(
+        bluesky_module,
+        "initial_token_request",
+        lambda *args: (
+            {"sub": "did:plc:mallory", "access_token": "x", "scope": SCOPE},
+            "",
+        ),
+    )
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"), {"code": "c", "state": "state-1"}
+    )
+    assert response.status_code == 200
+    assert b"Authentication failed" in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_rejects_iss_mismatch(client, bluesky_enabled):
+    _prime_pending(client)
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"),
+        {"code": "c", "state": "state-1", "iss": "https://evil.example"},
+    )
+    assert response.status_code == 200
+    assert b"Authentication failed" in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_shows_authserver_error(client, bluesky_enabled):
+    _prime_pending(client)
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"),
+        {"error": "access_denied", "error_description": "user said no"},
+    )
+    assert response.status_code == 200
+    assert b"user said no" in response.content
+    assert "atproto_oauth" not in client.session

--- a/neodb/tests/mastodon/test_bluesky_oauth.py
+++ b/neodb/tests/mastodon/test_bluesky_oauth.py
@@ -479,3 +479,82 @@ def test_oauth_callback_shows_authserver_error(client, bluesky_enabled):
     assert response.status_code == 200
     assert b"user said no" in response.content
     assert "atproto_oauth" not in client.session
+
+
+def test_authserver_metadata_rejects_http_endpoint(monkeypatch, settings):
+    settings.DEBUG = False
+    meta = {
+        "issuer": "https://auth.example",
+        "authorization_endpoint": "https://auth.example/authorize",
+        "token_endpoint": "http://169.254.169.254/token",
+        "pushed_authorization_request_endpoint": "https://auth.example/par",
+    }
+    monkeypatch.setattr(
+        bluesky_oauth.httpx,
+        "get",
+        lambda url, timeout=None: httpx.Response(
+            200, json=meta, request=httpx.Request("GET", url)
+        ),
+    )
+    with pytest.raises(OAuthError, match="token_endpoint"):
+        bluesky_oauth.fetch_authserver_metadata("https://auth.example")
+
+
+def test_account_force_refresh_rotates_unexpired_token(monkeypatch):
+    # the PDS may reject a token before its recorded expiry; a forced
+    # refresh must not trust expires_at and return the same token
+    account = BlueskyAccount(uid="did:plc:alice", domain="-")
+    account.access_data = {}
+    account._set_oauth(_oauth_session(expires_at=int(time.time()) + 3600))
+    monkeypatch.setattr(
+        bluesky_module,
+        "refresh_token_request",
+        lambda *args: (
+            {"access_token": "rotated", "refresh_token": "r2", "expires_in": 600},
+            "n2",
+        ),
+    )
+
+    assert account.get_access_token() == "old-token"
+    assert account.get_access_token(force_refresh=True) == "rotated"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_oauth_callback_persists_tokens_even_if_refresh_fails(
+    client, monkeypatch, bluesky_enabled
+):
+    from users.models import User
+
+    user = User.register(email="cb@example.com", username="cbuser")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:alice", handle="alice.test"
+    )
+    account._set_oauth(_oauth_session(access_token="stale"), save=True)
+    _prime_pending(client)
+    monkeypatch.setattr(
+        bluesky_module,
+        "initial_token_request",
+        lambda *args: (
+            {
+                "sub": "did:plc:alice",
+                "access_token": "fresh",
+                "refresh_token": "rt-2",
+                "expires_in": 300,
+                "scope": SCOPE,
+            },
+            "n1",
+        ),
+    )
+    # simulate a transient PDS failure right after the token exchange
+    monkeypatch.setattr(
+        BlueskyAccount, "refresh", lambda self, save=True, did_check=True: False
+    )
+
+    response = client.get(
+        reverse("mastodon:bluesky_oauth"), {"code": "c", "state": "state-1"}
+    )
+
+    assert response.status_code == 302
+    stored = BlueskyAccount.objects.get(pk=account.pk)._get_oauth()
+    assert stored["access_token"] == "fresh"
+    assert stored["refresh_token"] == "rt-2"

--- a/neodb/tests/users/test_login_view.py
+++ b/neodb/tests/users/test_login_view.py
@@ -297,6 +297,9 @@ class TestLoginProof:
     def test_mastodon_threads_and_bluesky_accept_valid_proofs(
         self, client, proof, monkeypatch
     ):
+        enabled = SiteConfig.system.model_copy(update={"enable_login_bluesky": True})
+        monkeypatch.setattr(SiteConfig, "system", enabled)
+        monkeypatch.setattr(SiteConfig, "__forced__", True, raising=False)
         calls = []
         monkeypatch.setattr(
             Mastodon,
@@ -314,8 +317,10 @@ class TestLoginProof:
         )
         monkeypatch.setattr(
             Bluesky,
-            "authenticate",
-            lambda handle, password: calls.append(("bluesky", handle)),
+            "generate_auth_url",
+            lambda handle, request: (
+                calls.append(("bluesky", handle)) or "https://pds.example/authorize"
+            ),
         )
 
         mastodon = client.post(
@@ -330,13 +335,13 @@ class TestLoginProof:
             reverse("mastodon:bluesky_login"),
             {
                 "username": "alice.bsky.social",
-                "password": "app-password",
                 "altcha": proof(client, "bluesky"),
             },
         )
         assert mastodon.status_code == 302
         assert threads.status_code == 302
-        assert b"Invalid account data from Bluesky" in bluesky.content
+        assert bluesky.status_code == 302
+        assert bluesky.url == "https://pds.example/authorize"
         assert calls == [
             ("mastodon", "mastodon.online"),
             ("threads", None),

--- a/neodb/users/templates/users/account.html
+++ b/neodb/users/templates/users/account.html
@@ -191,22 +191,13 @@
                     <input required
                            name="username"
                            autofocus
-                           placeholder="{% trans 'Bluesky Login ID' %}"
-                           autocorrect="off"
-                           autocapitalize="off"
-                           autocomplete="off"
-                           spellcheck="false" />
-                    <input required
-                           type="password"
-                           name="password"
-                           placeholder="{% trans 'Bluesky app password' %}"
+                           placeholder="{% trans 'ATProto handle' %}"
                            autocorrect="off"
                            autocapitalize="off"
                            autocomplete="off"
                            spellcheck="false" />
                     <input type="submit"
                            value="{% if request.user.bluesky %} {% trans 'Link with a different ATProto identity' %} {% else %} {% trans "Link with an ATProto identity" %} {% endif %} " />
-                    <small>{% blocktrans %}App password can be created on <a href="https://bsky.app/settings/app-passwords" target="_blank">bsky.app</a>.{% endblocktrans %}</small>
                   </fieldset>
                 </form>
                 {% if request.user.bluesky %}

--- a/neodb/users/templates/users/login.html
+++ b/neodb/users/templates/users/login.html
@@ -219,18 +219,9 @@
          autocomplete="off"
          spellcheck="false" />
   <small>{% trans "Please input your ATProto handle (e.g. neodb.bsky.social, without the leading @), do not use email. If you changed handle recently, just use the latest one." %}</small>
-  <input required
-         type="password"
-         name="password"
-         placeholder="{% trans 'Bluesky app password' %}"
-         autocorrect="off"
-         autocapitalize="off"
-         autocomplete="off"
-         spellcheck="false" />
-  <small>{% blocktrans %}App password can be created on <a href="https://bsky.app/settings/app-passwords" target="_blank">bsky.app</a>.{% endblocktrans %}</small>
   <input type="submit"
          class="login-submit"
-         value="{% trans 'Authorize via bsky.app' %}"
+         value="{% trans 'Authorize via ATProto server' %}"
          disabled />
   <altcha-widget class="login-proof" challenge="{% url 'users:login_proof' %}?method=bluesky" auto="onsubmit" display="invisible" name="altcha" workers="2"></altcha-widget>
   <small class="login-proof-status" role="status" aria-live="polite"></small>


### PR DESCRIPTION
## Summary

Bluesky / ATProto login no longer asks users for an app password. The login form takes only a handle; NeoDB resolves it (handle -> DID -> PDS -> authorization server) and redirects the user to their own server to authorize, per the [ATProto OAuth spec](https://atproto.com/specs/oauth).

- **New `mastodon/models/bluesky_oauth.py`**: PAR + PKCE + DPoP client implemented with `cryptography` (no new dependencies). NeoDB acts as a confidential client: the client metadata document is served at `/account/bluesky/client-metadata.json` (its URL is the `client_id`), and token requests are authenticated with a `private_key_jwt` assertion signed by an ES256 key that is auto-generated on first use and persisted in SiteConfig (visible/rotatable on the Advanced settings page).
- **`DpopRequest`**: a transport for the atproto SDK `Client` that signs every XRPC call with the account's DPoP key and access token, and transparently handles server nonce rotation (`use_dpop_nonce`) and expired-token refresh, so all existing posting / record / graph code works unchanged.
- **`BlueskyAccount`**: stores the OAuth session (tokens, per-session DPoP key, server nonces) encrypted in `access_data`; refresh tokens are single-use so refreshes are serialized across workers with a cache lock and re-read from the DB. Accounts that linked with an app password keep working through their stored legacy session until they re-authorize; scheduled for removal in a future release.
- **Views**: `bluesky_login` now starts the redirect flow (rate limiting and login proof kept, plus an `enable_login_bluesky` check matching Mastodon); new `bluesky/oauth` callback verifies state / iss / sub / scope before creating the account; templates lose the password fields.
- **i18n**: zh_Hans translations updated for the new strings.

Not included (can follow up): token revocation on disconnect; `transition:generic` is used rather than granular scopes.

## Test plan

- unit tests for JWT/DPoP signing (independently verified with `cryptography`), nonce retry, client metadata document, DPoP transport retry/refresh behavior, account token refresh persistence, auth-url generation and every callback failure mode (state/iss/sub mismatch, authserver error)
- full suite run locally: 1854 passed; remaining failures are pre-existing environment-dependent tests (network scrapers, S3)
- manual flow against bsky.social requires a publicly reachable deployment (client metadata must be fetchable); would appreciate a staging check before merge