### PR TITLE
ci: run setup-python and setup-uv on Node 24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Run pre-commit check
@@ -34,11 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Run mkdocs build
@@ -53,11 +53,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install Dependencies

--- a/.github/workflows/publish-lexicons.yml
+++ b/.github/workflows/publish-lexicons.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Publish lexicons to ATProto

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,11 +56,11 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     - name: Install Dependencies
@@ -111,11 +111,11 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
     - name: Install Dependencies


### PR DESCRIPTION
`actions/setup-python@v5` and `astral-sh/setup-uv@v6` target the deprecated Node.js 20 runtime, which GitHub Actions now force-runs on Node 24 while emitting a deprecation warning in every `lint`, `doc`, `type-checker`, and test job.

Bump both to their first Node 24 native majors:

- `actions/setup-python@v5` -> `@v6`
- `astral-sh/setup-uv@v6` -> `@v7`

`setup-uv@v7` (rather than v8/v9) keeps the floating major tag this repo uses; setup-uv v8+ no longer publishes major tags. Both bumps only drop inputs this repo doesn't use (`pip-install`, `server-url`); all existing `with:` inputs (`cache`, `enable-cache`, `python-version`) remain valid. Applied across `check.yml`, `tests.yml`, and `publish-lexicons.yml`.