### PR TITLE
fix(federation): handle JSON-LD list "type" on remote actors

### DIFF
--- a/neodb/takahe/management/commands/fetch.py
+++ b/neodb/takahe/management/commands/fetch.py
@@ -19,6 +19,19 @@ JSON_AP_TYPES = ("application/activity+json", "application/ld+json")
 JSON_MEDIA_TYPES = ("application/json",) + JSON_AP_TYPES
 
 
+def first_known_type(value) -> str:
+    """
+    Normalise an AS ``type`` value, which JSON-LD permits to be a list
+    (e.g. ["Person", "foaf:Person"]), into the first type we recognise.
+    Falls back to the first plain string so unknown types still get named.
+    """
+    if not isinstance(value, list):
+        value = [value]
+    types = [item.lower() for item in value if isinstance(item, str) and item]
+    known = actor_types + post_types
+    return next((item for item in types if item in known), types[0] if types else "")
+
+
 def _split_link_entries(value: str) -> list[str]:
     entries: list[str] = []
     depth = 0
@@ -148,7 +161,7 @@ class Command(SiteCommand):
                     bare_media_type = content_type.split(";", 1)[0].strip().lower()
             if bare_media_type in JSON_MEDIA_TYPES:
                 j = response.json()
-                typ = j.get("type", "").lower()
+                typ = first_known_type(j.get("type"))
                 uri = j.get("id", "")
                 if not typ or not uri:
                     self.stdout.write(self.style.WARNING("Unknown object id/type"))

--- a/neodb/tests/core/test_takahe.py
+++ b/neodb/tests/core/test_takahe.py
@@ -1,6 +1,6 @@
 import httpx
 
-from takahe.management.commands.fetch import find_ap_alternate_url
+from takahe.management.commands.fetch import find_ap_alternate_url, first_known_type
 
 
 def _resp(url: str, *, content: bytes = b"", headers=None) -> httpx.Response:
@@ -115,3 +115,15 @@ def test_find_ap_alternate_url_ignores_non_alternate_rels():
         ],
     )
     assert find_ap_alternate_url(response) is None
+
+
+def test_first_known_type():
+    assert first_known_type("Person") == "person"
+    assert first_known_type("Note") == "note"
+    # JSON-LD allows a list of types; the known one wins regardless of order
+    assert first_known_type(["Person", "foaf:Person"]) == "person"
+    assert first_known_type(["foaf:Person", "Person"]) == "person"
+    # Unknown types are still named so the error message stays useful
+    assert first_known_type(["foaf:Agent"]) == "foaf:agent"
+    assert first_known_type(None) == ""
+    assert first_known_type([]) == ""

--- a/takahe/activities/services/search.py
+++ b/takahe/activities/services/search.py
@@ -1,7 +1,7 @@
 import httpx
 from core.files import SSRFAttemptError
 from core.json import find_ap_alternate, json_from_response
-from core.ld import canonicalise
+from core.ld import canonicalise, get_first_concrete_type
 from users.models.system_actor import SystemActor
 
 from activities.models import Hashtag, Post
@@ -115,7 +115,14 @@ class SearchService:
             document = canonicalise(json_data, include_security=True, outbound=False)
         except ValueError:
             return None
-        type = document.get("type", "unknown").lower()
+        # JSON-LD allows a list of types (e.g. ["Person", "foaf:Person"])
+        post_types = [value.lower() for value in Post.Types.values]
+        type = (
+            get_first_concrete_type(
+                document.get("type"), preferred=Identity.ACTOR_TYPES + post_types
+            )
+            or "unknown"
+        )
 
         # Is it an identity?
         if type in Identity.ACTOR_TYPES:
@@ -126,7 +133,7 @@ class SearchService:
             return identity
 
         # Is it a post?
-        elif type in [value.lower() for value in Post.Types.values]:
+        elif type in post_types:
             # Try and retrieve the post by URI
             # (we do not trust the JSON we just got - fetch from source!)
             try:

--- a/takahe/core/ld.py
+++ b/takahe/core/ld.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import urllib.parse as urllib_parse
+from collections.abc import Container
 
 from dateutil import parser
 from pyld import jsonld
@@ -794,19 +795,27 @@ GENERIC_AS_TYPES = frozenset(
 )
 
 
-def get_first_concrete_type(value) -> str | None:
+def get_first_concrete_type(
+    value, preferred: Container[str] | None = None
+) -> str | None:
     """
     Given an AS ``type`` value (a string or, per JSON-LD, a list of
     strings), return the first concrete type lowercased, preferring
     anything over the generic ActivityStreams base classes.
+
+    ``preferred`` is an optional set of known types to pick first
+    regardless of order, so a vocabulary-prefixed duplicate does not win
+    (e.g. ["foaf:Person", "Person"] -> "person").
     """
