### PR TITLE
fix(federation): honour Follow Accept while still unrequested

### DIFF
--- a/takahe/core/exceptions.py
+++ b/takahe/core/exceptions.py
@@ -14,3 +14,18 @@ class ActorMismatchError(ActivityPubError):
     """
     The actor is not authorised to do the action we saw
     """
+
+
+class ActivityPubDeliveryError(ValueError):
+    """
+    A remote server permanently refused (4xx) an activity we delivered, so
+    sending the same activity again will not succeed.
+
+    Subclasses ValueError as that is what delivery failures used to raise.
+    """
+
+    def __init__(self, uri: str, status_code: int, content: bytes) -> None:
+        self.uri = uri
+        self.status_code = status_code
+        self.content = content
+        super().__init__(f"POST error to {uri}: {status_code} {content!r}")

--- a/takahe/core/exceptions.py
+++ b/takahe/core/exceptions.py
@@ -18,14 +18,26 @@ class ActorMismatchError(ActivityPubError):
 
 class ActivityPubDeliveryError(ValueError):
     """
-    A remote server permanently refused (4xx) an activity we delivered, so
-    sending the same activity again will not succeed.
+    A remote server refused (4xx) an activity we delivered.
 
     Subclasses ValueError as that is what delivery failures used to raise.
     """
+
+    # Refusals that mean "not right now" rather than "never"
+    retryable_statuses = [408, 429]
+    # Refusals that mean the server will not take this activity from us at all
+    unauthorized_statuses = [401, 403]
 
     def __init__(self, uri: str, status_code: int, content: bytes) -> None:
         self.uri = uri
         self.status_code = status_code
         self.content = content
         super().__init__(f"POST error to {uri}: {status_code} {content!r}")
+
+    @property
+    def retryable(self) -> bool:
+        return self.status_code in self.retryable_statuses
+
+    @property
+    def unauthorized(self) -> bool:
+        return self.status_code in self.unauthorized_statuses

--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -19,6 +19,7 @@ from idna.core import InvalidCodepoint
 from pyld import jsonld
 
 from core import sentry
+from core.exceptions import ActivityPubDeliveryError
 from core.files import SSRFAttemptError, check_url_safety
 from core.ld import format_ld_date
 
@@ -358,8 +359,8 @@ class HttpSignature:
                 and response.status_code < 500
                 and response.status_code not in [404, 410]
             ):
