### PR TITLE
feat(article): add featured image support

### DIFF
--- a/neodb/journal/apis/article.py
+++ b/neodb/journal/apis/article.py
@@ -1,9 +1,12 @@
 from datetime import datetime
 from typing import Any, List
 
+from django import forms
+from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpRequest
-from ninja import Field, Schema, Status
+from ninja import Field, File, Schema, Status
+from ninja.files import UploadedFile
 from ninja.pagination import paginate
 
 from common.api import (
@@ -17,6 +20,7 @@ from common.api import (
 from common.sentry import record_activity
 
 from ..models import Article
+from ..models.collection import COVER_MAX_BYTES
 from ..models.common import prefetch_latest_posts
 
 
@@ -34,6 +38,7 @@ class ArticleSchema(Schema):
     language: str = ""
     tags: list[str] = []
     html_content: str
+    cover_image_url: str | None = None
 
 
 class ArticleInSchema(Schema):
@@ -160,6 +165,63 @@ def update_article(request, article_uuid: str, a_in: ArticleInSchema):
         share_to_mastodon=a_in.post_to_fediverse,
         application_id=getattr(request, "application_id", None),
     )
+    record_activity("article", "api")
+    return article
+
+
+@api.put(
+    "/me/article/{article_uuid}/cover",
+    response={200: ArticleSchema, 400: Result, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+)
+def set_article_cover(request, article_uuid: str, cover: File[UploadedFile]):
+    """
+    Set the featured image of an article owned by current user.
+
+    Send the image as `multipart/form-data` with a `cover` file field;
+    it must be a valid image no larger than 5MB. Saving re-syncs the article's
+    federated post and Bluesky records so the new image propagates.
+    """
+    article = Article.get_by_url_and_owner(article_uuid, request.user.identity.pk)
+    if not article:
+        return NOT_FOUND
+    if (cover.size or 0) > COVER_MAX_BYTES:
+        return Status(400, {"message": "Image file too large"})
+    try:
+        f = forms.ImageField().to_python(cover)
+    except forms.ValidationError:
+        return Status(400, {"message": "Invalid image file"})
+    if f is None:
+        return Status(400, {"message": "Invalid image file"})
+    # normalize the filename from the detected format so the stored path gets
+    # a meaningful extension even for extension-less uploads
+    image = getattr(f, "image", None)  # set by ImageField.to_python
+    fmt = (image.format or "").lower() if image else ""
+    ext = {"jpeg": "jpg"}.get(fmt, fmt)
+    if ext:
+        f.name = f"cover.{ext}"
+    article.cover = f
+    article.application_id_when_save = getattr(request, "application_id", None)
+    article.save()
+    record_activity("article", "api")
+    return article
+
+
+@api.delete(
+    "/me/article/{article_uuid}/cover",
+    response={200: ArticleSchema, 401: Result, 403: Result, 404: Result},
+    tags=["article"],
+)
+def remove_article_cover(request, article_uuid: str):
+    """
+    Remove the featured image of an article owned by current user.
+    """
+    article = Article.get_by_url_and_owner(article_uuid, request.user.identity.pk)
+    if not article:
+        return NOT_FOUND
+    article.cover = settings.DEFAULT_ITEM_COVER
+    article.application_id_when_save = getattr(request, "application_id", None)
+    article.save()
     record_activity("article", "api")
     return article
 

--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -143,11 +143,29 @@ class NdjsonExporter(Task):
                 total += 1
                 for url in re.findall(r"(?<=!\[\]\()([^)]+)(?=\))", art.body):
                     _save_image(url)
+                # bundle the featured image file (the ap_object only carries a
+                # URL that may be unreachable after migration), mirroring how
+                # Collection covers are archived and restored on import
+                cover_file = None
+                if art.cover and str(art.cover) != settings.DEFAULT_ITEM_COVER:
+                    cover_filename = os.path.basename(str(art.cover))
+                    cover_dest = os.path.join(attachment_path, cover_filename)
+                    try:
+                        with art.cover.open("rb") as src:
+                            with open(cover_dest, "wb") as dst:
+                                shutil.copyfileobj(src, dst)
+                        cover_file = f"attachments/{cover_filename}"
+                    except Exception as e:
+                        logger.error(
+                            f"error copying cover {cover_filename} to {cover_dest}",
+                            extra={"exception": e},
+                        )
                 o = {
                     "type": "Article",
                     "content": art.ap_object,
                     "visibility": art.visibility,
                     "metadata": art.metadata,
+                    "cover": cover_file,
                 }
                 f.write(json.dumps(o, default=str) + "\n")
 

--- a/neodb/journal/forms.py
+++ b/neodb/journal/forms.py
@@ -59,7 +59,9 @@ class ReviewForm(forms.ModelForm):
 class ArticleForm(forms.ModelForm):
     class Meta:
         model = Article
-        fields = ["id", "title", "body", "summary", "sensitive", "visibility"]
+        fields = ["id", "title", "cover", "body", "summary", "sensitive", "visibility"]
+        widgets = {"cover": PreviewImageInput()}
+        labels = {"cover": _("Featured image (optional)")}
 
     # Labels are pinned for accessibility (screen readers / HTML
     # ``<label>``-by-association) but the visible UI surfaces them as

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -180,15 +180,29 @@ class NdjsonImporter(BaseImporter):
                 owner=owner, title=title, created_time=published_dt
             ).exists():
                 return "skipped"
-            article = Article.update_local_article(
-                owner=owner,
-                title=title,
-                body=body,
-                summary=summary,
-                sensitive=sensitive,
-                visibility=visibility,
-                tags=tags,
-            )
+            # Restore the bundled featured image (if any) as part of the
+            # initial create so the federated post carries it too. Keep the
+            # handle open across the create — the ImageField reads it on save.
+            cover_src = self._resolve_temp_path(data.get("cover"))
+            cover_arg = None
+            cover_fh = None
+            if cover_src and os.path.isfile(cover_src):
+                cover_fh = open(cover_src, "rb")
+                cover_arg = File(cover_fh, name=os.path.basename(cover_src))
+            try:
+                article = Article.update_local_article(
+                    owner=owner,
+                    title=title,
+                    body=body,
+                    summary=summary,
+                    sensitive=sensitive,
+                    visibility=visibility,
+                    tags=tags,
+                    cover=cover_arg,
+                )
+            finally:
+                if cover_fh is not None:
+                    cover_fh.close()
             # ``update_local_article`` overwrites metadata['word_count'];
             # merge any other keys (e.g. author-specific extras) the bundle
             # carried back in.

--- a/neodb/journal/migrations/0017_article_cover.py
+++ b/neodb/journal/migrations/0017_article_cover.py
@@ -1,0 +1,20 @@
+import catalog.models.utils
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("journal", "0016_backfill_member_progress"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="article",
+            name="cover",
+            field=models.ImageField(
+                blank=True,
+                default="item/default.svg",
+                upload_to=catalog.models.utils.piece_cover_path,
+            ),
+        ),
+    ]

--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -69,7 +69,9 @@ def _image_url_from_ap(obj: Any) -> str:
     candidates: list[Any] = []
     image = obj.get("image")
     candidates += image if isinstance(image, list) else [image]
-    for att in obj.get("attachment", []) or []:
+    # ``attachment`` may be a single object or an array (both valid AS2)
+    attachment = obj.get("attachment")
+    for att in attachment if isinstance(attachment, list) else [attachment]:
         if isinstance(att, dict) and str(att.get("type", "")).lower() == "image":
             candidates.append(att)
     for c in candidates:

