### PR TITLE
feat(social): render linked page card before content for converted objects

### DIFF
--- a/neodb/common/static/scss/_post.scss
+++ b/neodb/common/static/scss/_post.scss
@@ -4,6 +4,26 @@
 		margin-bottom: 0.5em;
 	}
 
+	// Page/converted objects: render the linked page card first, then user
+	// content, then image attachments. DOM order is unchanged; only visual
+	// order is reordered so ordinary posts are unaffected.
+	.pagecard-order {
+		display: flex;
+		flex-direction: column;
+
+		> .converted-object-card {
+			order: -2;
+		}
+
+		> .content {
+			order: -1;
+		}
+
+		> .attachments {
+			order: 0;
+		}
+	}
+
 	.converted-object-card {
 		display: flex;
 		gap: 0.75em;

--- a/neodb/social/templates/_event_post.html
+++ b/neodb/social/templates/_event_post.html
@@ -104,7 +104,8 @@
         {% if post.type != 'Article' %}<div>{{ post.summary|default:'' }}</div>{% endif %}
         <div style="display:flex;">
           <div style="flex-grow:1"
-               {% if post.type != 'Article' %}{% if post.summary or post.sensitive %}class="spoiler" _="on click toggle .revealed on me"{% endif %}
+               class="{% if post.converted_preview_card %}pagecard-order{% endif %}{% if post.type != 'Article' %}{% if post.summary or post.sensitive %} spoiler{% endif %}{% endif %}"
+               {% if post.type != 'Article' %}{% if post.summary or post.sensitive %}_="on click toggle .revealed on me"{% endif %}
                {% endif %}>
             <div class="attachments">
               {% for attachment in post.attachments.all %}

--- a/neodb/tests/social/test_post_type_rendering.py
+++ b/neodb/tests/social/test_post_type_rendering.py
@@ -73,6 +73,8 @@ def test_single_post_renders_converted_object_card(post_type):
     assert response.status_code == 200
     html = response.content.decode()
     assert 'class="converted-object-card ' in html
+    # page objects reorder the body so the linked page card renders first
+    assert "pagecard-order" in html
     assert f"{post_type} title" in html
     assert f"{post_type} summary" in html
     assert f"/proxy/preview_card/{card.pk}/" in html

--- a/takahe/templates/activities/_post.html
+++ b/takahe/templates/activities/_post.html
@@ -33,6 +33,8 @@
     {% endif %}
 
     <div class="content {% if post.summary %}hidden {% endif %}"{% if post.language %} lang="{{ post.language }}"{% endif %}>
+        {% include "activities/_preview_card.html" %}
+
         {% if post.type == "Question" %}
             {% include "activities/_type_question.html" with sanitized_content=post.safe_content_note_local interactive=True %}
         {% else %}
@@ -69,8 +71,6 @@
                 {% endfor %}
             </div>
         {% endif %}
-
-        {% include "activities/_preview_card.html" %}
     </div>
 
     {% if post.edited %}


### PR DESCRIPTION
## What

For federated **Page/converted objects** (`Page`/`Image`/`Audio`/`Video`/`Event`) that carry a preview card, render the **linked page card first**, then the user content (with the trailing object link kept inside it, as today), then image attachments.

Previously the linked page card rendered **last**, after content and image.

## Changes

- **takahe web UI** (`activities/_post.html`): move the `_preview_card.html` include to the top of the content block. Content already precedes attachments here, so the result is card -> content -> image.
- **NeoDB feed** (`social/_event_post.html`): add a `pagecard-order` modifier class on the post body column, gated on `post.converted_preview_card`, and reorder with CSS `order`. DOM order is unchanged and ordinary posts are unaffected (only converted objects get the modifier).
- **`_post.scss`**: flex-column ordering rule for `.pagecard-order` (card, then content, then attachments).
- **test**: assert the reorder is activated for every converted object type.

## Notes

- The post link stays inside the content body (unchanged), so the Mastodon API `content`/`card` fields are unchanged.
- Non-converted posts render exactly as before.