### PR TITLE
feat(config): make default UI language configurable in site settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Most configuration settings can be managed through the web-based Site Settings p
 
  - **Branding** - site name, logo, icon, color theme, description, footer links, custom HTML head
  - **Discover** - minimum marks, update interval, language filtering, local-only mode, popular posts/tags
- - **Access** - invite-only mode, local-only posting, email delivery, Mastodon/Bluesky/Threads login, preferred languages
+ - **Access** - invite-only mode, local-only posting, email delivery, Mastodon/Bluesky/Threads login, default and preferred languages
  - **Federation** - default relay, fanout limit, prune horizon, search sites/peers, hidden categories
  - **API Keys** - Spotify, TMDB, Google Books, Discogs, IGDB, Steam, DeepL, LibreTranslate, Threads, Discord webhooks
  - **Downloader** - scraping providers, proxy list, provider API keys, timeouts
@@ -306,7 +306,7 @@ The following settings can still be set in `.env` for bootstrap or backward-comp
  - `NEODB_SITE_HEAD`
  - `NEODB_SITE_DESCRIPTION`
  - `NEODB_SITE_LINKS`
- - `NEODB_PREFERRED_LANGUAGES`
+ - `NEODB_PREFERRED_LANGUAGES` (sets both *Preferred Languages* and the initial *Default Language*, which are separate settings in the UI)
  - `NEODB_ALTERNATIVE_DOMAINS`
  - `NEODB_INVITE_ONLY`
  - `NEODB_ENABLE_LOCAL_ONLY`

--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -509,6 +509,10 @@ if TESTING:  # force en if testing
     LANGUAGE_CODE = "en"
     PREFERRED_LANGUAGES = ["en"]
 
+# SiteConfig overwrites LANGUAGE_CODE at runtime; keep the env-derived value so it
+# stays available as the fallback when no DB override is set.
+LANGUAGE_CODE_ENV = LANGUAGE_CODE
+
 LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
 
 TIME_ZONE = env("NEODB_TIMEZONE", default="Asia/Shanghai")

--- a/neodb/catalog/common/downloaders.py
+++ b/neodb/catalog/common/downloaders.py
@@ -17,7 +17,7 @@ from PIL import Image
 from requests import Response
 from requests.exceptions import RequestException
 
-from common.models import SiteConfig
+from common.models import SiteConfig, register_language_cache_refresh
 from common.sentry import count as sentry_count
 from common.sentry import url_domain
 from common.validators import is_valid_url
@@ -207,6 +207,10 @@ class BasicDownloader:
         "Cache-Control": "no-cache",
     }
 
+    @classmethod
+    def _refresh_accept_language(cls) -> None:
+        cls.headers["Accept-Language"] = cls.get_accept_language()
+
     @property
     def timeout(self):
         if hasattr(self, "_timeout"):
@@ -289,6 +293,12 @@ class BasicDownloader:
         if self.response_type == RESPONSE_OK and resp:
             return resp
         raise DownloadError(self)
+
+
+# headers is a class attribute that callers also read directly (and spread into
+# their own dicts), so the language entry is rewritten in place when the site
+# language settings change rather than resolved per request.
+register_language_cache_refresh(BasicDownloader._refresh_accept_language)
 
 
 class BasicDownloader2(BasicDownloader):

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -18,6 +18,7 @@ from common.models import (
     country_display_name,
     genre_choices_for,
     jsondata,
+    register_language_cache_refresh,
 )
 
 
@@ -237,6 +238,28 @@ LANGUAGE_CHOICES_JSONFORM = get_locale_choices_for_jsonform(
 )
 SCRIPT_CHOICES_JSONFORM = get_locale_choices_for_jsonform(SCRIPT_CHOICES, const=True)
 
+_OTHER_LANGUAGE_JSONFORM = {"title": "Other", "type": "string"}
+# LanguageListField() embeds these in a schema captured at model definition time,
+# so they must stay the same list objects across a language cache refresh.
+LANGUAGE_ONEOF_JSONFORM = LANGUAGE_CHOICES_JSONFORM + [_OTHER_LANGUAGE_JSONFORM]
+SCRIPT_ONEOF_JSONFORM = SCRIPT_CHOICES_JSONFORM + [_OTHER_LANGUAGE_JSONFORM]
+
+
+def _refresh_jsonform_choices() -> None:
+    """Re-derive jsonform choices after common.models.lang rebuilds its caches."""
+    LOCALE_CHOICES_JSONFORM[:] = get_locale_choices_for_jsonform(LOCALE_CHOICES)
+    LANGUAGE_CHOICES_JSONFORM[:] = get_locale_choices_for_jsonform(
+        LANGUAGE_CHOICES, const=True
+    )
+    SCRIPT_CHOICES_JSONFORM[:] = get_locale_choices_for_jsonform(
+        SCRIPT_CHOICES, const=True
+    )
+    LANGUAGE_ONEOF_JSONFORM[:] = LANGUAGE_CHOICES_JSONFORM + [_OTHER_LANGUAGE_JSONFORM]
+    SCRIPT_ONEOF_JSONFORM[:] = SCRIPT_CHOICES_JSONFORM + [_OTHER_LANGUAGE_JSONFORM]
+
+
+register_language_cache_refresh(_refresh_jsonform_choices)
+
 LOCALIZED_LABEL_SCHEMA = {
     "type": "list",
     "items": {
@@ -398,10 +421,7 @@ def LanguageListField(script=False):
         schema={
             "type": "array",
             "items": {
-                "oneOf": (
-                    SCRIPT_CHOICES_JSONFORM if script else LANGUAGE_CHOICES_JSONFORM
-                )
-                + [{"title": "Other", "type": "string"}]
+                "oneOf": (SCRIPT_ONEOF_JSONFORM if script else LANGUAGE_ONEOF_JSONFORM)
             },
             "uniqueItems": True,
         },

--- a/neodb/catalog/sites/tmdb.py
+++ b/neodb/catalog/sites/tmdb.py
@@ -29,6 +29,9 @@ from .douban import *
 _logger = logging.getLogger(__name__)
 
 
+# Both are resolved per call: the site language settings they read are
+# runtime-configurable, so caching them at import time would pin TMDB requests
+# to whatever was in the environment at startup.
 def _get_language_code():
     match settings.LANGUAGE_CODE:
         case "zh-hans":
@@ -49,12 +52,8 @@ def _get_preferred_languages():
     return langs
 
 
-TMDB_DEFAULT_LANG = _get_language_code()
-TMDB_PREFERRED_LANGS = _get_preferred_languages()
-
-
 def search_tmdb_by_imdb_id(imdb_id):
-    tmdb_api_url = f"https://api.themoviedb.org/3/find/{imdb_id}?api_key={SiteConfig.system.tmdb_api_key}&language={TMDB_DEFAULT_LANG}&external_source=imdb_id"
+    tmdb_api_url = f"https://api.themoviedb.org/3/find/{imdb_id}?api_key={SiteConfig.system.tmdb_api_key}&language={_get_language_code()}&external_source=imdb_id"
     try:
         return BasicDownloader(tmdb_api_url).download().json()
     except Exception:
@@ -62,7 +61,7 @@ def search_tmdb_by_imdb_id(imdb_id):
 
 
 def query_tmdb_tv_episode(tv, season, episode):
-    tmdb_api_url = f"https://api.themoviedb.org/3/tv/{tv}/season/{season}/episode/{episode}?api_key={SiteConfig.system.tmdb_api_key}&language={TMDB_DEFAULT_LANG}&append_to_response=external_ids"
+    tmdb_api_url = f"https://api.themoviedb.org/3/tv/{tv}/season/{season}/episode/{episode}?api_key={SiteConfig.system.tmdb_api_key}&language={_get_language_code()}&append_to_response=external_ids"
     res_data = BasicDownloader(tmdb_api_url).download().json()
     return res_data
 
@@ -149,7 +148,7 @@ class TMDB_Movie(AbstractSite):
         localized_desc = []
         # GET api urls in all locales
         # btw it seems no way to tell if TMDB does not have a certain translation
-        for lang, lang_param in reversed(TMDB_PREFERRED_LANGS.items()):
+        for lang, lang_param in reversed(_get_preferred_languages().items()):
             api_url = f"https://api.themoviedb.org/3/movie/{self.id_value}?api_key={SiteConfig.system.tmdb_api_key}&language={lang_param}&append_to_response=external_ids,credits"
             res_data = BasicDownloader(api_url).download().json()
             if (
@@ -249,7 +248,7 @@ class TMDB_Movie(AbstractSite):
         p = (page - 1) * page_size // 20 + 1
         offset = (page - 1) * page_size % 20
         results = []
-        api_url = f"https://api.themoviedb.org/3/search/multi?query={quote_plus(q)}&page={p}&api_key={SiteConfig.system.tmdb_api_key}&language={TMDB_DEFAULT_LANG}&include_adult=true"
+        api_url = f"https://api.themoviedb.org/3/search/multi?query={quote_plus(q)}&page={p}&api_key={SiteConfig.system.tmdb_api_key}&language={_get_language_code()}&include_adult=true"
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(api_url, timeout=2)
@@ -312,7 +311,7 @@ class TMDB_TV(AbstractSite):
         res_data = {}
         localized_title = []
         localized_desc = []
-        for lang, lang_param in reversed(TMDB_PREFERRED_LANGS.items()):
+        for lang, lang_param in reversed(_get_preferred_languages().items()):
             api_url = f"https://api.themoviedb.org/3/tv/{self.id_value}?api_key={SiteConfig.system.tmdb_api_key}&language={lang_param}&append_to_response=external_ids,credits"
             res_data = BasicDownloader(api_url).download().json()
             if (
@@ -459,7 +458,7 @@ class TMDB_TVSeason(AbstractSite):
         res_data = {}
         localized_title = []
         localized_desc = []
-        for lang, lang_param in reversed(TMDB_PREFERRED_LANGS.items()):
+        for lang, lang_param in reversed(_get_preferred_languages().items()):
             api_url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_id}?api_key={SiteConfig.system.tmdb_api_key}&language={lang_param}&append_to_response=external_ids,credits"
             res_data = BasicDownloader(api_url).download().json()
             localized_title.append({"lang": lang, "text": res_data["name"]})
@@ -545,7 +544,7 @@ class TMDB_TVSeason(AbstractSite):
             )
         else:
             ep = pd.metadata["episode_number_list"][0]
-            api_url2 = f"https://api.themoviedb.org/3/tv/{v[0]}/season/{v[1]}/episode/{ep}?api_key={SiteConfig.system.tmdb_api_key}&language={TMDB_DEFAULT_LANG}&append_to_response=external_ids,credits"
+            api_url2 = f"https://api.themoviedb.org/3/tv/{v[0]}/season/{v[1]}/episode/{ep}?api_key={SiteConfig.system.tmdb_api_key}&language={_get_language_code()}&append_to_response=external_ids,credits"
             d2 = BasicDownloader(api_url2).download().json()
             if not d2.get("id"):
                 raise ParseError(self, "first episode id for season")
@@ -591,7 +590,7 @@ class TMDB_TVEpisode(AbstractSite):
         episode_id = v[2]
         site = TMDB_TV(TMDB_TV.id_to_url(show_id))
         site.get_resource_ready(auto_create=False, auto_link=False)
-        api_url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_id}/episode/{episode_id}?api_key={SiteConfig.system.tmdb_api_key}&language={TMDB_DEFAULT_LANG}&append_to_response=external_ids,credits"
+        api_url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_id}/episode/{episode_id}?api_key={SiteConfig.system.tmdb_api_key}&language={_get_language_code()}&append_to_response=external_ids,credits"
         d = BasicDownloader(api_url).download().json()
         if not d.get("id"):
             raise ParseError(self, "id")
@@ -657,7 +656,7 @@ class TMDB_Person(AbstractSite):
         localized_name = []
         localized_bio = []
         res_data = {}