-    if isinstance(value, str):
-        return value.lower() or None
     if not isinstance(value, list):
-        return None
+        value = [value]
     types = [item.lower() for item in value if isinstance(item, str) and item]
     if not types:
         return None
+    if preferred is not None:
+        known = next((item for item in types if item in preferred), None)
+        if known:
+            return known
     return next((item for item in types if item not in GENERIC_AS_TYPES), types[0])
 
 

--- a/takahe/tests/activities/services/test_search.py
+++ b/takahe/tests/activities/services/test_search.py
@@ -3,6 +3,7 @@ import pytest
 
 from activities.models import Post
 from activities.services.search import SearchService
+from users.models import Identity
 from users.models.system_actor import SystemActor
 
 
@@ -139,3 +140,42 @@ def test_search_url_does_not_loop_on_self_referential_alternate(
 
     assert SearchService(url, None).search_url() is None
     assert call_count == 1
+
+
+@pytest.mark.django_db
+def test_search_url_handles_list_type(monkeypatch, config_system):
+    """An actor whose JSON-LD "type" is a list (e.g. ActivityPods emits
+    ["Person", "foaf:Person"]) must still be recognised as an identity."""
+    url = "https://pods.example/u/test"
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                {"foaf": "http://xmlns.com/foaf/0.1/"},
+            ],
+            "id": url,
+            "type": ["Person", "foaf:Person"],
+            "inbox": f"{url}/inbox",
+            "preferredUsername": "test",
+        },
+        request=httpx.Request("GET", url),
+    )
+
+    def fake_signed_request(self, method, uri, body=None):
+        return response
+
+    monkeypatch.setattr(SystemActor, "signed_request", fake_signed_request)
+
+    captured: dict = {}
+
+    def fake_by_actor_uri(cls, uri, create=False):
+        captured["uri"] = uri
+        return None
+
+    monkeypatch.setattr(Identity, "by_actor_uri", classmethod(fake_by_actor_uri))
+
+    assert SearchService(url, None).search_url() is None
+    # Routed to the identity branch, not dropped as an unknown type
+    assert captured["uri"] == url

--- a/takahe/tests/core/test_ld.py
+++ b/takahe/tests/core/test_ld.py
@@ -2,7 +2,12 @@ import datetime
 
 from dateutil.tz import tzutc
 
-from core.ld import canonicalise, get_language, parse_ld_date
+from core.ld import (
+    canonicalise,
+    get_first_concrete_type,
+    get_language,
+    parse_ld_date,
+)
 
 
 def test_parse_ld_date():
@@ -144,3 +149,32 @@ def test_get_language():
     assert get_language({"contentMap": {"EN": "<p>Hello</p>"}}) == "en"
     assert get_language({"contentMap": {"und": "<p>Hello</p>"}}) is None
     assert get_language({}) is None
+
+
+def test_get_first_concrete_type():
+    """
+    JSON-LD permits "type" to be a list, so we have to cope with both forms
+    """
+    ACTOR_TYPES = ["person", "service", "application", "group", "organization"]
+
+    assert get_first_concrete_type("Person") == "person"
+    assert get_first_concrete_type(["Person"]) == "person"
+    # Generic AS base classes lose to a concrete sibling
+    assert get_first_concrete_type(["Object", "Note"]) == "note"
+    assert get_first_concrete_type(["Activity", "Create"]) == "create"
+    # ... but are still returned if that's all we got
+    assert get_first_concrete_type(["Collection"]) == "collection"
+
+    # A known type wins regardless of position, so a vocabulary-prefixed
+    # duplicate doesn't get stored as the actor type
+    assert get_first_concrete_type(["Person", "foaf:Person"], ACTOR_TYPES) == "person"
+    assert get_first_concrete_type(["foaf:Person", "Person"], ACTOR_TYPES) == "person"
+    # Nothing known: fall back to the first concrete type
+    assert get_first_concrete_type(["foaf:Person"], ACTOR_TYPES) == "foaf:person"
+
+    # Junk in, None out
+    assert get_first_concrete_type(None) is None
+    assert get_first_concrete_type("") is None
+    assert get_first_concrete_type([]) is None
+    assert get_first_concrete_type([{"id": "Person"}]) is None
+    assert get_first_concrete_type({"@value": "Person"}) is None

