### PR TITLE
fix(api): return 302 instead of 500 for paginated views on merged items

### DIFF
--- a/neodb/common/api.py
+++ b/neodb/common/api.py
@@ -95,8 +95,11 @@ class PageNumberPagination(NinjaPageNumberPagination):
         request: HttpRequest,
         **params: Any,
     ):
-        if isinstance(queryset, tuple):
-            return queryset
+        if isinstance(queryset, dict):
+            # ninja unwraps Status(code, payload) before paginating, so a view
+            # returning e.g. Status(302, {"message": ...}) lands here as a bare
+            # payload: pass it through with the items attribute ninja expects.
+            return {self.items_attribute: [], "count": 0, "pages": 0, **queryset}
         val = super().paginate_queryset(queryset, pagination, request, **params)
         return {
             "data": val["data"],

--- a/neodb/journal/apis/article.py
+++ b/neodb/journal/apis/article.py
@@ -72,9 +72,7 @@ class ArticlePageNumberPagination(PageNumberPagination):
         **params: Any,
     ):
         val = super().paginate_queryset(queryset, pagination, request, **params)
-        if isinstance(val, tuple):
-            return val
-        data = val.get("data") if isinstance(val, dict) else None
+        data = val.get("data")
         if data:
             prefetch_latest_posts(list(data))
         return val

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -59,9 +59,7 @@ class CollectionPageNumberPagination(PageNumberPagination):
         **params: Any,
     ):
         val = super().paginate_queryset(queryset, pagination, request, **params)
-        if isinstance(val, tuple):
-            return val
-        data = val.get("data") if isinstance(val, dict) else None
+        data = val.get("data")
         if data:
             collections = list(data)
             Collection.attach_item_count_by_category(collections)
@@ -164,9 +162,7 @@ class CollectionItemPageNumberPagination(PageNumberPagination):
         **params: Any,
     ):
         val = super().paginate_queryset(queryset, pagination, request, **params)
-        if isinstance(val, tuple):
-            return val
-        data = val.get("data") if isinstance(val, dict) else None
+        data = val.get("data")
         if data:
             _prefetch_collection_member_items(list(data))
         return val

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -72,8 +72,6 @@ class ShelfPageNumberPagination(PageNumberPagination):
         **params: Any,
     ):
         val = super().paginate_queryset(queryset, pagination, request, **params)
-        if isinstance(val, tuple):
-            return val
         _prefetch_shelf_members(val["data"])
         return val
 

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1251,6 +1251,32 @@ def test_shelf_api_list_delete_and_logs():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_shelf_api_logs_on_merged_item_redirects():
+    user = User.register(email="shelf-merged@example.com", username="shelfuser3")
+    merged_item = Edition.objects.create(title="Merged Away Book")
+    target_item = Edition.objects.create(title="Surviving Book")
+    merged_item.merge_to(target_item)
+
+    app = Takahe.get_or_create_app(
+        "Shelf API Merge Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    response = client.get(
+        f"/api/me/shelf/item/{merged_item.uuid}/logs",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == f"/api/me/shelf/item/{target_item.uuid}/logs"
+    assert response.json() == {"message": "Item merged"}
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_note_api_crud():
     user = User.register(email="note@example.com", username="noteuser")
     item = Edition.objects.create(title="Note Book")


### PR DESCRIPTION
## Problem

`GET /api/me/shelf/item/{item_uuid}/logs` returns a 500 whenever the item has been merged into another item.

```
KeyError: slice(0, 100, None)
  File "ninja/pagination.py", line 171, in paginate_queryset
    self.items_attribute: queryset[offset : offset + page_size],
  File "common/api.py", line 100, in paginate_queryset
    val = super().paginate_queryset(queryset, pagination, request, **params)
```

Sentry: `NEODB-SOCIAL-7SG`

## Root cause

`get_mark_logs_by_item` is `@paginate`-decorated and early-returns `Status(302, {"message": "Item merged", "url": ...})` for merged items.

`PageNumberPagination.paginate_queryset` tried to let that through with `isinstance(queryset, tuple)`. That guard dates from the older `return 302, {...}` bare-tuple style and is dead code today:

- `ninja.responses.Status` is a plain `Generic[T]` class with `__slots__` — not a tuple, so the check never matches.
- `@paginate`'s wrapper *unwraps* `Status` before pagination (`ninja/pagination.py:665-667`), so the paginator receives the bare payload `dict`.

The dict then reaches the base paginator, which slices it like a queryset: `{"message": ...}[0:100]` → `KeyError`.

The same dead pattern existed in the four subclass paginators, which checked `isinstance(val, tuple)` on the *result* of `super()`. Those could never help, since `super()` raised first.

## Fix

Detect the unwrapped payload dict in `PageNumberPagination.paginate_queryset` and pass it through, adding the items attribute the ninja wrapper dereferences immediately afterwards (`result[paginator.items_attribute]`). Payload keys win over the defaults, so the `Result` schema for 302 still serializes `message`.

Dead `isinstance(val, tuple)` guards dropped from `ShelfPageNumberPagination`, `CollectionPageNumberPagination`, `CollectionItemPageNumberPagination` and `ArticlePageNumberPagination`. Each already no-ops on the empty passthrough page, so the prefetch hooks are unaffected.

`get_mark_logs_by_item` was the only `@paginate` view in the codebase with a non-queryset early return, but the fix is in the shared base class, so the whole pattern is covered.

## Testing

- New regression test `test_shelf_api_logs_on_merged_item_redirects` asserts 302, the `Location` header, and the body. Verified it reproduces the exact production `KeyError: slice(...)` at the same ninja line when the paginator fix is reverted.
- `tests/journal/ tests/catalog/test_api.py` → 716 passed, byte-identical failure list to an unmodified-`main` baseline run.
- `uv run pre-commit run -a` passes, including `ty`.

## Note, out of scope

This endpoint declares `302: Result`, so the `url` the view puts in the payload is dropped on serialization. Sibling merged-item endpoints in `catalog/apis.py` declare `302: RedirectedResult`, which keeps it. Left alone here since changing it alters the documented response shape.