### PR TITLE
chore: disable codeberg sync

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,31 +1,33 @@
-name: Mirror to Codeberg
-
-on:
-  push:
-    branches: [main]
-    tags: ["*"]
-  delete:
-
-permissions:
-  contents: read
-
-jobs:
-  to_codeberg:
-    if: github.repository_owner == 'neodb-social' && (github.event_name != 'delete' || github.event.ref_type == 'tag')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Push main and tags to Codeberg
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.CODEBERG_SSH_PRIVATEKEY }}
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_codeberg
-          chmod 600 ~/.ssh/id_codeberg
-          ssh-keyscan codeberg.org >> ~/.ssh/known_hosts
-          export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_codeberg'
-          git push --prune git@codeberg.org:NeoDB/neodb.git \
-            '+refs/remotes/origin/main:refs/heads/main' \
-            '+refs/tags/*:refs/tags/*'
+# Codeberg sync disabled
+#
+# name: Mirror to Codeberg
+#
+# on:
+#   push:
+#     branches: [main]
+#     tags: ["*"]
+#   delete:
+#
+# permissions:
+#   contents: read
+#
+# jobs:
+#   to_codeberg:
+#     if: github.repository_owner == 'neodb-social' && (github.event_name != 'delete' || github.event.ref_type == 'tag')
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v5
+#         with:
+#           fetch-depth: 0
+#       - name: Push main and tags to Codeberg
+#         env:
+#           SSH_PRIVATE_KEY: ${{ secrets.CODEBERG_SSH_PRIVATEKEY }}
+#         run: |
+#           mkdir -p ~/.ssh
+#           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_codeberg
+#           chmod 600 ~/.ssh/id_codeberg
+#           ssh-keyscan codeberg.org >> ~/.ssh/known_hosts
+#           export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_codeberg'
+#           git push --prune git@codeberg.org:NeoDB/neodb.git \
+#             '+refs/remotes/origin/main:refs/heads/main' \
+#             '+refs/tags/*:refs/tags/*'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,6 @@ extra:
       link: https://discord.gg/QBHkrV8bxK
     - icon: fontawesome/brands/github
       link: https://github.com/neodb-social/neodb
-    - icon: fontawesome/brands/git-alt
-      link: https://codeberg.org/NeoDB/neodb
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/u/neodb
 extra_css:


### PR DESCRIPTION
Comment out the Codeberg mirror workflow and remove the Codeberg link from docs.

https://codeberg.org/Codeberg/org/pulls/1253
> You must not share projects that mostly consist of code written by "generative AI"-tools

not sure if we are, or at some point will be, violating the new rule, due to existing and growing coding agents usage.