--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -1,6 +1,9 @@
+import mimetypes
 import re
 from typing import Any
 
+from django.conf import settings
+from django.core.files.base import File
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
@@ -10,6 +13,8 @@ from django.utils.translation import gettext as _
 from loguru import logger
 from markdownify import markdownify as md
 
+from catalog.models.utils import piece_cover_path
+from common.utils import get_file_absolute_url
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -21,6 +26,11 @@ from .tag import Tag as TagModel
 _RE_SPOILER_TAG = re.compile(r'<(div|span)\sclass="spoiler">.*</(div|span)>')
 
 _TAG_MAX_COUNT = 30
+
+# ATProto blob (Bluesky external-embed thumb, site.standard.document
+# coverImage) and the AS ``image`` are all backed by the same cover file;
+# the lexicons cap the blob at 1MB, so skip anything larger than the card.
+_COVER_BLOB_MAX_SIZE = 1000000
 
 
 def _normalize_tags(values: Any) -> list[str]:
@@ -39,6 +49,34 @@ def _normalize_tags(values: Any) -> list[str]:
         if len(out) >= _TAG_MAX_COUNT:
             break
     return out
+
+
+def _image_url_from_ap(obj: Any) -> str:
+    """Featured-image URL from an AS object's ``image`` (falling back to an
+    ``attachment`` Image), or '' when none. The value may be a URL string, a
+    single Image/Link dict, or a list of them. Only ``http(s)`` URLs are
+    returned so a malformed remote payload cannot smuggle a local/file ref."""
+
+    def _url(v: Any) -> str:
+        if isinstance(v, str):
+            u = v
+        elif isinstance(v, dict):
+            u = v.get("url") or v.get("href") or ""
+        else:
+            u = ""
+        return u if isinstance(u, str) and u.startswith(("http://", "https://")) else ""
+
+    candidates: list[Any] = []
+    image = obj.get("image")
+    candidates += image if isinstance(image, list) else [image]
+    for att in obj.get("attachment", []) or []:
+        if isinstance(att, dict) and str(att.get("type", "")).lower() == "image":
+            candidates.append(att)
+    for c in candidates:
+        u = _url(c)
+        if u:
+            return u
+    return ""
 
 
 class Article(Piece):
@@ -74,6 +112,13 @@ class Article(Piece):
     language = models.CharField(max_length=8, blank=True, default="")
     attachments = models.JSONField(default=list)
     tags = models.JSONField(default=list)
+    # Featured/cover image. Optional; mirrors ``Collection.cover`` (same
+    # ``upload_to`` and default sentinel). Federated as the AS ``image``
+    # (plus an ``attachment`` mirror) and used for the Bluesky external-card
+    # thumb and the ``site.standard.document`` coverImage blob.
+    cover = models.ImageField(
+        upload_to=piece_cover_path, default=settings.DEFAULT_ITEM_COVER, blank=True
+    )
 
     class Meta:
         indexes = [
@@ -87,6 +132,18 @@ class Article(Piece):
     @property
     def display_title(self) -> str:
         return self.title
+
+    @property
+    def cover_image_url(self) -> str | None:
+        """Absolute URL of the featured image, or ``None`` when unset.
+
+        Local articles store the file in ``cover``; a federated remote article
+        carries only a URL, cached in ``metadata['cover_url']`` by
+        ``params_from_ap_object`` (the image is never downloaded locally)."""
+        url = get_file_absolute_url(self.cover)
+        if url:
+            return url
+        return (self.metadata or {}).get("cover_url") or None
 
     @property
     def html_content(self) -> str:
@@ -157,6 +214,26 @@ class Article(Piece):
                 text = marker
         return text
 
+    def _ap_image_object(self) -> dict | None:
+        """AS ``Image`` for the featured image, or ``None`` when unset.
+
+        Emitted both as the object's ``image`` (the AS spec's banner/featured
+        slot, honored by Ghost / Lemmy / the WordPress ActivityPub plugin) and
+        mirrored into ``attachment`` -- Mastodon/Pleroma ignore an object-level
+        ``image`` and only render media listed in ``attachment``. Consumers
+        that read both may show it twice; this matches the WordPress plugin's
+        deliberate belt-and-suspenders emission."""
+        url = self.cover_image_url
+        if not url:
+            return None
+        image: dict[str, Any] = {"type": "Image", "url": url}
+        media_type = mimetypes.guess_type(url)[0]
+        if media_type:
+            image["mediaType"] = media_type
+        if self.title:
+            image["name"] = self.title  # doubles as alt text
+        return image
+
     @property
     def ap_object(self) -> dict:
         # No ``id`` key on purpose: ``get_ap_data()`` is merged into the
@@ -177,6 +254,10 @@ class Article(Piece):
             "href": self.absolute_url,
             "tag": [{"type": "Hashtag", "name": f"#{t}"} for t in self.normalized_tags],
         }
+        image = self._ap_image_object()
+        if image:
+            d["image"] = image
+            d["attachment"] = [dict(image)]
         # AS ``summary`` here carries the *raw* user-supplied text only.
         # NDJSON export and inbound ``update_by_ap_object`` both round-trip
         # through ``ap_object``, so storing the auto-marker here would
@@ -234,6 +315,31 @@ class Article(Piece):
             description=self.display_summary or self.excerpt,
             tags=self.normalized_tags,
         )