--- a/takahe/tests/users/models/test_identity.py
+++ b/takahe/tests/users/models/test_identity.py
@@ -297,6 +297,62 @@ def test_fetch_actor_without_url_falls_back_to_actor_uri(httpx_mock, config_syst
 
 @pytest.mark.django_db
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_fetch_actor_with_list_type(httpx_mock, config_system):
+    """
+    JSON-LD allows "type" to be a list, and ActivityPods-style servers emit
+    ["Person", "foaf:Person"]. It should resolve to the known actor type.
+    """
+    identity = Identity.objects.create(
+        actor_uri="https://pods.example/u/test",
+        local=False,
+    )
+    httpx_mock.add_response(
+        url="https://pods.example/.well-known/webfinger?resource=acct:test@pods.example",
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "subject": "acct:test@pods.example",
+            "links": [
+                {
+                    "rel": "self",
+                    "type": "application/activity+json",
+                    "href": "https://pods.example/u/test",
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        url="https://pods.example/u/test",
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://w3id.org/security/v1",
+                {"foaf": "http://xmlns.com/foaf/0.1/"},
+            ],
+            "id": "https://pods.example/u/test",
+            "type": ["Person", "foaf:Person"],
+            "inbox": "https://pods.example/u/test/inbox",
+            "followers": "https://pods.example/u/test/followers",
+            "publicKey": {
+                "id": "https://pods.example/u/test#main-key",
+                "owner": "https://pods.example/u/test",
+                "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nits-a-faaaake\n-----END PUBLIC KEY-----\n",
+            },
+            "name": "Test Pod User",
+            "preferredUsername": "test",
+            "url": "https://pods.example/u/test",
+        },
+    )
+    assert identity.fetch_actor()
+
+    identity = Identity.objects.get(pk=identity.pk)
+    assert identity.actor_type == "person"
+    assert identity.username == "test"
+    assert identity.name == "Test Pod User"
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
 def test_fetch_webfinger_url(httpx_mock: HTTPXMock, config_system):
     """
     Ensures that we can deal with various kinds of webfinger URLs

--- a/takahe/users/models/identity.py
+++ b/takahe/users/models/identity.py
@@ -14,6 +14,7 @@ from core.json import json_from_response
 from core.ld import (
     canonicalise,
     format_ld_date,
+    get_first_concrete_type,
     get_first_image_url,
     get_list,
     media_type_from_filename,
@@ -1118,7 +1119,11 @@ class Identity(StatorModel):
         self.following_uri = document.get("following")
         self.featured_collection_uri = document.get("featured")
         self.featured_tags_uri = document.get("featuredTags")
-        self.actor_type = document["type"].lower()
+        # JSON-LD allows a list of types (e.g. ["Person", "foaf:Person"])
+        self.actor_type = (
+            get_first_concrete_type(document["type"], preferred=self.ACTOR_TYPES)
+            or "person"
+        )
         self.shared_inbox_uri = document.get("endpoints", {}).get("sharedInbox")
         self.summary = document.get("summary")
         self.username = document.get("preferredUsername")


### PR DESCRIPTION
## Problem

JSON-LD permits `type` to be an array. ActivityPods-style servers use it, e.g. `https://touchgrass.network/u/youronlyone` returns:

```json
"type": ["Person", "foaf:Person"]
```

`Identity.fetch_actor()` called `.lower()` on the value directly, so every refetch of such an actor raised:

```
AttributeError: 'list' object has no attribute 'lower'
  File "stator/models.py", line 204, in transition_attempt
  File "users/models/identity.py", line 209, in handle_outdated
  File "users/models/identity.py", line 1121, in fetch_actor
    self.actor_type = document["type"].lower()
```

`handle_outdated` therefore never returned `updated`, leaving the identity stuck in `outdated` and retrying hourly. Confirmed that `canonicalise()` preserves the list as `['Person', 'foaf:Person']`, so it reaches the assignment unchanged.

## Fix

Use the existing `get_first_concrete_type()` helper (already used by `post.py` and `inbox_message.py` for the same reason), extended with an optional `preferred` set of known types.

The `preferred` argument matters: `get_first_concrete_type` otherwise takes the first non-generic entry, so `["foaf:Person", "Person"]` would store `foaf:person` and `APIdentity.is_person` / `is_group` / `is_bot` would all misreport. Passing `Identity.ACTOR_TYPES` makes a recognised type win regardless of position.

The same crash class is fixed on the two sibling paths that read an actor's `type`:

- `SearchService.search_url()` — how such an identity gets created in the first place, and a 500 for anyone searching that URL
- the `fetch` management command — would die on this very actor while investigating

## Not changed

Other `["type"].lower()` sites read *tag* or *activity* types rather than actor types and are left alone to keep this focused: `inbox_message.message_type`, `post.py:1736`, `identity.py:1185`, `post_interaction.py:484-490`, `core/signatures.py:399`.

## Tests

- `test_get_first_concrete_type` — helper unit coverage including the `preferred` ordering case and junk input
- `test_fetch_actor_with_list_type` — verified it reproduces the exact `AttributeError` against the unpatched line, and passes with the fix
- `test_search_url_handles_list_type` — list-typed actor routes to the identity branch instead of being dropped as unknown
- `test_first_known_type` — the management command helper

Full takahe suite: 480 passed. `neodb/tests/core/test_takahe.py`: 8 passed. `pre-commit run -a` clean.