### PR TITLE
fix(catalog): localize linked-person credit names on item detail page

### DIFF
--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -184,6 +184,24 @@ class ItemCredit(models.Model):
     def person_api_url(self) -> str | None:
         return self.person.api_url if self.person else None
 
+    @property
+    def display_name(self) -> str:
+        """Localized name for HTML display.
+
+        When linked to a People whose ``localized_name`` is already loaded, use
+        its live-localized ``display_name`` so the credit follows the viewer's
+        language (``name`` is a snapshot frozen at sync time). Fall back to the
+        stored ``name`` for ad-hoc (unlinked) credits, when the linked person
+        has no localized name, or when the person was loaded with ``metadata``
+        deferred -- reading it would trigger a per-credit query (the batch
+        ``credits_prefetch`` defers it on card/list surfaces). Detail pages opt
+        in via ``credits_prefetch(with_person_metadata=True)``.
+        """
+        person = self.person
+        if person is not None and "metadata" not in person.get_deferred_fields():
+            return person.display_name or self.name
+        return self.name
+
     def __str__(self):
         linked = f" -> {self.person}" if self.person else ""
         return f"{self.name} ({self.role}) on {self.item}{linked}"
@@ -204,6 +222,8 @@ class ExternalResourceSchema(Schema):
 
 class CreditSchema(Schema):
     role: str
+    # Stored snapshot, not display_name: this schema backs ap_object (served as
+    # activity+json) and catalog backups, which must stay locale-independent.
     name: str
     character_name: str = ""
     person_url: str | None = Field(None, alias="person_api_url")
@@ -811,7 +831,7 @@ class Item(PolymorphicModel):
             prefetch_related_objects(performanceproductions, "show")
 
     @staticmethod
-    def credits_prefetch() -> models.Prefetch:
+    def credits_prefetch(*, with_person_metadata: bool = False) -> models.Prefetch:
         """Optimized ``Prefetch`` for ``item.credits`` used by templates/APIs.
 
         ``_credits.html`` and the API ``CreditSchema`` only read
@@ -820,19 +840,28 @@ class Item(PolymorphicModel):
         join to those columns so the batch prefetch no longer pulls the large
         ``metadata`` JSON on each credited person, which made it a slow DB
         query (EGGPLANT-1EF).
+
+        Pass ``with_person_metadata=True`` to also load ``person__metadata``
+        (which holds ``localized_name``) so ``ItemCredit.display_name`` can
+        localize credit names without a per-credit deferred load. Use this only
+        on the single-item detail page -- not on high-cardinality card/list
+        surfaces, where loading person metadata is the cost EGGPLANT-1EF avoided.
         """
+        fields = [
+            "item_id",
+            "person_id",
+            "role",
+            "name",
+            "character_name",
+            "order",
+            "person__uid",
+            "person__people_type",
+        ]
+        if with_person_metadata:
+            fields.append("person__metadata")
         return models.Prefetch(
             "credits",
-            queryset=ItemCredit.objects.select_related("person").only(
-                "item_id",
-                "person_id",
-                "role",
-                "name",
-                "character_name",
-                "order",
-                "person__uid",
-                "person__people_type",
-            ),
+            queryset=ItemCredit.objects.select_related("person").only(*fields),
         )
 
     @staticmethod
@@ -1337,7 +1366,14 @@ class Item(PolymorphicModel):
         return self._credits_with_person()
 
     def credit_names_by_role(self, role: str) -> list[str]:
-        """Return credit names as list[str] from the credits table."""
+        """Return credit names as list[str] from the credits table.
+
+        Uses the stored ``name`` snapshot (not the localized display name):
+        this feeds canonical/locale-independent surfaces -- ActivityPub
+        ``ap_object``, catalog backups, schema.org markup and StoryGraph
+        import matching. Localization happens only at the HTML display layer
+        via ``ItemCredit.display_name``.
+        """
         return [c.name for c in self.role_credits.get(role, [])]
 
     @cached_property

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -30,7 +30,7 @@ from common.models import (
     uniq,
 )
 from common.models.genre import normalize_genres