-                raise ValueError(
-                    f"POST error to {uri}: {response.status_code} {response.content!r}"
+                raise ActivityPubDeliveryError(
+                    uri, response.status_code, response.content
                 )
             return response
 

--- a/takahe/tests/users/models/test_follow.py
+++ b/takahe/tests/users/models/test_follow.py
@@ -117,6 +117,47 @@ def test_follow_refused_delivery_is_not_resent(
     assert len(deliveries) == 1
 
 
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_follow_deferred_delivery_is_retried(
+    identity: Identity,
+    remote_identity: Identity,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A Follow refused with a retryable status is sent again later.
+    """
+    follow = IdentityService(identity).follow(remote_identity)
+    httpx_mock.add_response(
+        url="https://remote.test/@test/inbox/",
+        status_code=429,
+    )
+    stator.run_single_cycle()
+    assert Follow.objects.get(pk=follow.pk).state == FollowStates.unrequested
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_follow_unauthorized_delivery_is_rejected(
+    identity: Identity,
+    remote_identity: Identity,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A Follow the target refuses to authorise is dropped rather than waiting
+    for an Accept that cannot arrive.
+    """
+    follow = IdentityService(identity).follow(remote_identity)
+    httpx_mock.add_response(
+        url="https://remote.test/@test/inbox/",
+        status_code=403,
+    )
+    stator.run_single_cycle()
+    assert Follow.objects.get(pk=follow.pk).state == FollowStates.rejecting
+
+
 def _stats(i: Identity) -> dict:
     return Identity.objects.get(pk=i.pk).stats or {}
 

--- a/takahe/tests/users/models/test_follow.py
+++ b/takahe/tests/users/models/test_follow.py
@@ -1,5 +1,6 @@
 import json
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -56,6 +57,64 @@ def test_follow(
     stator.run_single_cycle()
     stator.run_single_cycle()
     assert Follow.objects.get(pk=follow.pk).state == FollowStates.accepted
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_follow_accepted_after_failed_delivery(
+    identity: Identity,
+    remote_identity: Identity,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    An Accept is honoured even when delivering the Follow looked like a
+    failure to us: the target may have processed it before we timed out.
+    """
+    follow = IdentityService(identity).follow(remote_identity)
+    httpx_mock.add_exception(httpx.ReadTimeout("timed out"))
+    stator.run_single_cycle()
+    assert Follow.objects.get(pk=follow.pk).state == FollowStates.unrequested
+    # The target accepted it regardless
+    InboxMessage.objects.create(
+        message={
+            "type": "Accept",
+            "id": "test",
+            "actor": remote_identity.actor_uri,
+            "object": f"{identity.actor_uri}follow/{follow.pk}/",
+        }
+    )
+    stator.run_single_cycle()
+    stator.run_single_cycle()
+    assert Follow.objects.get(pk=follow.pk).state == FollowStates.accepted
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_follow_refused_delivery_is_not_resent(
+    identity: Identity,
+    remote_identity: Identity,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A Follow refused with a 4xx is not sent again: servers deduplicating by
+    activity id (Lemmy) refuse every resend of one they already processed.
+    """
+    follow = IdentityService(identity).follow(remote_identity)
+    httpx_mock.add_response(
+        url="https://remote.test/@test/inbox/",
+        status_code=400,
+        content=b'{"error":"unknown","message":""}',
+    )
+    stator.run_single_cycle()
+    assert Follow.objects.get(pk=follow.pk).state == FollowStates.pending_approval
+    # Nothing resends it while it waits for an Accept
+    stator.run_single_cycle()
+    deliveries = httpx_mock.get_requests(
+        url="https://remote.test/@test/inbox/", method="POST"
+    )
+    assert len(deliveries) == 1
 
 
 def _stats(i: Identity) -> dict:

--- a/takahe/users/models/follow.py
+++ b/takahe/users/models/follow.py
@@ -83,9 +83,18 @@ class FollowStates(StateGraph):
             except httpx.RequestError:
                 return
             except ActivityPubDeliveryError as error:
-                # Resending the same Follow will not change the answer: servers
-                # that deduplicate by activity id (Lemmy) reject every resend of
-                # one they already processed. Wait for an Accept/Reject instead.
+                if error.retryable:
+                    # The target will take it later, so ask again next cycle
+                    logger.info("Follow %s was deferred: %s", instance.pk, error)
+                    return
+                if error.unauthorized:
+                    # The target will not take follows from us at all
+                    logger.warning("Follow %s was rejected: %s", instance.pk, error)
+                    return cls.rejecting
+                # Any other 4xx is ambiguous, and resending cannot resolve it:
+                # servers that deduplicate by activity id (Lemmy) refuse every
+                # resend of a Follow they already recorded. Wait for the
+                # Accept/Reject instead of retrying for a day.
                 logger.warning("Follow %s was refused: %s", instance.pk, error)
             return cls.pending_approval
         # local/remote follow local, check deleted & manually_approve

--- a/takahe/users/models/follow.py
+++ b/takahe/users/models/follow.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import httpx
-from core.exceptions import ActorMismatchError
+from core.exceptions import ActivityPubDeliveryError, ActorMismatchError
 from core.ld import canonicalise, get_str_or_id
 from core.snowflake import Snowflake
 from django.db import models, transaction
@@ -82,6 +82,11 @@ class FollowStates(StateGraph):
                 )
             except httpx.RequestError:
                 return
+            except ActivityPubDeliveryError as error:
+                # Resending the same Follow will not change the answer: servers
+                # that deduplicate by activity id (Lemmy) reject every resend of
+                # one they already processed. Wait for an Accept/Reject instead.
+                logger.warning("Follow %s was refused: %s", instance.pk, error)
             return cls.pending_approval
         # local/remote follow local, check deleted & manually_approve
         if instance.target.deleted:
@@ -410,8 +415,11 @@ class Follow(StatorModel):
             raise ActorMismatchError(
                 "Accept actor does not match its Follow object", data
             )
-        # If the follow was waiting to be accepted, transition it
-        if follow and follow.state == FollowStates.pending_approval:
+        # If the follow was waiting to be accepted, transition it. An Accept can
+        # also arrive while the follow is still unrequested: the target may have
+        # processed our Follow even though delivering it looked like a failure
+        # to us (a timeout, or a refusal of a resend it had already handled).
+        if follow.state in [FollowStates.unrequested, FollowStates.pending_approval]:
             follow.transition_perform(FollowStates.accepting)
 
     @classmethod


### PR DESCRIPTION
## Problem

Following a Lemmy community never completes, and the attempt logs an error every 10 minutes for a day (Sentry `EGGPLANT-1H3`, 116 events from a single `Follow` row):

```
ValueError: POST error to https://lemmy.zip/c/neodb/inbox: 400 b'{"error":"unknown","message":""}'
  users/models/follow.py:78 in handle_unrequested
  core/signatures.py:361 in signed_request
```

The empty-message 400 is Lemmy's duplicate-activity check. `ReceivedActivity::create` answers a repeat activity id with `Err(DatabaseError(UniqueViolation, Box::<String>::default()))`, whose `Display` is the empty string ([`crates/db_schema/src/impls/activity.rs`](https://github.com/LemmyNet/lemmy/blob/0.19.19/crates/db_schema/src/impls/activity.rs#L44-L64)). So the 400 means *Lemmy already has our Follow* — not that it dislikes the payload. Replaying our exact body against the live inbox confirms it parses and reaches signature verification unharmed.

The full sequence:

1. The first `Follow` POST exceeds `REMOTE_TIMEOUT` (5s — Lemmy dereferences our actor before answering). `handle_unrequested` swallows `httpx.RequestError`, so the follow stays `unrequested`. Lemmy, meanwhile, completed the follow and sent an `Accept`.
2. `handle_accept_ap` only acted on `pending_approval`, so that `Accept` was **dropped**.
3. Each retry resends the same activity id, Lemmy refuses it as a duplicate, the `ValueError` reaches Stator's `logger.exception`, and after 24h the row times out to `removed` — while Lemmy still lists us as a follower and keeps delivering the community's posts.

## Fix

- `handle_accept_ap` also transitions a follow that is still `unrequested`. The state graph already declares `unrequested -> accepting`, and the existing "Accept actor must be the follow's target" check keeps this safe for inbound follows.
- `signed_request` raises `ActivityPubDeliveryError` instead of a bare `ValueError`, carrying the status and body so callers can classify a refusal. It subclasses `ValueError` and keeps the same message, so existing handlers (e.g. `fan_out`'s 401-on-delete case) are unaffected.
- `handle_unrequested` now answers a refused Follow by status rather than raising:
  - **408, 429** — asked again next cycle, matching the retry classification already used for identity fetches (`identity.py`, `[408, 429, 504]`).
  - **401, 403** — the target will not take follows from us, so the follow goes to `rejecting` and is removed instead of waiting for an `Accept` that cannot arrive.
  - **any other 4xx** — ambiguous, and resending cannot resolve it, so it waits in `pending_approval` for the `Accept`/`Reject` rather than being resent 144 times.

The ambiguous case is deliberately kept rather than removed: after a duplicate refusal the remote *does* hold the follow, so dropping our side would lose it and leave us receiving orphan `Announce`s. The cost is that such a follow shows as "Requested" until the user cancels it.

## Out of scope, noted while reviewing

`StatorModel.transition_perform_queryset()` updates by primary key unconditionally, so an inbox transition that lands while a handler is mid-flight can be overwritten by that handler's return value (an `Accept` arriving during the outbound POST could be clobbered back to `pending_approval`). That hazard predates this change and applies to every state handler, so fixing it means giving Stator compare-and-set semantics — happy to open a separate issue if that is wanted.

## Tests

Four new cases in `takahe/tests/users/models/test_follow.py`: an `Accept` arriving after the delivery timed out reaches `accepted`; a 400-refused Follow lands in `pending_approval` without being resent; a 429-refused Follow stays `unrequested` for retry; a 403-refused Follow goes to `rejecting`.

Full takahe suite (481 tests) and `pre-commit run -a` pass.