### PR TITLE
fix(users): populate remote profile url and avatar for Lemmy actors

### DIFF
--- a/neodb/tests/users/test_models.py
+++ b/neodb/tests/users/test_models.py
@@ -261,3 +261,47 @@ class TestAPIdentityModel:
 
     def test_actor_type(self):
         assert self.identity.actor_type is not None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRemoteAPIdentity:
+    """Remote identities from implementations (e.g. Lemmy) that omit the
+    web profile url and/or an avatar must still render sensible values."""
+
+    def _make_remote(self, *, profile_uri=None, icon_uri="", actor_type="group"):
+        from django.conf import settings
+        from takahe.models import Domain, Identity
+        from takahe.utils import Takahe
+
+        self.settings = settings
+        domain, _ = Domain.objects.get_or_create(
+            domain="lemmy.example", defaults={"local": False}
+        )
+        identity = Identity.objects.create(
+            actor_uri="https://lemmy.example/c/books",
+            local=False,
+            username="books",
+            domain=domain,
+            actor_type=actor_type,
+            profile_uri=profile_uri,
+            icon_uri=icon_uri,
+        )
+        return Takahe.get_or_create_remote_apidentity(identity)
+
+    def test_profile_uri_falls_back_to_actor_uri(self):
+        identity = self._make_remote(profile_uri=None)
+        assert identity.profile_uri == "https://lemmy.example/c/books"
+
+    def test_profile_uri_uses_url_when_present(self):
+        identity = self._make_remote(profile_uri="https://lemmy.example/c/books/view")
+        assert identity.profile_uri == "https://lemmy.example/c/books/view"
+
+    def test_avatar_falls_back_to_default_when_no_icon(self):
+        identity = self._make_remote(icon_uri="")
+        assert identity.avatar == self.settings.SITE_INFO["user_icon"]
+
+    def test_avatar_uses_proxy_when_icon_present(self):
+        identity = self._make_remote(
+            icon_uri="https://lemmy.example/pictrs/image/books.png"
+        )
+        assert identity.avatar == f"/proxy/identity_icon/{identity.pk}/"

--- a/neodb/users/models/apidentity.py
+++ b/neodb/users/models/apidentity.py
@@ -130,7 +130,10 @@ class APIdentity(models.Model):
 
     @property
     def profile_uri(self):
-        return self.takahe_identity.profile_uri
+        # Some implementations (e.g. Lemmy) don't provide a separate web
+        # profile url; the actor uri is the web profile. Fall back to it so
+        # already-fetched identities aren't left with an empty link.
+        return self.takahe_identity.profile_uri or self.takahe_identity.actor_uri
 
     @cached_property
     def display_name(self):
@@ -156,8 +159,12 @@ class APIdentity(models.Model):
                 if self.takahe_identity.icon
                 else self.takahe_identity.icon_uri or settings.SITE_INFO["user_icon"]
             )
-        else:
+        elif self.takahe_identity.icon_uri:
             return f"/proxy/identity_icon/{self.pk}/"
+        else:
+            # Remote identity without an avatar: the icon proxy would 404, so
+            # fall back to the default user icon instead of a broken image.
+            return settings.SITE_INFO["user_icon"]
 
     @property
     def url(self):