-from common.models.lang import normalize_languages
+from common.models.lang import localized_label_text, normalize_languages
 from common.utils import get_file_absolute_url, json_ld_dumps
 
 from .common import (
@@ -157,6 +157,11 @@ class ItemCredit(models.Model):
         item_id: int
         person_id: int | None
 
+    #: Per-request localized display name, set by
+    #: ``Item.attach_localized_credit_names``; not a DB field. Empty means
+    #: "use the stored ``name`` snapshot" (see ``display_name``).
+    _localized_name: str = ""
+
     item = models.ForeignKey("Item", on_delete=models.CASCADE, related_name="credits")
     person = models.ForeignKey(
         "People",
@@ -186,21 +191,16 @@ class ItemCredit(models.Model):
 
     @property
     def display_name(self) -> str:
-        """Localized name for HTML display.
+        """Request-localized name for HTML display, else the stored snapshot.
 
-        When linked to a People whose ``localized_name`` is already loaded, use
-        its live-localized ``display_name`` so the credit follows the viewer's
-        language (``name`` is a snapshot frozen at sync time). Fall back to the
-        stored ``name`` for ad-hoc (unlinked) credits, when the linked person
-        has no localized name, or when the person was loaded with ``metadata``
-        deferred -- reading it would trigger a per-credit query (the batch
-        ``credits_prefetch`` defers it on card/list surfaces). Detail pages opt
-        in via ``credits_prefetch(with_person_metadata=True)``.
+        ``name`` is frozen at sync time (under the source's locale). The
+        localized value is populated only when ``Item.attach_localized_credit_names``
+        has run for this render (detail pages); otherwise this returns ``name``.
+        This property never issues a query on its own -- it reads an attribute
+        set by that bounded batch helper, so card/list/API surfaces that skip it
+        pay nothing and keep the snapshot.
         """
-        person = self.person
-        if person is not None and "metadata" not in person.get_deferred_fields():
-            return person.display_name or self.name
-        return self.name
+        return self._localized_name or self.name
 
     def __str__(self):
         linked = f" -> {self.person}" if self.person else ""
@@ -831,7 +831,7 @@ class Item(PolymorphicModel):
             prefetch_related_objects(performanceproductions, "show")
 
     @staticmethod
-    def credits_prefetch(*, with_person_metadata: bool = False) -> models.Prefetch:
+    def credits_prefetch() -> models.Prefetch:
         """Optimized ``Prefetch`` for ``item.credits`` used by templates/APIs.
 
         ``_credits.html`` and the API ``CreditSchema`` only read
@@ -841,28 +841,63 @@ class Item(PolymorphicModel):
         ``metadata`` JSON on each credited person, which made it a slow DB
         query (EGGPLANT-1EF).
 
-        Pass ``with_person_metadata=True`` to also load ``person__metadata``
-        (which holds ``localized_name``) so ``ItemCredit.display_name`` can
-        localize credit names without a per-credit deferred load. Use this only
-        on the single-item detail page -- not on high-cardinality card/list
-        surfaces, where loading person metadata is the cost EGGPLANT-1EF avoided.
+        This intentionally does NOT load ``localized_name`` (which lives in the
+        deferred ``metadata`` JSON): to localize credit names for display, call
+        ``attach_localized_credit_names`` instead, which fetches only that JSON
+        sub-key in one bounded query.
         """
-        fields = [
-            "item_id",
-            "person_id",
-            "role",
-            "name",
-            "character_name",
-            "order",
-            "person__uid",
-            "person__people_type",
-        ]
-        if with_person_metadata:
-            fields.append("person__metadata")
         return models.Prefetch(
             "credits",
-            queryset=ItemCredit.objects.select_related("person").only(*fields),
+            queryset=ItemCredit.objects.select_related("person").only(
+                "item_id",
+                "person_id",
+                "role",
+                "name",
+                "character_name",
+                "order",
+                "person__uid",
+                "person__people_type",
+            ),
         )
+
+    @staticmethod
+    def attach_localized_credit_names(items: "Iterable[Item]") -> None:
+        """Attach request-localized display names to each item's credits.
+
+        Credit rows store ``name`` as a snapshot frozen at sync time (under the
+        source's locale), so an English viewer could see a Chinese director. The
+        linked ``People`` carries a localized name, but it lives in the heavy,
+        deliberately-deferred person ``metadata`` JSON (EGGPLANT-1EF), so we must
+        not select it via ``credits_prefetch``. Instead fetch only the
+        ``localized_name`` sub-key for every credited person in ONE bounded
+        query (flat regardless of cast size) and stash the localized string on
+        each credit; ``ItemCredit.display_name`` then prefers it over ``name``.
+
+        Call this on HTML display surfaces (item detail) after credits are
+        loaded. Surfaces that skip it keep the stored snapshot -- and canonical
+        outputs (ap_object, backups, schema.org, import matching) always do.
+        """
+        from .people import People
+
+        by_person: dict[int, list[ItemCredit]] = {}
+        for it in items:
+            if it is None:
+                continue
+            for group in it.role_credits.values():
+                for credit in group:
+                    if credit.person_id:
+                        by_person.setdefault(credit.person_id, []).append(credit)
+        if not by_person:
+            return
+        locales = get_current_locales()
+        rows = People.objects.filter(pk__in=by_person).values_list(
+            "pk", "metadata__localized_name"
+        )
+        for pk, localized in rows:
+            name = localized_label_text(localized, locales)
+            if name:
+                for credit in by_person[pk]:
+                    credit._localized_name = name
 
     @staticmethod
     def external_resources_prefetch(

--- a/neodb/catalog/templates/_credits.html
+++ b/neodb/catalog/templates/_credits.html
@@ -8,9 +8,9 @@
       {% if forloop.counter <= max %}
         {% if not forloop.first %}/{% endif %}
         {% if credit.person %}
-          <a href="{{ credit.person.url }}">{{ credit.name }}</a>
+          <a href="{{ credit.person.url }}">{{ credit.display_name }}</a>
         {% else %}
-          <span>{{ credit.name }}</span>
+          <span>{{ credit.display_name }}</span>
         {% endif %}
       {% elif forloop.last %}
         …

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -119,7 +119,9 @@ def retrieve(request, item_path, item_uuid):
     prefetch_related_objects(
         [item],
         Item.external_resources_prefetch(with_metadata=item.class_name == "album"),
-        Item.credits_prefetch(),
+        # Load person metadata so credit names localize on the detail page
+        # (ItemCredit.display_name); cheap here (one item, few credits).
+        Item.credits_prefetch(with_person_metadata=True),
     )
     Item.prefetch_parent_items([item])
     # Public tags are shown on the item detail page; aggregate for this single

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -119,10 +119,11 @@ def retrieve(request, item_path, item_uuid):
     prefetch_related_objects(
         [item],
         Item.external_resources_prefetch(with_metadata=item.class_name == "album"),
-        # Load person metadata so credit names localize on the detail page
-        # (ItemCredit.display_name); cheap here (one item, few credits).
-        Item.credits_prefetch(with_person_metadata=True),
+        Item.credits_prefetch(),
     )
+    # Localize credit names for display (one bounded query, no heavy person
+    # metadata load) so _credits.html follows the viewer's language.
+    Item.attach_localized_credit_names([item])
     Item.prefetch_parent_items([item])
     # Public tags are shown on the item detail page; aggregate for this single
     # item only (list pages no longer attach tags -- NEODB-SOCIAL-7KW).

--- a/neodb/common/models/lang.py
+++ b/neodb/common/models/lang.py
@@ -399,6 +399,23 @@ def get_current_locales() -> list[str]:
     return locales
 
 
+def localized_label_text(
+    labels: list[dict] | None, locales: list[str] | None = None
+) -> str | None:
+    """First matching ``text`` from a ``[{lang, text}]`` label list for the
+    given locale preference (defaults to the request's ``get_current_locales``).
+    """
+    if not labels:
+        return None
+    if locales is None:
+        locales = get_current_locales()
+    for loc in locales:
+        v = next((t.get("text") for t in labels if t.get("lang") == loc), None)
+        if v:
+            return v
+    return None
+
+
 _eng = re.compile(r"^[A-Z-a-z0-9]+$")
 # Intentionally broad Unicode ranges below cover Chinese text:
 # U+4E00..U+9FFF  CJK Unified Ideographs

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -246,53 +246,52 @@ class TestSchemaCreditResolvers:
 
 @pytest.mark.django_db(databases="__all__")
 class TestCreditDisplayNameLocalization:
-    """ItemCredit.display_name localizes a linked-person credit name for HTML
-    display, following the viewer's language instead of the snapshot frozen at
-    sync time -- but only when the person's localized_name is already loaded
-    (no per-credit query). Canonical surfaces (credit_names_by_role, which
-    feeds ap_object / backups / schema.org / import matching) keep the snapshot.
+    """ItemCredit.display_name shows a request-localized credit name for HTML
+    display once Item.attach_localized_credit_names has run, instead of the
+    snapshot frozen at sync time. attach_localized_credit_names fetches only the
+    localized_name JSON sub-key in one bounded query -- never the heavy person
+    metadata blob (EGGPLANT-1EF) and never a per-credit query. Canonical
+    surfaces (credit_names_by_role, which feeds ap_object / backups / schema.org
+    / import matching) always keep the snapshot.
 
     Regression: a Douban-sourced movie froze the director credit name in
     Chinese, so the movie page rendered Chinese even for English viewers, while
     the person page (which localizes live) showed English.
     """
 
-    def _linked_movie(self) -> Movie:
-        person = People.objects.create(people_type="person", title="del Toro")
-        person.localized_name = [
-            {"lang": "zh-cn", "text": "吉尔莫·德尔·托罗"},
-            {"lang": "en", "text": "Guillermo del Toro"},
-        ]
-        person.save()
+    def _linked_movie(self, n: int = 1) -> Movie:
         m = Movie.objects.create(title="Test Film")
         m.localized_title = [{"lang": "en", "text": "Test Film"}]
         m.save()
-        # Frozen snapshot in Chinese, as captured at sync time.
-        ItemCredit.objects.create(
-            item=m,
-            role=CreditRole.Director,
-            name="吉尔莫·德尔·托罗",
-            person=person,
-            order=0,
-        )
+        for i in range(n):
+            person = People.objects.create(people_type="person", title=f"del Toro {i}")
+            person.localized_name = [
+                {"lang": "zh-cn", "text": "吉尔莫·德尔·托罗"},
+                {"lang": "en", "text": "Guillermo del Toro"},
+            ]
+            person.save()
+            # Frozen snapshot in Chinese, as captured at sync time.
+            ItemCredit.objects.create(
+                item=m,
+                role=CreditRole.Director,
+                name="吉尔莫·德尔·托罗",
+                person=person,
+                order=i,
+            )
         return m
 
-    def _director_credit(self, movie: Movie) -> ItemCredit:
-        # Full person load (metadata not deferred), as on a detail request with
-        # credits_prefetch(with_person_metadata=True). Fresh per language since
-        # People.display_name is cached per instance.
-        return (
-            Movie.objects.get(pk=movie.pk)
-            .credits.select_related("person")
-            .get(role=CreditRole.Director)
-        )
+    def _localized_director(self, movie: Movie) -> ItemCredit:
+        # Fresh objects per language (People localization is per-request).
+        m = Movie.objects.get(pk=movie.pk)
+        Item.attach_localized_credit_names([m])
+        return m.role_credits[CreditRole.Director][0]
 
-    def test_linked_credit_follows_request_language(self):
+    def test_attach_localizes_linked_credit_by_language(self):
         m = self._linked_movie()
         with translation.override("en"):
-            assert self._director_credit(m).display_name == "Guillermo del Toro"
+            assert self._localized_director(m).display_name == "Guillermo del Toro"
         with translation.override("zh-hans"):
-            assert self._director_credit(m).display_name == "吉尔莫·德尔·托罗"
+            assert self._localized_director(m).display_name == "吉尔莫·德尔·托罗"
 
     def test_unlinked_credit_uses_frozen_name(self):
         m = Movie.objects.create(title="Test Film")
@@ -302,7 +301,19 @@ class TestCreditDisplayNameLocalization:
             item=m, role=CreditRole.Director, name="吉尔莫·德尔·托罗", order=0
         )
         with translation.override("en"):
-            assert self._director_credit(m).display_name == "吉尔莫·德尔·托罗"
+            assert self._localized_director(m).display_name == "吉尔莫·德尔·托罗"
+
+    def test_without_attach_display_name_is_frozen_and_issues_no_query(self):
+        # Surfaces that don't call attach (cards/lists/API) keep the snapshot,
+        # and display_name must never trigger a query on its own.
+        base = self._linked_movie()
+        with translation.override("en"):
+            m = Movie.objects.get(pk=base.pk)
+            prefetch_related_objects([m], Item.credits_prefetch())
+            credit = m.role_credits[CreditRole.Director][0]
+            with CaptureQueriesContext(connection) as ctx:
+                assert credit.display_name == "吉尔莫·德尔·托罗"
+            assert len(ctx) == 0
 
     def test_credit_names_by_role_stays_canonical(self):
         # ap_object / backups / schema.org / import matching must not localize.
@@ -312,31 +323,19 @@ class TestCreditDisplayNameLocalization:
                 m = Movie.objects.get(pk=base.pk)
                 assert m.credit_names_by_role("director") == ["吉尔莫·德尔·托罗"]
 
-    def test_deferred_person_metadata_falls_back_without_query(self):
-        # Card/list prefetch defers person metadata; display_name must not fire
-        # a per-credit query, so it returns the frozen snapshot.
-        base = self._linked_movie()
+    def test_attach_uses_single_query_regardless_of_cast_size(self):
+        # One bounded query for all credited people -- flat, not an N+1, and it
+        # must not pull the heavy person metadata column.
+        base = self._linked_movie(n=12)
         with translation.override("en"):
             m = Movie.objects.get(pk=base.pk)
-            prefetch_related_objects([m], Item.credits_prefetch())
-            credit = list(m.credits.all())[0]
+            _ = m.role_credits  # warm the credits load out of the measured block
             with CaptureQueriesContext(connection) as ctx:
-                assert credit.display_name == "吉尔莫·德尔·托罗"
-            assert len(ctx) == 0
-
-    def test_detail_prefetch_localizes_without_n_plus_one(self):
-        # with_person_metadata=True loads localized_name in the batch join, so
-        # display_name localizes with no extra per-credit query.
-        base = self._linked_movie()
-        with translation.override("en"):
-            m = Movie.objects.get(pk=base.pk)
-            prefetch_related_objects(
-                [m], Item.credits_prefetch(with_person_metadata=True)
+                Item.attach_localized_credit_names([m])
+            assert len(ctx) == 1
+            assert m.role_credits[CreditRole.Director][0].display_name == (
+                "Guillermo del Toro"
             )
-            credit = list(m.credits.all())[0]
-            with CaptureQueriesContext(connection) as ctx:
-                assert credit.display_name == "Guillermo del Toro"
-            assert len(ctx) == 0
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -1,4 +1,8 @@
 import pytest
+from django.db import connection
+from django.db.models import prefetch_related_objects
+from django.test.utils import CaptureQueriesContext
+from django.utils import translation
 
 from catalog.models import (
     CreditRole,
@@ -238,6 +242,101 @@ class TestSchemaCreditResolvers:
         assert ap["publisher"] == ["Penguin"]
         # Deprecated scalar still exposed for API back-compat.
         assert ap["pub_house"] == "Penguin"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCreditDisplayNameLocalization:
+    """ItemCredit.display_name localizes a linked-person credit name for HTML
+    display, following the viewer's language instead of the snapshot frozen at
+    sync time -- but only when the person's localized_name is already loaded
+    (no per-credit query). Canonical surfaces (credit_names_by_role, which
+    feeds ap_object / backups / schema.org / import matching) keep the snapshot.
+
+    Regression: a Douban-sourced movie froze the director credit name in
+    Chinese, so the movie page rendered Chinese even for English viewers, while
+    the person page (which localizes live) showed English.
+    """
+
+    def _linked_movie(self) -> Movie:
+        person = People.objects.create(people_type="person", title="del Toro")
+        person.localized_name = [
+            {"lang": "zh-cn", "text": "吉尔莫·德尔·托罗"},
+            {"lang": "en", "text": "Guillermo del Toro"},
+        ]
+        person.save()
+        m = Movie.objects.create(title="Test Film")
+        m.localized_title = [{"lang": "en", "text": "Test Film"}]
+        m.save()
+        # Frozen snapshot in Chinese, as captured at sync time.
+        ItemCredit.objects.create(
+            item=m,
+            role=CreditRole.Director,
+            name="吉尔莫·德尔·托罗",
+            person=person,
+            order=0,
+        )
+        return m
+
+    def _director_credit(self, movie: Movie) -> ItemCredit:
+        # Full person load (metadata not deferred), as on a detail request with
+        # credits_prefetch(with_person_metadata=True). Fresh per language since
+        # People.display_name is cached per instance.
+        return (
+            Movie.objects.get(pk=movie.pk)
+            .credits.select_related("person")
+            .get(role=CreditRole.Director)
+        )
+
+    def test_linked_credit_follows_request_language(self):
+        m = self._linked_movie()
+        with translation.override("en"):
+            assert self._director_credit(m).display_name == "Guillermo del Toro"
+        with translation.override("zh-hans"):
+            assert self._director_credit(m).display_name == "吉尔莫·德尔·托罗"
+
+    def test_unlinked_credit_uses_frozen_name(self):
+        m = Movie.objects.create(title="Test Film")
+        m.localized_title = [{"lang": "en", "text": "Test Film"}]
+        m.save()
+        ItemCredit.objects.create(
+            item=m, role=CreditRole.Director, name="吉尔莫·德尔·托罗", order=0
+        )
+        with translation.override("en"):
+            assert self._director_credit(m).display_name == "吉尔莫·德尔·托罗"
+
+    def test_credit_names_by_role_stays_canonical(self):
+        # ap_object / backups / schema.org / import matching must not localize.
+        base = self._linked_movie()
+        for lang in ("en", "zh-hans"):
+            with translation.override(lang):
+                m = Movie.objects.get(pk=base.pk)
+                assert m.credit_names_by_role("director") == ["吉尔莫·德尔·托罗"]
+
+    def test_deferred_person_metadata_falls_back_without_query(self):
+        # Card/list prefetch defers person metadata; display_name must not fire
+        # a per-credit query, so it returns the frozen snapshot.
+        base = self._linked_movie()
+        with translation.override("en"):
+            m = Movie.objects.get(pk=base.pk)
+            prefetch_related_objects([m], Item.credits_prefetch())
+            credit = list(m.credits.all())[0]
+            with CaptureQueriesContext(connection) as ctx:
+                assert credit.display_name == "吉尔莫·德尔·托罗"
+            assert len(ctx) == 0
+
+    def test_detail_prefetch_localizes_without_n_plus_one(self):
+        # with_person_metadata=True loads localized_name in the batch join, so
+        # display_name localizes with no extra per-credit query.
+        base = self._linked_movie()
+        with translation.override("en"):
+            m = Movie.objects.get(pk=base.pk)
+            prefetch_related_objects(
+                [m], Item.credits_prefetch(with_person_metadata=True)
+            )
+            credit = list(m.credits.all())[0]
+            with CaptureQueriesContext(connection) as ctx:
+                assert credit.display_name == "Guillermo del Toro"
+            assert len(ctx) == 0
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Problem

On an item detail page, credit names (director, actor, author, ...) were rendered from the **frozen `ItemCredit.name` snapshot** — captured at scrape/sync time under the source's locale (e.g. Chinese for Douban) — instead of the linked `People`'s localized name.

So an English-preferring viewer opening e.g. a movie page saw the director as `吉尔莫·德尔·托罗`, while the director's own person page (which localizes live per request) correctly showed `Guillermo del Toro`.

## Fix

Localize at the **HTML display layer only**:

- New `Item.attach_localized_credit_names(items)` — a single **bounded query** fetches only the `localized_name` JSON sub-key (`metadata__localized_name`) for every credited person and stashes the request-localized string on each `ItemCredit`. `ItemCredit.display_name` returns that value, or the stored snapshot when it wasn't attached. It never issues a query on its own.
- The item detail view calls the helper after the (unchanged, slim) `credits_prefetch()`; `_credits.html` renders `credit.display_name`.
- Adds a shared `common.models.lang.localized_label_text` helper for locale-preference label picking.

### Why not just load the person's localized name in the prefetch?

`localized_name` lives inside the person's heavy `metadata` JSON, which `credits_prefetch` deliberately defers (EGGPLANT-1EF) — and `tests/journal/test_n_plus_one.py::TestItemRetrieveCreditsPrefetch` explicitly guards that the detail page never selects that column, even for one item (large casts). The bounded helper fetches **only** the `localized_name` sub-key in one query (flat regardless of cast size), so it respects that guard.

### Canonical surfaces stay locale-independent

`credit_names_by_role` and `CreditSchema` are left on the stored snapshot — they feed ActivityPub `ap_object` (served as `activity+json`), NDJSON catalog backups, schema.org markup, and StoryGraph import matching, none of which may vary by the requester's language.

## Tradeoff

Compact item **cards/lists** (and related/child items rendered on a detail page) keep the frozen snapshot name — they don't call the helper, so they add no queries. The reported bug (item **detail** page, main item) is fixed.

## Tests

`TestCreditDisplayNameLocalization`:
- attach localizes a linked credit per request language (`en` / `zh-hans`); unlinked uses the frozen name
- `credit_names_by_role` stays canonical (frozen) under both languages
- without attach, `display_name` returns the snapshot and issues **zero** queries
- attach uses exactly **one** query regardless of cast size

Also verified locally: `TestItemRetrieveCreditsPrefetch` (the N+1 guards), catalog model/people/api and journal ndjson/n+1 suites — 228 passing. `ruff` + `ty` pass.