+
+    def atproto_document_cover_image(self) -> bytes | None:
+        """Featured-image bytes for the ``site.standard.document`` coverImage
+        blob, or ``None`` when unset or too large.
+
+        Read through ``storage.open`` (an independent handle) so it never
+        disturbs the ``cover`` FieldFile's lazily-opened state that the
+        Bluesky external-embed thumb path reads from in the same crosspost."""
+        if not self.cover or str(self.cover) == settings.DEFAULT_ITEM_COVER:
+            return None
+        name = self.cover.name
+        if not name:
+            return None
+        try:
+            f = self.cover.storage.open(name, "rb")
+            try:
+                data = f.read()
+            finally:
+                f.close()
+        except Exception as e:
+            logger.warning(f"{self} cover read error {e}")
+            return None
+        if not data or len(data) > _COVER_BLOB_MAX_SIZE:
+            return None
+        return data
 
     def to_indexable_doc(self) -> dict[str, Any]:
         return {
@@ -297,16 +403,24 @@ class Article(Piece):
             logger.warning(f"Article {obj.get('id')} has unparseable timestamps")
             return None
         d = cls.params_from_ap_object(post, obj, existing)
+        # Remote articles carry the featured image as a URL only; cache it in
+        # metadata (no download) so cover_image_url can surface it.
+        cover_url = _image_url_from_ap(obj)
         if existing:
             if existing.edited_time >= edited:
                 return existing  # stale; no-op
             for k, v in d.items():
                 setattr(existing, k, v)
             existing.edited_time = edited
-            existing.metadata = {
+            meta = {
                 **(existing.metadata or {}),
                 "word_count": existing._compute_word_count(),
             }
+            if cover_url:
+                meta["cover_url"] = cover_url
+            else:
+                meta.pop("cover_url", None)
+            existing.metadata = meta
             existing.save(
                 update_fields=list(d.keys()) + ["edited_time", "metadata"],
                 post_when_save=False,
@@ -325,6 +439,8 @@ class Article(Piece):
         )
         article = cls(**d)
         article.metadata = {"word_count": article._compute_word_count()}
+        if cover_url:
+            article.metadata["cover_url"] = cover_url
         article.previous_visibility = visibility
         article.save(link_post_id=post.id, post_when_save=False)
         return article
@@ -344,6 +460,7 @@ class Article(Piece):
         article: "Article | None" = None,
         share_to_mastodon: bool = False,
         application_id: int | None = None,
+        cover: "File | None" = None,
     ) -> "Article":
         if article is None:
             article = cls(owner=owner)
@@ -358,6 +475,11 @@ class Article(Piece):
         article.visibility = int(visibility)
         article.language = language or ""
         article.tags = _normalize_tags(tags or [])
+        # A falsy cover (no upload / API call that omits it) leaves the current
+        # image untouched; removal has a dedicated endpoint. Assigning the
+        # unchanged FieldFile back on edit is a harmless no-op.
+        if cover:
+            article.cover = cover
         article.edited_time = timezone.now()
         article.metadata = {
             **(article.metadata or {}),

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -387,6 +387,12 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         """
         return set()
 
+    def atproto_document_cover_image(self) -> "bytes | None":
+        """Bytes for this piece's ``site.standard.document`` coverImage blob,
+        or ``None``. Long-form subclasses with a featured image (article)
+        override this; the default publishes no cover."""
+        return None
+
     def atproto_document_rkey(self) -> str:
         """Record key for this piece's ``site.standard.document``.
 
@@ -812,6 +818,31 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                     f"{self} sync document {collection} to {bluesky} error {e}"
                 )
 
+    def _with_document_cover(self, bluesky, document: dict) -> dict:
+        """Return ``document`` with a ``coverImage`` blob attached when the
+        piece exposes cover bytes, else unchanged.
+
+        The blob is uploaded to the PDS here (not in the pure record builder)
+        because a blob ref can only be minted with a live client. Failures are
+        logged and swallowed so a cover problem never blocks the document
+        write itself.
+        """
+        if "coverImage" in document:
+            return document
+        try:
+            data = self.atproto_document_cover_image()
+        except Exception as e:
+            logger.warning(f"{self} document cover read error {e}")
+            return document
+        if not data:
+            return document
+        try:
+            blob = bluesky.upload_blob_dict(data)
+        except Exception as e:
+            logger.warning(f"{self} document cover upload error {e}")
+            return document
+        return {**document, "coverImage": blob}
+
     def _put_document_record(self, bluesky, document=None) -> dict[str, str] | None:
         """Write this piece's ``site.standard.document`` and return the
         record's strong ref (uri + cid), or ``None`` when the piece publishes
@@ -829,6 +860,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 return None
         if not document:
             return None
+        document = self._with_document_cover(bluesky, document)
         rkey = self.atproto_document_rkey()
         ref = None
         for collection in collections:

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -836,11 +836,19 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             return document
         if not data:
             return document
+        # A full crosspost writes the document twice (embed refs, then again
+        # with bskyPostRef); cache the uploaded blob on the instance, keyed by
+        # PDS, so the same cover is not re-uploaded on the second write.
+        uid = getattr(bluesky, "uid", None)
+        cache = getattr(self, "_atproto_cover_blob_cache", None)
+        if cache and cache.get("uid") == uid:
+            return {**document, "coverImage": cache["blob"]}
         try:
             blob = bluesky.upload_blob_dict(data)
         except Exception as e:
             logger.warning(f"{self} document cover upload error {e}")
             return document
+        self._atproto_cover_blob_cache = {"uid": uid, "blob": blob}
         return {**document, "coverImage": blob}
 
     def _put_document_record(self, bluesky, document=None) -> dict[str, str] | None:

--- a/neodb/journal/templates/article.html
+++ b/neodb/journal/templates/article.html
@@ -42,6 +42,8 @@
     {% if article.classname == "review" %}
       <meta property="og:image" content="{{ article.item.cover|thumb:'normal' }}">
       <script type="application/ld+json">{{ article.to_schema_org_json | safe }}</script>
+    {% elif article.cover_image_url %}
+      <meta property="og:image" content="{{ article.cover_image_url }}">
     {% endif %}
     {% if article.latest_post %}
       <link rel="alternate"
@@ -139,6 +141,14 @@
                class="markdown-content"
                {% if article.classname == "article" and article.sensitive %}hidden{% endif %}>
             {% if request.user.is_authenticated or article.owner.anonymous_viewable %}
+              {% if article.classname == "article" and article.cover_image_url %}
+                <img class="article-cover"
+                     src="{{ article.cover_image_url }}"
+                     alt="{{ article.title }}"
+                     style="max-width:100%;
+                            height:auto;
+                            margin-bottom:1rem">
+              {% endif %}
               {{ article.html_content | safe }}
             {% else %}
               <p class="empty">

--- a/neodb/journal/templates/article_edit.html
+++ b/neodb/journal/templates/article_edit.html
@@ -30,10 +30,12 @@
     <main>
       <div>
         <article>
-          <form method="post" class="review-form">
+          <form method="post" class="review-form" enctype="multipart/form-data">
             {% csrf_token %}
             {{ form.id }}
             {{ form.title }}
+            <label for="{{ form.cover.id_for_label }}">{{ form.cover.label }}</label>
+            {{ form.cover }}
             {{ form.summary }}
             {{ form.body }}
             {{ form.tags }}

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -63,9 +63,9 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
             },
         )
     form = (
-        ArticleForm(request.POST, instance=article)
+        ArticleForm(request.POST, request.FILES, instance=article)
         if article
-        else ArticleForm(request.POST)
+        else ArticleForm(request.POST, request.FILES)
     )
     if not form.is_valid():
         # Re-render with the bound form so users see field-level errors
@@ -93,6 +93,7 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
         tags=tags,
         article=article,
         share_to_mastodon=bool(form.cleaned_data.get("share_to_mastodon", False)),
+        cover=form.cleaned_data.get("cover"),
     )
     record_activity("article", "web")
     return redirect(reverse("journal:article_retrieve", args=[article.uuid]))

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 00:06-0400\n"
+"POT-Creation-Date: 2026-07-24 11:13+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1073,7 +1073,7 @@ msgid "hide this tooltip"
 msgstr ""
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
 msgid "translate"
 msgstr ""
 
@@ -1187,7 +1187,7 @@ msgstr ""
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:186
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
 #: journal/templates/collection.html:179 journal/templates/collection.html:187
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
@@ -1383,7 +1383,7 @@ msgstr ""
 #: catalog/templates/_sidebar_edit.html:240
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:189 journal/templates/collection.html:182
+#: journal/templates/article.html:199 journal/templates/collection.html:182
 #: journal/templates/mark.html:157 journal/templates/note.html:84
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1648,7 +1648,7 @@ msgstr ""
 #: catalog/templates/catalog_edit.html:65
 #: common/templates/manage/settings.html:136
 #: journal/templates/add_to_collection.html:43
-#: journal/templates/article_edit.html:57
+#: journal/templates/article_edit.html:59
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:69
 #: journal/templates/mark.html:142 journal/templates/note.html:67
 #: journal/templates/post_compose.html:103
@@ -2133,7 +2133,7 @@ msgstr ""
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:156
 #: catalog/views/verify.py:203 journal/views/article.py:39
-#: journal/views/article.py:121 journal/views/article.py:141
+#: journal/views/article.py:122 journal/views/article.py:142
 #: journal/views/collection.py:238 journal/views/collection.py:299
 #: journal/views/collection.py:318 journal/views/collection.py:342
 #: journal/views/collection.py:415 journal/views/collection.py:458
@@ -2235,7 +2235,7 @@ msgid "Please wait a moment before trying again."
 msgstr ""
 
 #: catalog/views/verify.py:162 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:174 journal/views/review.py:170
+#: journal/views/article.py:175 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr ""
@@ -3793,7 +3793,7 @@ msgstr ""
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:233 journal/forms.py:197
+#: common/templates/_sidebar.html:233 journal/forms.py:199
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4006,7 +4006,7 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:192
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:193
 #: journal/views/profile.py:540 journal/views/review.py:188
 msgid "Login required"
 msgstr ""
@@ -4703,32 +4703,32 @@ msgstr ""
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:70
-#: journal/forms.py:73 journal/forms.py:140
+#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:72
+#: journal/forms.py:75 journal/forms.py:142
 msgid "Title"
 msgstr ""
 
 #: journal/forms.py:30 journal/forms.py:35 journal/forms.py:36
-#: journal/forms.py:89 journal/forms.py:94 journal/forms.py:95
-#: journal/forms.py:142
+#: journal/forms.py:91 journal/forms.py:96 journal/forms.py:97
+#: journal/forms.py:144
 msgid "Content (Markdown)"
 msgstr ""
 
-#: journal/forms.py:41 journal/forms.py:206 journal/templates/comment.html:62
+#: journal/forms.py:41 journal/forms.py:208 journal/templates/comment.html:62
 #: journal/templates/mark.html:115
 msgid "Crosspost to timeline"
 msgstr ""
 
-#: journal/forms.py:44 journal/forms.py:117
+#: journal/forms.py:44 journal/forms.py:119
 msgid "Keep leading spaces"
 msgstr ""
 
-#: journal/forms.py:45 journal/forms.py:118
+#: journal/forms.py:45 journal/forms.py:120
 msgid "When saving, replace leading spaces with full-width spaces"
 msgstr ""
 
-#: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
-#: journal/forms.py:199 journal/templates/collection_share.html:24
+#: journal/forms.py:51 journal/forms.py:126 journal/forms.py:151
+#: journal/forms.py:201 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
 #: users/templates/users/data.html:98 users/templates/users/data.html:155
 #: users/templates/users/data.html:206 users/templates/users/data.html:269
@@ -4738,45 +4738,49 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-#: journal/forms.py:77 journal/forms.py:83 journal/forms.py:84
+#: journal/forms.py:64
+msgid "Featured image (optional)"
+msgstr ""
+
+#: journal/forms.py:79 journal/forms.py:85 journal/forms.py:86
 msgid "Summary (optional)"
 msgstr ""
 
-#: journal/forms.py:100 journal/forms.py:105 journal/forms.py:106
+#: journal/forms.py:102 journal/forms.py:107 journal/forms.py:108
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: journal/forms.py:111 journal/templates/post_compose.html:86
+#: journal/forms.py:113 journal/templates/post_compose.html:86
 msgid "Mark as sensitive"
 msgstr ""
 
-#: journal/forms.py:114
+#: journal/forms.py:116
 msgid "Crosspost to Mastodon"
 msgstr ""
 
-#: journal/forms.py:133
+#: journal/forms.py:135
 msgid "owner only"
 msgstr ""
 
-#: journal/forms.py:134
+#: journal/forms.py:136
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:156 journal/templates/collection.html:187
+#: journal/forms.py:158 journal/templates/collection.html:187
 #: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:191 users/templates/users/crossposts.html:51
+#: journal/forms.py:193 users/templates/users/crossposts.html:51
 #: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
-#: journal/forms.py:193 journal/templates/comment.html:16
+#: journal/forms.py:195 journal/templates/comment.html:16
 msgid "Comment"
 msgstr ""
 
-#: journal/forms.py:195
+#: journal/forms.py:197
 msgid "Rating"
 msgstr ""
 
@@ -4815,7 +4819,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:153 journal/views/article.py:206
+#: journal/models/article.py:210 journal/views/article.py:207
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -4929,27 +4933,27 @@ msgstr ""
 msgid "Mentioned Only"
 msgstr ""
 
-#: journal/models/common.py:711
+#: journal/models/common.py:730
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:874
+#: journal/models/common.py:919
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:907
+#: journal/models/common.py:952
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:917
+#: journal/models/common.py:962
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:931
+#: journal/models/common.py:976
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:940
+#: journal/models/common.py:985
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 
@@ -5523,7 +5527,7 @@ msgstr ""
 msgid "Update note"
 msgstr ""
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:121
+#: journal/templates/_list_item.html:100 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5657,7 +5661,7 @@ msgid "View post"
 msgstr ""
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:180 journal/templates/collection.html:168
+#: journal/templates/article.html:190 journal/templates/collection.html:168
 msgid "Quote"
 msgstr ""
 
@@ -5666,7 +5670,7 @@ msgid "reply"
 msgstr ""
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:171 journal/templates/collection.html:159
+#: journal/templates/article.html:181 journal/templates/collection.html:159
 msgid "Reply"
 msgstr ""
 
@@ -5683,19 +5687,19 @@ msgstr ""
 msgid "Create a new collection"
 msgstr ""
 
-#: journal/templates/article.html:102 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:81
 msgid "wrote a review"
 msgstr ""
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:83
 msgid "wrote an article"
 msgstr ""
 
-#: journal/templates/article.html:134
+#: journal/templates/article.html:136
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr ""
 
-#: journal/templates/article.html:145
+#: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr ""
 
@@ -6060,16 +6064,16 @@ msgstr ""
 msgid "#%(year)s_report"
 msgstr ""
 
-#: journal/views/article.py:172 journal/views/review.py:168
+#: journal/views/article.py:173 journal/views/review.py:168
 msgid "User not local"
 msgstr ""
 
-#: journal/views/article.py:180 journal/views/article.py:194
+#: journal/views/article.py:181 journal/views/article.py:195
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr ""
 
-#: journal/views/article.py:182 journal/views/article.py:190
+#: journal/views/article.py:183 journal/views/article.py:191
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 00:06-0400\n"
+"POT-Creation-Date: 2026-07-24 11:13+0800\n"
 "PO-Revision-Date: 2026-07-02 15:01+0000\n"
 "Last-Translator: Hosted Weblate user 54392 <hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1072,7 +1072,7 @@ msgid "hide this tooltip"
 msgstr "不再提示"
 
 #: catalog/templates/_item_comments.html:58
-#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:81
+#: catalog/templates/item_mark_list.html:46 journal/templates/article.html:83
 msgid "translate"
 msgstr "翻译"
 
@@ -1186,7 +1186,7 @@ msgstr "设置进度"
 #: catalog/templates/_item_user_pieces.html:101
 #: catalog/templates/catalog_edit.html:12
 #: journal/templates/action_edit_post.html:6
-#: journal/templates/action_edit_post.html:8 journal/templates/article.html:186
+#: journal/templates/action_edit_post.html:8 journal/templates/article.html:196
 #: journal/templates/collection.html:179 journal/templates/collection.html:187
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_edit.html:26
@@ -1382,7 +1382,7 @@ msgstr "合并到另一条目"
 #: catalog/templates/_sidebar_edit.html:240
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
-#: journal/templates/article.html:189 journal/templates/collection.html:182
+#: journal/templates/article.html:199 journal/templates/collection.html:182
 #: journal/templates/mark.html:157 journal/templates/note.html:84
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
@@ -1647,7 +1647,7 @@ msgstr "创建"
 #: catalog/templates/catalog_edit.html:65
 #: common/templates/manage/settings.html:136
 #: journal/templates/add_to_collection.html:43
-#: journal/templates/article_edit.html:57
+#: journal/templates/article_edit.html:59
 #: journal/templates/collection_edit.html:39 journal/templates/comment.html:69
 #: journal/templates/mark.html:142 journal/templates/note.html:67
 #: journal/templates/post_compose.html:103
@@ -2132,7 +2132,7 @@ msgstr "条目不可被删除。"
 #: catalog/views/edit.py:390 catalog/views/edit.py:479
 #: catalog/views/edit.py:511 catalog/views/verify.py:156
 #: catalog/views/verify.py:203 journal/views/article.py:39
-#: journal/views/article.py:121 journal/views/article.py:141
+#: journal/views/article.py:122 journal/views/article.py:142
 #: journal/views/collection.py:238 journal/views/collection.py:299
 #: journal/views/collection.py:318 journal/views/collection.py:342
 #: journal/views/collection.py:415 journal/views/collection.py:458
@@ -2234,7 +2234,7 @@ msgid "Please wait a moment before trying again."
 msgstr "重试前请稍等。"
 
 #: catalog/views/verify.py:162 common/utils.py:109 common/utils.py:150
-#: journal/views/article.py:174 journal/views/review.py:170
+#: journal/views/article.py:175 journal/views/review.py:170
 #: users/views/actions.py:37 users/views/actions.py:123
 msgid "User not found"
 msgstr "用户不存在"
@@ -3792,7 +3792,7 @@ msgstr "正在阅读"
 msgid "Currently watching"
 msgstr "正在追看"
 
-#: common/templates/_sidebar.html:233 journal/forms.py:197
+#: common/templates/_sidebar.html:233 journal/forms.py:199
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4026,7 +4026,7 @@ msgstr "用户不存在了"
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:192
+#: common/utils.py:128 common/utils.py:130 journal/views/article.py:193
 #: journal/views/profile.py:540 journal/views/review.py:188
 msgid "Login required"
 msgstr "登录后访问"
@@ -4723,32 +4723,32 @@ msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
-#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:70
-#: journal/forms.py:73 journal/forms.py:140
+#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:72
+#: journal/forms.py:75 journal/forms.py:142
 msgid "Title"
 msgstr "标题"
 
 #: journal/forms.py:30 journal/forms.py:35 journal/forms.py:36
-#: journal/forms.py:89 journal/forms.py:94 journal/forms.py:95
-#: journal/forms.py:142
+#: journal/forms.py:91 journal/forms.py:96 journal/forms.py:97
+#: journal/forms.py:144
 msgid "Content (Markdown)"
 msgstr "内容 （Markdown格式）"
 
-#: journal/forms.py:41 journal/forms.py:206 journal/templates/comment.html:62
+#: journal/forms.py:41 journal/forms.py:208 journal/templates/comment.html:62
 #: journal/templates/mark.html:115
 msgid "Crosspost to timeline"
 msgstr "转发到时间轴"
 
-#: journal/forms.py:44 journal/forms.py:117
+#: journal/forms.py:44 journal/forms.py:119
 msgid "Keep leading spaces"
 msgstr "保留行首空格"
 
-#: journal/forms.py:45 journal/forms.py:118
+#: journal/forms.py:45 journal/forms.py:120
 msgid "When saving, replace leading spaces with full-width spaces"
 msgstr "保存时将行首空格替换为全角"
 
-#: journal/forms.py:51 journal/forms.py:124 journal/forms.py:149
-#: journal/forms.py:199 journal/templates/collection_share.html:24
+#: journal/forms.py:51 journal/forms.py:126 journal/forms.py:151
+#: journal/forms.py:201 journal/templates/collection_share.html:24
 #: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
 #: users/templates/users/data.html:98 users/templates/users/data.html:155
 #: users/templates/users/data.html:206 users/templates/users/data.html:269
@@ -4758,45 +4758,49 @@ msgstr "保存时将行首空格替换为全角"
 msgid "Visibility"
 msgstr "可见性"
 
-#: journal/forms.py:77 journal/forms.py:83 journal/forms.py:84
+#: journal/forms.py:64
+msgid "Featured image (optional)"
+msgstr "封面图片（选填）"
+
+#: journal/forms.py:79 journal/forms.py:85 journal/forms.py:86
 msgid "Summary (optional)"
 msgstr "摘要（选填）"
 
-#: journal/forms.py:100 journal/forms.py:105 journal/forms.py:106
+#: journal/forms.py:102 journal/forms.py:107 journal/forms.py:108
 msgid "Tags (comma separated)"
 msgstr "标签（逗号分隔）"
 
-#: journal/forms.py:111 journal/templates/post_compose.html:86
+#: journal/forms.py:113 journal/templates/post_compose.html:86
 msgid "Mark as sensitive"
 msgstr "标记为敏感"
 
-#: journal/forms.py:114
+#: journal/forms.py:116
 msgid "Crosspost to Mastodon"
 msgstr "转发到Mastodon"
 
-#: journal/forms.py:133
+#: journal/forms.py:135
 msgid "owner only"
 msgstr "仅创建者"
 
-#: journal/forms.py:134
+#: journal/forms.py:136
 msgid "owner and their local mutuals"
 msgstr "创建者和他们的本地互关"
 
-#: journal/forms.py:156 journal/templates/collection.html:187
+#: journal/forms.py:158 journal/templates/collection.html:187
 #: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:191 users/templates/users/crossposts.html:51
+#: journal/forms.py:193 users/templates/users/crossposts.html:51
 #: users/templates/users/data.html:483
 msgid "Status"
 msgstr "状态"
 
-#: journal/forms.py:193 journal/templates/comment.html:16
+#: journal/forms.py:195 journal/templates/comment.html:16
 msgid "Comment"
 msgstr "短评"
 
-#: journal/forms.py:195
+#: journal/forms.py:197
 msgid "Rating"
 msgstr "评分"
 
@@ -4835,7 +4839,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:153 journal/views/article.py:206
+#: journal/models/article.py:210 journal/views/article.py:207
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -4949,27 +4953,27 @@ msgstr "仅关注者"
 msgid "Mentioned Only"
 msgstr "自己和提到的人"
 
-#: journal/models/common.py:711
+#: journal/models/common.py:730
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "帖文未能发布到Bluesky，请重新使用ATProto验证登录。"
 
-#: journal/models/common.py:874
+#: journal/models/common.py:919
 msgid "A recent post was not posted to Threads."
 msgstr "帖文未能发布到Threads。"
 
-#: journal/models/common.py:907
+#: journal/models/common.py:952
 msgid "A recent post was not boosted on Mastodon."
 msgstr "帖文未能在联邦实例转播。"
 
-#: journal/models/common.py:917
+#: journal/models/common.py:962
 msgid "Original post no longer exists."
 msgstr "原帖文已不存在。"
 
-#: journal/models/common.py:931
+#: journal/models/common.py:976
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "帖文未能发布到联邦实例，请重新验证登录。"
 
-#: journal/models/common.py:940
+#: journal/models/common.py:985
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能发布到联邦实例。"
 
@@ -5543,7 +5547,7 @@ msgstr "更新标记"
 msgid "Update note"
 msgstr "修改备注"
 
-#: journal/templates/_list_item.html:100 journal/templates/article.html:121
+#: journal/templates/_list_item.html:100 journal/templates/article.html:123
 #: journal/templates/review_edit.html:11
 #: journal/templates/user_review_list.html:7
 msgid "Review"
@@ -5677,7 +5681,7 @@ msgid "View post"
 msgstr "查看帖文"
 
 #: journal/templates/action_quote_post.html:3
-#: journal/templates/article.html:180 journal/templates/collection.html:168
+#: journal/templates/article.html:190 journal/templates/collection.html:168
 msgid "Quote"
 msgstr "引用"
 
@@ -5686,7 +5690,7 @@ msgid "reply"
 msgstr "回应"
 
 #: journal/templates/action_reply_post.html:3
-#: journal/templates/article.html:171 journal/templates/collection.html:159
+#: journal/templates/article.html:181 journal/templates/collection.html:159
 msgid "Reply"
 msgstr "回应"
 
@@ -5703,19 +5707,19 @@ msgstr "添加到收藏单"
 msgid "Create a new collection"
 msgstr "创建新收藏单"
 
-#: journal/templates/article.html:102 social/templates/_event_post.html:81
+#: journal/templates/article.html:104 social/templates/_event_post.html:81
 msgid "wrote a review"
 msgstr "写了评论"
 
-#: journal/templates/article.html:104 social/templates/_event_post.html:83
+#: journal/templates/article.html:106 social/templates/_event_post.html:83
 msgid "wrote an article"
 msgstr "写了文章"
 
-#: journal/templates/article.html:134
+#: journal/templates/article.html:136
 msgid "This article may contain sensitive content. Click to reveal."
 msgstr "文章可能包含敏感内容，点击显示全文。"
 
-#: journal/templates/article.html:145
+#: journal/templates/article.html:155
 msgid "The author has set it to be viewable only by logged-in users."
 msgstr "作者已设置仅限已登录用户查看。"
 
@@ -6125,16 +6129,16 @@ msgstr "分享年度小结"
 msgid "#%(year)s_report"
 msgstr "#我的#%(year)s书影音"
 
-#: journal/views/article.py:172 journal/views/review.py:168
+#: journal/views/article.py:173 journal/views/review.py:168
 msgid "User not local"
 msgstr "用户不在本站"
 
-#: journal/views/article.py:180 journal/views/article.py:194
+#: journal/views/article.py:181 journal/views/article.py:195
 #, python-brace-format
 msgid "Articles by {0}"
 msgstr "{0} 的文章"
 
-#: journal/views/article.py:182 journal/views/article.py:190
+#: journal/views/article.py:183 journal/views/article.py:191
 #: journal/views/review.py:178 journal/views/review.py:186
 msgid "Link invalid"
 msgstr "链接无效"

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -809,6 +809,14 @@ class BlueskyAccount(SocialAccount):
         )
         return {"uri": r.uri, "cid": r.cid}
 
+    def upload_blob_dict(self, data: bytes) -> dict[str, typing.Any]:
+        """Upload bytes as a blob and return its ref as a plain dict.
+
+        ``model_dump(by_alias=True)`` yields the ``{"$type": "blob", ...}``
+        wire shape, suitable for embedding in a hand-built record dict passed
+        to :meth:`put_record` (mirrors the publication-icon blob path)."""
+        return self._client.upload_blob(data).blob.model_dump(by_alias=True)
+
     def delete_record(self, collection: str, rkey: str) -> None:
         """Delete a record by key. Idempotent: no error if it does not exist."""
         self._client.com.atproto.repo.delete_record(

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -763,6 +763,75 @@ def test_collection_cover_api(tmp_path):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_article_cover_api(tmp_path):
+    owner = User.register(email="artcoverapi@example.com", username="artcoverapi")
+    other = User.register(email="artcoverother@example.com", username="artcoverother")
+    app = Takahe.get_or_create_app(
+        "Article Cover API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=owner.identity.pk,
+    )
+    token = Takahe.refresh_token(app, owner.identity.pk, owner.pk)
+    other_token = Takahe.refresh_token(app, other.identity.pk, other.pk)
+    client = Client()
+
+    buf = BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    png = buf.getvalue()
+
+    def upload(path, content, auth_token, filename="cover.png"):
+        extra = {"HTTP_AUTHORIZATION": f"Bearer {auth_token}"} if auth_token else {}
+        return client.put(
+            path,
+            data=encode_multipart(
+                BOUNDARY,
+                {"cover": SimpleUploadedFile(filename, content, "image/png")},
+            ),
+            content_type=MULTIPART_CONTENT,
+            **extra,
+        )
+
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        resp = client.post(
+            "/api/me/article/",
+            data=json.dumps({"title": "Cover Me", "body": "body", "visibility": 0}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert resp.status_code == 200
+        created = resp.json()
+        assert created["cover_image_url"] is None
+        url = f"/api/me/article/{created['uuid']}/cover"
+
+        assert upload(url, png, None).status_code == 401
+        # article lookups are owner-scoped: a non-owner gets 404 (not 403),
+        # matching update_article/delete_article so existence stays private
+        assert upload(url, png, other_token).status_code == 404
+        missing = "7" * 22
+        assert upload(f"/api/me/article/{missing}/cover", png, token).status_code == 404
+        assert upload(url, b"not an image", token).status_code == 400
+        assert upload(url, b"\0" * (5 * 1024 * 1024 + 1), token).status_code == 400
+
+        resp = upload(url, png, token)
+        assert resp.status_code == 200
+        assert resp.json()["cover_image_url"]
+
+        # extension-less filename normalized from the detected format
+        resp = upload(url, png, token, filename="blob")
+        assert resp.status_code == 200
+        assert resp.json()["cover_image_url"].endswith(".png")
+
+        assert (
+            client.delete(url, HTTP_AUTHORIZATION=f"Bearer {other_token}").status_code
+            == 404
+        )
+        resp = client.delete(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        assert resp.status_code == 200
+        assert resp.json()["cover_image_url"] is None
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_collection_reorder_items():
     user = User.register(email="reorder@example.com", username="reorderer")
     book1 = Edition.objects.create(title="Reorder Book 1")

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -579,6 +579,15 @@ class TestArticleInboundParsing:
         assert article is not None
         assert article.cover_image_url == "https://remote.example/att.png"
 
+    def test_inbound_image_from_singular_attachment(self):
+        # a peer may send a single Image object rather than an array
+        post = _make_remote_post(self.identity.pk)
+        ap = self._ap_obj()
+        ap["attachment"] = {"type": "Image", "url": "https://remote.example/one.png"}
+        article = Article.update_by_ap_object(self.identity, None, ap, post)
+        assert article is not None
+        assert article.cover_image_url == "https://remote.example/one.png"
+
     def test_inbound_image_rejects_non_http_url(self):
         post = _make_remote_post(self.identity.pk)
         ap = self._ap_obj()

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -1,18 +1,32 @@
 """Tests for the standalone Article piece (item-less, markdown-authored)."""
 
+import io
 from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.loader import render_to_string
-from django.test import Client
+from django.test import Client, override_settings
 from django.utils import timezone
+from PIL import Image
 
 from journal.models import Article
 from journal.search import JournalQueryParser
 from takahe.ap_handlers import post_deleted
 from takahe.utils import Takahe
 from users.models import User
+
+
+def _png_bytes() -> bytes:
+    """A tiny valid PNG so ImageField/form validation accepts the upload."""
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _png_upload(name: str = "cover.png") -> SimpleUploadedFile:
+    return SimpleUploadedFile(name, _png_bytes(), content_type="image/png")
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -303,6 +317,78 @@ class TestArticleModel:
         assert "Some body" in doc["content"]
         assert sorted(doc["tag"]) == ["bar", "foo"]
 
+    def test_cover_stored_and_ap_emits_image_and_attachment(self, tmp_path):
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            article = Article.update_local_article(
+                owner=self.identity,
+                title="Covered",
+                body="body",
+                visibility=0,
+                cover=_png_upload(),
+            )
+            assert str(article.cover) != "item/default.svg"
+            url = article.cover_image_url
+            assert url and url.endswith(".png")
+            obj = article.ap_object
+            # spec-correct featured-image slot
+            assert obj["image"] == {
+                "type": "Image",
+                "url": url,
+                "mediaType": "image/png",
+                "name": "Covered",
+            }
+            # mirrored into attachment (Mastodon/Pleroma only render that),
+            # as a distinct dict so a consumer mutating one leaves the other
+            assert obj["attachment"] == [obj["image"]]
+            assert obj["attachment"][0] is not obj["image"]
+
+    def test_ap_object_omits_image_without_cover(self):
+        article = Article.update_local_article(
+            owner=self.identity, title="Bare", body="body", visibility=0
+        )
+        obj = article.ap_object
+        assert "image" not in obj
+        assert "attachment" not in obj
+        assert article.cover_image_url is None
+
+    def test_cover_unchanged_on_edit_without_new_upload(self, tmp_path):
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            article = Article.update_local_article(
+                owner=self.identity,
+                title="V1",
+                body="first",
+                visibility=0,
+                cover=_png_upload(),
+            )
+            name = article.cover.name
+            # a later edit that passes no cover must not drop the existing one
+            article = Article.update_local_article(
+                owner=self.identity,
+                title="V2",
+                body="second",
+                visibility=0,
+                article=article,
+            )
+            article.refresh_from_db()
+            assert article.cover.name == name
+
+    def test_atproto_document_cover_image_returns_bytes(self, tmp_path):
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            article = Article.update_local_article(
+                owner=self.identity,
+                title="Doc Cover",
+                body="body",
+                visibility=0,
+                cover=_png_upload(),
+            )
+            data = article.atproto_document_cover_image()
+            assert isinstance(data, bytes) and data[:8] == b"\x89PNG\r\n\x1a\n"
+
+        plain = Article.update_local_article(
+            owner=self.identity, title="No Cover", body="body", visibility=0
+        )
+        assert plain.atproto_document_cover_image() is None
+
 
 @pytest.mark.django_db(databases="__all__")
 class TestArticleSearchParser:
@@ -474,6 +560,45 @@ class TestArticleInboundParsing:
         assert result.title == "Round Trip"
         assert result.body == "**Mark** _down_"
         assert sorted(result.normalized_tags) == ["alpha", "beta"]
+
+    def test_inbound_image_cached_in_metadata(self):
+        post = _make_remote_post(self.identity.pk)
+        ap = self._ap_obj()
+        ap["image"] = {"type": "Image", "url": "https://remote.example/cover.jpg"}
+        article = Article.update_by_ap_object(self.identity, None, ap, post)
+        assert article is not None
+        # remote covers are cached as a URL (never downloaded)
+        assert article.metadata["cover_url"] == "https://remote.example/cover.jpg"
+        assert article.cover_image_url == "https://remote.example/cover.jpg"
+
+    def test_inbound_image_from_attachment_fallback(self):
+        post = _make_remote_post(self.identity.pk)
+        ap = self._ap_obj()
+        ap["attachment"] = [{"type": "Image", "url": "https://remote.example/att.png"}]
+        article = Article.update_by_ap_object(self.identity, None, ap, post)
+        assert article is not None
+        assert article.cover_image_url == "https://remote.example/att.png"
+
+    def test_inbound_image_rejects_non_http_url(self):
+        post = _make_remote_post(self.identity.pk)
+        ap = self._ap_obj()
+        ap["image"] = {"type": "Image", "url": "file:///etc/passwd"}
+        article = Article.update_by_ap_object(self.identity, None, ap, post)
+        assert article is not None
+        assert "cover_url" not in article.metadata
+        assert article.cover_image_url is None
+
+    def test_inbound_image_removal_clears_cached_url(self):
+        post = _make_remote_post(self.identity.pk)
+        ap = self._ap_obj()
+        ap["image"] = {"type": "Image", "url": "https://remote.example/cover.jpg"}
+        Article.update_by_ap_object(self.identity, None, ap, post)
+        # a newer update that dropped the image must clear the cached url
+        ap2 = self._ap_obj()
+        ap2["updated"] = (timezone.now() + timedelta(seconds=5)).isoformat()
+        article = Article.update_by_ap_object(self.identity, None, ap2, post)
+        assert article is not None
+        assert "cover_url" not in article.metadata
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -800,3 +925,34 @@ class TestArticlePageMarkup:
         assert 'property="article:modified_time"' in html
         # the page title is the document's only h1; body headings start at h2
         assert html.count("<h1>") == 1
+
+    def test_article_page_renders_featured_image(self, tmp_path):
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            article = Article.update_local_article(
+                owner=self.identity,
+                title="With Cover",
+                body="body",
+                visibility=0,
+                cover=_png_upload(),
+            )
+            resp = self.client.get(article.url)
+            assert resp.status_code == 200
+            html = resp.content.decode()
+            url = article.cover_image_url
+            assert url
+            assert 'class="article-cover"' in html
+            assert f'src="{url}"' in html
+            assert f'property="og:image" content="{url}"' in html
+
+    def test_article_page_no_featured_image_without_cover(self):
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="No Cover Page",
+            body="body",
+            visibility=0,
+        )
+        resp = self.client.get(article.url)
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        assert 'class="article-cover"' not in html
+        assert 'property="og:image"' not in html

--- a/neodb/tests/journal/test_atproto_records.py
+++ b/neodb/tests/journal/test_atproto_records.py
@@ -412,6 +412,27 @@ def test_article_document_includes_cover_image_blob(tmp_path):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_article_document_cover_uploaded_once_per_crosspost(tmp_path):
+    user = User.register(email="artcov1@example.com", username="artcov1user")
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        article = Article.update_local_article(
+            user.identity,
+            "Covered Once",
+            "body",
+            cover=SimpleUploadedFile("cover.png", _png_bytes(), "image/png"),
+        )
+        fake = FakeBluesky()
+        # a full crosspost writes the document twice (embed refs, then again
+        # with bskyPostRef); the cover blob must be uploaded only once
+        article._atproto_embed_refs(fake)
+        article._sync_records_to_bluesky(fake)
+
+    rkey = build_document_rkey(article)
+    assert "coverImage" in fake.puts[(DOCUMENT_NSID, rkey)]
+    assert len(fake.blobs) == 1
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_article_document_omits_cover_image_without_cover():
     user = User.register(email="artnocov@example.com", username="artnocovuser")
     article = Article.update_local_article(user.identity, "Bare Essay", "body")

--- a/neodb/tests/journal/test_atproto_records.py
+++ b/neodb/tests/journal/test_atproto_records.py
@@ -1,10 +1,14 @@
+import io
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from types import SimpleNamespace
 
 import pytest
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.utils import timezone
+from PIL import Image
 
 from catalog.models import Edition, ExternalResource, TVSeason, TVShow
 from journal.models import (
@@ -32,6 +36,12 @@ from users.models import User
 _TID_ALPHABET = "234567abcdefghijklmnopqrstuvwxyz"
 
 
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
 class FakeBluesky:
     """Stand-in for BlueskyAccount capturing record writes/deletes."""
 
@@ -39,10 +49,15 @@ class FakeBluesky:
         self.uid = "did:plc:fake"
         self.puts: dict[tuple[str, str], dict] = {}
         self.deletes: list[tuple[str, str]] = []
+        self.blobs: list[bytes] = []
 
     def put_record(self, collection, rkey, record):
         self.puts[(collection, rkey)] = record
         return {"uri": f"at://{self.uid}/{collection}/{rkey}", "cid": "cid"}
+
+    def upload_blob_dict(self, data):
+        self.blobs.append(data)
+        return {"$type": "blob", "ref": {"$link": "fakecid"}, "size": len(data)}
 
     def delete_record(self, collection, rkey):
         self.deletes.append((collection, rkey))
@@ -370,6 +385,42 @@ def test_article_document_description_prefers_summary():
     doc = article.to_atproto_document()
 
     assert doc["description"] == "hand-written teaser"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_document_includes_cover_image_blob(tmp_path):
+    user = User.register(email="artcov@example.com", username="artcovuser")
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        article = Article.update_local_article(
+            user.identity,
+            "Covered Essay",
+            "body",
+            cover=SimpleUploadedFile("cover.png", _png_bytes(), "image/png"),
+        )
+        fake = FakeBluesky()
+        article._sync_records_to_bluesky(fake)
+
+    rkey = build_document_rkey(article)
+    doc = fake.puts[(DOCUMENT_NSID, rkey)]
+    # the featured image is uploaded as a blob and referenced by coverImage
+    assert doc["coverImage"] == {
+        "$type": "blob",
+        "ref": {"$link": "fakecid"},
+        "size": len(_png_bytes()),
+    }
+    assert fake.blobs and fake.blobs[0][:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_document_omits_cover_image_without_cover():
+    user = User.register(email="artnocov@example.com", username="artnocovuser")
+    article = Article.update_local_article(user.identity, "Bare Essay", "body")
+    fake = FakeBluesky()
+    article._sync_records_to_bluesky(fake)
+
+    rkey = build_document_rkey(article)
+    assert "coverImage" not in fake.puts[(DOCUMENT_NSID, rkey)]
+    assert fake.blobs == []
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1,12 +1,16 @@
 import json
 import os
 import zipfile
+from io import BytesIO
 from tempfile import TemporaryDirectory
 
 import pytest
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.utils.dateparse import parse_datetime
 from loguru import logger
+from PIL import Image
 
 from catalog.models import (
     Edition,
@@ -672,6 +676,34 @@ class TestNdjsonExportImport:
         assert a2.sensitive is True
         assert a2.summary == "careful"
         assert a2.normalized_tags == ["opinion"]
+
+    def test_ndjson_article_cover_round_trip(self, tmp_path):
+        """A featured image is bundled on export and restored on import."""
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            buf = BytesIO()
+            Image.new("RGB", (2, 2), "blue").save(buf, format="PNG")
+            Article.update_local_article(
+                owner=self.user1.identity,
+                title="Covered Read",
+                body="body",
+                visibility=0,
+                cover=SimpleUploadedFile("cover.png", buf.getvalue(), "image/png"),
+            )
+            exporter = NdjsonExporter.create(user=self.user1)
+            exporter.run()
+            export_path = exporter.metadata["file"]
+
+            importer = NdjsonImporter.create(
+                user=self.user2, file=export_path, visibility=0
+            )
+            importer.run()
+            assert importer.metadata["failed"] == 0
+
+            imported = Article.objects.get(
+                owner=self.user2.identity, title="Covered Read"
+            )
+            assert str(imported.cover) != settings.DEFAULT_ITEM_COVER
+            assert (imported.cover_image_url or "").endswith(".png")
 
     def test_ndjson_article_reimport_dedup(self):
         """Re-importing the same Article bundle doesn't duplicate rows."""


### PR DESCRIPTION
## Motivation

Articles had no featured/cover image. This also showed up in Bluesky crossposts: an article's `app.bsky.embed.external` card had no `thumb`, so bsky.app rendered a bare text-only link card (unlike book/movie marks, which carry the item cover). This PR adds an optional featured image to standalone Articles and wires it through display, ActivityPub, and Bluesky, following how other Fediverse software represents a long-form hero image.

## What

- **Model**: new optional `Article.cover` `ImageField` (mirrors `Collection.cover` — same `upload_to`, default sentinel) + migration `0017_article_cover`. `cover_image_url` property with a metadata fallback for remote articles.
- **Authoring**: `ArticleForm` gains the cover field (`PreviewImageInput` live preview); compose/edit form is now `multipart/form-data`; the view passes `request.FILES` into `Article.update_local_article(cover=...)`.
- **Display**: the article page renders the featured image (respecting the sensitive/login gates) and sets `og:image` — Mastodon builds its link "PreviewCard" from OpenGraph, not the AP payload.
- **ActivityPub**: emits the AS2 `image` property **and** mirrors it into `attachment`. `image` is the spec-correct featured slot (used by Ghost, Lemmy, the WordPress ActivityPub plugin), but Mastodon/Pleroma only render object media from `attachment` — so we emit both, matching the WordPress plugin. Inbound remote `image` (or an `attachment` Image) is cached as a URL in metadata for display (no download; `http(s)` only).
- **Bluesky**: the existing external-embed `thumb` path now picks up `Article.cover` automatically, and the `site.standard.document` record gains a `coverImage` blob (uploaded via a new `BlueskyAccount.upload_blob_dict`, mirroring the publication-icon blob path).
- **REST API**: `cover_image_url` in `ArticleSchema`; `PUT`/`DELETE /me/article/{uuid}/cover` (mirrors the collection cover endpoints, 5MB limit + image validation).
- **i18n**: `zh_Hans` translation added.

## References (Fediverse conventions)

- AS2 vocab: `image` = unconstrained banner/featured image; `icon` = small square avatar; `attachment` = email-attachment-like media.
- Ghost / Lemmy / WordPress ActivityPub plugin put the featured image in `image` (WordPress additionally mirrors into `attachment`); Mastodon consumes `attachment` and regenerates the hero card from `og:image`.
- Bluesky: `app.bsky.embed.external.thumb` (blob, ≤1MB); standard.site `site.standard.document.coverImage` (blob, <1MB).

## Testing

- Added tests in `tests/journal/test_article.py`, `test_atproto_records.py`, `test_api.py` (AP image+attachment, inbound parsing, document coverImage blob, page render, cover API).
- `pre-commit run -a` clean; fork CI (code check + unit test) green.

Draft: opening for review of the AP representation choice (image + attachment) and the document `coverImage` approach.