--- a/takahe/tests/users/models/test_identity.py
+++ b/takahe/tests/users/models/test_identity.py
@@ -236,6 +236,67 @@ def test_fetch_actor(httpx_mock, config_system):
 
 @pytest.mark.django_db
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_fetch_actor_without_url_falls_back_to_actor_uri(httpx_mock, config_system):
+    """
+    Lemmy (and some other implementations) don't emit a top-level "url"; the
+    actor id is the web profile. profile_uri should fall back to actor_uri.
+    """
+    identity = Identity.objects.create(
+        actor_uri="https://lemmy.example/c/books",
+        local=False,
+    )
+    httpx_mock.add_response(
+        url="https://lemmy.example/.well-known/webfinger?resource=acct:books@lemmy.example",
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "subject": "acct:books@lemmy.example",
+            "links": [
+                {
+                    "rel": "self",
+                    "type": "application/activity+json",
+                    "href": "https://lemmy.example/c/books",
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        url="https://lemmy.example/c/books",
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://w3id.org/security/v1",
+            ],
+            "id": "https://lemmy.example/c/books",
+            "type": "Group",
+            "inbox": "https://lemmy.example/c/books/inbox",
+            "followers": "https://lemmy.example/c/books/followers",
+            "publicKey": {
+                "id": "https://lemmy.example/c/books#main-key",
+                "owner": "https://lemmy.example/c/books",
+                "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nits-a-faaaake\n-----END PUBLIC KEY-----\n",
+            },
+            "name": "Books",
+            "preferredUsername": "books",
+            "summary": "<p>Book reader community.</p>",
+            "icon": {
+                "type": "Image",
+                "url": "https://lemmy.example/pictrs/image/books.png",
+            },
+        },
+    )
+    identity.fetch_actor()
+
+    identity = Identity.objects.get(pk=identity.pk)
+    assert identity.username == "books"
+    assert identity.actor_type == "group"
+    # No top-level "url" in the document -> fall back to the actor uri
+    assert identity.profile_uri == "https://lemmy.example/c/books"
+    assert identity.icon_uri == "https://lemmy.example/pictrs/image/books.png"
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
 def test_fetch_webfinger_url(httpx_mock: HTTPXMock, config_system):
     """
     Ensures that we can deal with various kinds of webfinger URLs

--- a/takahe/users/models/identity.py
+++ b/takahe/users/models/identity.py
@@ -1108,7 +1108,10 @@ class Identity(StatorModel):
             return False
         _neodb_sync = self.username != document.get("preferredUsername")
         self.name = document.get("name")
-        self.profile_uri = document.get("url")
+        # Lemmy and some other implementations omit the top-level "url" (the
+        # actor id is the web profile). Fall back to actor_uri so the profile
+        # link is never empty.
+        self.profile_uri = document.get("url") or self.actor_uri
         self.inbox_uri = document.get("inbox")
         self.outbox_uri = document.get("outbox")
         self.followers_uri = document.get("followers")


### PR DESCRIPTION
## Problem

Remote profile pages for Lemmy users/communities (e.g. `@books@lemmy.ml`, `@oat@lemmy.zip`) show:

1. An "original home" (fediverse) link whose `href` is `none`.
2. For actors without an avatar (e.g. `@oat@lemmy.zip`), a broken profile image.

## Root cause

- Lemmy `Person`/`Group` actors don't emit a top-level `url` field. The actor `id` *is* the web profile URL. `Identity.fetch_actor()` stored `profile_uri = document.get("url")` with no fallback, so `profile_uri` was left `None`. The template renders `{{ identity.profile_uri }}` directly, producing `href="None"`. (The Mastodon/AP serializers already fall back to `actor_uri`; this path just didn't.)
- `APIdentity.avatar` unconditionally routes remote identities through `/proxy/identity_icon/{pk}/`, and that proxy raises `Http404` when `icon_uri` is empty — so avatar-less remote actors get a broken image instead of the default placeholder.

## Changes

- `takahe/users/models/identity.py`: `fetch_actor()` falls back to `self.actor_uri` when the document has no `url`.
- `neodb/users/models/apidentity.py`:
  - `profile_uri` falls back to `actor_uri` so already-fetched identities render correctly without waiting for a re-fetch.
  - `avatar` returns the default user icon for remote identities without an `icon_uri`, instead of the proxy URL that would 404.
- Tests for the actor-fetch fallback and the `APIdentity` accessors.

## Notes

Existing icon parsing already handles Lemmy's `icon` shape, so actors that *do* have an avatar (e.g. `@books@lemmy.ml`) were unaffected there.