-        for lang, lang_param in reversed(TMDB_PREFERRED_LANGS.items()):
+        for lang, lang_param in reversed(_get_preferred_languages().items()):
             api_url = (
                 f"https://api.themoviedb.org/3/person/{self.id_value}"
                 f"?api_key={SiteConfig.system.tmdb_api_key}"

--- a/neodb/common/models/__init__.py
+++ b/neodb/common/models/__init__.py
@@ -36,6 +36,8 @@ from .lang import (
     SITE_PREFERRED_LOCALES,
     detect_language,
     get_current_locales,
+    refresh_language_caches,
+    register_language_cache_refresh,
 )
 from .misc import int_, uniq
 from .music_format import (
@@ -95,6 +97,8 @@ __all__ = [
     "normalize_media_formats",
     "normalize_price",
     "parse_duration_text",
+    "refresh_language_caches",
+    "register_language_cache_refresh",
     "parse_partial_date",
     "partial_date_to_int",
     "uniq",

--- a/neodb/common/models/lang.py
+++ b/neodb/common/models/lang.py
@@ -23,6 +23,7 @@ https://en.wikipedia.org/wiki/IETF_language_tag
 
 import hashlib
 import re
+from collections.abc import Callable
 from typing import Any
 
 import deepl
@@ -38,9 +39,11 @@ from loguru import logger
 from common.models.site_config import SiteConfig
 
 FALLBACK_LANGUAGE = "en"
-SITE_PREFERRED_LANGUAGES: list[str] = settings.PREFERRED_LANGUAGES or [
-    FALLBACK_LANGUAGE
-]
+# Copy: SiteConfig rewrites this list in place, and settings.PREFERRED_LANGUAGES
+# must keep the env-derived value it reads back as the fallback.
+SITE_PREFERRED_LANGUAGES: list[str] = list(
+    settings.PREFERRED_LANGUAGES or [FALLBACK_LANGUAGE]
+)
 SITE_DEFAULT_LANGUAGE: str = SITE_PREFERRED_LANGUAGES[0]
 
 ISO_639_1 = {
@@ -378,6 +381,37 @@ LANGUAGE_CHOICES: list[tuple[str, Any]] = _get_language_choices()
 LANGUAGE_CODES = {k: v for k, v in LANGUAGE_CHOICES}
 SCRIPT_CODES = {k: v for k, v in SCRIPT_CHOICES}
 LOCALE_CODES = {k: v for k, v in LOCALE_CHOICES}
+
+# Caches above are ordered by SITE_PREFERRED_LANGUAGES, which is only known from
+# env at import time: SiteConfig is not readable until apps are loaded. Modules
+# that derive their own structures from them register a callback here so a later
+# SiteConfig change can rebuild everything. All refreshes mutate in place, since
+# importers hold direct references to these objects.
+_refresh_callbacks: list[Callable[[], None]] = []
+
+
+def register_language_cache_refresh(callback: Callable[[], None]) -> None:
+    """Register a callback to run whenever the language caches are rebuilt."""
+    _refresh_callbacks.append(callback)
+
+
+def refresh_language_caches() -> None:
+    """Re-derive the preferred-language-ordered caches from the current value of
+    SITE_PREFERRED_LANGUAGES. Called by SiteConfig when the setting changes."""
+    _BASE_LANGUAGE_LIST.clear()
+    _BASE_LANGUAGE_LIST.update(_get_base_language_list())
+    LOCALE_CHOICES[:] = _get_locale_choices()
+    SCRIPT_CHOICES[:] = _get_script_choices()
+    LANGUAGE_CHOICES[:] = _get_language_choices()
+    for codes, choices in (
+        (LANGUAGE_CODES, LANGUAGE_CHOICES),
+        (SCRIPT_CODES, SCRIPT_CHOICES),
+        (LOCALE_CODES, LOCALE_CHOICES),
+    ):
+        codes.clear()
+        codes.update(choices)
+    for callback in _refresh_callbacks:
+        callback()
 
 
 def get_current_locales() -> list[str]:

--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -399,20 +399,25 @@ class SiteConfig(models.Model):
         ]
         lang_module.SITE_DEFAULT_LANGUAGE = lang_module.SITE_PREFERRED_LANGUAGES[0]
         lang_module.SITE_PREFERRED_LOCALES[:] = lang_module.get_preferred_locales()
-        if previous_languages != lang_module.SITE_PREFERRED_LANGUAGES:
-            # Ordering of the language/locale/script choices follows the preferred
-            # list. Rebuilding is not free and mutates shared lists in place, so
-            # only do it when the preferred languages actually changed.
-            lang_module.refresh_language_caches()
+        languages_changed = previous_languages != lang_module.SITE_PREFERRED_LANGUAGES
 
-        # Default UI language, read live by users.middlewares.LanguageMiddleware
-        if settings.LANGUAGE_CODE != opts.language_code:
+        # Default UI language, read live by users.middlewares.LanguageMiddleware.
+        # Assigned before the refresh below so consumers derived from it see the
+        # new value.
+        language_code_changed = settings.LANGUAGE_CODE != opts.language_code
+        if language_code_changed:
             settings.LANGUAGE_CODE = opts.language_code
             # trans_real caches the default translation object, built from
             # LANGUAGE_CODE on first use and consulted whenever no language is
             # active (RQ jobs, management commands). Django resets it the same
             # way when LANGUAGE_CODE changes, in django/test/signals.py.
             trans_real._default = None  # ty: ignore[unresolved-attribute]
+
+        if languages_changed or language_code_changed:
+            # Rebuilds the choice caches (ordered by the preferred list) and
+            # notifies everything derived from either setting. Not free, and it
+            # mutates shared objects in place, so only run it on a real change.
+            lang_module.refresh_language_caches()
 
         # Timeouts read from settings at call time in mastodon/takahe clients
         settings.MASTODON_TIMEOUT = opts.mastodon_timeout

--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
 from django.db.utils import DatabaseError, ProgrammingError
+from django.utils.translation import trans_real
 from loguru import logger
 
 from common.config import resolve_email_settings
@@ -76,6 +77,10 @@ class SiteConfig(models.Model):
 
         # Localization
         preferred_languages: list[str] = ["en", "zh"]
+        # Default UI language for visitors and users with no language preference.
+        # Unlike preferred_languages this keeps the sub-tag (e.g. zh-hant), so it
+        # cannot be derived from that list.
+        language_code: str = "en"
 
         # Federation
         disable_default_relay: bool = False
@@ -146,6 +151,17 @@ class SiteConfig(models.Model):
         disable_cron_jobs: list[str] = []
         index_aliases: dict = {"catalog": "catalog2"}
         skip_migrations: list[str] = []
+
+        @pydantic.field_validator("language_code")
+        @classmethod
+        def validate_language_code(cls, value: str) -> str:
+            supported = getattr(settings, "SUPPORTED_UI_LANGUAGES", {})
+            if supported and value not in supported:
+                raise ValueError(
+                    f"{value} is not a supported UI language: "
+                    f"{', '.join(supported.keys())}"
+                )
+            return value
 
         @pydantic.field_validator("email_url")
         @classmethod
@@ -219,6 +235,10 @@ class SiteConfig(models.Model):
             "preferred_languages": list(
                 getattr(settings, "PREFERRED_LANGUAGES", ["en", "zh"])
             ),
+            "language_code": getattr(
+                settings, "LANGUAGE_CODE_ENV", getattr(settings, "LANGUAGE_CODE", "en")
+            )
+            or "en",
             # Federation
             "disable_default_relay": getattr(settings, "DISABLE_DEFAULT_RELAY", False),
             "fanout_limit_days": getattr(settings, "FANOUT_LIMIT_DAYS", 9),
@@ -373,11 +393,26 @@ class SiteConfig(models.Model):
         # Refresh module-level language caches
         import common.models.lang as lang_module
 
+        previous_languages = list(lang_module.SITE_PREFERRED_LANGUAGES)
         lang_module.SITE_PREFERRED_LANGUAGES[:] = opts.preferred_languages or [
             lang_module.FALLBACK_LANGUAGE
         ]
         lang_module.SITE_DEFAULT_LANGUAGE = lang_module.SITE_PREFERRED_LANGUAGES[0]
         lang_module.SITE_PREFERRED_LOCALES[:] = lang_module.get_preferred_locales()
+        if previous_languages != lang_module.SITE_PREFERRED_LANGUAGES:
+            # Ordering of the language/locale/script choices follows the preferred
+            # list. Rebuilding is not free and mutates shared lists in place, so
+            # only do it when the preferred languages actually changed.
+            lang_module.refresh_language_caches()
+
+        # Default UI language, read live by users.middlewares.LanguageMiddleware
+        if settings.LANGUAGE_CODE != opts.language_code:
+            settings.LANGUAGE_CODE = opts.language_code
+            # trans_real caches the default translation object, built from
+            # LANGUAGE_CODE on first use and consulted whenever no language is
+            # active (RQ jobs, management commands). Django resets it the same
+            # way when LANGUAGE_CODE changes, in django/test/signals.py.
+            trans_real._default = None  # ty: ignore[unresolved-attribute]
 
         # Timeouts read from settings at call time in mastodon/takahe clients
         settings.MASTODON_TIMEOUT = opts.mastodon_timeout

--- a/neodb/common/views_manage.py
+++ b/neodb/common/views_manage.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 
 import pydantic
 from django import forms
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.shortcuts import redirect
@@ -519,6 +520,14 @@ class AccessSettings(SiteConfigSettingsPage):
             "title": _("Email From"),
             "help_text": _("Sender name and address for outgoing email."),
         },
+        "language_code": {
+            "title": _("Default Language"),
+            "choices": list(settings.LANGUAGES),
+            "help_text": _(
+                "Interface language for visitors and for users who have not "
+                "chosen one themselves."
+            ),
+        },
         "preferred_languages": {
             "title": _("Preferred Languages"),
             "help_text": _(
@@ -543,6 +552,7 @@ class AccessSettings(SiteConfigSettingsPage):
             "email_from",
         ],
         _("Localization"): [
+            "language_code",
             "preferred_languages",
         ],
     }

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 11:13+0800\n"
+"POT-Creation-Date: 2026-07-24 18:08-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:223
+#: boofilsic/settings.py:472 common/models/lang.py:224
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:473 common/models/lang.py:70
+#: boofilsic/settings.py:473 common/models/lang.py:71
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:474 common/models/lang.py:71
+#: boofilsic/settings.py:474 common/models/lang.py:72
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:475 common/models/lang.py:176
+#: boofilsic/settings.py:475 common/models/lang.py:177
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:80
+#: boofilsic/settings.py:476 common/models/lang.py:81
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:477 common/models/lang.py:105
+#: boofilsic/settings.py:477 common/models/lang.py:106
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:478 common/models/lang.py:159
-#: common/models/lang.py:298
+#: boofilsic/settings.py:478 common/models/lang.py:160
+#: common/models/lang.py:299
 msgid "Portuguese"
 msgstr ""
 
@@ -51,19 +51,19 @@ msgstr ""
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:309
+#: boofilsic/settings.py:480 common/models/lang.py:310
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:310
+#: boofilsic/settings.py:481 common/models/lang.py:311
 msgid "Traditional Chinese"
 msgstr ""
 
-#: catalog/forms.py:35 catalog/models/item.py:271
+#: catalog/forms.py:35 catalog/models/item.py:291
 msgid "Primary ID Type"
 msgstr ""
 
-#: catalog/forms.py:40 catalog/models/item.py:274
+#: catalog/forms.py:40 catalog/models/item.py:294
 msgid "Primary ID Value"
 msgstr ""
 
@@ -72,12 +72,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:247 catalog/models/common.py:265
+#: catalog/models/common.py:270 catalog/models/common.py:288
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:250 catalog/models/common.py:270
+#: catalog/models/common.py:273 catalog/models/common.py:293
 msgid "text content"
 msgstr ""
 
@@ -170,421 +170,421 @@ msgstr ""
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:25 common/models/lang.py:249
+#: catalog/models/common.py:26 common/models/lang.py:250
 msgid "Unknown"
 msgstr ""
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:27
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:27 catalog/models/common.py:76
+#: catalog/models/common.py:28 catalog/models/common.py:77
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:78
+#: catalog/models/common.py:29 catalog/models/common.py:79
 msgid "Google Books"
 msgstr ""
 
-#: catalog/models/common.py:29
+#: catalog/models/common.py:30
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:30 catalog/models/common.py:87
-#: catalog/models/common.py:89
+#: catalog/models/common.py:31 catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:88
+#: catalog/models/common.py:32 catalog/models/common.py:89
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:71
+#: catalog/models/common.py:33 catalog/models/common.py:72
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
 msgstr ""
 
-#: catalog/models/common.py:33
+#: catalog/models/common.py:34
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:34 catalog/models/common.py:90
+#: catalog/models/common.py:35 catalog/models/common.py:91
 msgid "Bandcamp"
 msgstr ""
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:36
 msgid "Spotify"
 msgstr ""
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:37
 msgid "IGDB"
 msgstr ""
 
-#: catalog/models/common.py:37
+#: catalog/models/common.py:38
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:38 catalog/models/common.py:110
+#: catalog/models/common.py:39 catalog/models/common.py:111
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:111
+#: catalog/models/common.py:40 catalog/models/common.py:112
 msgid "Bangumi"
 msgstr ""
 
-#: catalog/models/common.py:40
+#: catalog/models/common.py:41
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:41 catalog/models/common.py:112
+#: catalog/models/common.py:42 catalog/models/common.py:113
 msgid "Apple Podcast"
 msgstr ""
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:43
 msgid "RSS"
 msgstr ""
 
-#: catalog/models/common.py:43
+#: catalog/models/common.py:44
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:44 catalog/models/common.py:113
+#: catalog/models/common.py:45 catalog/models/common.py:114
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:115
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:49 catalog/models/common.py:119
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:119
+#: catalog/models/common.py:50 catalog/models/common.py:120
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:61
+#: catalog/models/common.py:51 catalog/models/common.py:62
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:120
+#: catalog/models/common.py:52 catalog/models/common.py:121
 msgid "Open Library"
 msgstr ""
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:53
 msgid "MusicBrainz"
 msgstr ""
 
-#: catalog/models/common.py:53
+#: catalog/models/common.py:54
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:54 catalog/models/common.py:122
+#: catalog/models/common.py:55 catalog/models/common.py:123
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:123
+#: catalog/models/common.py:56 catalog/models/common.py:124
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:114
+#: catalog/models/common.py:57 catalog/models/common.py:115
 msgid "YouTube Music"
 msgstr ""
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:58
 msgid "RateYourMusic"
 msgstr ""
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:63
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:63 catalog/templates/edition.html:19
+#: catalog/models/common.py:64 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:78
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:80
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:98
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:100
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:121
+#: catalog/models/common.py:122
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:124
+#: catalog/models/common.py:125
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:145
+#: catalog/models/common.py:146
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:146 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:148
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:148 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:149 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:149
+#: catalog/models/common.py:150
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:150 catalog/models/common.py:166
-#: catalog/models/common.py:180 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:151 catalog/models/common.py:167
+#: catalog/models/common.py:181 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:151
+#: catalog/models/common.py:152
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:152 catalog/models/common.py:169
-#: catalog/models/common.py:183 common/templates/_header.html:43
+#: catalog/models/common.py:153 catalog/models/common.py:170
+#: catalog/models/common.py:184 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:153
+#: catalog/models/common.py:154
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:154
+#: catalog/models/common.py:155
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:155 catalog/models/common.py:171
-#: catalog/models/common.py:185 common/templates/_header.html:47
+#: catalog/models/common.py:156 catalog/models/common.py:172
+#: catalog/models/common.py:186 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:157
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:157
+#: catalog/models/common.py:158
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:158 catalog/models/common.py:175
+#: catalog/models/common.py:159 catalog/models/common.py:176
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:161 catalog/models/common.py:174
+#: catalog/models/common.py:162 catalog/models/common.py:175
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:165 catalog/models/common.py:179
+#: catalog/models/common.py:166 catalog/models/common.py:180
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:167 catalog/models/common.py:181
+#: catalog/models/common.py:168 catalog/models/common.py:182
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:168 catalog/models/common.py:182
+#: catalog/models/common.py:169 catalog/models/common.py:183
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:170 catalog/models/common.py:184
+#: catalog/models/common.py:171 catalog/models/common.py:185
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:313 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:336 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:351
+#: catalog/models/common.py:374
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:380 catalog/templates/album.html:33
+#: catalog/models/common.py:403 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:384 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:407 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr ""
 
-#: catalog/models/common.py:388
+#: catalog/models/common.py:411
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:393 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr ""
@@ -769,60 +769,60 @@ msgstr ""
 msgid "publishing house"
 msgstr ""
 
-#: catalog/models/item.py:168 catalog/models/people.py:476
+#: catalog/models/item.py:173 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr ""
 
-#: catalog/models/item.py:169 catalog/models/people.py:155
+#: catalog/models/item.py:174 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr ""
 
-#: catalog/models/item.py:171 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr ""
 
-#: catalog/models/item.py:268 catalog/models/item.py:300
+#: catalog/models/item.py:288 catalog/models/item.py:320
 #: journal/models/collection.py:93
 msgid "title"
 msgstr ""
 
-#: catalog/models/item.py:269 catalog/models/item.py:308
+#: catalog/models/item.py:289 catalog/models/item.py:328
 #: journal/models/collection.py:94
 msgid "description"
 msgstr ""
 
-#: catalog/models/item.py:280 catalog/models/people.py:484
+#: catalog/models/item.py:300 catalog/models/people.py:484
 msgid "metadata"
 msgstr ""
 
-#: catalog/models/item.py:282 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr ""
 
-#: catalog/models/item.py:1414
+#: catalog/models/item.py:1485
 msgid "source site"
 msgstr ""
 
-#: catalog/models/item.py:1416
+#: catalog/models/item.py:1487
 msgid "ID on source site"
 msgstr ""
 
-#: catalog/models/item.py:1418
+#: catalog/models/item.py:1489
 msgid "source url"
 msgstr ""
 
-#: catalog/models/item.py:1434
+#: catalog/models/item.py:1505
 msgid "IdType of the source site"
 msgstr ""
 
-#: catalog/models/item.py:1440
+#: catalog/models/item.py:1511
 msgid "Primary Id on the source site"
 msgstr ""
 
-#: catalog/models/item.py:1443
+#: catalog/models/item.py:1514
 msgid "url to the resource"
 msgstr ""
 
@@ -1631,12 +1631,12 @@ msgid "Item has been marked by users."
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:49
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
 msgid "Yes"
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:49
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
 msgid "No"
 msgstr ""
 
@@ -1756,8 +1756,8 @@ msgstr ""
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:143
-#: common/views_manage.py:351 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:144
+#: common/views_manage.py:352 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -2252,11 +2252,11 @@ msgstr ""
 msgid "Item not found"
 msgstr ""
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:187
+#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
 msgid "Item no longer exists"
 msgstr ""
 
-#: catalog/views/view.py:184
+#: catalog/views/view.py:187
 msgid "Invalid role"
 msgstr ""
 
@@ -2740,759 +2740,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:47
+#: common/models/lang.py:48
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:48
+#: common/models/lang.py:49
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:49
+#: common/models/lang.py:50
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:50
+#: common/models/lang.py:51
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:51
+#: common/models/lang.py:52
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:52
+#: common/models/lang.py:53
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:53
+#: common/models/lang.py:54
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:55
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:56
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:57
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:58
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:59
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:60
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:61
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:62
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:63
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:64
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:65
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:66
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:67
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:68
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:69
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:70
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:73
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:74
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:75
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:76
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:77
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:77
+#: common/models/lang.py:78
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:78
+#: common/models/lang.py:79
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:80
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:82
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:83
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:84
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:85
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:86
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:87
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:87
+#: common/models/lang.py:88
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:89
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:90
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:91
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:92
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:93
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:94
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:95
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:96
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:97
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:98
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:99
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:100
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:101
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:102
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:103
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:104
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:105
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:107
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:108
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:109
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:110
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:111
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:112
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:112
+#: common/models/lang.py:113
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:114
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:115
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:116
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:117
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:118
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:119
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:120
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:121
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:122
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:123
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:124
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:125
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:126
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:127
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:128
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:129
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:130
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:131
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:132
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:133
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:134
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:135
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:136
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:137
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:138
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:139
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:140
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:141
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:142
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:143
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:143 common/models/lang.py:144
+#: common/models/lang.py:144 common/models/lang.py:145
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:146
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:147
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:148
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:149
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:150
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:150
+#: common/models/lang.py:151
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:151
+#: common/models/lang.py:152
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:153
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:154
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:155
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:156
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:157
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:158
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:159
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:161
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:162
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:163
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:164
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:165
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:166
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:166
+#: common/models/lang.py:167
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:168
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:169
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:170
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:171
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:172
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:173
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:174
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:175
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:176
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:178
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:179
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:180
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:181
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:182
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:183
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:183
+#: common/models/lang.py:184
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:185
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:186
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:187
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:188
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:189
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:190
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:191
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:192
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:193
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:194
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:195
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:196
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:197
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:198
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:199
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:200
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:201
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:202
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:203
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:204
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:205
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:206
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:207
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:208
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:209
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:210
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:211
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:212
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:213
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:214
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:215
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:216
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:217
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:218
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:219
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:220
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:221
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:222
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:223
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:225
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:226
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:227
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:228
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:229
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:230
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:230
+#: common/models/lang.py:231
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:232
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:293
+#: common/models/lang.py:294
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:294
+#: common/models/lang.py:295
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:295
+#: common/models/lang.py:296
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:303
+#: common/models/lang.py:304
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:306
+#: common/models/lang.py:307
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:307
+#: common/models/lang.py:308
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:308
+#: common/models/lang.py:309
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:316
+#: common/models/lang.py:317
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:317
+#: common/models/lang.py:318
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:321
+#: common/models/lang.py:322
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:322
+#: common/models/lang.py:323
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:324
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3865,7 +3865,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:489
+#: common/templates/common/about.html:35 common/views_manage.py:490
 msgid "Invite Only"
 msgstr ""
 
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:523
+#: common/templates/common/about.html:40 common/views_manage.py:532
 msgid "Preferred Languages"
 msgstr ""
 
@@ -3929,7 +3929,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:592
+#: common/templates/common/scan.html:60 common/views_manage.py:602
 msgid "Search"
 msgstr ""
 
@@ -4011,695 +4011,703 @@ msgstr ""
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:142 common/views_manage.py:293
+#: common/views_manage.py:143 common/views_manage.py:294
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:144
+#: common/views_manage.py:145
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:146 common/views_manage.py:587
+#: common/views_manage.py:147 common/views_manage.py:597
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:147
+#: common/views_manage.py:148
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:150 common/views_manage.py:301
+#: common/views_manage.py:151 common/views_manage.py:302
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:200
+#: common/views_manage.py:201
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:204
+#: common/views_manage.py:205
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:209
+#: common/views_manage.py:210
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:229
+#: common/views_manage.py:230
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:313
+#: common/views_manage.py:314
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:315
+#: common/views_manage.py:316
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:329
+#: common/views_manage.py:330
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:331
+#: common/views_manage.py:332
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:343
+#: common/views_manage.py:344
 msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:345
+#: common/views_manage.py:346
 msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:384
+#: common/views_manage.py:385
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:386
+#: common/views_manage.py:387
 msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:391
+#: common/views_manage.py:392
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:393
+#: common/views_manage.py:394
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:399
+#: common/views_manage.py:400
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:401
+#: common/views_manage.py:402
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:407
+#: common/views_manage.py:408
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:408
+#: common/views_manage.py:409
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:412
+#: common/views_manage.py:413
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:413
+#: common/views_manage.py:414
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:417
+#: common/views_manage.py:418
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:419
+#: common/views_manage.py:420
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:424
+#: common/views_manage.py:425
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:426
+#: common/views_manage.py:427
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:432
+#: common/views_manage.py:433
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:434
+#: common/views_manage.py:435
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:440
+#: common/views_manage.py:441
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:442
+#: common/views_manage.py:443
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:448
+#: common/views_manage.py:449
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:450
+#: common/views_manage.py:451
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:456
+#: common/views_manage.py:457
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:458
+#: common/views_manage.py:459
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:465
+#: common/views_manage.py:466
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:468
+#: common/views_manage.py:469
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:475
+#: common/views_manage.py:476
 msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:491
+#: common/views_manage.py:492
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:496
+#: common/views_manage.py:497
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:497
+#: common/views_manage.py:498
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:500
+#: common/views_manage.py:501
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:502
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:504
+#: common/views_manage.py:505
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:507
+#: common/views_manage.py:508
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:510
+#: common/views_manage.py:511
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:513
+#: common/views_manage.py:514
 msgid "Email URL"
 msgstr ""
 
-#: common/views_manage.py:515
+#: common/views_manage.py:516
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:519
+#: common/views_manage.py:520
 msgid "Email From"
 msgstr ""
 
-#: common/views_manage.py:520
+#: common/views_manage.py:521
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:525
+#: common/views_manage.py:524
+msgid "Default Language"
+msgstr ""
+
+#: common/views_manage.py:527
+msgid "Interface language for visitors and for users who have not chosen one themselves."
+msgstr ""
+
+#: common/views_manage.py:534
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:531
+#: common/views_manage.py:540
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:536
+#: common/views_manage.py:545
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:541 mastodon/models/common.py:28
+#: common/views_manage.py:550 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:545
+#: common/views_manage.py:554
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:555
+#: common/views_manage.py:565
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:557
+#: common/views_manage.py:567
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:562
+#: common/views_manage.py:572
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:563
+#: common/views_manage.py:573
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:567
+#: common/views_manage.py:577
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:569
+#: common/views_manage.py:579
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:574
+#: common/views_manage.py:584
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:575
+#: common/views_manage.py:585
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:578
+#: common/views_manage.py:588
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:579
+#: common/views_manage.py:589
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:582
+#: common/views_manage.py:592
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:583
+#: common/views_manage.py:593
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:604
+#: common/views_manage.py:614
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:605
+#: common/views_manage.py:615
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:608
+#: common/views_manage.py:618
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:609
+#: common/views_manage.py:619
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:612
+#: common/views_manage.py:622
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:613
+#: common/views_manage.py:623
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:616
+#: common/views_manage.py:626
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:628
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:622
+#: common/views_manage.py:632
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:623
+#: common/views_manage.py:633
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:626
+#: common/views_manage.py:636
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:629
+#: common/views_manage.py:639
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:631
+#: common/views_manage.py:641
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:636 users/templates/users/steam_import.html:26
+#: common/views_manage.py:646 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:638
+#: common/views_manage.py:648
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:643
+#: common/views_manage.py:653
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:644
+#: common/views_manage.py:654
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:647
+#: common/views_manage.py:657
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:650
+#: common/views_manage.py:660
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:653
+#: common/views_manage.py:663
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:654
+#: common/views_manage.py:664
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:657
+#: common/views_manage.py:667
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:660
+#: common/views_manage.py:670
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:662
+#: common/views_manage.py:672
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:679
+#: common/views_manage.py:689
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:699
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:704
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:698 social/templates/feed.html:27
+#: common/views_manage.py:708 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:708
+#: common/views_manage.py:718
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:709
+#: common/views_manage.py:719
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:712
+#: common/views_manage.py:722
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:713
+#: common/views_manage.py:723
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:716
+#: common/views_manage.py:726
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:729
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:722
+#: common/views_manage.py:732
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:725
+#: common/views_manage.py:735
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:728
+#: common/views_manage.py:738
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:731
+#: common/views_manage.py:741
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:732
+#: common/views_manage.py:742
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:735
+#: common/views_manage.py:745
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:739
+#: common/views_manage.py:749
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:743
+#: common/views_manage.py:753
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:748
+#: common/views_manage.py:758
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:753
+#: common/views_manage.py:763
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:760
+#: common/views_manage.py:770
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:772
+#: common/views_manage.py:782
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:783
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:776
+#: common/views_manage.py:786
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:777
+#: common/views_manage.py:787
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:780
+#: common/views_manage.py:790
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:782
+#: common/views_manage.py:792
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:788
+#: common/views_manage.py:798
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:789
+#: common/views_manage.py:799
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:802
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:793
+#: common/views_manage.py:803
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:803
+#: common/views_manage.py:813
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:805
+#: common/views_manage.py:815
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:821
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:823
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:819
+#: common/views_manage.py:829
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:821
+#: common/views_manage.py:831
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:828
+#: common/views_manage.py:838
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:831
+#: common/views_manage.py:841
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:857
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:849
+#: common/views_manage.py:859
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:854
+#: common/views_manage.py:864
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:856
+#: common/views_manage.py:866
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:861
+#: common/views_manage.py:871
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:863
+#: common/views_manage.py:873
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:868
+#: common/views_manage.py:878
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:870
+#: common/views_manage.py:880
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:875
+#: common/views_manage.py:885
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:877
+#: common/views_manage.py:887
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:882
+#: common/views_manage.py:892
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:884
+#: common/views_manage.py:894
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:900
 msgid "Genres by Category"
 msgstr ""
 
@@ -4819,7 +4827,7 @@ msgstr ""
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/models/article.py:210 journal/views/article.py:207
+#: journal/models/article.py:212 journal/views/article.py:207
 msgid "(may contain sensitive content)"
 msgstr ""
 
@@ -4937,23 +4945,23 @@ msgstr ""
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr ""
 
-#: journal/models/common.py:919
+#: journal/models/common.py:927
 msgid "A recent post was not posted to Threads."
 msgstr ""
 
-#: journal/models/common.py:952
+#: journal/models/common.py:960
 msgid "A recent post was not boosted on Mastodon."
 msgstr ""
 
-#: journal/models/common.py:962
+#: journal/models/common.py:970
 msgid "Original post no longer exists."
 msgstr ""
 
-#: journal/models/common.py:976
+#: journal/models/common.py:984
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr ""
 
-#: journal/models/common.py:985
+#: journal/models/common.py:993
 msgid "A recent post was not posted to Mastodon."
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 11:13+0800\n"
+"POT-Creation-Date: 2026-07-24 18:08-0400\n"
 "PO-Revision-Date: 2026-07-02 15:01+0000\n"
 "Last-Translator: Hosted Weblate user 54392 <hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:223
+#: boofilsic/settings.py:472 common/models/lang.py:224
 msgid "English"
 msgstr "英语"
 
-#: boofilsic/settings.py:473 common/models/lang.py:70
+#: boofilsic/settings.py:473 common/models/lang.py:71
 msgid "Danish"
 msgstr "丹麦语"
 
-#: boofilsic/settings.py:474 common/models/lang.py:71
+#: boofilsic/settings.py:474 common/models/lang.py:72
 msgid "German"
 msgstr "德语"
 
-#: boofilsic/settings.py:475 common/models/lang.py:176
+#: boofilsic/settings.py:475 common/models/lang.py:177
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: boofilsic/settings.py:476 common/models/lang.py:80
+#: boofilsic/settings.py:476 common/models/lang.py:81
 msgid "French"
 msgstr "法语"
 
-#: boofilsic/settings.py:477 common/models/lang.py:105
+#: boofilsic/settings.py:477 common/models/lang.py:106
 msgid "Italian"
 msgstr "意大利语"
 
-#: boofilsic/settings.py:478 common/models/lang.py:159
-#: common/models/lang.py:298
+#: boofilsic/settings.py:478 common/models/lang.py:160
+#: common/models/lang.py:299
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
@@ -50,19 +50,19 @@ msgstr "葡萄牙语"
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: boofilsic/settings.py:480 common/models/lang.py:309
+#: boofilsic/settings.py:480 common/models/lang.py:310
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: boofilsic/settings.py:481 common/models/lang.py:310
+#: boofilsic/settings.py:481 common/models/lang.py:311
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
-#: catalog/forms.py:35 catalog/models/item.py:271
+#: catalog/forms.py:35 catalog/models/item.py:291
 msgid "Primary ID Type"
 msgstr "主要标识类型"
 
-#: catalog/forms.py:40 catalog/models/item.py:274
+#: catalog/forms.py:40 catalog/models/item.py:294
 msgid "Primary ID Value"
 msgstr "主要标识数据"
 
@@ -71,12 +71,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "日期无效，应为 YYYY、YYYY-MM 或 YYYY-MM-DD。"
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:247 catalog/models/common.py:265
+#: catalog/models/common.py:270 catalog/models/common.py:288
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:250 catalog/models/common.py:270
+#: catalog/models/common.py:273 catalog/models/common.py:293
 msgid "text content"
 msgstr "文本内容"
 
@@ -169,421 +169,421 @@ msgstr "价格"
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:25 common/models/lang.py:249
+#: catalog/models/common.py:26 common/models/lang.py:250
 msgid "Unknown"
 msgstr "未知"
 
-#: catalog/models/common.py:26
+#: catalog/models/common.py:27
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:27 catalog/models/common.py:76
+#: catalog/models/common.py:28 catalog/models/common.py:77
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:28 catalog/models/common.py:78
+#: catalog/models/common.py:29 catalog/models/common.py:79
 msgid "Google Books"
 msgstr "谷歌图书"
 
-#: catalog/models/common.py:29
+#: catalog/models/common.py:30
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:30 catalog/models/common.py:87
-#: catalog/models/common.py:89
+#: catalog/models/common.py:31 catalog/models/common.py:88
+#: catalog/models/common.py:90
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:31 catalog/models/common.py:88
+#: catalog/models/common.py:32 catalog/models/common.py:89
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:32 catalog/models/common.py:71
+#: catalog/models/common.py:33 catalog/models/common.py:72
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
 msgstr "IMDb"
 
-#: catalog/models/common.py:33
+#: catalog/models/common.py:34
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:34 catalog/models/common.py:90
+#: catalog/models/common.py:35 catalog/models/common.py:91
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
-#: catalog/models/common.py:35
+#: catalog/models/common.py:36
 msgid "Spotify"
 msgstr "Spotify"
 
-#: catalog/models/common.py:36
+#: catalog/models/common.py:37
 msgid "IGDB"
 msgstr "IGDB"
 
-#: catalog/models/common.py:37
+#: catalog/models/common.py:38
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:38 catalog/models/common.py:110
+#: catalog/models/common.py:39 catalog/models/common.py:111
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:39 catalog/models/common.py:111
+#: catalog/models/common.py:40 catalog/models/common.py:112
 msgid "Bangumi"
 msgstr "Bangumi"
 
-#: catalog/models/common.py:40
+#: catalog/models/common.py:41
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:41 catalog/models/common.py:112
+#: catalog/models/common.py:42 catalog/models/common.py:113
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
-#: catalog/models/common.py:42
+#: catalog/models/common.py:43
 msgid "RSS"
 msgstr "RSS"
 
-#: catalog/models/common.py:43
+#: catalog/models/common.py:44
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:44 catalog/models/common.py:113
+#: catalog/models/common.py:45 catalog/models/common.py:114
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:45 catalog/models/common.py:115
+#: catalog/models/common.py:46 catalog/models/common.py:116
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:47 catalog/models/common.py:117
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:48 catalog/models/common.py:118
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:49 catalog/models/common.py:119
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:49 catalog/models/common.py:119
+#: catalog/models/common.py:50 catalog/models/common.py:120
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:50 catalog/models/common.py:61
+#: catalog/models/common.py:51 catalog/models/common.py:62
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:51 catalog/models/common.py:120
+#: catalog/models/common.py:52 catalog/models/common.py:121
 msgid "Open Library"
 msgstr "开放图书馆"
 
-#: catalog/models/common.py:52
+#: catalog/models/common.py:53
 msgid "MusicBrainz"
 msgstr "MusicBrainz"
 
-#: catalog/models/common.py:53
+#: catalog/models/common.py:54
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:54 catalog/models/common.py:122
+#: catalog/models/common.py:55 catalog/models/common.py:123
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:55 catalog/models/common.py:123
+#: catalog/models/common.py:56 catalog/models/common.py:124
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:56 catalog/models/common.py:114
+#: catalog/models/common.py:57 catalog/models/common.py:115
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
-#: catalog/models/common.py:57
+#: catalog/models/common.py:58
 msgid "RateYourMusic"
 msgstr "RateYourMusic"
 
-#: catalog/models/common.py:62
+#: catalog/models/common.py:63
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:63 catalog/templates/edition.html:19
+#: catalog/models/common.py:64 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:64
+#: catalog/models/common.py:65
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:72
+#: catalog/models/common.py:73
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:77
+#: catalog/models/common.py:78
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:79
+#: catalog/models/common.py:80
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:91
+#: catalog/models/common.py:92
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:97
+#: catalog/models/common.py:98
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:99
+#: catalog/models/common.py:100
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz艺术家"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:121
+#: catalog/models/common.py:122
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:124
+#: catalog/models/common.py:125
 msgid "RateYourMusic Release"
 msgstr "RateYourMusic发行"
 
-#: catalog/models/common.py:145
+#: catalog/models/common.py:146
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:146 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:147
+#: catalog/models/common.py:148
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:148 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:149 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:149
+#: catalog/models/common.py:150
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:150 catalog/models/common.py:166
-#: catalog/models/common.py:180 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:151 catalog/models/common.py:167
+#: catalog/models/common.py:181 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:151
+#: catalog/models/common.py:152
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:152 catalog/models/common.py:169
-#: catalog/models/common.py:183 common/templates/_header.html:43
+#: catalog/models/common.py:153 catalog/models/common.py:170
+#: catalog/models/common.py:184 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:153
+#: catalog/models/common.py:154
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:154
+#: catalog/models/common.py:155
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:155 catalog/models/common.py:171
-#: catalog/models/common.py:185 common/templates/_header.html:47
+#: catalog/models/common.py:156 catalog/models/common.py:172
+#: catalog/models/common.py:186 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:156
+#: catalog/models/common.py:157
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:157
+#: catalog/models/common.py:158
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:158 catalog/models/common.py:175
+#: catalog/models/common.py:159 catalog/models/common.py:176
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:161 catalog/models/common.py:174
+#: catalog/models/common.py:162 catalog/models/common.py:175
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:165 catalog/models/common.py:179
+#: catalog/models/common.py:166 catalog/models/common.py:180
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:167 catalog/models/common.py:181
+#: catalog/models/common.py:168 catalog/models/common.py:182
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:168 catalog/models/common.py:182
+#: catalog/models/common.py:169 catalog/models/common.py:183
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:170 catalog/models/common.py:184
+#: catalog/models/common.py:171 catalog/models/common.py:185
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:313 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:336 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:351
+#: catalog/models/common.py:374
 msgid "origin country"
 msgstr "制片国家/地区"
 
-#: catalog/models/common.py:380 catalog/templates/album.html:33
+#: catalog/models/common.py:403 catalog/templates/album.html:33
 msgid "album type"
 msgstr "专辑类型"
 
-#: catalog/models/common.py:384 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:407 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/common.py:388
+#: catalog/models/common.py:411
 msgid "media format"
 msgstr "介质"
 
-#: catalog/models/common.py:393 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:416 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr "语言"
@@ -768,60 +768,60 @@ msgstr "声优"
 msgid "publishing house"
 msgstr "出版社"
 
-#: catalog/models/item.py:168 catalog/models/people.py:476
+#: catalog/models/item.py:173 catalog/models/people.py:476
 #: catalog/models/performance.py:115 catalog/models/performance.py:134
 msgid "role"
 msgstr "角色"
 
-#: catalog/models/item.py:169 catalog/models/people.py:155
+#: catalog/models/item.py:174 catalog/models/people.py:155
 #: catalog/models/performance.py:114 catalog/models/performance.py:129
 #: users/models/webauthn.py:14
 msgid "name"
 msgstr "名字"
 
-#: catalog/models/item.py:171 catalog/templates/_item_credits_list.html:138
+#: catalog/models/item.py:176 catalog/templates/_item_credits_list.html:138
 msgid "character name"
 msgstr "角色名"
 
-#: catalog/models/item.py:268 catalog/models/item.py:300
+#: catalog/models/item.py:288 catalog/models/item.py:320
 #: journal/models/collection.py:93
 msgid "title"
 msgstr "标题"
 
-#: catalog/models/item.py:269 catalog/models/item.py:308
+#: catalog/models/item.py:289 catalog/models/item.py:328
 #: journal/models/collection.py:94
 msgid "description"
 msgstr "描述"
 
-#: catalog/models/item.py:280 catalog/models/people.py:484
+#: catalog/models/item.py:300 catalog/models/people.py:484
 msgid "metadata"
 msgstr "元数据"
 
-#: catalog/models/item.py:282 catalog/templates/_item_card.html:34
+#: catalog/models/item.py:302 catalog/templates/_item_card.html:34
 msgid "cover"
 msgstr "封面"
 
-#: catalog/models/item.py:1414
+#: catalog/models/item.py:1485
 msgid "source site"
 msgstr "来源站点"
 
-#: catalog/models/item.py:1416
+#: catalog/models/item.py:1487
 msgid "ID on source site"
 msgstr "来源站点标识"
 
-#: catalog/models/item.py:1418
+#: catalog/models/item.py:1489
 msgid "source url"
 msgstr "来源站点网址"
 
-#: catalog/models/item.py:1434
+#: catalog/models/item.py:1505
 msgid "IdType of the source site"
 msgstr "来源站点的主要标识类型"
 
-#: catalog/models/item.py:1440
+#: catalog/models/item.py:1511
 msgid "Primary Id on the source site"
 msgstr "来源站点的主要标识数据"
 
-#: catalog/models/item.py:1443
+#: catalog/models/item.py:1514
 msgid "url to the resource"
 msgstr "指向外部资源的网址"
 
@@ -1630,12 +1630,12 @@ msgid "Item has been marked by users."
 msgstr "条目已被用户标记过。"
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:49
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
 msgid "Yes"
 msgstr "是"
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:49
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
 msgid "No"
 msgstr "否"
 
@@ -1755,8 +1755,8 @@ msgstr "发送反馈"
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr "对创作者验证有疑问或遇到问题？请告知站点管理员。"
 
-#: catalog/templates/discover.html:28 common/views_manage.py:143
-#: common/views_manage.py:351 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:144
+#: common/views_manage.py:352 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "发现"
 
@@ -2251,11 +2251,11 @@ msgstr "创作者验证已移除。"
 msgid "Item not found"
 msgstr "条目不存在"
 
-#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:187
+#: catalog/views/view.py:78 catalog/views/view.py:107 catalog/views/view.py:190
 msgid "Item no longer exists"
 msgstr "条目已不存在"
 
-#: catalog/views/view.py:184
+#: catalog/views/view.py:187
 msgid "Invalid role"
 msgstr "无效职务或角色。"
 
@@ -2739,759 +2739,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr "健康"
 
-#: common/models/lang.py:47
+#: common/models/lang.py:48
 msgid "Afar"
 msgstr "阿法尔语"
 
-#: common/models/lang.py:48
+#: common/models/lang.py:49
 msgid "Afrikaans"
 msgstr "南非荷兰语"
 
-#: common/models/lang.py:49
+#: common/models/lang.py:50
 msgid "Akan"
 msgstr "阿坎语"
 
-#: common/models/lang.py:50
+#: common/models/lang.py:51
 msgid "Aragonese"
 msgstr "阿拉贡语"
 
-#: common/models/lang.py:51
+#: common/models/lang.py:52
 msgid "Assamese"
 msgstr "阿萨姆语"
 
-#: common/models/lang.py:52
+#: common/models/lang.py:53
 msgid "Avaric"
 msgstr "阿瓦尔语"
 
-#: common/models/lang.py:53
+#: common/models/lang.py:54
 msgid "Avestan"
 msgstr "阿维斯陀语"
 
-#: common/models/lang.py:54
+#: common/models/lang.py:55
 msgid "Aymara"
 msgstr "艾马拉语"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:56
 msgid "Azerbaijani"
 msgstr "阿塞拜疆"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:57
 msgid "Bashkir"
 msgstr "巴什基尔语"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:58
 msgid "Bambara"
 msgstr "班巴拉语"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:59
 msgid "Bislama"
 msgstr "比斯拉马语"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:60
 msgid "Tibetan"
 msgstr "藏语"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:61
 msgid "Breton"
 msgstr "布列塔尼语"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:62
 msgid "Catalan"
 msgstr "加泰罗尼亚"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:63
 msgid "Czech"
 msgstr "捷克语"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:64
 msgid "Chechen"
 msgstr "车臣"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:65
 msgid "Slavic"
 msgstr "斯拉夫"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:66
 msgid "Chuvash"
 msgstr "楚瓦什语"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:67
 msgid "Cornish"
 msgstr "康沃尔语"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:68
 msgid "Corsican"
 msgstr "科西嘉语"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:69
 msgid "Cree"
 msgstr "克里语"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:70
 msgid "Welsh"
 msgstr "威尔士语"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:73
 msgid "Divehi"
 msgstr "迪维希语"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:74
 msgid "Dzongkha"
 msgstr "宗喀语"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:75
 msgid "Esperanto"
 msgstr "世界语"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:76
 msgid "Estonian"
 msgstr "爱沙尼亚语"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:77
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: common/models/lang.py:77
+#: common/models/lang.py:78
 msgid "Faroese"
 msgstr "法罗语"
 
-#: common/models/lang.py:78
+#: common/models/lang.py:79
 msgid "Fijian"
 msgstr "斐济语"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:80
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:82
 msgid "Frisian"
 msgstr "弗里西语"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:83
 msgid "Fulah"
 msgstr "富拉语"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:84
 msgid "Gaelic"
 msgstr "盖尔语"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:85
 msgid "Irish"
 msgstr "爱尔兰语"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:86
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:87
 msgid "Manx"
 msgstr "马恩语"
 
-#: common/models/lang.py:87
+#: common/models/lang.py:88
 msgid "Guarani"
 msgstr "瓜拉尼语"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:89
 msgid "Gujarati"
 msgstr "古吉拉特语"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:90
 msgid "Haitian; Haitian Creole"
 msgstr "海地语; 海地克里奥尔语"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:91
 msgid "Hausa"
 msgstr "豪萨语"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:92
 msgid "Serbo-Croatian"
 msgstr "塞尔维亚-克罗地亚语"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:93
 msgid "Herero"
 msgstr "赫雷罗语"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:94
 msgid "Hiri Motu"
 msgstr "希里莫图语"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:95
 msgid "Croatian"
 msgstr "克罗地亚语"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:96
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:97
 msgid "Igbo"
 msgstr "伊博语"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:98
 msgid "Ido"
 msgstr "伊多语"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:99
 msgid "Yi"
 msgstr "彝语"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:100
 msgid "Inuktitut"
 msgstr "因纽特语"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:101
 msgid "Interlingue"
 msgstr "西方国际语"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:102
 msgid "Interlingua"
 msgstr "国际语"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:103
 msgid "Indonesian"
 msgstr "印度尼西亚语"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:104
 msgid "Inupiaq"
 msgstr "伊努皮克语"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:105
 msgid "Icelandic"
 msgstr "冰岛语"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:107
 msgid "Javanese"
 msgstr "爪哇语"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:108
 msgid "Japanese"
 msgstr "日语"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:109
 msgid "Kalaallisut"
 msgstr "格陵兰语"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:110
 msgid "Kannada"
 msgstr "卡纳达语"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:111
 msgid "Kashmiri"
 msgstr "克什米尔语"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:112
 msgid "Kanuri"
 msgstr "卡努里语"
 
-#: common/models/lang.py:112
+#: common/models/lang.py:113
 msgid "Kazakh"
 msgstr "哈萨克语"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:114
 msgid "Khmer"
 msgstr "高棉语"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:115
 msgid "Kikuyu"
 msgstr "基库尤语"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:116
 msgid "Kinyarwanda"
 msgstr "卢旺达语"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:117
 msgid "Kirghiz"
 msgstr "吉尔吉斯语"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:118
 msgid "Komi"
 msgstr "科米语"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:119
 msgid "Kongo"
 msgstr "刚果语"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:120
 msgid "Korean"
 msgstr "韩语"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:121
 msgid "Kuanyama"
 msgstr "宽亚玛语"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:122
 msgid "Kurdish"
 msgstr "库尔德语"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:123
 msgid "Lao"
 msgstr "老挝语"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:124
 msgid "Latin"
 msgstr "拉丁"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:125
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:126
 msgid "Limburgish"
 msgstr "林堡语"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:127
 msgid "Lingala"
 msgstr "林加拉语"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:128
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:129
 msgid "Letzeburgesch"
 msgstr "卢森堡语"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:130
 msgid "Luba-Katanga"
 msgstr "卢巴-加丹加语"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:131
 msgid "Ganda"
 msgstr "干达语"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:132
 msgid "Marshall"
 msgstr "马绍尔语"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:133
 msgid "Malayalam"
 msgstr "马拉雅拉姆语"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:134
 msgid "Marathi"
 msgstr "马拉地语"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:135
 msgid "Malagasy"
 msgstr "马达加斯加语"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:136
 msgid "Maltese"
 msgstr "马耳他语"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:137
 msgid "Moldavian"
 msgstr "摩尔多瓦语"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:138
 msgid "Mongolian"
 msgstr "蒙古语"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:139
 msgid "Maori"
 msgstr "毛利语"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:140
 msgid "Malay"
 msgstr "马来语"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:141
 msgid "Burmese"
 msgstr "缅甸语"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:142
 msgid "Nauru"
 msgstr "瑙鲁语"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:143
 msgid "Navajo"
 msgstr "纳瓦霍语"
 
-#: common/models/lang.py:143 common/models/lang.py:144
+#: common/models/lang.py:144 common/models/lang.py:145
 msgid "Ndebele"
 msgstr "恩德贝莱语"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:146
 msgid "Ndonga"
 msgstr "恩东加语"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:147
 msgid "Nepali"
 msgstr "尼泊尔语"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:148
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:149
 msgid "Norwegian Nynorsk"
 msgstr "挪威尼诺斯克语"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:150
 msgid "Norwegian Bokmål"
 msgstr "挪威博克马尔语"
 
-#: common/models/lang.py:150
+#: common/models/lang.py:151
 msgid "Norwegian"
 msgstr "挪威语"
 
-#: common/models/lang.py:151
+#: common/models/lang.py:152
 msgid "Chichewa; Nyanja"
 msgstr "奇切瓦语; 尼扬贾语"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:153
 msgid "Occitan"
 msgstr "奥克语"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:154
 msgid "Ojibwa"
 msgstr "奥吉布瓦语"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:155
 msgid "Oriya"
 msgstr "奥里亚语"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:156
 msgid "Oromo"
 msgstr "奥罗莫语"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:157
 msgid "Ossetian; Ossetic"
 msgstr "奥塞梯语"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:158
 msgid "Pali"
 msgstr "巴利语"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:159
 msgid "Polish"
 msgstr "波兰语"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:161
 msgid "Quechua"
 msgstr "克丘亚语"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:162
 msgid "Raeto-Romance"
 msgstr "罗曼什语"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:163
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:164
 msgid "Rundi"
 msgstr "基隆迪语"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:165
 msgid "Russian"
 msgstr "俄语"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:166
 msgid "Sango"
 msgstr "桑戈语"
 
-#: common/models/lang.py:166
+#: common/models/lang.py:167
 msgid "Sanskrit"
 msgstr "梵语"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:168
 msgid "Sinhalese"
 msgstr "僧伽罗语"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:169
 msgid "Slovak"
 msgstr "斯洛伐克语"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:170
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:171
 msgid "Northern Sami"
 msgstr "北萨米语"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:172
 msgid "Samoan"
 msgstr "萨摩亚语"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:173
 msgid "Shona"
 msgstr "绍纳语"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:174
 msgid "Sindhi"
 msgstr "信德语"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:175
 msgid "Somali"
 msgstr "索马里语"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:176
 msgid "Sotho"
 msgstr "索托语"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:178
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:179
 msgid "Sardinian"
 msgstr "萨丁尼亚语"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:180
 msgid "Serbian"
 msgstr "塞尔维亚语"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:181
 msgid "Swati"
 msgstr "斯瓦特语"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:182
 msgid "Sundanese"
 msgstr "巽他语"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:183
 msgid "Swahili"
 msgstr "斯瓦希里语"
 
-#: common/models/lang.py:183
+#: common/models/lang.py:184
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:185
 msgid "Tahitian"
 msgstr "塔希提语"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:186
 msgid "Tamil"
 msgstr "泰米尔语"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:187
 msgid "Tatar"
 msgstr "鞑靼语"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:188
 msgid "Telugu"
 msgstr "泰卢固语"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:189
 msgid "Tajik"
 msgstr "塔吉克语"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:190
 msgid "Tagalog"
 msgstr "他加禄语"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:191
 msgid "Thai"
 msgstr "泰语"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:192
 msgid "Tigrinya"
 msgstr "提格利尼亚语"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:193
 msgid "Tonga"
 msgstr "汤加语"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:194
 msgid "Tswana"
 msgstr "茨瓦纳语"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:195
 msgid "Tsonga"
 msgstr "聪加语"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:196
 msgid "Turkmen"
 msgstr "土库曼语"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:197
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:198
 msgid "Twi"
 msgstr "契维语"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:199
 msgid "Uighur"
 msgstr "维吾尔语"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:200
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:201
 msgid "Urdu"
 msgstr "乌尔都语"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:202
 msgid "Uzbek"
 msgstr "乌兹别克语"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:203
 msgid "Venda"
 msgstr "文达语"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:204
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:205
 msgid "Volapük"
 msgstr "沃拉普克语"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:206
 msgid "Walloon"
 msgstr "瓦隆语"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:207
 msgid "Wolof"
 msgstr "沃洛夫语"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:208
 msgid "Xhosa"
 msgstr "科萨语"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:209
 msgid "Yiddish"
 msgstr "意第绪语"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:210
 msgid "Zhuang"
 msgstr "壮语"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:211
 msgid "Zulu"
 msgstr "祖鲁语"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:212
 msgid "Abkhazian"
 msgstr "阿布哈兹语"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:213
 msgid "Chinese"
 msgstr "中文"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:214
 msgid "Pushto"
 msgstr "普什图语"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:215
 msgid "Amharic"
 msgstr "阿姆哈拉语"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:216
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:217
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:218
 msgid "Macedonian"
 msgstr "马其顿语"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:219
 msgid "Greek"
 msgstr "希腊语"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:220
 msgid "Persian"
 msgstr "波斯语"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:221
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:222
 msgid "Hindi"
 msgstr "印度语"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:223
 msgid "Armenian"
 msgstr "亚美尼亚语"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:225
 msgid "Ewe"
 msgstr "埃维语"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:226
 msgid "Georgian"
 msgstr "格鲁吉亚语"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:227
 msgid "Punjabi"
 msgstr "旁遮普语"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:228
 msgid "Bengali"
 msgstr "孟加拉语"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:229
 msgid "Bosnian"
 msgstr "波斯尼亚语"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:230
 msgid "Chamorro"
 msgstr "查莫罗语"
 
-#: common/models/lang.py:230
+#: common/models/lang.py:231
 msgid "Belarusian"
 msgstr "白俄罗斯语"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:232
 msgid "Yoruba"
 msgstr "约鲁巴语"
 
-#: common/models/lang.py:293
+#: common/models/lang.py:294
 msgid "Simplified Chinese (Mainland)"
 msgstr "简体中文(大陆)"
 
-#: common/models/lang.py:294
+#: common/models/lang.py:295
 msgid "Traditional Chinese (Taiwan)"
 msgstr "正体中文(台湾)"
 
-#: common/models/lang.py:295
+#: common/models/lang.py:296
 msgid "Traditional Chinese (Hongkong)"
 msgstr "繁体中文(香港)"
 
-#: common/models/lang.py:303
+#: common/models/lang.py:304
 msgid "Portuguese (Brazil)"
 msgstr "葡萄牙语(巴西)"
 
-#: common/models/lang.py:306
+#: common/models/lang.py:307
 msgid "Simplified Chinese (Singapore)"
 msgstr "简体中文(新加坡)"
 
-#: common/models/lang.py:307
+#: common/models/lang.py:308
 msgid "Simplified Chinese (Malaysia)"
 msgstr "简体中文(马来西亚)"
 
-#: common/models/lang.py:308
+#: common/models/lang.py:309
 msgid "Traditional Chinese (Macau)"
 msgstr "繁体中文(澳门)"
 
-#: common/models/lang.py:316
+#: common/models/lang.py:317
 msgid "Mandarin Chinese"
 msgstr "普通话"
 
-#: common/models/lang.py:317
+#: common/models/lang.py:318
 msgid "Yue Chinese"
 msgstr "粤语"
 
-#: common/models/lang.py:321
+#: common/models/lang.py:322
 msgid "Min Nan Chinese"
 msgstr "闽南语"
 
-#: common/models/lang.py:322
+#: common/models/lang.py:323
 msgid "Wu Chinese"
 msgstr "吴语"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:324
 msgid "Hakka Chinese"
 msgstr "客家话"
 
@@ -3885,7 +3885,7 @@ msgstr "源代码"
 msgid "Registration"
 msgstr "注册"
 
-#: common/templates/common/about.html:35 common/views_manage.py:489
+#: common/templates/common/about.html:35 common/views_manage.py:490
 msgid "Invite Only"
 msgstr "仅限邀请"
 
@@ -3893,7 +3893,7 @@ msgstr "仅限邀请"
 msgid "Open Registration"
 msgstr "开放注册"
 
-#: common/templates/common/about.html:40 common/views_manage.py:523
+#: common/templates/common/about.html:40 common/views_manage.py:532
 msgid "Preferred Languages"
 msgstr "主要语言"
 
@@ -3949,7 +3949,7 @@ msgstr "正在请求摄像头权限…"
 msgid "Or type barcode / ISBN manually"
 msgstr "或手动输入条形码 / ISBN"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:592
+#: common/templates/common/scan.html:60 common/views_manage.py:602
 msgid "Search"
 msgstr "搜索"
 
@@ -4031,695 +4031,703 @@ msgstr "访问被拒绝"
 msgid "Login required"
 msgstr "登录后访问"
 
-#: common/views_manage.py:142 common/views_manage.py:293
+#: common/views_manage.py:143 common/views_manage.py:294
 msgid "Branding"
 msgstr "品牌"
 
-#: common/views_manage.py:144
+#: common/views_manage.py:145
 msgid "Recommendations"
 msgstr "推荐"
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Access"
 msgstr "访问"
 
-#: common/views_manage.py:146 common/views_manage.py:587
+#: common/views_manage.py:147 common/views_manage.py:597
 msgid "Federation"
 msgstr "联邦"
 
-#: common/views_manage.py:147
+#: common/views_manage.py:148
 msgid "Catalog"
 msgstr "目录"
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "API Keys"
 msgstr "API 密钥"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "Downloader"
 msgstr "下载器"
 
-#: common/views_manage.py:150 common/views_manage.py:301
+#: common/views_manage.py:151 common/views_manage.py:302
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr "高级"
 
-#: common/views_manage.py:200
+#: common/views_manage.py:201
 msgid "Invalid value."
 msgstr "无效值。"
 
-#: common/views_manage.py:204
+#: common/views_manage.py:205
 msgid "Invalid configuration. Please check your input."
 msgstr "配置无效"
 
-#: common/views_manage.py:209
+#: common/views_manage.py:210
 msgid "Settings have been saved."
 msgstr "设置已保存"
 
-#: common/views_manage.py:229
+#: common/views_manage.py:230
 msgid "Site Name"
 msgstr "站点名称"
 
-#: common/views_manage.py:232
+#: common/views_manage.py:233
 msgid "Site Description"
 msgstr "站点描述"
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Short description shown in metadata and about page."
 msgstr "在元数据和关于页面中显示的简短描述。"
 
-#: common/views_manage.py:236
+#: common/views_manage.py:237
 msgid "Site Logo URL"
 msgstr "站点 Logo URL"
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "URL path to the site logo image."
 msgstr "站点 Logo 图片的 URL 路径。"
 
-#: common/views_manage.py:240
+#: common/views_manage.py:241
 msgid "Site Icon URL"
 msgstr "站点图标 URL"
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "URL path to the site icon/favicon."
 msgstr "站点图标/favicon 的 URL 路径。"
 
-#: common/views_manage.py:244
+#: common/views_manage.py:245
 msgid "Default User Avatar URL"
 msgstr "默认用户头像 URL"
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "URL path to the default user avatar."
 msgstr "默认用户头像的 URL 路径。"
 
-#: common/views_manage.py:248
+#: common/views_manage.py:249
 msgid "Site Color Theme"
 msgstr "站点配色主题"
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "PicoCSS color theme."
 msgstr "PicoCSS 配色主题。"
 
-#: common/views_manage.py:274
+#: common/views_manage.py:275
 msgid "Site Introduction"
 msgstr "站点介绍"
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "URL path for the intro/welcome sidebar page."
 msgstr "介绍/欢迎侧边栏页面的 URL 路径。"
 
-#: common/views_manage.py:278
+#: common/views_manage.py:279
 msgid "Custom HTML Head"
 msgstr "自定义 HTML Head"
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr "注入所有页面 <head> 的额外 HTML。"
 
-#: common/views_manage.py:283
+#: common/views_manage.py:284
 msgid "Footer Links"
 msgstr "页脚链接"
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Link title mapped to URL."
 msgstr "链接标题到 URL 的映射。"
 
-#: common/views_manage.py:313
+#: common/views_manage.py:314
 msgid "Minimum Marks for Discover"
 msgstr "进入发现页的最少标记数"
 
-#: common/views_manage.py:315
+#: common/views_manage.py:316
 msgid "Number of marks required for an item to appear in discover."
 msgstr "条目出现在发现页所需的最少标记数。"
 
-#: common/views_manage.py:320
+#: common/views_manage.py:321
 msgid "Update Interval (minutes)"
 msgstr "更新间隔（分钟）"
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "How often to refresh the popular items list."
 msgstr "刷新热门条目列表的频率。"
 
-#: common/views_manage.py:325
+#: common/views_manage.py:326
 msgid "Filter by Preferred Languages"
 msgstr "按偏好语言过滤"
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Only show items with titles in the preferred languages."
 msgstr "仅显示标题为偏好语言的条目。"
 
-#: common/views_manage.py:329
+#: common/views_manage.py:330
 msgid "Show Local Only"
 msgstr "仅显示本站内容"
 
-#: common/views_manage.py:331
+#: common/views_manage.py:332
 msgid "Only show items marked by local users, not the entire network."
 msgstr "仅显示本站用户标记的条目，而非整个联邦网络。"
 
-#: common/views_manage.py:335
+#: common/views_manage.py:336
 msgid "Show Popular Posts"
 msgstr "显示热门帖文"
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show popular public posts instead of recent ones."
 msgstr "显示热门公开帖文，而非最近的帖文。"
 
-#: common/views_manage.py:339
+#: common/views_manage.py:340
 msgid "Show Popular Tags"
 msgstr "显示热门标签"
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show popular public tags on the discover page."
 msgstr "在发现页显示热门公开标签。"
 
-#: common/views_manage.py:343
+#: common/views_manage.py:344
 msgid "Show Verified Podcasts"
 msgstr "显示已验证播客"
 
-#: common/views_manage.py:345
+#: common/views_manage.py:346
 msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr "在发现页显示一个货架，展示拥有已验证创作者的播客的最新单集。"
 
-#: common/views_manage.py:384
+#: common/views_manage.py:385
 msgid "Enable Recommendations"
 msgstr "启用推荐"
 
-#: common/views_manage.py:386
+#: common/views_manage.py:387
 msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr "推荐功能总开关。关闭时，所有推荐界面都会被隐藏，相关定时任务也不会被调度。"
 
-#: common/views_manage.py:391
+#: common/views_manage.py:392
 msgid "Source Item Mark Threshold"
 msgstr "源条目标记阈值"
 
-#: common/views_manage.py:393
+#: common/views_manage.py:394
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr "为某条目构建相似条目所需的最少公开标记数。"
 
-#: common/views_manage.py:399
+#: common/views_manage.py:400
 msgid "Target Item Mark Threshold"
 msgstr "目标条目标记阈值"
 
-#: common/views_manage.py:401
+#: common/views_manage.py:402
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr "条目作为推荐目标所需的最少公开标记数。"
 
-#: common/views_manage.py:407
+#: common/views_manage.py:408
 msgid "Top-K Similar Items per Source"
 msgstr "每个源条目的最相似条目数 (Top-K)"
 
-#: common/views_manage.py:408
+#: common/views_manage.py:409
 msgid "Number of similar items stored per source item."
 msgstr "每个源条目保存的相似条目数量。"
 
-#: common/views_manage.py:412
+#: common/views_manage.py:413
 msgid "Top-N Recommendations per User"
 msgstr "每位用户的推荐条目数 (Top-N)"
 
-#: common/views_manage.py:413
+#: common/views_manage.py:414
 msgid "Number of personalised rows stored per user."
 msgstr "每位用户保存的个性化推荐数量。"
 
-#: common/views_manage.py:417
+#: common/views_manage.py:418
 msgid "Dampen Heavy Shelvers"
 msgstr "抑制高频标记用户"
 
-#: common/views_manage.py:419
+#: common/views_manage.py:420
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr "对每位用户的贡献按 1/sqrt(n_marks) 加权，以削弱超大量标记用户对相似度评分的影响。"
 
-#: common/views_manage.py:424
+#: common/views_manage.py:425
 msgid "Per-User Mark Cap (training)"
 msgstr "每用户标记上限（训练）"
 
-#: common/views_manage.py:426
+#: common/views_manage.py:427
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr "构建相似度矩阵时，仅截取每位用户最近的 N 条标记。"
 
-#: common/views_manage.py:432
+#: common/views_manage.py:433
 msgid "Active-User Window (days)"
 msgstr "活跃用户窗口（天）"
 
-#: common/views_manage.py:434
+#: common/views_manage.py:435
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr "为最近 N 天内至少有一条公开标记的用户刷新个性化推荐。"
 
-#: common/views_manage.py:440
+#: common/views_manage.py:441
 msgid "Per-User Seed Cap (serving)"
 msgstr "每用户种子标记上限（投递）"
 
-#: common/views_manage.py:442
+#: common/views_manage.py:443
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr "为单个用户计算个性化推荐时，用作种子的最近标记数量。"
 
-#: common/views_manage.py:448
+#: common/views_manage.py:449
 msgid "Lazy Refresh TTL (days)"
 msgstr "懒刷新 TTL（天）"
 
-#: common/views_manage.py:450
+#: common/views_manage.py:451
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr "按需推荐缓存的有效期，过期后下一次请求会触发刷新。"
 
-#: common/views_manage.py:456
+#: common/views_manage.py:457
 msgid "Circles Window (days)"
 msgstr "好友圈窗口（天）"
 
-#: common/views_manage.py:458
+#: common/views_manage.py:459
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr "回溯 N 天，查找浏览者关注的用户最近标记过的条目。"
 
-#: common/views_manage.py:465
+#: common/views_manage.py:466
 msgid "Master Switch"
 msgstr "总开关"
 
-#: common/views_manage.py:468
+#: common/views_manage.py:469
 msgid "Similarity Builder"
 msgstr "相似度构建器"
 
-#: common/views_manage.py:475
+#: common/views_manage.py:476
 msgid "Personalisation"
 msgstr "个性化"
 
-#: common/views_manage.py:491
+#: common/views_manage.py:492
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr "注册需要邀请令牌。可使用 neodb-manage invite --create 生成邀请令牌。"
 
-#: common/views_manage.py:496
+#: common/views_manage.py:497
 msgid "Enable Local-Only Posting"
 msgstr "启用仅本站可见帖文"
 
-#: common/views_manage.py:497
+#: common/views_manage.py:498
 msgid "Allow users to create posts visible only to local users."
 msgstr "允许用户创建仅本站用户可见的帖文。"
 
-#: common/views_manage.py:500
+#: common/views_manage.py:501
 msgid "Mastodon Login Whitelist"
 msgstr "Mastodon 登录白名单"
 
-#: common/views_manage.py:501
+#: common/views_manage.py:502
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr "每行一个域名。留空则允许任意实例。"
 
-#: common/views_manage.py:504
+#: common/views_manage.py:505
 msgid "Enable Mastodon Login"
 msgstr "启用 Mastodon 登录"
 
-#: common/views_manage.py:507
+#: common/views_manage.py:508
 msgid "Enable Bluesky Login"
 msgstr "启用 Bluesky 登录"
 
-#: common/views_manage.py:510
+#: common/views_manage.py:511
 msgid "Enable Threads Login"
 msgstr "启用 Threads 登录"
 
-#: common/views_manage.py:513
+#: common/views_manage.py:514
 msgid "Email URL"
 msgstr "邮件服务 URL"
 
-#: common/views_manage.py:515
+#: common/views_manage.py:516
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr "用于发送登录验证码的邮件后端 URL，例如 SMTP 或 Anymail URL。"
 
-#: common/views_manage.py:519
+#: common/views_manage.py:520
 msgid "Email From"
 msgstr "邮件发件人"
 
-#: common/views_manage.py:520
+#: common/views_manage.py:521
 msgid "Sender name and address for outgoing email."
 msgstr "外发邮件所使用的发件人名称和地址。"
 
-#: common/views_manage.py:525
+#: common/views_manage.py:524
+msgid "Default Language"
+msgstr "默认语言"
+
+#: common/views_manage.py:527
+msgid "Interface language for visitors and for users who have not chosen one themselves."
+msgstr "访客以及未自行选择语言的用户所使用的界面语言。"
+
+#: common/views_manage.py:534
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr "语言代码，每行一个（如 en、zh、ja）。第一个为默认语言。"
 
-#: common/views_manage.py:531
+#: common/views_manage.py:540
 msgid "Access Control"
 msgstr "访问控制"
 
-#: common/views_manage.py:536
+#: common/views_manage.py:545
 msgid "Login Methods"
 msgstr "登录方式"
 
-#: common/views_manage.py:541 mastodon/models/common.py:28
+#: common/views_manage.py:550 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "电子邮件"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:554
 msgid "Localization"
 msgstr "本地化"
 
-#: common/views_manage.py:555
+#: common/views_manage.py:565
 msgid "Disable Default Relay"
 msgstr "禁用默认中继"
 
-#: common/views_manage.py:557
+#: common/views_manage.py:567
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr "禁用 relay.neodb.net 联邦中继（用于跨实例共享公开评分）。"
 
-#: common/views_manage.py:562
+#: common/views_manage.py:572
 msgid "Fanout Limit (days)"
 msgstr "扩散范围（天）"
 
-#: common/views_manage.py:563
+#: common/views_manage.py:573
 msgid "Posts older than this many days will not be fanned out."
 msgstr "超过此天数的帖文将不再扩散投递。"
 
-#: common/views_manage.py:567
+#: common/views_manage.py:577
 msgid "Remote Prune Horizon (days)"
 msgstr "远端清理期限（天）"
 
-#: common/views_manage.py:569
+#: common/views_manage.py:579
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr "不活跃超过此天数的远端用户资料将被清理。"
 
-#: common/views_manage.py:574
+#: common/views_manage.py:584
 msgid "Search Sites"
 msgstr "搜索站点"
 
-#: common/views_manage.py:575
+#: common/views_manage.py:585
 msgid "External search sites to include, one per line."
 msgstr "要包含的外部搜索站点，每行一个。"
 
-#: common/views_manage.py:578
+#: common/views_manage.py:588
 msgid "Federated Search Peers"
 msgstr "联邦搜索节点"
 
-#: common/views_manage.py:579
+#: common/views_manage.py:589
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr "用于联邦搜索的 NeoDB 节点实例，每行一个。"
 
-#: common/views_manage.py:582
+#: common/views_manage.py:592
 msgid "Hidden Categories"
 msgstr "隐藏的分类"
 
-#: common/views_manage.py:583
+#: common/views_manage.py:593
 msgid "Category values to hide from the catalog, one per line."
 msgstr "在目录中隐藏的分类值，每行一个。"
 
-#: common/views_manage.py:604
+#: common/views_manage.py:614
 msgid "Spotify API Key"
 msgstr "Spotify API 密钥"
 
-#: common/views_manage.py:605
+#: common/views_manage.py:615
 msgid "https://developer.spotify.com/"
 msgstr "https://developer.spotify.com/"
 
-#: common/views_manage.py:608
+#: common/views_manage.py:618
 msgid "TMDB API Key"
 msgstr "TMDB API 密钥"
 
-#: common/views_manage.py:609
+#: common/views_manage.py:619
 msgid "https://developer.themoviedb.org/"
 msgstr "https://developer.themoviedb.org/"
 
-#: common/views_manage.py:612
+#: common/views_manage.py:622
 msgid "Google Books API Key"
 msgstr "Google Books API 密钥"
 
-#: common/views_manage.py:613
+#: common/views_manage.py:623
 msgid "https://developers.google.com/books/"
 msgstr "https://developers.google.com/books/"
 
-#: common/views_manage.py:616
+#: common/views_manage.py:626
 msgid "Discogs API Key"
 msgstr "Discogs API 密钥"
 
-#: common/views_manage.py:618
+#: common/views_manage.py:628
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr "来自 https://www.discogs.com/settings/developers 的个人访问令牌"
 
-#: common/views_manage.py:622
+#: common/views_manage.py:632
 msgid "IGDB Client ID"
 msgstr "IGDB 客户端 ID"
 
-#: common/views_manage.py:623
+#: common/views_manage.py:633
 msgid "https://api-docs.igdb.com/"
 msgstr "https://api-docs.igdb.com/"
 
-#: common/views_manage.py:626
+#: common/views_manage.py:636
 msgid "IGDB Client Secret"
 msgstr "IGDB 客户端密钥"
 
-#: common/views_manage.py:629
+#: common/views_manage.py:639
 msgid "BoardGameGeek API Token"
 msgstr "BoardGameGeek API 令牌"
 
-#: common/views_manage.py:631
+#: common/views_manage.py:641
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr "来自 https://boardgamegeek.com/applications 的 Bearer 令牌（参见 https://boardgamegeek.com/using_the_xml_api#toc9）。"
 
-#: common/views_manage.py:636 users/templates/users/steam_import.html:26
+#: common/views_manage.py:646 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr "Steam API 密钥"
 
-#: common/views_manage.py:638
+#: common/views_manage.py:648
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr "https://steamcommunity.com/dev - Steam 导入器的备用密钥。用户可在导入时提供自己的密钥。"
 
-#: common/views_manage.py:643
+#: common/views_manage.py:653
 msgid "DeepL API Key"
 msgstr "DeepL API 密钥"
 
-#: common/views_manage.py:644
+#: common/views_manage.py:654
 msgid "For translation features."
 msgstr "用于翻译功能。"
 
-#: common/views_manage.py:647
+#: common/views_manage.py:657
 msgid "LibreTranslate API URL"
 msgstr "LibreTranslate API URL"
 
-#: common/views_manage.py:650
+#: common/views_manage.py:660
 msgid "LibreTranslate API Key"
 msgstr "LibreTranslate API 密钥"
 
-#: common/views_manage.py:653
+#: common/views_manage.py:663
 msgid "Threads App ID"
 msgstr "Threads 应用 ID"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:664
 msgid "OAuth app ID for Threads login."
 msgstr "用于 Threads 登录的 OAuth 应用 ID。"
 
-#: common/views_manage.py:657
+#: common/views_manage.py:667
 msgid "Threads App Secret"
 msgstr "Threads 应用密钥"
 
-#: common/views_manage.py:660
+#: common/views_manage.py:670
 msgid "Discord Webhooks"
 msgstr "Discord Webhook"
 
-#: common/views_manage.py:662
+#: common/views_manage.py:672
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr "按频道（default、report、audit、suggest、system）映射的 Webhook URL。所有频道必须是 Discord 论坛或媒体频道（线程模式），因为通知以线程形式发布。"
 
-#: common/views_manage.py:679
+#: common/views_manage.py:689
 msgid "Catalog APIs"
 msgstr "目录 API"
 
-#: common/views_manage.py:689
+#: common/views_manage.py:699
 msgid "Translation"
 msgstr "翻译"
 
-#: common/views_manage.py:694
+#: common/views_manage.py:704
 msgid "Third-Party Login"
 msgstr "第三方登录"
 
-#: common/views_manage.py:698 social/templates/feed.html:27
+#: common/views_manage.py:708 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "通知"
 
-#: common/views_manage.py:708
+#: common/views_manage.py:718
 msgid "Scraping Providers"
 msgstr "抓取服务"
 
-#: common/views_manage.py:709
+#: common/views_manage.py:719
 msgid "Comma-separated list of providers to try in order."
 msgstr "按顺序尝试的服务列表，以逗号分隔。"
 
-#: common/views_manage.py:712
+#: common/views_manage.py:722
 msgid "Proxy List"
 msgstr "代理列表"
 
-#: common/views_manage.py:713
+#: common/views_manage.py:723
 msgid "One per line, format: http://server?url=__URL__"
 msgstr "每行一个，格式：http://server?url=__URL__"
 
-#: common/views_manage.py:716
+#: common/views_manage.py:726
 msgid "Backup Proxy"
 msgstr "备用代理"
 
-#: common/views_manage.py:719
+#: common/views_manage.py:729
 msgid "Scrapfly API Key"
 msgstr "Scrapfly API 密钥"
 
-#: common/views_manage.py:722
+#: common/views_manage.py:732
 msgid "Decodo Base64 Auth Token"
 msgstr "Decodo Base64 鉴权令牌"
 
-#: common/views_manage.py:725
+#: common/views_manage.py:735
 msgid "ScraperAPI Key"
 msgstr "ScraperAPI 密钥"
 
-#: common/views_manage.py:728
+#: common/views_manage.py:738
 msgid "ScrapingBee API Key"
 msgstr "ScrapingBee API 密钥"
 
-#: common/views_manage.py:731
+#: common/views_manage.py:741
 msgid "Custom Scraper URL"
 msgstr "自定义抓取器 URL"
 
-#: common/views_manage.py:732
+#: common/views_manage.py:742
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr "包含 __URL__ 和 __SELECTOR__ 占位符的 URL。"
 
-#: common/views_manage.py:735
+#: common/views_manage.py:745
 msgid "Request Timeout (seconds)"
 msgstr "请求超时（秒）"
 
-#: common/views_manage.py:739
+#: common/views_manage.py:749
 msgid "Cache Timeout (seconds)"
 msgstr "缓存超时（秒）"
 
-#: common/views_manage.py:743
+#: common/views_manage.py:753
 msgid "Retries"
 msgstr "重试次数"
 
-#: common/views_manage.py:748
+#: common/views_manage.py:758
 msgid "Providers"
 msgstr "服务"
 
-#: common/views_manage.py:753
+#: common/views_manage.py:763
 msgid "Provider Keys"
 msgstr "服务密钥"
 
-#: common/views_manage.py:760
+#: common/views_manage.py:770
 msgid "Timeouts"
 msgstr "超时设置"
 
-#: common/views_manage.py:772
+#: common/views_manage.py:782
 msgid "Alternative Domains"
 msgstr "备用域名"
 
-#: common/views_manage.py:773
+#: common/views_manage.py:783
 msgid "One domain per line."
 msgstr "每行一个域名。"
 
-#: common/views_manage.py:776
+#: common/views_manage.py:786
 msgid "Mastodon Client Scope"
 msgstr "Mastodon 客户端授权范围"
 
-#: common/views_manage.py:777
+#: common/views_manage.py:787
 msgid "OAuth scope when creating Mastodon apps."
 msgstr "创建 Mastodon 应用时使用的 OAuth 授权范围。"
 
-#: common/views_manage.py:780
+#: common/views_manage.py:790
 msgid "Mastodon API Timeout (seconds)"
 msgstr "Mastodon API 超时（秒）"
 
-#: common/views_manage.py:782
+#: common/views_manage.py:792
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr "请求 Mastodon 实例及远程联邦宇宙服务器的超时时间。"
 
-#: common/views_manage.py:788
+#: common/views_manage.py:798
 msgid "Disable Cron Jobs"
 msgstr "禁用定时任务"
 
-#: common/views_manage.py:789
+#: common/views_manage.py:799
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr "要禁用的任务名，每行一个。使用 * 禁用所有任务。"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:802
 msgid "Index Aliases"
 msgstr "索引别名"
 
-#: common/views_manage.py:793
+#: common/views_manage.py:803
 msgid "Map index names to their aliases."
 msgstr "索引名称到别名的映射。"
 
-#: common/views_manage.py:803
+#: common/views_manage.py:813
 msgid "Task Cleanup (days)"
 msgstr "任务清理（天）"
 
-#: common/views_manage.py:805
+#: common/views_manage.py:815
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr "在此天数后删除导入/导出任务及其文件。设为 0 则禁用清理。"
 
-#: common/views_manage.py:811
+#: common/views_manage.py:821
 msgid "Skip Migration Jobs"
 msgstr "跳过迁移任务"
 
-#: common/views_manage.py:813
+#: common/views_manage.py:823
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr "要跳过的迁移后任务键，每行一个（如 normalize_genre）。worker 在出队时检查；被跳过的任务会记录警告并通知 Discord system 频道。"
 
-#: common/views_manage.py:819
+#: common/views_manage.py:829
 msgid "ATProto OAuth Client Key"
 msgstr "ATProto OAuth 客户端密钥"
 
-#: common/views_manage.py:821
+#: common/views_manage.py:831
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr "用于向 ATProto 授权服务器标识本站点的私钥（JWK 格式）。首次 Bluesky 登录时自动生成；清空后将重新生成。"
 
-#: common/views_manage.py:828
+#: common/views_manage.py:838
 msgid "Domains"
 msgstr "域名"
 
-#: common/views_manage.py:831
+#: common/views_manage.py:841
 msgid "Operational"
 msgstr "运维"
 
-#: common/views_manage.py:847
+#: common/views_manage.py:857
 msgid "Movie Genres"
 msgstr "电影类型"
 
-#: common/views_manage.py:849
+#: common/views_manage.py:859
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "电影编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:854
+#: common/views_manage.py:864
 msgid "TV Genres"
 msgstr "剧集类型"
 
-#: common/views_manage.py:856
+#: common/views_manage.py:866
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "剧集编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:861
+#: common/views_manage.py:871
 msgid "Music Genres"
 msgstr "音乐类型"
 
-#: common/views_manage.py:863
+#: common/views_manage.py:873
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "音乐编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:868
+#: common/views_manage.py:878
 msgid "Game Genres"
 msgstr "游戏类型"
 
-#: common/views_manage.py:870
+#: common/views_manage.py:880
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "游戏编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:875
+#: common/views_manage.py:885
 msgid "Podcast Genres"
 msgstr "播客类型"
 
-#: common/views_manage.py:877
+#: common/views_manage.py:887
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "播客编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:882
+#: common/views_manage.py:892
 msgid "Performance Genres"
 msgstr "演出类型"
 
-#: common/views_manage.py:884
+#: common/views_manage.py:894
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:890
+#: common/views_manage.py:900
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
@@ -4839,7 +4847,7 @@ msgstr "匹配文件丢失，无法导入。"
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/models/article.py:210 journal/views/article.py:207
+#: journal/models/article.py:212 journal/views/article.py:207
 msgid "(may contain sensitive content)"
 msgstr "（可能包含剧透或敏感内容）"
 
@@ -4957,23 +4965,23 @@ msgstr "自己和提到的人"
 msgid "A recent post was not posted to Bluesky, please login NeoDB using ATProto again to re-authorize."
 msgstr "帖文未能发布到Bluesky，请重新使用ATProto验证登录。"
 
-#: journal/models/common.py:919
+#: journal/models/common.py:927
 msgid "A recent post was not posted to Threads."
 msgstr "帖文未能发布到Threads。"
 
-#: journal/models/common.py:952
+#: journal/models/common.py:960
 msgid "A recent post was not boosted on Mastodon."
 msgstr "帖文未能在联邦实例转播。"
 
-#: journal/models/common.py:962
+#: journal/models/common.py:970
 msgid "Original post no longer exists."
 msgstr "原帖文已不存在。"
 
-#: journal/models/common.py:976
+#: journal/models/common.py:984
 msgid "A recent post was not posted to Mastodon, please re-authorize."
 msgstr "帖文未能发布到联邦实例，请重新验证登录。"
 
-#: journal/models/common.py:985
+#: journal/models/common.py:993
 msgid "A recent post was not posted to Mastodon."
 msgstr "帖文未能发布到联邦实例。"
 

--- a/neodb/tests/core/test_lang_coverage.py
+++ b/neodb/tests/core/test_lang_coverage.py
@@ -1,9 +1,13 @@
+from typing import Any
+
 import pytest
 from django.conf import settings
 from django.utils import translation
 
 import catalog.models.common as catalog_common
+import catalog.sites.tmdb as tmdb
 import common.models.lang as lang
+from catalog.common.downloaders import BasicDownloader
 from common.models.lang import get_current_locales, localize_number
 
 
@@ -88,6 +92,44 @@ class TestPreferredLanguagesIsolation:
             assert list(settings.PREFERRED_LANGUAGES) == original_setting
         finally:
             lang.SITE_PREFERRED_LANGUAGES[:] = original_cache
+
+
+class TestLanguageConsumersFollowSettings:
+    """settings.LANGUAGE_CODE is runtime-configurable, so values derived from it
+    must not stay pinned to whatever was in the environment at startup."""
+
+    def test_tmdb_keeps_no_import_time_language_cache(self) -> None:
+        """These were module constants, so TMDB requests kept the startup
+        language for the life of the process. Keep them per-call."""
+        assert not hasattr(tmdb, "TMDB_DEFAULT_LANG")
+        assert not hasattr(tmdb, "TMDB_PREFERRED_LANGS")
+
+    def test_tmdb_language_is_resolved_per_call(self, settings: Any) -> None:
+        settings.LANGUAGE_CODE = "zh-hant"
+
+        assert tmdb._get_language_code() == "zh-TW"
+
+    def test_tmdb_preferred_languages_are_resolved_per_call(self) -> None:
+        original = list(lang.SITE_PREFERRED_LANGUAGES)
+        try:
+            lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+
+            assert list(tmdb._get_preferred_languages()) == ["ja", "en"]
+        finally:
+            lang.SITE_PREFERRED_LANGUAGES[:] = original
+
+    def test_downloader_accept_language_follows_a_refresh(self, settings: Any) -> None:
+        original = BasicDownloader.headers["Accept-Language"]
+        try:
+            settings.LANGUAGE_CODE = "zh-hans"
+
+            lang.refresh_language_caches()
+
+            assert BasicDownloader.headers["Accept-Language"].startswith("zh-CN")
+            # callers that spread the class attribute see it too
+            assert {**BasicDownloader.headers}["Accept-Language"].startswith("zh-CN")
+        finally:
+            BasicDownloader.headers["Accept-Language"] = original
 
 
 class TestLanguageCacheRefresh:

--- a/neodb/tests/core/test_lang_coverage.py
+++ b/neodb/tests/core/test_lang_coverage.py
@@ -1,5 +1,9 @@
+import pytest
+from django.conf import settings
 from django.utils import translation
 
+import catalog.models.common as catalog_common
+import common.models.lang as lang
 from common.models.lang import get_current_locales, localize_number
 
 
@@ -66,3 +70,82 @@ class TestGetCurrentLocales:
             locales = get_current_locales()
             assert locales[0] == "fr"
             assert "en" in locales
+
+
+class TestPreferredLanguagesIsolation:
+    def test_runtime_cache_does_not_alias_the_setting(self):
+        """SiteConfig rewrites SITE_PREFERRED_LANGUAGES in place and reads
+        settings.PREFERRED_LANGUAGES back as the env fallback, so the two must
+        not be the same list."""
+        assert lang.SITE_PREFERRED_LANGUAGES is not settings.PREFERRED_LANGUAGES
+
+    def test_rewriting_the_cache_leaves_the_setting_alone(self):
+        original_setting = list(settings.PREFERRED_LANGUAGES)
+        original_cache = list(lang.SITE_PREFERRED_LANGUAGES)
+        try:
+            lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+
+            assert list(settings.PREFERRED_LANGUAGES) == original_setting
+        finally:
+            lang.SITE_PREFERRED_LANGUAGES[:] = original_cache
+
+
+class TestLanguageCacheRefresh:
+    """The choice caches are ordered by SITE_PREFERRED_LANGUAGES, which is only
+    known from env at import time. A later SiteConfig change must reach them."""
+
+    @pytest.fixture(autouse=True)
+    def restore_caches(self):
+        original = list(lang.SITE_PREFERRED_LANGUAGES)
+        yield
+        lang.SITE_PREFERRED_LANGUAGES[:] = original
+        lang.refresh_language_caches()
+
+    def test_preferred_languages_lead_the_choices(self):
+        lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+
+        lang.refresh_language_caches()
+
+        assert lang.LANGUAGE_CHOICES[0][0] == "ja"
+        assert lang.LOCALE_CHOICES[0][0] == "ja"
+        assert lang.SCRIPT_CHOICES[0][0] == "ja"
+        assert next(iter(lang.LANGUAGE_CODES)) == "ja"
+        # every language stays offered, only the order changes
+        assert len(lang.LANGUAGE_CODES) == len(dict(lang.LANGUAGE_CHOICES))
+        assert "en" in lang.LANGUAGE_CODES
+
+    def test_refresh_keeps_object_identity_for_importers(self):
+        """Importers bind these by name, so a rebind would never reach them."""
+        locale_choices = lang.LOCALE_CHOICES
+        language_codes = lang.LANGUAGE_CODES
+        jsonform = catalog_common.LOCALE_CHOICES_JSONFORM
+
+        lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+        lang.refresh_language_caches()
+
+        assert locale_choices is lang.LOCALE_CHOICES
+        assert language_codes is lang.LANGUAGE_CODES
+        assert jsonform is catalog_common.LOCALE_CHOICES_JSONFORM
+        assert jsonform[0]["value"] == "ja"
+
+    def test_field_schema_built_before_refresh_follows_it(self):
+        """Model fields capture the schema at class definition time."""
+        field = catalog_common.LanguageListField()
+        one_of = field.schema["items"]["oneOf"]
+
+        lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+        lang.refresh_language_caches()
+
+        assert one_of is field.schema["items"]["oneOf"]
+        assert one_of[0]["const"] == "ja"
+        assert one_of[-1] == {"title": "Other", "type": "string"}
+
+    def test_script_field_schema_follows_refresh(self):
+        field = catalog_common.LanguageListField(script=True)
+        one_of = field.schema["items"]["oneOf"]
+
+        lang.SITE_PREFERRED_LANGUAGES[:] = ["ja", "en"]
+        lang.refresh_language_caches()
+
+        assert one_of[0]["const"] == "ja"
+        assert one_of[-1] == {"title": "Other", "type": "string"}

--- a/neodb/tests/core/test_views_manage.py
+++ b/neodb/tests/core/test_views_manage.py
@@ -2,12 +2,16 @@ from typing import Any
 
 import pydantic
 import pytest
+from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import translation
+from django.utils.translation import trans_real
 
 from boofilsic import settings as boofilsic_settings
 from common.config import resolve_email_settings
 from common.models import SiteConfig
+from users.middlewares import activate_language_for_user
 from common.views_manage import (
     AccessSettings,
     AdvancedSettings,
@@ -341,3 +345,117 @@ class TestMastodonTimeoutApply:
             settings.TAKAHE_REMOTE_TIMEOUT = old_takahe
             if old_system is not None:
                 SiteConfig.system = old_system
+
+
+class TestLanguageCodeOptions:
+    def test_default_is_english(self) -> None:
+        assert SiteConfig.SystemOptions().language_code == "en"
+
+    def test_environment_value_is_the_fallback(self, settings: Any) -> None:
+        settings.LANGUAGE_CODE_ENV = "zh-hant"
+
+        assert SiteConfig._env_defaults()["language_code"] == "zh-hant"
+
+    def test_environment_subtag_is_not_flattened_by_preferred_languages(
+        self, settings: Any
+    ) -> None:
+        """preferred_languages collapses zh-hant to zh; language_code must not."""
+        settings.LANGUAGE_CODE_ENV = "zh-hant"
+        settings.PREFERRED_LANGUAGES = ["zh", "en"]
+
+        defaults = SiteConfig._env_defaults()
+
+        assert defaults["language_code"] == "zh-hant"
+        assert defaults["preferred_languages"] == ["zh", "en"]
+
+    def test_missing_environment_value_falls_back_to_english(
+        self, settings: Any
+    ) -> None:
+        settings.LANGUAGE_CODE_ENV = None
+
+        assert SiteConfig._env_defaults()["language_code"] == "en"
+
+    def test_unsupported_code_is_rejected(self) -> None:
+        with pytest.raises(pydantic.ValidationError, match="not a supported"):
+            SiteConfig.SystemOptions(language_code="tlh")
+
+    def test_supported_code_is_accepted(self) -> None:
+        assert SiteConfig.SystemOptions(language_code="zh-hant").language_code
+
+    def test_offered_choices_are_supported_ui_languages(self) -> None:
+        choices = AccessSettings.options["language_code"]["choices"]
+
+        assert [code for code, _label in choices] == list(
+            settings.SUPPORTED_UI_LANGUAGES
+        )
+
+    def test_renders_as_a_select(self) -> None:
+        form = AccessSettings().get_form_class()()
+
+        widget = form.fields["language_code"].widget
+
+        assert isinstance(widget, forms.Select)
+        assert "zh-hans" in [code for code, _label in widget.choices]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestLanguageCodeApply:
+    """DB-stored language_code must reach settings.LANGUAGE_CODE on reload."""
+
+    def test_db_value_overrides_environment_fallback(self, settings: Any) -> None:
+        settings.LANGUAGE_CODE_ENV = "en"
+        old_language = settings.LANGUAGE_CODE
+        old_system = getattr(SiteConfig, "system", None)
+        try:
+            SiteConfig.set_system(language_code="zh-hans")
+
+            SiteConfig.reload()
+
+            assert SiteConfig.system.language_code == "zh-hans"
+            assert settings.LANGUAGE_CODE == "zh-hans"
+            # the cached default translation must not survive the change
+            assert trans_real._default is None  # ty: ignore[unresolved-attribute]
+        finally:
+            SiteConfig.objects.filter(pk=1).delete()
+            settings.LANGUAGE_CODE = old_language
+            trans_real._default = None  # ty: ignore[unresolved-attribute]
+            if old_system is not None:
+                SiteConfig.system = old_system
+                SiteConfig._apply_to_settings(old_system)
+
+    def test_applies_to_visitors_without_a_preference(self, settings: Any) -> None:
+        settings.LANGUAGE_CODE_ENV = "en"
+        old_language = settings.LANGUAGE_CODE
+        old_system = getattr(SiteConfig, "system", None)
+        try:
+            SiteConfig.set_system(language_code="zh-hans")
+            SiteConfig.reload()
+
+            activate_language_for_user(None)
+
+            assert translation.get_language() == "zh-hans"
+        finally:
+            translation.deactivate()
+            SiteConfig.objects.filter(pk=1).delete()
+            settings.LANGUAGE_CODE = old_language
+            trans_real._default = None  # ty: ignore[unresolved-attribute]
+            if old_system is not None:
+                SiteConfig.system = old_system
+                SiteConfig._apply_to_settings(old_system)
+
+    def test_unchanged_value_leaves_cached_translation_alone(
+        self, settings: Any
+    ) -> None:
+        """The 30s config refresh must not clear the translation cache."""
+        settings.LANGUAGE_CODE_ENV = settings.LANGUAGE_CODE
+        translation.activate(settings.LANGUAGE_CODE)
+        trans_real._default = trans_real.translation(  # ty: ignore[unresolved-attribute]
+            settings.LANGUAGE_CODE
+        )
+        try:
+            SiteConfig._apply_to_settings(SiteConfig.load_system())
+
+            assert trans_real._default is not None  # ty: ignore[unresolved-attribute]
+        finally:
+            translation.deactivate()
+            trans_real._default = None  # ty: ignore[unresolved-attribute]

--- a/neodb/tests/core/test_views_manage.py
+++ b/neodb/tests/core/test_views_manage.py
@@ -413,8 +413,11 @@ class TestLanguageCodeApply:
 
             assert SiteConfig.system.language_code == "zh-hans"
             assert settings.LANGUAGE_CODE == "zh-hans"
-            # the cached default translation must not survive the change
-            assert trans_real._default is None  # ty: ignore[unresolved-attribute]
+            # No catalog for the old language may survive. It is dropped on
+            # change, and anything that forces a lazy string afterwards (the
+            # cache refresh does) rebuilds it for the new language.
+            cached = trans_real._default  # ty: ignore[unresolved-attribute]
+            assert cached is None or cached.language() == "zh-hans"
         finally:
             SiteConfig.objects.filter(pk=1).delete()
             settings.LANGUAGE_CODE = old_language


### PR DESCRIPTION
## What

`LANGUAGE_CODE` was derived from `NEODB_PREFERRED_LANGUAGES` once at settings load and never revisited, so the default interface language — used for visitors and for logged-in users who have not picked a language — could only be changed by editing `.env` and restarting, even though everything else on that settings page is DB-backed.

This adds a **Default Language** select to the Access settings page, following the usual `DB value > env value > default` precedence.

## Why a separate option instead of deriving it from `preferred_languages`

The two values are computed together by `_init_language_settings` but keep different precision: the default-language pick preserves the sub-tag (`zh-hant` stays `zh-hant`) while the preferred list collapses it (`zh-hant` -> `zh`). Deriving `LANGUAGE_CODE` from the stored list would silently move any site running `NEODB_PREFERRED_LANGUAGES=zh-hant,...` to `zh-hans`. With no DB override set, behavior is unchanged.

## Notes

- The env-derived value is snapshotted as `LANGUAGE_CODE_ENV` and used as the fallback, mirroring the existing `EMAIL_URL_ENV` pattern, because `_apply_to_settings` now writes `settings.LANGUAGE_CODE`.
- Changing the value clears `trans_real._default`, the cached default translation object consulted whenever no language is active (RQ jobs, management commands). This is the same reset Django performs in `django/test/signals.py`. It is guarded on the value actually changing so the 30s config refresh stays off the hot translation path.
- No migration: `SystemOptions` is a JSON blob.

## Also in here

**Choice-list ordering now follows the runtime setting.** `LANGUAGE_CHOICES` / `LOCALE_CHOICES` / `SCRIPT_CHOICES` are built at import time, before `SiteConfig` is readable, so their "preferred languages first" ordering was pinned to the env value permanently — a restart did not help. They are now rebuilt in place when the setting changes, with a callback registry so catalog's derived jsonform schemas follow too. In-place mutation is required: importers bind these by name and model fields embed the schema lists at class definition time. All languages were always present, so the previous impact was ordering only.

**Fix `SITE_PREFERRED_LANGUAGES` aliasing `settings.PREFERRED_LANGUAGES`.** `settings.PREFERRED_LANGUAGES or [FALLBACK_LANGUAGE]` returns the setting's own list object when non-empty, so rewriting the cache in place clobbered the env-derived fallback that `_env_defaults()` reads back. Saving Preferred Languages therefore compared against a moving target: setting it to the current runtime value dropped the DB override (so a fresh process silently reverted to env), and setting it back to the real env value kept a redundant override. Fixed by copying the list.

## Test plan

- New tests: env fallback and `zh-hant` preservation, DB override reaching `settings.LANGUAGE_CODE`, unsupported codes rejected, translation cache cleared on change and left alone when unchanged, anonymous-visitor language, widget renders as a select, cache-refresh ordering and object identity, field schemas built before a refresh following it, and the aliasing regression.
- Full suite: 1943 passed. The 3 `tests/mastodon/test_lexicons.py` failures are pre-existing and unrelated — verified failing identically on unmodified `main` in the same container, which does not mount `docs/`.
- Verified end to end against a dev cluster: setting Default Language to `zh-hans` makes an anonymous request render in `zh-hans` while `LANGUAGE_CODE_ENV` stays `en`; setting it back to the env value prunes the override; preferred-language changes reorder the live choice lists and the derived jsonform lists.
- `uv run pre-commit run -a` clean; `makemessages -l zh_Hans` run with both new strings translated and no fuzzies.