### PR TITLE
feat(catalog): add AniList as a catalog site for anime and manga

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -4,6 +4,7 @@ The following external sites are supported for importing catalog items.
 
 | Site | Media types | Import archive |
 | ---- | ----------- | -------------- |
+| AniList | Movie · TV (Season) · Book (Edition) | |
 | Apple Music | Music (Album) | |
 | Apple Podcasts | Podcast | |
 | Archive of Our Own | Book (Edition) | |

--- a/neodb/catalog/models/common.py
+++ b/neodb/catalog/models/common.py
@@ -56,6 +56,7 @@ class SiteName(models.TextChoices):
     StoryGraph = "storygraph", _("StoryGraph")
     YouTubeMusic = "yt_music", _("YouTube Music")
     RateYourMusic = "rateyourmusic", _("RateYourMusic")
+    AniList = "anilist", _("AniList")
 
 
 class IdType(models.TextChoices):  # values must be in lowercase
@@ -123,6 +124,13 @@ class IdType(models.TextChoices):  # values must be in lowercase
     MobyGames = "mobygames", _("MobyGames")
     StoryGraph = "storygraph", _("StoryGraph")
     RateYourMusic_Release = "rateyourmusic_release", _("RateYourMusic Release")
+    # AniList shares one numeric id space between anime and manga, so the two
+    # are separate id types to keep them from colliding; MyAnimeList uses two
+    # distinct spaces. Both pairs map 1:1 onto their Wikidata properties.
+    AniList_Anime = "anilist_anime", _("AniList Anime")
+    AniList_Manga = "anilist_manga", _("AniList Manga")
+    MAL_Anime = "mal_anime", _("MyAnimeList Anime")
+    MAL_Manga = "mal_manga", _("MyAnimeList Manga")
 
 
 IdealIdTypes = [

--- a/neodb/catalog/sites/__init__.py
+++ b/neodb/catalog/sites/__init__.py
@@ -1,4 +1,5 @@
 from ..common.sites import SiteManager
+from .anilist import AniListAnime, AniListManga
 from .ao3 import ArchiveOfOurOwn
 from .apple_music import AppleMusic
 from .apple_podcast import ApplePodcast
@@ -38,6 +39,8 @@ from .ypshuo import Ypshuo
 
 __all__ = [
     "SiteManager",
+    "AniListAnime",
+    "AniListManga",
     "ArchiveOfOurOwn",
     "AppleMusic",
     "ApplePodcast",

--- a/neodb/catalog/sites/anilist.py
+++ b/neodb/catalog/sites/anilist.py
@@ -1,0 +1,439 @@
+"""
+AniList (https://anilist.co)
+
+A single GraphQL endpoint covers both anime and manga and needs no API key or
+client registration. Anime maps to TVSeason/Movie, manga (including light
+novels) maps to Edition, following the type dispatch bangumi.py already uses.
+
+AniList also returns `idMal` on virtually every entry, which is stored as a
+lookup id so a future MyAnimeList integration (and Wikidata's P4086/P4087)
+lands on existing items instead of creating duplicates.
+"""
+
+import re
+import threading
+from collections import OrderedDict
+from typing import Any
+
+import httpx
+from django.conf import settings
+from loguru import logger
+
+from catalog.common import *
+from catalog.common.rate_limit import RedisRateLimiter
+from catalog.models import (
+    Edition,
+    IdType,
+    ItemCategory,
+    Movie,
+    SiteName,
+    TVSeason,
+)
+from catalog.search import ExternalSearchResultItem, record_search_failure
+from common.models import SiteConfig
+from common.models.lang import detect_language
+from journal.models.renderers import html_to_text
+
+_API_URL = "https://graphql.anilist.co"
+
+# AniList documents 90 requests/minute but the live x-ratelimit-limit header
+# has been serving 30, so pace for the lower number.
+_ANILIST_RATE = 0.5
+
+_anilist_limiter: RedisRateLimiter | None = None
+_anilist_limiter_lock = threading.Lock()
+
+
+def anilist_limiter() -> RedisRateLimiter:
+    """Singleton limiter for graphql.anilist.co calls."""
+    global _anilist_limiter
+    if _anilist_limiter is None:
+        with _anilist_limiter_lock:
+            if _anilist_limiter is None:
+                _anilist_limiter = RedisRateLimiter(
+                    key="ratelimit:graphql.anilist.co",
+                    rate=_ANILIST_RATE,
+                )
+    return _anilist_limiter
+
+
+_MEDIA_FIELDS = """
+    id
+    idMal
+    type
+    format
+    status
+    siteUrl
+    description(asHtml: false)
+    episodes
+    duration
+    chapters
+    volumes
+    countryOfOrigin
+    startDate { year month day }
+    genres
+    synonyms
+    title { romaji english native }
+    coverImage { extraLarge large }
+    studios { edges { isMain node { name } } }
+    staff(sort: RELEVANCE, perPage: 25) { edges { role node { name { full } } } }
+    externalLinks { site url }
+"""
+
+_MEDIA_QUERY = "query ($id: Int) { Media(id: $id) {" + _MEDIA_FIELDS + "} }"
+
+_SEARCH_QUERY = """
+query ($q: String, $type: MediaType, $page: Int, $perPage: Int) {
+  Page(page: $page, perPage: $perPage) {
+    media(search: $q, type: $type) {
+      id
+      format
+      title { romaji english native }
+      startDate { year }
+      coverImage { large }
+      description(asHtml: false)
+    }
+  }
+}
+"""
+
+# Anime formats that are standalone videos rather than a run of episodes.
+# Everything else (TV, TV_SHORT, OVA, ONA, SPECIAL) becomes a TVSeason, which
+# is also how bangumi.py treats OVA.
+_MOVIE_FORMATS = {"MOVIE", "MUSIC"}
+
+_DIRECTOR_ROLES = {"director", "chief director"}
+_WRITER_ROLES = {"script", "screenplay", "series composition"}
+# Matches "Story", "Art", "Story & Art", "Original Story"; not "Artist"/"Assistant".
+_AUTHOR_ROLE_RE = re.compile(r"\b(story|art)\b")
+
+# Roles carry a trailing scope, e.g. "Director (eps 1-479)" or
+# "ADR Director (Italian; eps 287-348)". Strip it so the base role can be
+# matched exactly, which keeps "Episode Director"/"Assistant Director" out of
+# the director credit while still catching an episode-scoped main director.
+_ROLE_SCOPE_RE = re.compile(r"\s*\([^()]*\)\s*$")
+
+
+def _base_role(role: str) -> str:
+    return _ROLE_SCOPE_RE.sub("", role).strip().lower()
+
+# The native title's language follows the work's country of origin.
+_LANG_BY_COUNTRY = {"JP": "ja", "KR": "ko", "CN": "zh-cn", "TW": "zh-tw"}
+
+
+def _parse_date(d: dict[str, Any] | None) -> str | None:
+    """AniList FuzzyDate -> "YYYY-MM-DD", only when fully specified."""
+    if not d or not d.get("year") or not d.get("month") or not d.get("day"):
+        return None
+    return f"{d['year']:04d}-{d['month']:02d}-{d['day']:02d}"
+
+
+def _staff_names(media: dict[str, Any], match) -> list[str]:
+    names = []
+    for edge in (media.get("staff") or {}).get("edges") or []:
+        role = _base_role(edge.get("role") or "")
+        name = ((edge.get("node") or {}).get("name") or {}).get("full")
+        if name and match(role) and name not in names:
+            names.append(name)
+    return names
+
+
+def _main_studios(media: dict[str, Any]) -> list[str]:
+    names = []
+    for edge in (media.get("studios") or {}).get("edges") or []:
+        if not edge.get("isMain"):
+            continue
+        name = (edge.get("node") or {}).get("name")
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _official_site(media: dict[str, Any]) -> str | None:
+    for link in media.get("externalLinks") or []:
+        if link.get("site") == "Official Site" and link.get("url"):
+            return link["url"]
+    return None
+
+
+def _titles(media: dict[str, Any]) -> "OrderedDict[str, str | None]":
+    """Ordered candidate titles mapped to a known language (None = detect)."""
+    title = media.get("title") or {}
+    country = media.get("countryOfOrigin")
+    titles: OrderedDict[str, str | None] = OrderedDict()
+    if title.get("romaji"):
+        titles[title["romaji"]] = None
+    if title.get("english"):
+        titles.setdefault(title["english"], "en")
+    if title.get("native"):
+        titles.setdefault(title["native"], _LANG_BY_COUNTRY.get(country))
+    for syn in media.get("synonyms") or []:
+        if syn:
+            titles.setdefault(syn, None)
+    return titles
+
+
+def _localized(titles: "OrderedDict[str, str | None]") -> list[dict[str, str]]:
+    return [
+        {"lang": lang or detect_language(text), "text": text}
+        for text, lang in titles.items()
+        if text
+    ]
+
+
+def _description(media: dict[str, Any]) -> str:
+    # AniList descriptions carry <br>/<i> markup even with asHtml: false.
+    return html_to_text(media.get("description") or "").strip()
+
+
+class AniList(AbstractSite):
+    """Shared fetch and mapping; subclasses bind a MediaType and URL path."""
+
+    SITE_NAME = SiteName.AniList
+    MEDIA_TYPE = ""
+    URL_PATH = ""
+    # bound by the subclasses
+    MAL_ID_TYPE: IdType
+    SEARCH_CATEGORIES: set[str] = set()
+
+    @classmethod
+    def id_to_url(cls, id_value):
+        return f"https://anilist.co/{cls.URL_PATH}/{id_value}"
+
+    @classmethod
+    def _post(cls, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+        r = httpx.post(
+            _API_URL,
+            json=payload,
+            headers={
+                "User-Agent": settings.NEODB_USER_AGENT,
+                "Accept": "application/json",
+            },
+            timeout=timeout,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def _fetch(self) -> dict[str, Any]:
+        if not self.id_value:
+            raise ParseError(self, "id")
+        # One constant POST URL would collapse every mock fixture onto the same
+        # filename, so key them by a synthetic string (as igdb.api_query does).
+        key = f"anilist:media:{self.id_value}"
+        if get_mock_mode():
+            j = BasicDownloader(key).download().json()
+        else:
+            anilist_limiter().acquire(timeout=30.0)
+            try:
+                j = self._post(
+                    {
+                        "query": _MEDIA_QUERY,
+                        "variables": {"id": int(self.id_value)},
+                    },
+                    SiteConfig.system.downloader_request_timeout,
+                )
+            except (httpx.HTTPError, ValueError) as e:
+                logger.warning(
+                    "AniList fetch failed",
+                    extra={"url": self.url, "exception": e},
+                )
+                raise ParseError(self, "media") from e
+        media = (j.get("data") or {}).get("Media")
+        if not media:
+            raise ParseError(self, "media")
+        return media
+
+    def scrape(self) -> ResourceContent:
+        media = self._fetch()
+        titles = _titles(media)
+        brief = _description(media)
+        cover_url = (media.get("coverImage") or {}).get("extraLarge") or (
+            media.get("coverImage") or {}
+        ).get("large")
+        data: dict[str, Any] = {
+            "localized_description": (
+                [{"lang": detect_language(brief), "text": brief}] if brief else []
+            ),
+            "brief": brief,
+            "genre": media.get("genres") or [],
+            "cover_image_url": cover_url,
+        }
+        data.update(self.parse_media(media, titles))
+
+        raw_img = None
+        ext = None
+        if cover_url:
+            raw_img, ext = BasicImageDownloader.download_image(cover_url, None)
+        lookup_ids = {}
+        if media.get("idMal"):
+            lookup_ids[self.MAL_ID_TYPE] = str(media["idMal"])
+        return ResourceContent(
+            metadata={k: v for k, v in data.items() if v is not None},
+            cover_image=raw_img,
+            cover_image_extention=ext,
+            lookup_ids=lookup_ids,
+        )
+
+    def parse_media(
+        self, media: dict[str, Any], titles: "OrderedDict[str, str | None]"
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def _search_category(cls, media: dict[str, Any]) -> ItemCategory:
+        raise NotImplementedError
+
+    @classmethod
+    async def search_task(
+        cls, q: str, page: int, category: str, page_size: int
+    ) -> list[ExternalSearchResultItem]:
+        if category not in cls.SEARCH_CATEGORIES:
+            return []
+        results = []
+        # Deliberately not rate-limited: search_task runs inside the interactive
+        # external-search dispatcher (asyncio.gather over every searchable
+        # site), and blocking a user's search to wait for a slot would freeze
+        # the whole result page. Same reasoning as musicbrainz.search_task.
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    _API_URL,
+                    json={
+                        "query": _SEARCH_QUERY,
+                        "variables": {
+                            "q": q,
+                            "type": cls.MEDIA_TYPE,
+                            "page": page,
+                            "perPage": page_size,
+                        },
+                    },
+                    headers={
+                        "User-Agent": settings.NEODB_USER_AGENT,
+                        "Accept": "application/json",
+                    },
+                    timeout=5,
+                )
+                response.raise_for_status()
+                j = response.json()
+                for media in ((j.get("data") or {}).get("Page") or {}).get(
+                    "media"
+                ) or []:
+                    titles = _titles(media)
+                    if not titles:
+                        continue
+                    title = next(iter(titles))
+                    year = (media.get("startDate") or {}).get("year")
+                    subtitle = " · ".join(
+                        str(x) for x in (media.get("format"), year) if x
+                    )
+                    results.append(
+                        ExternalSearchResultItem(
+                            category=cls._search_category(media),
+                            source_site=cls.SITE_NAME,
+                            source_url=cls.id_to_url(media["id"]),
+                            title=title,
+                            subtitle=subtitle,
+                            brief=_description(media),
+                            cover_url=(media.get("coverImage") or {}).get("large") or "",
+                        )
+                    )
+            except httpx.TimeoutException:
+                logger.warning("AniList search timeout", extra={"query": q})
+                record_search_failure(cls.SITE_NAME.value, "timeout")
+            except Exception as e:
+                logger.error(
+                    "AniList search error", extra={"query": q, "exception": e}
+                )
+                record_search_failure(cls.SITE_NAME.value, "error")
+        return results
+
+
+@SiteManager.register
+class AniListAnime(AniList):
+    ID_TYPE = IdType.AniList_Anime
+    MAL_ID_TYPE = IdType.MAL_Anime
+    MEDIA_TYPE = "ANIME"
+    URL_PATH = "anime"
+    URL_PATTERNS = [r"\w+://anilist\.co/anime/(\d+)"]
+    WIKI_PROPERTY_ID = "P8729"
+    MATCHABLE_MODELS = [TVSeason, Movie]
+    SEARCH_CATEGORIES = {"all", "movietv", "movie", "tv"}
+
+    @classmethod
+    def _search_category(cls, media: dict[str, Any]) -> ItemCategory:
+        return (
+            ItemCategory.Movie
+            if media.get("format") in _MOVIE_FORMATS
+            else ItemCategory.TV
+        )
+
+    def parse_media(
+        self, media: dict[str, Any], titles: "OrderedDict[str, str | None]"
+    ) -> dict[str, Any]:
+        is_movie = media.get("format") in _MOVIE_FORMATS
+        duration = media.get("duration")
+        # single_episode_length and length are stored in seconds
+        length = duration * 60 if duration else None
+        title = media.get("title") or {}
+        country = media.get("countryOfOrigin")
+        data: dict[str, Any] = {
+            "preferred_model": "Movie" if is_movie else "TVSeason",
+            "localized_title": _localized(titles),
+            "orig_title": title.get("native") or title.get("romaji"),
+            "release_date": _parse_date(media.get("startDate")),
+            "origin_country": [country] if country else [],
+            "director": _staff_names(media, lambda r: r in _DIRECTOR_ROLES),
+            "playwright": _staff_names(media, lambda r: r in _WRITER_ROLES),
+            "producer": _main_studios(media),
+            "site": _official_site(media),
+        }
+        if is_movie:
+            data["length"] = length
+        else:
+            data["episode_count"] = media.get("episodes")
+            data["single_episode_length"] = length
+        return data
+
+
+@SiteManager.register
+class AniListManga(AniList):
+    ID_TYPE = IdType.AniList_Manga
+    MAL_ID_TYPE = IdType.MAL_Manga
+    MEDIA_TYPE = "MANGA"
+    URL_PATH = "manga"
+    URL_PATTERNS = [r"\w+://anilist\.co/manga/(\d+)"]
+    WIKI_PROPERTY_ID = "P8731"
+    DEFAULT_MODEL = Edition
+    SEARCH_CATEGORIES = {"all", "book"}
+
+    @classmethod
+    def _search_category(cls, media: dict[str, Any]) -> ItemCategory:
+        return ItemCategory.Book
+
+    def parse_media(
+        self, media: dict[str, Any], titles: "OrderedDict[str, str | None]"
+    ) -> dict[str, Any]:
+        title = media.get("title") or {}
+        start = media.get("startDate") or {}
+        # Edition allows exactly one localized title (maxItems 1), so prefer a
+        # latinized/English one for readability and keep the rest as other_title.
+        primary = title.get("english") or title.get("romaji") or title.get("native")
+        others = [t for t in titles if t != primary]
+        return {
+            "preferred_model": "Edition",
+            "localized_title": (
+                [
+                    {
+                        "lang": titles.get(primary) or detect_language(primary),
+                        "text": primary,
+                    }
+                ]
+                if primary
+                else []
+            ),
+            "other_title": others or None,
+            "orig_title": title.get("native"),
+            "author": _staff_names(media, lambda r: bool(_AUTHOR_ROLE_RE.search(r))),
+            "pub_year": start.get("year"),
+            "pub_month": start.get("month"),
+        }

--- a/neodb/catalog/sites/anilist.py
+++ b/neodb/catalog/sites/anilist.py
@@ -13,13 +13,17 @@ lands on existing items instead of creating duplicates.
 import re
 import threading
 from collections import OrderedDict
-from typing import Any
+from pathlib import Path
+from typing import Any, cast
 
 import httpx
+import requests
 from django.conf import settings
 from loguru import logger
+from requests.exceptions import RequestException
 
 from catalog.common import *
+from catalog.common.downloaders import DownloaderResponse, get_mock_file
 from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import (
     Edition,
@@ -30,7 +34,6 @@ from catalog.models import (
     TVSeason,
 )
 from catalog.search import ExternalSearchResultItem, record_search_failure
-from common.models import SiteConfig
 from common.models.lang import detect_language
 from journal.models.renderers import html_to_text
 
@@ -57,6 +60,66 @@ def anilist_limiter() -> RedisRateLimiter:
     return _anilist_limiter
 
 
+class AniListDownloader(RetryDownloader):
+    """POST a GraphQL query while keeping per-query mock fixtures.
+
+    Going through the downloader framework rather than calling httpx directly
+    buys the retry loop and, more importantly, the right error classification:
+    a 429 or 5xx becomes DownloadError, which callers such as
+    catalog.search.utils treat as an expected third-party failure instead of
+    logging it as an internal error.
+
+    Every query hits the same endpoint, so ``url`` carries a synthetic
+    "anilist:media:<id>" key that names the mock fixture, while live requests
+    always POST to the real endpoint.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict | None = None,
+        timeout: float | None = None,
+    ):
+        super().__init__(url, headers=headers, timeout=timeout)
+        self._payload = payload
+
+    def _download(self, url):
+        if get_mock_mode():
+            return super()._download(url)
+        anilist_limiter().acquire(timeout=30.0)
+        try:
+            resp = cast(
+                DownloaderResponse,
+                requests.post(
+                    _API_URL,
+                    json=self._payload,
+                    headers=self.headers,
+                    timeout=self.timeout,
+                ),
+            )
+            resp.__class__ = DownloaderResponse
+            if settings.DOWNLOADER_SAVEDIR:
+                savedir = Path(settings.DOWNLOADER_SAVEDIR).resolve()
+                target = (savedir / get_mock_file(url)).resolve()
+                if target.is_relative_to(savedir):
+                    try:
+                        with open(target, "w", encoding="utf-8") as fp:
+                            fp.write(resp.text)
+                    except Exception:
+                        logger.warning("Save downloaded data failed.")
+            response_type = self.validate_response(resp)
+            self.logs.append(
+                {"response_type": response_type, "url": url, "exception": None}
+            )
+            return resp, response_type
+        except RequestException as e:
+            self.logs.append(
+                {"response_type": RESPONSE_NETWORK_ERROR, "url": url, "exception": e}
+            )
+            return None, RESPONSE_NETWORK_ERROR
+
+
 _MEDIA_FIELDS = """
     id
     idMal
@@ -80,7 +143,16 @@ _MEDIA_FIELDS = """
     externalLinks { site url }
 """
 
-_MEDIA_QUERY = "query ($id: Int) { Media(id: $id) {" + _MEDIA_FIELDS + "} }"
+# The type is constrained here, not just selected: AniList keeps anime and
+# manga in one id space, so an unconstrained Media(id:) happily returns the
+# manga for an /anime/<id> URL. That would build a TVSeason out of manga data
+# and, worse, file the manga's idMal under IdType.MAL_Anime. A mismatch now
+# yields no Media, which _fetch turns into a ParseError.
+_MEDIA_QUERY = (
+    "query ($id: Int, $type: MediaType) { Media(id: $id, type: $type) {"
+    + _MEDIA_FIELDS
+    + "} }"
+)
 
 _SEARCH_QUERY = """
 query ($q: String, $type: MediaType, $page: Int, $perPage: Int) {
@@ -104,8 +176,10 @@ _MOVIE_FORMATS = {"MOVIE", "MUSIC"}
 
 _DIRECTOR_ROLES = {"director", "chief director"}
 _WRITER_ROLES = {"script", "screenplay", "series composition"}
-# Matches "Story", "Art", "Story & Art", "Original Story"; not "Artist"/"Assistant".
-_AUTHOR_ROLE_RE = re.compile(r"\b(story|art)\b")
+# Exact roles only. A substring match would pull in "Art Director", "Story
+# Editor" and "Art Assistant", and author is the primary displayed creator for
+# a book as well as the source for People credits.
+_AUTHOR_ROLES = {"story & art", "story and art", "story", "art", "original story"}
 
 # Roles carry a trailing scope, e.g. "Director (eps 1-479)" or
 # "ADR Director (Italian; eps 287-348)". Strip it so the base role can be
@@ -117,8 +191,12 @@ _ROLE_SCOPE_RE = re.compile(r"\s*\([^()]*\)\s*$")
 def _base_role(role: str) -> str:
     return _ROLE_SCOPE_RE.sub("", role).strip().lower()
 
+
 # The native title's language follows the work's country of origin.
 _LANG_BY_COUNTRY = {"JP": "ja", "KR": "ko", "CN": "zh-cn", "TW": "zh-tw"}
+
+# The catalog's "Unknown" locale; detect_language() also falls back to it.
+_UNKNOWN_LANG = "x"
 
 
 def _parse_date(d: dict[str, Any] | None) -> str | None:
@@ -160,13 +238,24 @@ def _titles(media: dict[str, Any]) -> "OrderedDict[str, str | None]":
     """Ordered candidate titles mapped to a known language (None = detect)."""
     title = media.get("title") or {}
     country = media.get("countryOfOrigin")
+    romaji, english, native = (
+        title.get("romaji"),
+        title.get("english"),
+        title.get("native"),
+    )
     titles: OrderedDict[str, str | None] = OrderedDict()
-    if title.get("romaji"):
-        titles[title["romaji"]] = None
-    if title.get("english"):
-        titles.setdefault(title["english"], "en")
-    if title.get("native"):
-        titles.setdefault(title["native"], _LANG_BY_COUNTRY.get(country))
+    # romaji is romanized Japanese, never English, and langdetect guesses wildly
+    # on it ("NARUTO: Shippuuden" -> fi, "Sen to Chihiro no Kamikakushi" -> sw),
+    # so its language is always assigned rather than detected. It stands in as
+    # the readable latin title only when AniList has no English one.
+    if english:
+        titles[english] = "en"
+        if romaji:
+            titles.setdefault(romaji, _UNKNOWN_LANG)
+    elif romaji:
+        titles[romaji] = "en"
+    if native:
+        titles.setdefault(native, _LANG_BY_COUNTRY.get(country))
     for syn in media.get("synonyms") or []:
         if syn:
             titles.setdefault(syn, None)
@@ -174,11 +263,27 @@ def _titles(media: dict[str, Any]) -> "OrderedDict[str, str | None]":
 
 
 def _localized(titles: "OrderedDict[str, str | None]") -> list[dict[str, str]]:
-    return [
-        {"lang": lang or detect_language(text), "text": text}
-        for text, lang in titles.items()
-        if text
-    ]
+    """Tag each title with a language, letting no two claim the same one.
+
+    Synonyms are detected, and langdetect is confidently wrong often enough
+    that a later title would otherwise shadow an earlier, better one for a
+    whole locale (AniList's Icelandic title for Spirited Away detects as `hu`,
+    which would be served to Hungarian viewers). Titles are ordered
+    best-known-first, so a repeat language means the guess lost: keep the text
+    for search but mark its language unknown.
+    """
+    out = []
+    claimed = set()
+    for text, lang in titles.items():
+        if not text:
+            continue
+        code = lang or detect_language(text)
+        if code in claimed:
+            code = _UNKNOWN_LANG
+        else:
+            claimed.add(code)
+        out.append({"lang": code, "text": text})
+    return out
 
 
 def _description(media: dict[str, Any]) -> str:
@@ -200,47 +305,34 @@ class AniList(AbstractSite):
     def id_to_url(cls, id_value):
         return f"https://anilist.co/{cls.URL_PATH}/{id_value}"
 
-    @classmethod
-    def _post(cls, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
-        r = httpx.post(
-            _API_URL,
-            json=payload,
-            headers={
-                "User-Agent": settings.NEODB_USER_AGENT,
-                "Accept": "application/json",
-            },
-            timeout=timeout,
-        )
-        r.raise_for_status()
-        return r.json()
-
     def _fetch(self) -> dict[str, Any]:
         if not self.id_value:
             raise ParseError(self, "id")
-        # One constant POST URL would collapse every mock fixture onto the same
-        # filename, so key them by a synthetic string (as igdb.api_query does).
-        key = f"anilist:media:{self.id_value}"
-        if get_mock_mode():
-            j = BasicDownloader(key).download().json()
-        else:
-            anilist_limiter().acquire(timeout=30.0)
-            try:
-                j = self._post(
-                    {
-                        "query": _MEDIA_QUERY,
-                        "variables": {"id": int(self.id_value)},
-                    },
-                    SiteConfig.system.downloader_request_timeout,
-                )
-            except (httpx.HTTPError, ValueError) as e:
-                logger.warning(
-                    "AniList fetch failed",
-                    extra={"url": self.url, "exception": e},
-                )
-                raise ParseError(self, "media") from e
+        # Synthetic key so each query gets its own mock fixture; see
+        # AniListDownloader.
+        j = (
+            AniListDownloader(
+                f"anilist:media:{self.id_value}",
+                {
+                    "query": _MEDIA_QUERY,
+                    "variables": {"id": int(self.id_value), "type": self.MEDIA_TYPE},
+                },
+                headers={
+                    "User-Agent": settings.NEODB_USER_AGENT,
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+            )
+            .download()
+            .json()
+        )
         media = (j.get("data") or {}).get("Media")
         if not media:
             raise ParseError(self, "media")
+        # The query already constrains the type; re-check so a stale fixture or
+        # an API change can't smuggle a manga into the anime site or vice versa.
+        if media.get("type") != self.MEDIA_TYPE:
+            raise ParseError(self, "type")
         return media
 
     def scrape(self) -> ResourceContent:
@@ -334,16 +426,15 @@ class AniList(AbstractSite):
                             title=title,
                             subtitle=subtitle,
                             brief=_description(media),
-                            cover_url=(media.get("coverImage") or {}).get("large") or "",
+                            cover_url=(media.get("coverImage") or {}).get("large")
+                            or "",
                         )
                     )
             except httpx.TimeoutException:
                 logger.warning("AniList search timeout", extra={"query": q})
                 record_search_failure(cls.SITE_NAME.value, "timeout")
             except Exception as e:
-                logger.error(
-                    "AniList search error", extra={"query": q, "exception": e}
-                )
+                logger.error("AniList search error", extra={"query": q, "exception": e})
                 record_search_failure(cls.SITE_NAME.value, "error")
         return results
 
@@ -433,7 +524,7 @@ class AniListManga(AniList):
             ),
             "other_title": others or None,
             "orig_title": title.get("native"),
-            "author": _staff_names(media, lambda r: bool(_AUTHOR_ROLE_RE.search(r))),
+            "author": _staff_names(media, lambda r: r in _AUTHOR_ROLES),
             "pub_year": start.get("year"),
             "pub_month": start.get("month"),
         }

--- a/neodb/catalog/sites/wikidata.py
+++ b/neodb/catalog/sites/wikidata.py
@@ -196,6 +196,10 @@ class WikidataProperties:
     P10319 = "P10319"  # Douban book works ID
     P648 = "P648"  # Open Library ID
     P4300 = "P4300"  # YouTube playlist ID (YouTube Music album)
+    P8729 = "P8729"  # AniList anime ID
+    P8731 = "P8731"  # AniList manga ID
+    P4086 = "P4086"  # MyAnimeList anime ID
+    P4087 = "P4087"  # MyAnimeList manga ID
 
     # Person-specific external identifiers
     P4985 = "P4985"  # TMDb person ID
@@ -232,6 +236,12 @@ class WikidataProperties:
         # "P5842": IdType.ApplePodcasts,
         "P2205": IdType.Spotify_Album,
         "P4300": IdType.YouTubeMusic,  # YouTube playlist ID (YouTube Music album)
+        "P8729": IdType.AniList_Anime,
+        "P8731": IdType.AniList_Manga,
+        # No MyAnimeList fetcher exists; these are carried for dedupe so a
+        # future MAL integration lands on existing items.
+        "P4086": IdType.MAL_Anime,
+        "P4087": IdType.MAL_Manga,
         # Person-specific
         "P4985": IdType.TMDB_Person,
         "P2963": IdType.Goodreads_Author,

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 18:08-0400\n"
+"POT-Creation-Date: 2026-07-25 17:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:224
+#: boofilsic/settings.py:472 common/models/lang.py:226
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:473 common/models/lang.py:71
+#: boofilsic/settings.py:473 common/models/lang.py:73
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:474 common/models/lang.py:72
+#: boofilsic/settings.py:474 common/models/lang.py:74
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:475 common/models/lang.py:177
+#: boofilsic/settings.py:475 common/models/lang.py:179
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:81
+#: boofilsic/settings.py:476 common/models/lang.py:83
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:477 common/models/lang.py:106
+#: boofilsic/settings.py:477 common/models/lang.py:108
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:478 common/models/lang.py:160
-#: common/models/lang.py:299
+#: boofilsic/settings.py:478 common/models/lang.py:162
+#: common/models/lang.py:301
 msgid "Portuguese"
 msgstr ""
 
@@ -51,11 +51,11 @@ msgstr ""
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:310
+#: boofilsic/settings.py:480 common/models/lang.py:312
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:311
+#: boofilsic/settings.py:481 common/models/lang.py:313
 msgid "Traditional Chinese"
 msgstr ""
 
@@ -72,12 +72,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr ""
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:270 catalog/models/common.py:288
+#: catalog/models/common.py:278 catalog/models/common.py:296
 msgid "locale"
 msgstr ""
 
 #: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:273 catalog/models/common.py:293
+#: catalog/models/common.py:281 catalog/models/common.py:301
 msgid "text content"
 msgstr ""
 
@@ -170,7 +170,7 @@ msgstr ""
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:250
+#: catalog/models/common.py:26 common/models/lang.py:252
 msgid "Unknown"
 msgstr ""
 
@@ -178,11 +178,11 @@ msgstr ""
 msgid "Douban"
 msgstr ""
 
-#: catalog/models/common.py:28 catalog/models/common.py:77
+#: catalog/models/common.py:28 catalog/models/common.py:78
 msgid "Goodreads"
 msgstr ""
 
-#: catalog/models/common.py:29 catalog/models/common.py:79
+#: catalog/models/common.py:29 catalog/models/common.py:80
 msgid "Google Books"
 msgstr ""
 
@@ -190,16 +190,16 @@ msgstr ""
 msgid "BooksTW"
 msgstr ""
 
-#: catalog/models/common.py:31 catalog/models/common.py:88
-#: catalog/models/common.py:90
+#: catalog/models/common.py:31 catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "Bibliotek.dk"
 msgstr ""
 
-#: catalog/models/common.py:32 catalog/models/common.py:89
+#: catalog/models/common.py:32 catalog/models/common.py:90
 msgid "eReolen.dk"
 msgstr ""
 
-#: catalog/models/common.py:33 catalog/models/common.py:72
+#: catalog/models/common.py:33 catalog/models/common.py:73
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -209,7 +209,7 @@ msgstr ""
 msgid "TMDB"
 msgstr ""
 
-#: catalog/models/common.py:35 catalog/models/common.py:91
+#: catalog/models/common.py:35 catalog/models/common.py:92
 msgid "Bandcamp"
 msgstr ""
 
@@ -225,11 +225,11 @@ msgstr ""
 msgid "Steam"
 msgstr ""
 
-#: catalog/models/common.py:39 catalog/models/common.py:111
+#: catalog/models/common.py:39 catalog/models/common.py:112
 msgid "itch.io"
 msgstr ""
 
-#: catalog/models/common.py:40 catalog/models/common.py:112
+#: catalog/models/common.py:40 catalog/models/common.py:113
 msgid "Bangumi"
 msgstr ""
 
@@ -237,7 +237,7 @@ msgstr ""
 msgid "BGG"
 msgstr ""
 
-#: catalog/models/common.py:42 catalog/models/common.py:113
+#: catalog/models/common.py:42 catalog/models/common.py:114
 msgid "Apple Podcast"
 msgstr ""
 
@@ -249,35 +249,35 @@ msgstr ""
 msgid "Discogs"
 msgstr ""
 
-#: catalog/models/common.py:45 catalog/models/common.py:114
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Apple Music"
 msgstr ""
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:46 catalog/models/common.py:117
 msgid "Fediverse"
 msgstr ""
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:47 catalog/models/common.py:118
 msgid "Qidian"
 msgstr ""
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:48 catalog/models/common.py:119
 msgid "Ypshuo"
 msgstr ""
 
-#: catalog/models/common.py:49 catalog/models/common.py:119
+#: catalog/models/common.py:49 catalog/models/common.py:120
 msgid "Archive of Our Own"
 msgstr ""
 
-#: catalog/models/common.py:50 catalog/models/common.py:120
+#: catalog/models/common.py:50 catalog/models/common.py:121
 msgid "JinJiang"
 msgstr ""
 
-#: catalog/models/common.py:51 catalog/models/common.py:62
+#: catalog/models/common.py:51 catalog/models/common.py:63
 msgid "WikiData"
 msgstr ""
 
-#: catalog/models/common.py:52 catalog/models/common.py:121
+#: catalog/models/common.py:52 catalog/models/common.py:122
 msgid "Open Library"
 msgstr ""
 
@@ -289,15 +289,15 @@ msgstr ""
 msgid "WorldCat"
 msgstr ""
 
-#: catalog/models/common.py:55 catalog/models/common.py:123
+#: catalog/models/common.py:55 catalog/models/common.py:124
 msgid "MobyGames"
 msgstr ""
 
-#: catalog/models/common.py:56 catalog/models/common.py:124
+#: catalog/models/common.py:56 catalog/models/common.py:125
 msgid "StoryGraph"
 msgstr ""
 
-#: catalog/models/common.py:57 catalog/models/common.py:115
+#: catalog/models/common.py:57 catalog/models/common.py:116
 msgid "YouTube Music"
 msgstr ""
 
@@ -305,286 +305,306 @@ msgstr ""
 msgid "RateYourMusic"
 msgstr ""
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:59
+msgid "AniList"
+msgstr ""
+
+#: catalog/models/common.py:64
 msgid "ISBN10"
 msgstr ""
 
-#: catalog/models/common.py:64 catalog/templates/edition.html:19
+#: catalog/models/common.py:65 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr ""
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "ASIN"
 msgstr ""
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "ISSN"
 msgstr ""
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "CUBN"
 msgstr ""
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "ISRC"
 msgstr ""
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "GTIN UPC EAN"
 msgstr ""
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "OCLC Number"
 msgstr ""
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "RSS Feed URL"
 msgstr ""
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Series"
 msgstr ""
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB TV Season"
 msgstr ""
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "TMDB TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:77
 msgid "TMDB Movie"
 msgstr ""
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:79
 msgid "Goodreads Work"
 msgstr ""
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Book"
 msgstr ""
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Book Work"
 msgstr ""
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Movie"
 msgstr ""
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Music"
 msgstr ""
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Game"
 msgstr ""
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "Douban Drama"
 msgstr ""
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "Douban Drama Version"
 msgstr ""
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:88
 msgid "BooksTW Book"
 msgstr ""
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Spotify Album"
 msgstr ""
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Spotify Podcast"
 msgstr ""
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "Discogs Release"
 msgstr ""
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:96
 msgid "Discogs Master"
 msgstr ""
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:99
 msgid "MusicBrainz Release Group"
 msgstr ""
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "MusicBrainz Release"
 msgstr ""
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "MusicBrainz Artist"
 msgstr ""
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Douban Personage"
 msgstr ""
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "Goodreads Author"
 msgstr ""
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "Spotify Artist"
 msgstr ""
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "TMDB Person"
 msgstr ""
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "Open Library Author"
 msgstr ""
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "IGDB Company"
 msgstr ""
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "IGDB Game"
 msgstr ""
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "BGG Boardgame"
 msgstr ""
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:111
 msgid "Steam Game"
 msgstr ""
 
-#: catalog/models/common.py:122
+#: catalog/models/common.py:123
 msgid "Open Library Work"
 msgstr ""
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:126
 msgid "RateYourMusic Release"
 msgstr ""
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:130
+msgid "AniList Anime"
+msgstr ""
+
+#: catalog/models/common.py:131
+msgid "AniList Manga"
+msgstr ""
+
+#: catalog/models/common.py:132
+msgid "MyAnimeList Anime"
+msgstr ""
+
+#: catalog/models/common.py:133
+msgid "MyAnimeList Manga"
+msgstr ""
+
+#: catalog/models/common.py:154
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:155 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr ""
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:156
 msgid "TV Series"
 msgstr ""
 
-#: catalog/models/common.py:149 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr ""
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:158
 msgid "TV Episode"
 msgstr ""
 
-#: catalog/models/common.py:151 catalog/models/common.py:167
-#: catalog/models/common.py:181 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:159 catalog/models/common.py:175
+#: catalog/models/common.py:189 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr ""
 
-#: catalog/models/common.py:152
+#: catalog/models/common.py:160
 msgid "Album"
 msgstr ""
 
-#: catalog/models/common.py:153 catalog/models/common.py:170
-#: catalog/models/common.py:184 common/templates/_header.html:43
+#: catalog/models/common.py:161 catalog/models/common.py:178
+#: catalog/models/common.py:192 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr ""
 
-#: catalog/models/common.py:154
+#: catalog/models/common.py:162
 msgid "Podcast Program"
 msgstr ""
 
-#: catalog/models/common.py:155
+#: catalog/models/common.py:163
 msgid "Podcast Episode"
 msgstr ""
 
-#: catalog/models/common.py:156 catalog/models/common.py:172
-#: catalog/models/common.py:186 common/templates/_header.html:47
+#: catalog/models/common.py:164 catalog/models/common.py:180
+#: catalog/models/common.py:194 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr ""
 
-#: catalog/models/common.py:157
+#: catalog/models/common.py:165
 msgid "Production"
 msgstr ""
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:166
 msgid "Exhibition"
 msgstr ""
 
-#: catalog/models/common.py:159 catalog/models/common.py:176
+#: catalog/models/common.py:167 catalog/models/common.py:184
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr ""
 
-#: catalog/models/common.py:162 catalog/models/common.py:175
+#: catalog/models/common.py:170 catalog/models/common.py:183
 msgid "Person / Organization"
 msgstr ""
 
-#: catalog/models/common.py:166 catalog/models/common.py:180
+#: catalog/models/common.py:174 catalog/models/common.py:188
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr ""
 
-#: catalog/models/common.py:168 catalog/models/common.py:182
+#: catalog/models/common.py:176 catalog/models/common.py:190
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr ""
 
-#: catalog/models/common.py:169 catalog/models/common.py:183
+#: catalog/models/common.py:177 catalog/models/common.py:191
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr ""
 
-#: catalog/models/common.py:171 catalog/models/common.py:185
+#: catalog/models/common.py:179 catalog/models/common.py:193
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr ""
 
-#: catalog/models/common.py:336 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:344 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr ""
 
-#: catalog/models/common.py:374
+#: catalog/models/common.py:382
 msgid "origin country"
 msgstr ""
 
-#: catalog/models/common.py:403 catalog/templates/album.html:33
+#: catalog/models/common.py:411 catalog/templates/album.html:33
 msgid "album type"
 msgstr ""
 
-#: catalog/models/common.py:407 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:415 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr ""
 
-#: catalog/models/common.py:411
+#: catalog/models/common.py:419
 msgid "media format"
 msgstr ""
 
-#: catalog/models/common.py:416 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:424 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr ""
@@ -1384,7 +1404,7 @@ msgstr ""
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:182
-#: journal/templates/mark.html:157 journal/templates/note.html:84
+#: journal/templates/mark.html:149 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
@@ -1648,11 +1668,11 @@ msgstr ""
 #: catalog/templates/catalog_edit.html:65
 #: common/templates/manage/settings.html:136
 #: journal/templates/add_to_collection.html:43
-#: journal/templates/article_edit.html:59
-#: journal/templates/collection_edit.html:39 journal/templates/comment.html:69
-#: journal/templates/mark.html:142 journal/templates/note.html:67
+#: journal/templates/article_edit.html:60
+#: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
+#: journal/templates/mark.html:134 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
-#: journal/templates/review_edit.html:39 journal/templates/tag_edit.html:51
+#: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
 #: users/templates/users/account.html:38 users/templates/users/account.html:67
 #: users/templates/users/preferences.html:241
@@ -2139,7 +2159,7 @@ msgstr ""
 #: journal/views/collection.py:415 journal/views/collection.py:458
 #: journal/views/collection.py:497 journal/views/collection.py:509
 #: journal/views/collection.py:534 journal/views/collection.py:571
-#: journal/views/common.py:272 journal/views/mark.py:264
+#: journal/views/common.py:272 journal/views/mark.py:281
 #: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
 #: journal/views/post.py:165 journal/views/post.py:194
 #: journal/views/post.py:267 journal/views/post.py:282
@@ -2153,7 +2173,7 @@ msgstr ""
 #: catalog/views/verify.py:194 journal/views/collection.py:75
 #: journal/views/collection.py:100 journal/views/collection.py:514
 #: journal/views/collection.py:609 journal/views/common.py:193
-#: journal/views/mark.py:190 journal/views/post.py:112
+#: journal/views/mark.py:196 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
 #: journal/views/post.py:223 journal/views/post.py:236
@@ -2740,759 +2760,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:48
+#: common/models/lang.py:50
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:49
+#: common/models/lang.py:51
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:50
+#: common/models/lang.py:52
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:51
+#: common/models/lang.py:53
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:52
+#: common/models/lang.py:54
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:53
+#: common/models/lang.py:55
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:77
+#: common/models/lang.py:79
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:78
+#: common/models/lang.py:80
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:87
+#: common/models/lang.py:89
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:112
+#: common/models/lang.py:114
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:144 common/models/lang.py:145
+#: common/models/lang.py:146 common/models/lang.py:147
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:150
+#: common/models/lang.py:152
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:151
+#: common/models/lang.py:153
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:166
+#: common/models/lang.py:168
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:183
+#: common/models/lang.py:185
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:230
+#: common/models/lang.py:232
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:294
+#: common/models/lang.py:296
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:295
+#: common/models/lang.py:297
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:296
+#: common/models/lang.py:298
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:304
+#: common/models/lang.py:306
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:307
+#: common/models/lang.py:309
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:308
+#: common/models/lang.py:310
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:309
+#: common/models/lang.py:311
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:317
+#: common/models/lang.py:319
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:318
+#: common/models/lang.py:320
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:322
+#: common/models/lang.py:324
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -3793,7 +3813,7 @@ msgstr ""
 msgid "Currently watching"
 msgstr ""
 
-#: common/templates/_sidebar.html:233 journal/forms.py:199
+#: common/templates/_sidebar.html:233 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4711,84 +4731,91 @@ msgstr ""
 msgid "Genres by Category"
 msgstr ""
 
-#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:72
-#: journal/forms.py:75 journal/forms.py:142
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr ""
+
+#: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
+#: journal/forms.py:83 journal/forms.py:153
 msgid "Title"
 msgstr ""
 
-#: journal/forms.py:30 journal/forms.py:35 journal/forms.py:36
-#: journal/forms.py:91 journal/forms.py:96 journal/forms.py:97
-#: journal/forms.py:144
+#: journal/forms.py:35 journal/forms.py:40 journal/forms.py:41
+#: journal/forms.py:99 journal/forms.py:104 journal/forms.py:105
+#: journal/forms.py:155
 msgid "Content (Markdown)"
 msgstr ""
 
-#: journal/forms.py:41 journal/forms.py:208 journal/templates/comment.html:62
-#: journal/templates/mark.html:115
-msgid "Crosspost to timeline"
+#: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
+#: journal/forms.py:288 journal/views/note.py:38
+msgid "Crosspost"
 msgstr ""
 
-#: journal/forms.py:44 journal/forms.py:119
+#: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
+#: journal/forms.py:289 journal/views/note.py:39
+msgid "Crosspost to your connected social networks"
+msgstr ""
+
+#: journal/forms.py:52 journal/forms.py:130
 msgid "Keep leading spaces"
 msgstr ""
 
-#: journal/forms.py:45 journal/forms.py:120
+#: journal/forms.py:53 journal/forms.py:131
 msgid "When saving, replace leading spaces with full-width spaces"
 msgstr ""
 
-#: journal/forms.py:51 journal/forms.py:126 journal/forms.py:151
-#: journal/forms.py:201 journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:155
-#: users/templates/users/data.html:206 users/templates/users/data.html:269
-#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
+#: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
+#: journal/forms.py:219 journal/forms.py:281
+#: journal/templates/collection_share.html:24
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
+#: users/templates/users/data.html:45 users/templates/users/data.html:98
+#: users/templates/users/data.html:155 users/templates/users/data.html:206
+#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr ""
 
-#: journal/forms.py:64
+#: journal/forms.py:72
 msgid "Featured image (optional)"
 msgstr ""
 
-#: journal/forms.py:79 journal/forms.py:85 journal/forms.py:86
+#: journal/forms.py:87 journal/forms.py:93 journal/forms.py:94
 msgid "Summary (optional)"
 msgstr ""
 
-#: journal/forms.py:102 journal/forms.py:107 journal/forms.py:108
+#: journal/forms.py:110 journal/forms.py:115 journal/forms.py:116
 msgid "Tags (comma separated)"
 msgstr ""
 
-#: journal/forms.py:113 journal/templates/post_compose.html:86
+#: journal/forms.py:121 journal/templates/post_compose.html:86
 msgid "Mark as sensitive"
 msgstr ""
 
-#: journal/forms.py:116
-msgid "Crosspost to Mastodon"
-msgstr ""
-
-#: journal/forms.py:135
+#: journal/forms.py:146
 msgid "owner only"
 msgstr ""
 
-#: journal/forms.py:136
+#: journal/forms.py:147
 msgid "owner and their local mutuals"
 msgstr ""
 
-#: journal/forms.py:158 journal/templates/collection.html:187
+#: journal/forms.py:169 journal/templates/collection.html:187
 #: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr ""
 
-#: journal/forms.py:193 users/templates/users/crossposts.html:51
+#: journal/forms.py:204 users/templates/users/crossposts.html:51
 #: users/templates/users/data.html:483
 msgid "Status"
 msgstr ""
 
-#: journal/forms.py:195 journal/templates/comment.html:16
+#: journal/forms.py:209 journal/forms.py:275 journal/templates/comment.html:16
 msgid "Comment"
 msgstr ""
 
-#: journal/forms.py:197
+#: journal/forms.py:215
 msgid "Rating"
 msgstr ""
 
@@ -4900,12 +4927,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/comment.html:35
-#: journal/templates/mark.html:88 journal/templates/post_compose.html:58
-#: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
-#: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:164 users/templates/users/data.html:215
-#: users/templates/users/data.html:277 users/templates/users/data.html:337
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
+#: users/templates/users/data.html:107 users/templates/users/data.html:164
+#: users/templates/users/data.html:215 users/templates/users/data.html:277
+#: users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -4914,8 +4941,8 @@ msgid "Public"
 msgstr ""
 
 #: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/comment.html:42
-#: journal/templates/mark.html:95 journal/templates/post_compose.html:65
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
 #: users/templates/users/data.html:115 users/templates/users/data.html:172
 #: users/templates/users/data.html:223 users/templates/users/data.html:285
@@ -4928,8 +4955,7 @@ msgid "Followers Only"
 msgstr ""
 
 #: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/comment.html:49 journal/templates/mark.html:102
-#: journal/templates/post_compose.html:72
+#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
 #: users/templates/users/data.html:123 users/templates/users/data.html:180
 #: users/templates/users/data.html:231 users/templates/users/data.html:293
@@ -4977,8 +5003,8 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469 journal/views/note.py:117
-#: journal/views/note.py:177
+#: journal/models/mark.py:469 journal/views/note.py:124
+#: journal/views/note.py:184
 msgid "Only in-progress books can have reading progress."
 msgstr ""
 
@@ -5803,11 +5829,7 @@ msgstr ""
 msgid "for the sharing post only, not visibility of the collection"
 msgstr ""
 
-#: journal/templates/comment.html:24 journal/templates/mark.html:66
-msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
-msgstr ""
-
-#: journal/templates/comment.html:75
+#: journal/templates/comment.html:47
 msgid "share with playback position"
 msgstr ""
 
@@ -5819,15 +5841,15 @@ msgstr ""
 msgid "not rated"
 msgstr ""
 
-#: journal/templates/mark.html:74
+#: journal/templates/mark.html:70
 msgid "add a tag and press Enter"
 msgstr ""
 
-#: journal/templates/mark.html:130
+#: journal/templates/mark.html:122
 msgid "change mark date"
 msgstr ""
 
-#: journal/templates/mark.html:156
+#: journal/templates/mark.html:148
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr ""
 
@@ -5886,15 +5908,11 @@ msgstr ""
 msgid "Note with empty content will be deleted, sure to continue?"
 msgstr ""
 
-#: journal/templates/note.html:60 journal/templates/note.html:61
-msgid "Also publish this note to your connected social accounts."
-msgstr ""
-
-#: journal/templates/note.html:74 journal/templates/note.html:75
+#: journal/templates/note.html:72 journal/templates/note.html:73
 msgid "Clear progress"
 msgstr ""
 
-#: journal/templates/note.html:81
+#: journal/templates/note.html:79
 msgid "Are you sure to delete this note?"
 msgstr ""
 
@@ -6008,7 +6026,7 @@ msgstr ""
 msgid "add a reply"
 msgstr ""
 
-#: journal/templates/review_edit.html:42
+#: journal/templates/review_edit.html:49
 msgid "change review date"
 msgstr ""
 
@@ -6117,7 +6135,7 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: journal/views/common.py:146 journal/views/mark.py:153
+#: journal/views/common.py:146 journal/views/mark.py:159
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr ""
 
@@ -6129,16 +6147,16 @@ msgstr ""
 msgid "List not found."
 msgstr ""
 
-#: journal/views/mark.py:144
+#: journal/views/mark.py:150
 msgid "Content too long for your Fediverse instance."
 msgstr ""
 
-#: journal/views/mark.py:172
+#: journal/views/mark.py:178 journal/views/mark.py:238
 msgid "Invalid input"
 msgstr ""
 
-#: journal/views/mark.py:212 journal/views/mark.py:262
-#: journal/views/note.py:169 journal/views/profile.py:42
+#: journal/views/mark.py:225 journal/views/mark.py:279
+#: journal/views/note.py:176 journal/views/profile.py:42
 #: journal/views/review.py:50 journal/views/review.py:67
 msgid "Content not found"
 msgstr ""
@@ -6151,23 +6169,19 @@ msgstr ""
 msgid "Update progress"
 msgstr ""
 
-#: journal/views/note.py:34
-msgid "Crosspost"
-msgstr ""
-
-#: journal/views/note.py:52
+#: journal/views/note.py:59
 msgid "Progress (optional)"
 msgstr ""
 
-#: journal/views/note.py:54
+#: journal/views/note.py:61
 msgid "Note Content"
 msgstr ""
 
-#: journal/views/note.py:56
+#: journal/views/note.py:63
 msgid "Content Warning (optional)"
 msgstr ""
 
-#: journal/views/note.py:78
+#: journal/views/note.py:85
 msgid "Progress Type (optional)"
 msgstr ""
 
@@ -6237,7 +6251,7 @@ msgstr ""
 msgid "Mastodon"
 msgstr ""
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:112
+#: mastodon/models/common.py:30 users/templates/users/login.html:120
 msgid "Threads"
 msgstr ""
 
@@ -7088,7 +7102,7 @@ msgstr ""
 msgid "Disconnect with Threads"
 msgstr ""
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:120
+#: users/templates/users/account.html:173 users/templates/users/login.html:112
 msgid "Bluesky (ATProto)"
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 18:08-0400\n"
+"POT-Creation-Date: 2026-07-25 17:03+0000\n"
 "PO-Revision-Date: 2026-07-02 15:01+0000\n"
 "Last-Translator: Hosted Weblate user 54392 <hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:224
+#: boofilsic/settings.py:472 common/models/lang.py:226
 msgid "English"
 msgstr "英语"
 
-#: boofilsic/settings.py:473 common/models/lang.py:71
+#: boofilsic/settings.py:473 common/models/lang.py:73
 msgid "Danish"
 msgstr "丹麦语"
 
-#: boofilsic/settings.py:474 common/models/lang.py:72
+#: boofilsic/settings.py:474 common/models/lang.py:74
 msgid "German"
 msgstr "德语"
 
-#: boofilsic/settings.py:475 common/models/lang.py:177
+#: boofilsic/settings.py:475 common/models/lang.py:179
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: boofilsic/settings.py:476 common/models/lang.py:81
+#: boofilsic/settings.py:476 common/models/lang.py:83
 msgid "French"
 msgstr "法语"
 
-#: boofilsic/settings.py:477 common/models/lang.py:106
+#: boofilsic/settings.py:477 common/models/lang.py:108
 msgid "Italian"
 msgstr "意大利语"
 
-#: boofilsic/settings.py:478 common/models/lang.py:160
-#: common/models/lang.py:299
+#: boofilsic/settings.py:478 common/models/lang.py:162
+#: common/models/lang.py:301
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
@@ -50,11 +50,11 @@ msgstr "葡萄牙语"
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: boofilsic/settings.py:480 common/models/lang.py:310
+#: boofilsic/settings.py:480 common/models/lang.py:312
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: boofilsic/settings.py:481 common/models/lang.py:311
+#: boofilsic/settings.py:481 common/models/lang.py:313
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
@@ -71,12 +71,12 @@ msgid "Invalid date, expecting YYYY, YYYY-MM or YYYY-MM-DD."
 msgstr "日期无效，应为 YYYY、YYYY-MM 或 YYYY-MM-DD。"
 
 #: catalog/models/book.py:139 catalog/models/book.py:158
-#: catalog/models/common.py:270 catalog/models/common.py:288
+#: catalog/models/common.py:278 catalog/models/common.py:296
 msgid "locale"
 msgstr "区域语言"
 
 #: catalog/models/book.py:142 catalog/models/book.py:161
-#: catalog/models/common.py:273 catalog/models/common.py:293
+#: catalog/models/common.py:281 catalog/models/common.py:301
 msgid "text content"
 msgstr "文本内容"
 
@@ -169,7 +169,7 @@ msgstr "价格"
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:26 common/models/lang.py:250
+#: catalog/models/common.py:26 common/models/lang.py:252
 msgid "Unknown"
 msgstr "未知"
 
@@ -177,11 +177,11 @@ msgstr "未知"
 msgid "Douban"
 msgstr "豆瓣"
 
-#: catalog/models/common.py:28 catalog/models/common.py:77
+#: catalog/models/common.py:28 catalog/models/common.py:78
 msgid "Goodreads"
 msgstr "Goodreads"
 
-#: catalog/models/common.py:29 catalog/models/common.py:79
+#: catalog/models/common.py:29 catalog/models/common.py:80
 msgid "Google Books"
 msgstr "谷歌图书"
 
@@ -189,16 +189,16 @@ msgstr "谷歌图书"
 msgid "BooksTW"
 msgstr "博客來"
 
-#: catalog/models/common.py:31 catalog/models/common.py:88
-#: catalog/models/common.py:90
+#: catalog/models/common.py:31 catalog/models/common.py:89
+#: catalog/models/common.py:91
 msgid "Bibliotek.dk"
 msgstr "Bibliotek"
 
-#: catalog/models/common.py:32 catalog/models/common.py:89
+#: catalog/models/common.py:32 catalog/models/common.py:90
 msgid "eReolen.dk"
 msgstr "eReolen"
 
-#: catalog/models/common.py:33 catalog/models/common.py:72
+#: catalog/models/common.py:33 catalog/models/common.py:73
 #: catalog/templates/movie.html:41 catalog/templates/people.html:37
 #: catalog/templates/tvseason.html:58 catalog/templates/tvshow.html:53
 msgid "IMDb"
@@ -208,7 +208,7 @@ msgstr "IMDb"
 msgid "TMDB"
 msgstr "TMDB"
 
-#: catalog/models/common.py:35 catalog/models/common.py:91
+#: catalog/models/common.py:35 catalog/models/common.py:92
 msgid "Bandcamp"
 msgstr "Bandcamp"
 
@@ -224,11 +224,11 @@ msgstr "IGDB"
 msgid "Steam"
 msgstr "Steam"
 
-#: catalog/models/common.py:39 catalog/models/common.py:111
+#: catalog/models/common.py:39 catalog/models/common.py:112
 msgid "itch.io"
 msgstr "itch.io"
 
-#: catalog/models/common.py:40 catalog/models/common.py:112
+#: catalog/models/common.py:40 catalog/models/common.py:113
 msgid "Bangumi"
 msgstr "Bangumi"
 
@@ -236,7 +236,7 @@ msgstr "Bangumi"
 msgid "BGG"
 msgstr "BGG"
 
-#: catalog/models/common.py:42 catalog/models/common.py:113
+#: catalog/models/common.py:42 catalog/models/common.py:114
 msgid "Apple Podcast"
 msgstr "苹果播客"
 
@@ -248,35 +248,35 @@ msgstr "RSS"
 msgid "Discogs"
 msgstr "Discogs"
 
-#: catalog/models/common.py:45 catalog/models/common.py:114
+#: catalog/models/common.py:45 catalog/models/common.py:115
 msgid "Apple Music"
 msgstr "苹果音乐"
 
-#: catalog/models/common.py:46 catalog/models/common.py:116
+#: catalog/models/common.py:46 catalog/models/common.py:117
 msgid "Fediverse"
 msgstr "联邦宇宙"
 
-#: catalog/models/common.py:47 catalog/models/common.py:117
+#: catalog/models/common.py:47 catalog/models/common.py:118
 msgid "Qidian"
 msgstr "起点"
 
-#: catalog/models/common.py:48 catalog/models/common.py:118
+#: catalog/models/common.py:48 catalog/models/common.py:119
 msgid "Ypshuo"
 msgstr "阅评说"
 
-#: catalog/models/common.py:49 catalog/models/common.py:119
+#: catalog/models/common.py:49 catalog/models/common.py:120
 msgid "Archive of Our Own"
 msgstr "AO3"
 
-#: catalog/models/common.py:50 catalog/models/common.py:120
+#: catalog/models/common.py:50 catalog/models/common.py:121
 msgid "JinJiang"
 msgstr "晋江文学"
 
-#: catalog/models/common.py:51 catalog/models/common.py:62
+#: catalog/models/common.py:51 catalog/models/common.py:63
 msgid "WikiData"
 msgstr "维基数据"
 
-#: catalog/models/common.py:52 catalog/models/common.py:121
+#: catalog/models/common.py:52 catalog/models/common.py:122
 msgid "Open Library"
 msgstr "开放图书馆"
 
@@ -288,15 +288,15 @@ msgstr "MusicBrainz"
 msgid "WorldCat"
 msgstr "WorldCat"
 
-#: catalog/models/common.py:55 catalog/models/common.py:123
+#: catalog/models/common.py:55 catalog/models/common.py:124
 msgid "MobyGames"
 msgstr "MobyGames"
 
-#: catalog/models/common.py:56 catalog/models/common.py:124
+#: catalog/models/common.py:56 catalog/models/common.py:125
 msgid "StoryGraph"
 msgstr "StoryGraph"
 
-#: catalog/models/common.py:57 catalog/models/common.py:115
+#: catalog/models/common.py:57 catalog/models/common.py:116
 msgid "YouTube Music"
 msgstr "YouTube Music"
 
@@ -304,286 +304,306 @@ msgstr "YouTube Music"
 msgid "RateYourMusic"
 msgstr "RateYourMusic"
 
-#: catalog/models/common.py:63
+#: catalog/models/common.py:59
+msgid "AniList"
+msgstr "AniList"
+
+#: catalog/models/common.py:64
 msgid "ISBN10"
 msgstr "ISBN10"
 
-#: catalog/models/common.py:64 catalog/templates/edition.html:19
+#: catalog/models/common.py:65 catalog/templates/edition.html:19
 msgid "ISBN"
 msgstr "ISBN"
 
-#: catalog/models/common.py:65
+#: catalog/models/common.py:66
 msgid "ASIN"
 msgstr "ASIN"
 
-#: catalog/models/common.py:66
+#: catalog/models/common.py:67
 msgid "ISSN"
 msgstr "ISSN"
 
-#: catalog/models/common.py:67
+#: catalog/models/common.py:68
 msgid "CUBN"
 msgstr "统一书号"
 
-#: catalog/models/common.py:68
+#: catalog/models/common.py:69
 msgid "ISRC"
 msgstr "ISRC"
 
-#: catalog/models/common.py:69
+#: catalog/models/common.py:70
 msgid "GTIN UPC EAN"
 msgstr "条形码"
 
-#: catalog/models/common.py:70
+#: catalog/models/common.py:71
 msgid "OCLC Number"
 msgstr "OCLC控制号"
 
-#: catalog/models/common.py:71
+#: catalog/models/common.py:72
 msgid "RSS Feed URL"
 msgstr "RSS网址"
 
-#: catalog/models/common.py:73
+#: catalog/models/common.py:74
 msgid "TMDB TV Series"
 msgstr "TMDB电视剧集"
 
-#: catalog/models/common.py:74
+#: catalog/models/common.py:75
 msgid "TMDB TV Season"
 msgstr "TMDB电视分季"
 
-#: catalog/models/common.py:75
+#: catalog/models/common.py:76
 msgid "TMDB TV Episode"
 msgstr "TMDB电视单集"
 
-#: catalog/models/common.py:76
+#: catalog/models/common.py:77
 msgid "TMDB Movie"
 msgstr "TMDB电影"
 
-#: catalog/models/common.py:78
+#: catalog/models/common.py:79
 msgid "Goodreads Work"
 msgstr "Goodreads著作"
 
-#: catalog/models/common.py:80
+#: catalog/models/common.py:81
 msgid "Douban Book"
 msgstr "豆瓣图书"
 
-#: catalog/models/common.py:81
+#: catalog/models/common.py:82
 msgid "Douban Book Work"
 msgstr "豆瓣图书著作"
 
-#: catalog/models/common.py:82
+#: catalog/models/common.py:83
 msgid "Douban Movie"
 msgstr "豆瓣电影"
 
-#: catalog/models/common.py:83
+#: catalog/models/common.py:84
 msgid "Douban Music"
 msgstr "豆瓣音乐"
 
-#: catalog/models/common.py:84
+#: catalog/models/common.py:85
 msgid "Douban Game"
 msgstr "豆瓣游戏"
 
-#: catalog/models/common.py:85
+#: catalog/models/common.py:86
 msgid "Douban Drama"
 msgstr "豆瓣舞台剧"
 
-#: catalog/models/common.py:86
+#: catalog/models/common.py:87
 msgid "Douban Drama Version"
 msgstr "豆瓣舞台剧版本"
 
-#: catalog/models/common.py:87
+#: catalog/models/common.py:88
 msgid "BooksTW Book"
 msgstr "博客来图书"
 
-#: catalog/models/common.py:92
+#: catalog/models/common.py:93
 msgid "Spotify Album"
 msgstr "Spotify专辑"
 
-#: catalog/models/common.py:93
+#: catalog/models/common.py:94
 msgid "Spotify Podcast"
 msgstr "Spotify播客"
 
-#: catalog/models/common.py:94
+#: catalog/models/common.py:95
 msgid "Discogs Release"
 msgstr "Discogs发行"
 
-#: catalog/models/common.py:95
+#: catalog/models/common.py:96
 msgid "Discogs Master"
 msgstr "Discogs作品"
 
-#: catalog/models/common.py:98
+#: catalog/models/common.py:99
 msgid "MusicBrainz Release Group"
 msgstr "MusicBrainz发行列表"
 
-#: catalog/models/common.py:100
+#: catalog/models/common.py:101
 msgid "MusicBrainz Release"
 msgstr "MusicBrainz发行"
 
-#: catalog/models/common.py:101
+#: catalog/models/common.py:102
 msgid "MusicBrainz Artist"
 msgstr "MusicBrainz艺术家"
 
-#: catalog/models/common.py:102
+#: catalog/models/common.py:103
 msgid "Douban Personage"
 msgstr "豆瓣人物"
 
-#: catalog/models/common.py:103
+#: catalog/models/common.py:104
 msgid "Goodreads Author"
 msgstr "Goodreads作者"
 
-#: catalog/models/common.py:104
+#: catalog/models/common.py:105
 msgid "Spotify Artist"
 msgstr "Spotify艺术家"
 
-#: catalog/models/common.py:105
+#: catalog/models/common.py:106
 msgid "TMDB Person"
 msgstr "TMDB人物"
 
-#: catalog/models/common.py:106
+#: catalog/models/common.py:107
 msgid "Open Library Author"
 msgstr "开放图书馆作者"
 
-#: catalog/models/common.py:107
+#: catalog/models/common.py:108
 msgid "IGDB Company"
 msgstr "IGDB公司"
 
-#: catalog/models/common.py:108
+#: catalog/models/common.py:109
 msgid "IGDB Game"
 msgstr "IGDB游戏"
 
-#: catalog/models/common.py:109
+#: catalog/models/common.py:110
 msgid "BGG Boardgame"
 msgstr "BGG桌游"
 
-#: catalog/models/common.py:110
+#: catalog/models/common.py:111
 msgid "Steam Game"
 msgstr "Steam游戏"
 
-#: catalog/models/common.py:122
+#: catalog/models/common.py:123
 msgid "Open Library Work"
 msgstr "开放图书馆著作"
 
-#: catalog/models/common.py:125
+#: catalog/models/common.py:126
 msgid "RateYourMusic Release"
 msgstr "RateYourMusic发行"
 
-#: catalog/models/common.py:146
+#: catalog/models/common.py:130
+msgid "AniList Anime"
+msgstr "AniList动画"
+
+#: catalog/models/common.py:131
+msgid "AniList Manga"
+msgstr "AniList漫画"
+
+#: catalog/models/common.py:132
+msgid "MyAnimeList Anime"
+msgstr "MyAnimeList动画"
+
+#: catalog/models/common.py:133
+msgid "MyAnimeList Manga"
+msgstr "MyAnimeList漫画"
+
+#: catalog/models/common.py:154
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:147 catalog/templates/_sidebar_edit.html:249
+#: catalog/models/common.py:155 catalog/templates/_sidebar_edit.html:249
 msgid "Work"
 msgstr "作品"
 
-#: catalog/models/common.py:148
+#: catalog/models/common.py:156
 msgid "TV Series"
 msgstr "电视剧集"
 
-#: catalog/models/common.py:149 catalog/templates/_sidebar_edit.html:170
+#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:170
 msgid "TV Season"
 msgstr "电视分季"
 
-#: catalog/models/common.py:150
+#: catalog/models/common.py:158
 msgid "TV Episode"
 msgstr "电视单集"
 
-#: catalog/models/common.py:151 catalog/models/common.py:167
-#: catalog/models/common.py:181 catalog/templates/_sidebar_edit.html:163
+#: catalog/models/common.py:159 catalog/models/common.py:175
+#: catalog/models/common.py:189 catalog/templates/_sidebar_edit.html:163
 #: journal/templates/_sidebar_user_mark_list.html:35
 #: journal/templates/_sidebar_user_tag_filter.html:27
 msgid "Movie"
 msgstr "电影"
 
-#: catalog/models/common.py:152
+#: catalog/models/common.py:160
 msgid "Album"
 msgstr "专辑"
 
-#: catalog/models/common.py:153 catalog/models/common.py:170
-#: catalog/models/common.py:184 common/templates/_header.html:43
+#: catalog/models/common.py:161 catalog/models/common.py:178
+#: catalog/models/common.py:192 common/templates/_header.html:43
 #: journal/templates/_sidebar_user_mark_list.html:48
 #: journal/templates/_sidebar_user_tag_filter.html:39
 msgid "Game"
 msgstr "游戏"
 
-#: catalog/models/common.py:154
+#: catalog/models/common.py:162
 msgid "Podcast Program"
 msgstr "播客节目"
 
-#: catalog/models/common.py:155
+#: catalog/models/common.py:163
 msgid "Podcast Episode"
 msgstr "播客单集"
 
-#: catalog/models/common.py:156 catalog/models/common.py:172
-#: catalog/models/common.py:186 common/templates/_header.html:47
+#: catalog/models/common.py:164 catalog/models/common.py:180
+#: catalog/models/common.py:194 common/templates/_header.html:47
 #: journal/templates/_sidebar_user_mark_list.html:52
 #: journal/templates/_sidebar_user_tag_filter.html:43
 msgid "Performance"
 msgstr "演出"
 
-#: catalog/models/common.py:157
+#: catalog/models/common.py:165
 msgid "Production"
 msgstr "上演"
 
-#: catalog/models/common.py:158
+#: catalog/models/common.py:166
 msgid "Exhibition"
 msgstr "展览"
 
-#: catalog/models/common.py:159 catalog/models/common.py:176
+#: catalog/models/common.py:167 catalog/models/common.py:184
 #: journal/templates/collection.html:29 journal/templates/collection.html:40
 #: journal/templates/collection_edit.html:10
 #: journal/templates/collection_share.html:12
 msgid "Collection"
 msgstr "收藏单"
 
-#: catalog/models/common.py:162 catalog/models/common.py:175
+#: catalog/models/common.py:170 catalog/models/common.py:183
 msgid "Person / Organization"
 msgstr "人物 / 团体"
 
-#: catalog/models/common.py:166 catalog/models/common.py:180
+#: catalog/models/common.py:174 catalog/models/common.py:188
 #: common/templates/_header.html:27
 #: journal/templates/_sidebar_user_mark_list.html:32
 #: journal/templates/_sidebar_user_tag_filter.html:24
 msgid "Book"
 msgstr "图书"
 
-#: catalog/models/common.py:168 catalog/models/common.py:182
+#: catalog/models/common.py:176 catalog/models/common.py:190
 #: journal/templates/_sidebar_user_mark_list.html:38
 #: journal/templates/_sidebar_user_tag_filter.html:30
 msgid "TV"
 msgstr "剧集"
 
-#: catalog/models/common.py:169 catalog/models/common.py:183
+#: catalog/models/common.py:177 catalog/models/common.py:191
 #: common/templates/_header.html:39
 #: journal/templates/_sidebar_user_mark_list.html:45
 #: journal/templates/_sidebar_user_tag_filter.html:36
 msgid "Music"
 msgstr "音乐"
 
-#: catalog/models/common.py:171 catalog/models/common.py:185
+#: catalog/models/common.py:179 catalog/models/common.py:193
 #: catalog/templates/_sidebar_edit.html:182 common/templates/_header.html:35
 #: journal/templates/_sidebar_user_mark_list.html:42
 #: journal/templates/_sidebar_user_tag_filter.html:33
 msgid "Podcast"
 msgstr "播客"
 
-#: catalog/models/common.py:336 catalog/templates/_genre_list.html:5
+#: catalog/models/common.py:344 catalog/templates/_genre_list.html:5
 msgid "genre"
 msgstr "类型"
 
-#: catalog/models/common.py:374
+#: catalog/models/common.py:382
 msgid "origin country"
 msgstr "制片国家/地区"
 
-#: catalog/models/common.py:403 catalog/templates/album.html:33
+#: catalog/models/common.py:411 catalog/templates/album.html:33
 msgid "album type"
 msgstr "专辑类型"
 
-#: catalog/models/common.py:407 catalog/templates/_platform_list.html:5
+#: catalog/models/common.py:415 catalog/templates/_platform_list.html:5
 msgid "platform"
 msgstr "平台"
 
-#: catalog/models/common.py:411
+#: catalog/models/common.py:419
 msgid "media format"
 msgstr "介质"
 
-#: catalog/models/common.py:416 catalog/templates/_language_list.html:5
+#: catalog/models/common.py:424 catalog/templates/_language_list.html:5
 #: users/models/user.py:142
 msgid "language"
 msgstr "语言"
@@ -1383,7 +1403,7 @@ msgstr "合并到另一条目"
 #: catalog/templates/catalog_delete.html:12
 #: journal/templates/action_delete_post.html:10
 #: journal/templates/article.html:199 journal/templates/collection.html:182
-#: journal/templates/mark.html:157 journal/templates/note.html:84
+#: journal/templates/mark.html:149 journal/templates/note.html:82
 #: journal/templates/piece_delete.html:10
 #: journal/templates/piece_delete.html:34
 #: users/templates/users/account.html:254
@@ -1647,11 +1667,11 @@ msgstr "创建"
 #: catalog/templates/catalog_edit.html:65
 #: common/templates/manage/settings.html:136
 #: journal/templates/add_to_collection.html:43
-#: journal/templates/article_edit.html:59
-#: journal/templates/collection_edit.html:39 journal/templates/comment.html:69
-#: journal/templates/mark.html:142 journal/templates/note.html:67
+#: journal/templates/article_edit.html:60
+#: journal/templates/collection_edit.html:39 journal/templates/comment.html:41
+#: journal/templates/mark.html:134 journal/templates/note.html:65
 #: journal/templates/post_compose.html:103
-#: journal/templates/review_edit.html:39 journal/templates/tag_edit.html:51
+#: journal/templates/review_edit.html:46 journal/templates/tag_edit.html:51
 #: users/templates/users/_pref_device.html:37
 #: users/templates/users/account.html:38 users/templates/users/account.html:67
 #: users/templates/users/preferences.html:241
@@ -2138,7 +2158,7 @@ msgstr "条目不可被删除。"
 #: journal/views/collection.py:415 journal/views/collection.py:458
 #: journal/views/collection.py:497 journal/views/collection.py:509
 #: journal/views/collection.py:534 journal/views/collection.py:571
-#: journal/views/common.py:272 journal/views/mark.py:264
+#: journal/views/common.py:272 journal/views/mark.py:281
 #: journal/views/post.py:58 journal/views/post.py:78 journal/views/post.py:100
 #: journal/views/post.py:165 journal/views/post.py:194
 #: journal/views/post.py:267 journal/views/post.py:282
@@ -2152,7 +2172,7 @@ msgstr "权限不足"
 #: catalog/views/verify.py:194 journal/views/collection.py:75
 #: journal/views/collection.py:100 journal/views/collection.py:514
 #: journal/views/collection.py:609 journal/views/common.py:193
-#: journal/views/mark.py:190 journal/views/post.py:112
+#: journal/views/mark.py:196 journal/views/post.py:112
 #: journal/views/post.py:114 journal/views/post.py:161
 #: journal/views/post.py:180 journal/views/post.py:182
 #: journal/views/post.py:223 journal/views/post.py:236
@@ -2739,759 +2759,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr "健康"
 
-#: common/models/lang.py:48
+#: common/models/lang.py:50
 msgid "Afar"
 msgstr "阿法尔语"
 
-#: common/models/lang.py:49
+#: common/models/lang.py:51
 msgid "Afrikaans"
 msgstr "南非荷兰语"
 
-#: common/models/lang.py:50
+#: common/models/lang.py:52
 msgid "Akan"
 msgstr "阿坎语"
 
-#: common/models/lang.py:51
+#: common/models/lang.py:53
 msgid "Aragonese"
 msgstr "阿拉贡语"
 
-#: common/models/lang.py:52
+#: common/models/lang.py:54
 msgid "Assamese"
 msgstr "阿萨姆语"
 
-#: common/models/lang.py:53
+#: common/models/lang.py:55
 msgid "Avaric"
 msgstr "阿瓦尔语"
 
-#: common/models/lang.py:54
+#: common/models/lang.py:56
 msgid "Avestan"
 msgstr "阿维斯陀语"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:57
 msgid "Aymara"
 msgstr "艾马拉语"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:58
 msgid "Azerbaijani"
 msgstr "阿塞拜疆"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:59
 msgid "Bashkir"
 msgstr "巴什基尔语"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:60
 msgid "Bambara"
 msgstr "班巴拉语"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:61
 msgid "Bislama"
 msgstr "比斯拉马语"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:62
 msgid "Tibetan"
 msgstr "藏语"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:63
 msgid "Breton"
 msgstr "布列塔尼语"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:64
 msgid "Catalan"
 msgstr "加泰罗尼亚"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:65
 msgid "Czech"
 msgstr "捷克语"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:66
 msgid "Chechen"
 msgstr "车臣"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:67
 msgid "Slavic"
 msgstr "斯拉夫"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:68
 msgid "Chuvash"
 msgstr "楚瓦什语"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:69
 msgid "Cornish"
 msgstr "康沃尔语"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:70
 msgid "Corsican"
 msgstr "科西嘉语"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:71
 msgid "Cree"
 msgstr "克里语"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:72
 msgid "Welsh"
 msgstr "威尔士语"
 
-#: common/models/lang.py:73
+#: common/models/lang.py:75
 msgid "Divehi"
 msgstr "迪维希语"
 
-#: common/models/lang.py:74
+#: common/models/lang.py:76
 msgid "Dzongkha"
 msgstr "宗喀语"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:77
 msgid "Esperanto"
 msgstr "世界语"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:78
 msgid "Estonian"
 msgstr "爱沙尼亚语"
 
-#: common/models/lang.py:77
+#: common/models/lang.py:79
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: common/models/lang.py:78
+#: common/models/lang.py:80
 msgid "Faroese"
 msgstr "法罗语"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:81
 msgid "Fijian"
 msgstr "斐济语"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:82
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:84
 msgid "Frisian"
 msgstr "弗里西语"
 
-#: common/models/lang.py:83
+#: common/models/lang.py:85
 msgid "Fulah"
 msgstr "富拉语"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:86
 msgid "Gaelic"
 msgstr "盖尔语"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:87
 msgid "Irish"
 msgstr "爱尔兰语"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:88
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: common/models/lang.py:87
+#: common/models/lang.py:89
 msgid "Manx"
 msgstr "马恩语"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:90
 msgid "Guarani"
 msgstr "瓜拉尼语"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:91
 msgid "Gujarati"
 msgstr "古吉拉特语"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:92
 msgid "Haitian; Haitian Creole"
 msgstr "海地语; 海地克里奥尔语"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:93
 msgid "Hausa"
 msgstr "豪萨语"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:94
 msgid "Serbo-Croatian"
 msgstr "塞尔维亚-克罗地亚语"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:95
 msgid "Herero"
 msgstr "赫雷罗语"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:96
 msgid "Hiri Motu"
 msgstr "希里莫图语"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:97
 msgid "Croatian"
 msgstr "克罗地亚语"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:98
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:99
 msgid "Igbo"
 msgstr "伊博语"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:100
 msgid "Ido"
 msgstr "伊多语"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:101
 msgid "Yi"
 msgstr "彝语"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:102
 msgid "Inuktitut"
 msgstr "因纽特语"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:103
 msgid "Interlingue"
 msgstr "西方国际语"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:104
 msgid "Interlingua"
 msgstr "国际语"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:105
 msgid "Indonesian"
 msgstr "印度尼西亚语"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:106
 msgid "Inupiaq"
 msgstr "伊努皮克语"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:107
 msgid "Icelandic"
 msgstr "冰岛语"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:109
 msgid "Javanese"
 msgstr "爪哇语"
 
-#: common/models/lang.py:108
+#: common/models/lang.py:110
 msgid "Japanese"
 msgstr "日语"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:111
 msgid "Kalaallisut"
 msgstr "格陵兰语"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:112
 msgid "Kannada"
 msgstr "卡纳达语"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:113
 msgid "Kashmiri"
 msgstr "克什米尔语"
 
-#: common/models/lang.py:112
+#: common/models/lang.py:114
 msgid "Kanuri"
 msgstr "卡努里语"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:115
 msgid "Kazakh"
 msgstr "哈萨克语"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:116
 msgid "Khmer"
 msgstr "高棉语"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:117
 msgid "Kikuyu"
 msgstr "基库尤语"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:118
 msgid "Kinyarwanda"
 msgstr "卢旺达语"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:119
 msgid "Kirghiz"
 msgstr "吉尔吉斯语"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:120
 msgid "Komi"
 msgstr "科米语"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:121
 msgid "Kongo"
 msgstr "刚果语"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:122
 msgid "Korean"
 msgstr "韩语"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:123
 msgid "Kuanyama"
 msgstr "宽亚玛语"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:124
 msgid "Kurdish"
 msgstr "库尔德语"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:125
 msgid "Lao"
 msgstr "老挝语"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:126
 msgid "Latin"
 msgstr "拉丁"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:127
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:128
 msgid "Limburgish"
 msgstr "林堡语"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:129
 msgid "Lingala"
 msgstr "林加拉语"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:130
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:131
 msgid "Letzeburgesch"
 msgstr "卢森堡语"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:132
 msgid "Luba-Katanga"
 msgstr "卢巴-加丹加语"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:133
 msgid "Ganda"
 msgstr "干达语"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:134
 msgid "Marshall"
 msgstr "马绍尔语"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:135
 msgid "Malayalam"
 msgstr "马拉雅拉姆语"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:136
 msgid "Marathi"
 msgstr "马拉地语"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:137
 msgid "Malagasy"
 msgstr "马达加斯加语"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:138
 msgid "Maltese"
 msgstr "马耳他语"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:139
 msgid "Moldavian"
 msgstr "摩尔多瓦语"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:140
 msgid "Mongolian"
 msgstr "蒙古语"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:141
 msgid "Maori"
 msgstr "毛利语"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:142
 msgid "Malay"
 msgstr "马来语"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:143
 msgid "Burmese"
 msgstr "缅甸语"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:144
 msgid "Nauru"
 msgstr "瑙鲁语"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:145
 msgid "Navajo"
 msgstr "纳瓦霍语"
 
-#: common/models/lang.py:144 common/models/lang.py:145
+#: common/models/lang.py:146 common/models/lang.py:147
 msgid "Ndebele"
 msgstr "恩德贝莱语"
 
-#: common/models/lang.py:146
+#: common/models/lang.py:148
 msgid "Ndonga"
 msgstr "恩东加语"
 
-#: common/models/lang.py:147
+#: common/models/lang.py:149
 msgid "Nepali"
 msgstr "尼泊尔语"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:150
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:151
 msgid "Norwegian Nynorsk"
 msgstr "挪威尼诺斯克语"
 
-#: common/models/lang.py:150
+#: common/models/lang.py:152
 msgid "Norwegian Bokmål"
 msgstr "挪威博克马尔语"
 
-#: common/models/lang.py:151
+#: common/models/lang.py:153
 msgid "Norwegian"
 msgstr "挪威语"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:154
 msgid "Chichewa; Nyanja"
 msgstr "奇切瓦语; 尼扬贾语"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:155
 msgid "Occitan"
 msgstr "奥克语"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:156
 msgid "Ojibwa"
 msgstr "奥吉布瓦语"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:157
 msgid "Oriya"
 msgstr "奥里亚语"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:158
 msgid "Oromo"
 msgstr "奥罗莫语"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:159
 msgid "Ossetian; Ossetic"
 msgstr "奥塞梯语"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:160
 msgid "Pali"
 msgstr "巴利语"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:161
 msgid "Polish"
 msgstr "波兰语"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:163
 msgid "Quechua"
 msgstr "克丘亚语"
 
-#: common/models/lang.py:162
+#: common/models/lang.py:164
 msgid "Raeto-Romance"
 msgstr "罗曼什语"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:165
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:166
 msgid "Rundi"
 msgstr "基隆迪语"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:167
 msgid "Russian"
 msgstr "俄语"
 
-#: common/models/lang.py:166
+#: common/models/lang.py:168
 msgid "Sango"
 msgstr "桑戈语"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:169
 msgid "Sanskrit"
 msgstr "梵语"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:170
 msgid "Sinhalese"
 msgstr "僧伽罗语"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:171
 msgid "Slovak"
 msgstr "斯洛伐克语"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:172
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:173
 msgid "Northern Sami"
 msgstr "北萨米语"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:174
 msgid "Samoan"
 msgstr "萨摩亚语"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:175
 msgid "Shona"
 msgstr "绍纳语"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:176
 msgid "Sindhi"
 msgstr "信德语"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:177
 msgid "Somali"
 msgstr "索马里语"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:178
 msgid "Sotho"
 msgstr "索托语"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:180
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: common/models/lang.py:179
+#: common/models/lang.py:181
 msgid "Sardinian"
 msgstr "萨丁尼亚语"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:182
 msgid "Serbian"
 msgstr "塞尔维亚语"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:183
 msgid "Swati"
 msgstr "斯瓦特语"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:184
 msgid "Sundanese"
 msgstr "巽他语"
 
-#: common/models/lang.py:183
+#: common/models/lang.py:185
 msgid "Swahili"
 msgstr "斯瓦希里语"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:186
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:187
 msgid "Tahitian"
 msgstr "塔希提语"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:188
 msgid "Tamil"
 msgstr "泰米尔语"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:189
 msgid "Tatar"
 msgstr "鞑靼语"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:190
 msgid "Telugu"
 msgstr "泰卢固语"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:191
 msgid "Tajik"
 msgstr "塔吉克语"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:192
 msgid "Tagalog"
 msgstr "他加禄语"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:193
 msgid "Thai"
 msgstr "泰语"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:194
 msgid "Tigrinya"
 msgstr "提格利尼亚语"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:195
 msgid "Tonga"
 msgstr "汤加语"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:196
 msgid "Tswana"
 msgstr "茨瓦纳语"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:197
 msgid "Tsonga"
 msgstr "聪加语"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:198
 msgid "Turkmen"
 msgstr "土库曼语"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:199
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:200
 msgid "Twi"
 msgstr "契维语"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:201
 msgid "Uighur"
 msgstr "维吾尔语"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:202
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:203
 msgid "Urdu"
 msgstr "乌尔都语"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:204
 msgid "Uzbek"
 msgstr "乌兹别克语"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:205
 msgid "Venda"
 msgstr "文达语"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:206
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:207
 msgid "Volapük"
 msgstr "沃拉普克语"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:208
 msgid "Walloon"
 msgstr "瓦隆语"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:209
 msgid "Wolof"
 msgstr "沃洛夫语"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:210
 msgid "Xhosa"
 msgstr "科萨语"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:211
 msgid "Yiddish"
 msgstr "意第绪语"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:212
 msgid "Zhuang"
 msgstr "壮语"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:213
 msgid "Zulu"
 msgstr "祖鲁语"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:214
 msgid "Abkhazian"
 msgstr "阿布哈兹语"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:215
 msgid "Chinese"
 msgstr "中文"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:216
 msgid "Pushto"
 msgstr "普什图语"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:217
 msgid "Amharic"
 msgstr "阿姆哈拉语"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:218
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:219
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:220
 msgid "Macedonian"
 msgstr "马其顿语"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:221
 msgid "Greek"
 msgstr "希腊语"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:222
 msgid "Persian"
 msgstr "波斯语"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:223
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:224
 msgid "Hindi"
 msgstr "印度语"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:225
 msgid "Armenian"
 msgstr "亚美尼亚语"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:227
 msgid "Ewe"
 msgstr "埃维语"
 
-#: common/models/lang.py:226
+#: common/models/lang.py:228
 msgid "Georgian"
 msgstr "格鲁吉亚语"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:229
 msgid "Punjabi"
 msgstr "旁遮普语"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:230
 msgid "Bengali"
 msgstr "孟加拉语"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:231
 msgid "Bosnian"
 msgstr "波斯尼亚语"
 
-#: common/models/lang.py:230
+#: common/models/lang.py:232
 msgid "Chamorro"
 msgstr "查莫罗语"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:233
 msgid "Belarusian"
 msgstr "白俄罗斯语"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:234
 msgid "Yoruba"
 msgstr "约鲁巴语"
 
-#: common/models/lang.py:294
+#: common/models/lang.py:296
 msgid "Simplified Chinese (Mainland)"
 msgstr "简体中文(大陆)"
 
-#: common/models/lang.py:295
+#: common/models/lang.py:297
 msgid "Traditional Chinese (Taiwan)"
 msgstr "正体中文(台湾)"
 
-#: common/models/lang.py:296
+#: common/models/lang.py:298
 msgid "Traditional Chinese (Hongkong)"
 msgstr "繁体中文(香港)"
 
-#: common/models/lang.py:304
+#: common/models/lang.py:306
 msgid "Portuguese (Brazil)"
 msgstr "葡萄牙语(巴西)"
 
-#: common/models/lang.py:307
+#: common/models/lang.py:309
 msgid "Simplified Chinese (Singapore)"
 msgstr "简体中文(新加坡)"
 
-#: common/models/lang.py:308
+#: common/models/lang.py:310
 msgid "Simplified Chinese (Malaysia)"
 msgstr "简体中文(马来西亚)"
 
-#: common/models/lang.py:309
+#: common/models/lang.py:311
 msgid "Traditional Chinese (Macau)"
 msgstr "繁体中文(澳门)"
 
-#: common/models/lang.py:317
+#: common/models/lang.py:319
 msgid "Mandarin Chinese"
 msgstr "普通话"
 
-#: common/models/lang.py:318
+#: common/models/lang.py:320
 msgid "Yue Chinese"
 msgstr "粤语"
 
-#: common/models/lang.py:322
+#: common/models/lang.py:324
 msgid "Min Nan Chinese"
 msgstr "闽南语"
 
-#: common/models/lang.py:323
+#: common/models/lang.py:325
 msgid "Wu Chinese"
 msgstr "吴语"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:326
 msgid "Hakka Chinese"
 msgstr "客家话"
 
@@ -3792,7 +3812,7 @@ msgstr "正在阅读"
 msgid "Currently watching"
 msgstr "正在追看"
 
-#: common/templates/_sidebar.html:233 journal/forms.py:199
+#: common/templates/_sidebar.html:233 journal/forms.py:217
 #: journal/templates/user_tag_list.html:13
 #: journal/templates/user_tagmember_list.html:4
 msgid "Tags"
@@ -4731,84 +4751,91 @@ msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
-#: journal/forms.py:24 journal/forms.py:26 journal/forms.py:72
-#: journal/forms.py:75 journal/forms.py:142
+#: journal/forms.py:12
+msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
+msgstr "提示： 善用 >!文字!< 标记可隐藏剧透； 超过360字可能无法分享到联邦宇宙实例时间轴。"
+
+#: journal/forms.py:29 journal/forms.py:31 journal/forms.py:80
+#: journal/forms.py:83 journal/forms.py:153
 msgid "Title"
 msgstr "标题"
 
-#: journal/forms.py:30 journal/forms.py:35 journal/forms.py:36
-#: journal/forms.py:91 journal/forms.py:96 journal/forms.py:97
-#: journal/forms.py:144
+#: journal/forms.py:35 journal/forms.py:40 journal/forms.py:41
+#: journal/forms.py:99 journal/forms.py:104 journal/forms.py:105
+#: journal/forms.py:155
 msgid "Content (Markdown)"
 msgstr "内容 （Markdown格式）"
 
-#: journal/forms.py:41 journal/forms.py:208 journal/templates/comment.html:62
-#: journal/templates/mark.html:115
-msgid "Crosspost to timeline"
-msgstr "转发到时间轴"
+#: journal/forms.py:46 journal/forms.py:124 journal/forms.py:226
+#: journal/forms.py:288 journal/views/note.py:38
+msgid "Crosspost"
+msgstr "转发"
 
-#: journal/forms.py:44 journal/forms.py:119
+#: journal/forms.py:47 journal/forms.py:125 journal/forms.py:227
+#: journal/forms.py:289 journal/views/note.py:39
+msgid "Crosspost to your connected social networks"
+msgstr "转发到你已连接的社交网络"
+
+#: journal/forms.py:52 journal/forms.py:130
 msgid "Keep leading spaces"
 msgstr "保留行首空格"
 
-#: journal/forms.py:45 journal/forms.py:120
+#: journal/forms.py:53 journal/forms.py:131
 msgid "When saving, replace leading spaces with full-width spaces"
 msgstr "保存时将行首空格替换为全角"
 
-#: journal/forms.py:51 journal/forms.py:126 journal/forms.py:151
-#: journal/forms.py:201 journal/templates/collection_share.html:24
-#: journal/templates/wrapped_share.html:36 users/templates/users/data.html:45
-#: users/templates/users/data.html:98 users/templates/users/data.html:155
-#: users/templates/users/data.html:206 users/templates/users/data.html:269
-#: users/templates/users/data.html:328 users/templates/users/rym_import.html:81
+#: journal/forms.py:59 journal/forms.py:137 journal/forms.py:162
+#: journal/forms.py:219 journal/forms.py:281
+#: journal/templates/collection_share.html:24
+#: journal/templates/wrapped_share.html:36 journal/views/note.py:31
+#: users/templates/users/data.html:45 users/templates/users/data.html:98
+#: users/templates/users/data.html:155 users/templates/users/data.html:206
+#: users/templates/users/data.html:269 users/templates/users/data.html:328
+#: users/templates/users/rym_import.html:81
 #: users/templates/users/steam_import.html:125
 #: users/templates/users/storygraph_import.html:81
 msgid "Visibility"
 msgstr "可见性"
 
-#: journal/forms.py:64
+#: journal/forms.py:72
 msgid "Featured image (optional)"
 msgstr "封面图片（选填）"
 
-#: journal/forms.py:79 journal/forms.py:85 journal/forms.py:86
+#: journal/forms.py:87 journal/forms.py:93 journal/forms.py:94
 msgid "Summary (optional)"
 msgstr "摘要（选填）"
 
-#: journal/forms.py:102 journal/forms.py:107 journal/forms.py:108
+#: journal/forms.py:110 journal/forms.py:115 journal/forms.py:116
 msgid "Tags (comma separated)"
 msgstr "标签（逗号分隔）"
 
-#: journal/forms.py:113 journal/templates/post_compose.html:86
+#: journal/forms.py:121 journal/templates/post_compose.html:86
 msgid "Mark as sensitive"
 msgstr "标记为敏感"
 
-#: journal/forms.py:116
-msgid "Crosspost to Mastodon"
-msgstr "转发到Mastodon"
-
-#: journal/forms.py:135
+#: journal/forms.py:146
 msgid "owner only"
 msgstr "仅创建者"
 
-#: journal/forms.py:136
+#: journal/forms.py:147
 msgid "owner and their local mutuals"
 msgstr "创建者和他们的本地互关"
 
-#: journal/forms.py:158 journal/templates/collection.html:187
+#: journal/forms.py:169 journal/templates/collection.html:187
 #: journal/templates/collection.html:196
 msgid "Collaborative editing"
 msgstr "协作编辑"
 
-#: journal/forms.py:193 users/templates/users/crossposts.html:51
+#: journal/forms.py:204 users/templates/users/crossposts.html:51
 #: users/templates/users/data.html:483
 msgid "Status"
 msgstr "状态"
 
-#: journal/forms.py:195 journal/templates/comment.html:16
+#: journal/forms.py:209 journal/forms.py:275 journal/templates/comment.html:16
 msgid "Comment"
 msgstr "短评"
 
-#: journal/forms.py:197
+#: journal/forms.py:215
 msgid "Rating"
 msgstr "评分"
 
@@ -4920,12 +4947,12 @@ msgstr[0] "%(count)d 个条目"
 msgstr[1] "%(count)d 个条目"
 
 #: journal/models/common.py:50 journal/templates/action_open_post.html:15
-#: journal/templates/collection_share.html:35 journal/templates/comment.html:35
-#: journal/templates/mark.html:88 journal/templates/post_compose.html:58
-#: journal/templates/tag_edit.html:42 journal/templates/wrapped_share.html:43
-#: users/templates/users/data.html:54 users/templates/users/data.html:107
-#: users/templates/users/data.html:164 users/templates/users/data.html:215
-#: users/templates/users/data.html:277 users/templates/users/data.html:337
+#: journal/templates/collection_share.html:35 journal/templates/mark.html:84
+#: journal/templates/post_compose.html:58 journal/templates/tag_edit.html:42
+#: journal/templates/wrapped_share.html:43 users/templates/users/data.html:54
+#: users/templates/users/data.html:107 users/templates/users/data.html:164
+#: users/templates/users/data.html:215 users/templates/users/data.html:277
+#: users/templates/users/data.html:337
 #: users/templates/users/preferences.html:56
 #: users/templates/users/rym_import.html:84
 #: users/templates/users/steam_import.html:128
@@ -4934,8 +4961,8 @@ msgid "Public"
 msgstr "公开"
 
 #: journal/models/common.py:51 journal/templates/action_open_post.html:9
-#: journal/templates/collection_share.html:46 journal/templates/comment.html:42
-#: journal/templates/mark.html:95 journal/templates/post_compose.html:65
+#: journal/templates/collection_share.html:46 journal/templates/mark.html:91
+#: journal/templates/post_compose.html:65
 #: journal/templates/wrapped_share.html:49 users/templates/users/data.html:62
 #: users/templates/users/data.html:115 users/templates/users/data.html:172
 #: users/templates/users/data.html:223 users/templates/users/data.html:285
@@ -4948,8 +4975,7 @@ msgid "Followers Only"
 msgstr "仅关注者"
 
 #: journal/models/common.py:52 journal/templates/collection_share.html:57
-#: journal/templates/comment.html:49 journal/templates/mark.html:102
-#: journal/templates/post_compose.html:72
+#: journal/templates/mark.html:98 journal/templates/post_compose.html:72
 #: journal/templates/wrapped_share.html:55 users/templates/users/data.html:70
 #: users/templates/users/data.html:123 users/templates/users/data.html:180
 #: users/templates/users/data.html:231 users/templates/users/data.html:293
@@ -4997,8 +5023,8 @@ msgstr "失败"
 msgid "Retrying"
 msgstr "重试中"
 
-#: journal/models/mark.py:469 journal/views/note.py:117
-#: journal/views/note.py:177
+#: journal/models/mark.py:469 journal/views/note.py:124
+#: journal/views/note.py:184
 msgid "Only in-progress books can have reading progress."
 msgstr "只有正在阅读的书籍可以设置阅读进度。"
 
@@ -5823,11 +5849,7 @@ msgstr "拖拽修改条目顺序后点击这里保存"
 msgid "for the sharing post only, not visibility of the collection"
 msgstr "分享帖文的可见性，不同于收藏单本身的权限"
 
-#: journal/templates/comment.html:24 journal/templates/mark.html:66
-msgid "Tips: use >!text!< for spoilers; some instances may not be able to show posts longer than 360 charactors."
-msgstr "提示： 善用 >!文字!< 标记可隐藏剧透； 超过360字可能无法分享到联邦宇宙实例时间轴。"
-
-#: journal/templates/comment.html:75
+#: journal/templates/comment.html:47
 msgid "share with playback position"
 msgstr "分享播放位置"
 
@@ -5839,15 +5861,15 @@ msgstr "标记"
 msgid "not rated"
 msgstr "未评分"
 
-#: journal/templates/mark.html:74
+#: journal/templates/mark.html:70
 msgid "add a tag and press Enter"
 msgstr "回车增加标签"
 
-#: journal/templates/mark.html:130
+#: journal/templates/mark.html:122
 msgid "change mark date"
 msgstr "指定标记日期"
 
-#: journal/templates/mark.html:156
+#: journal/templates/mark.html:148
 msgid "Sure to delete mark, comment and tags for this item?"
 msgstr "确认删除这条标记、短评和标签？"
 
@@ -5951,15 +5973,11 @@ msgstr "笔记和进度"
 msgid "Note with empty content will be deleted, sure to continue?"
 msgstr "无内容的笔记会被删除，确定继续吗？"
 
-#: journal/templates/note.html:60 journal/templates/note.html:61
-msgid "Also publish this note to your connected social accounts."
-msgstr "同时将这则笔记发布到你已连接的社交账号。"
-
-#: journal/templates/note.html:74 journal/templates/note.html:75
+#: journal/templates/note.html:72 journal/templates/note.html:73
 msgid "Clear progress"
 msgstr "清除进度"
 
-#: journal/templates/note.html:81
+#: journal/templates/note.html:79
 msgid "Are you sure to delete this note?"
 msgstr "确认删除这则笔记吗？"
 
@@ -6073,7 +6091,7 @@ msgstr "暂无回应。"
 msgid "add a reply"
 msgstr "添加回应"
 
-#: journal/templates/review_edit.html:42
+#: journal/templates/review_edit.html:49
 msgid "change review date"
 msgstr "指定评论日期"
 
@@ -6182,7 +6200,7 @@ msgstr "找不到条目，请使用本站条目网址。"
 msgid "Saved."
 msgstr "已保存"
 
-#: journal/views/common.py:146 journal/views/mark.py:153
+#: journal/views/common.py:146 journal/views/mark.py:159
 msgid "Data saved but unable to crosspost to Fediverse instance."
 msgstr "数据已保存但未能转发到联邦实例。"
 
@@ -6194,16 +6212,16 @@ msgstr "正在重定向到你的联邦实例以重新认证。"
 msgid "List not found."
 msgstr "列表未找到。"
 
-#: journal/views/mark.py:144
+#: journal/views/mark.py:150
 msgid "Content too long for your Fediverse instance."
 msgstr "内容过长，超出了你的联邦实例的限制。"
 
-#: journal/views/mark.py:172
+#: journal/views/mark.py:178 journal/views/mark.py:238
 msgid "Invalid input"
 msgstr "无效输入"
 
-#: journal/views/mark.py:212 journal/views/mark.py:262
-#: journal/views/note.py:169 journal/views/profile.py:42
+#: journal/views/mark.py:225 journal/views/mark.py:279
+#: journal/views/note.py:176 journal/views/profile.py:42
 #: journal/views/review.py:50 journal/views/review.py:67
 msgid "Content not found"
 msgstr "内容未找到"
@@ -6216,23 +6234,19 @@ msgstr "进度"
 msgid "Update progress"
 msgstr "更新进度"
 
-#: journal/views/note.py:34
-msgid "Crosspost"
-msgstr "转发"
-
-#: journal/views/note.py:52
+#: journal/views/note.py:59
 msgid "Progress (optional)"
 msgstr "进度（选填）"
 
-#: journal/views/note.py:54
+#: journal/views/note.py:61
 msgid "Note Content"
 msgstr "笔记内容"
 
-#: journal/views/note.py:56
+#: journal/views/note.py:63
 msgid "Content Warning (optional)"
 msgstr "剧透或敏感内容提示（选填）"
 
-#: journal/views/note.py:78
+#: journal/views/note.py:85
 msgid "Progress Type (optional)"
 msgstr "进度类型（选填）"
 
@@ -6302,7 +6316,7 @@ msgstr "总结已发布到时间轴"
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: mastodon/models/common.py:30 users/templates/users/login.html:112
+#: mastodon/models/common.py:30 users/templates/users/login.html:120
 msgid "Threads"
 msgstr "Threads"
 
@@ -7212,7 +7226,7 @@ msgstr "关联一个threads.net账号"
 msgid "Disconnect with Threads"
 msgstr "取消关联"
 
-#: users/templates/users/account.html:173 users/templates/users/login.html:120
+#: users/templates/users/account.html:173 users/templates/users/login.html:112
 msgid "Bluesky (ATProto)"
 msgstr "Bluesky (ATProto)"
 

--- a/neodb/test_data/anilist_media_1735
+++ b/neodb/test_data/anilist_media_1735
@@ -1,0 +1,341 @@
+{
+ "data": {
+  "Media": {
+   "id": 1735,
+   "idMal": 1735,
+   "type": "ANIME",
+   "format": "TV",
+   "status": "FINISHED",
+   "siteUrl": "https://anilist.co/anime/1735",
+   "description": "Naruto: Shippuuden is the continuation of the original animated TV series Naruto. The story revolves around an older and slightly more matured Uzumaki Naruto and his quest to save his friend Uchiha Sasuke from the grips of the snake-like Shinobi, Orochimaru. After 2 and a half years Naruto finally returns to his village of Konoha, and sets about putting his ambitions to work, though it will not be easy, as he has amassed a few (more dangerous) enemies, in the likes of the shinobi organization; Akatsuki. <br><br>\n(Source: Anime News Network)",
+   "episodes": 500,
+   "duration": 23,
+   "chapters": null,
+   "volumes": null,
+   "countryOfOrigin": "JP",
+   "startDate": {
+    "year": 2007,
+    "month": 2,
+    "day": 15
+   },
+   "genres": [
+    "Action",
+    "Adventure",
+    "Comedy",
+    "Drama",
+    "Fantasy",
+    "Supernatural"
+   ],
+   "synonyms": [
+    "Naruto Shippuuden",
+    "Naruto Shippuden",
+    "נארוטו שיפודן",
+    "火影忍者 疾风传",
+    "นารูโตะ ตำนานวายุสลาตัน",
+    "ناروتو شيبودن",
+    "Наруто: Ураганные хроники"
+   ],
+   "title": {
+    "romaji": "NARUTO: Shippuuden",
+    "english": "Naruto: Shippuden",
+    "native": "NARUTO -ナルト- 疾風伝"
+   },
+   "coverImage": {
+    "extraLarge": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx1735-kGfVm0YqCPcu.png",
+    "large": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx1735-kGfVm0YqCPcu.png"
+   },
+   "studios": {
+    "edges": [
+     {
+      "isMain": true,
+      "node": {
+       "name": "Studio Pierrot"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "TV Tokyo"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "Aniplex"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "KSS"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "Viz Media"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "Rakuonsha"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "TV Tokyo Music"
+      }
+     }
+    ]
+   },
+   "staff": {
+    "edges": [
+     {
+      "role": "Original Creator",
+      "node": {
+       "name": {
+        "full": "Masashi Kishimoto"
+       }
+      }
+     },
+     {
+      "role": "Director (eps 1-479)",
+      "node": {
+       "name": {
+        "full": "Hayato Date"
+       }
+      }
+     },
+     {
+      "role": "Series Composition (eps 1-289, 296-479)",
+      "node": {
+       "name": {
+        "full": "Junki Takegami"
+       }
+      }
+     },
+     {
+      "role": "Character Design",
+      "node": {
+       "name": {
+        "full": "Tetsuya Nishio"
+       }
+      }
+     },
+     {
+      "role": "Character Design",
+      "node": {
+       "name": {
+        "full": "Hirofumi Suzuki"
+       }
+      }
+     },
+     {
+      "role": "Editing (eps 480-500)",
+      "node": {
+       "name": {
+        "full": "Seiji Morita"
+       }
+      }
+     },
+     {
+      "role": "Sound Director",
+      "node": {
+       "name": {
+        "full": "Yasunori Ebina"
+       }
+      }
+     },
+     {
+      "role": "Music (eps 2-256, 261-500)",
+      "node": {
+       "name": {
+        "full": "Yasuharu Takanashi"
+       }
+      }
+     },
+     {
+      "role": "Theme Song Performance",
+      "node": {
+       "name": {
+        "full": "AZU"
+       }
+      }
+     },
+     {
+      "role": "Episode Director (eps 5, 29, 63, 77, 90, 97, 105, 111, 125, 147, 156, 163, 171)",
+      "node": {
+       "name": {
+        "full": "Yuuki Kinoshita"
+       }
+      }
+     },
+     {
+      "role": "Episode Director (eps 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 89, 98, 106, 114, 122, 130, 139, 146, 155, 165, 175, 179, 189, 196, 206, 215)",
+      "node": {
+       "name": {
+        "full": "Hiroshi Kimura"
+       }
+      }
+     },
+     {
+      "role": "Storyboard (eps 223, 329)",
+      "node": {
+       "name": {
+        "full": "Tomoyuki Kurokawa"
+       }
+      }
+     },
+     {
+      "role": "Storyboard (eps 40, 48, 80, 89, 98, 106, 122, 130, 165, 175, 206, 215)",
+      "node": {
+       "name": {
+        "full": "Hiroshi Kimura"
+       }
+      }
+     },
+     {
+      "role": "Animation Director (eps 78, 87, 96, 104, 112, 119, 128, 136, 145, 154, 161)",
+      "node": {
+       "name": {
+        "full": "Yukari Kobayashi"
+       }
+      }
+     },
+     {
+      "role": "Animation Director (eps 35, 42, 55, 138)",
+      "node": {
+       "name": {
+        "full": "Masahiko Murata"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Yuuichi Tanaka"
+       }
+      }
+     },
+     {
+      "role": "Key Animation (ep 123)",
+      "node": {
+       "name": {
+        "full": "Chikara Sakurai"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Hiroshi Yakou"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Shuu Watanabe"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Yuuji Takagi"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Katsuya Kikuchi"
+       }
+      }
+     },
+     {
+      "role": "Key Animation",
+      "node": {
+       "name": {
+        "full": "Natsuko Suzuki"
+       }
+      }
+     },
+     {
+      "role": "In-Between Animation",
+      "node": {
+       "name": {
+        "full": "Naoki Kobayashi"
+       }
+      }
+     },
+     {
+      "role": "In-Between Animation",
+      "node": {
+       "name": {
+        "full": "Yuuji Takagi"
+       }
+      }
+     },
+     {
+      "role": "In-Between Animation",
+      "node": {
+       "name": {
+        "full": "Toshirou Fujii"
+       }
+      }
+     }
+    ]
+   },
+   "externalLinks": [
+    {
+     "site": "Crunchyroll",
+     "url": "http://www.crunchyroll.com/naruto-shippuden"
+    },
+    {
+     "site": "Hulu",
+     "url": "http://www.hulu.com/naruto-shippuden"
+    },
+    {
+     "site": "Adult Swim",
+     "url": "https://www.adultswim.com/videos/naruto-shippuden"
+    },
+    {
+     "site": "Netflix",
+     "url": "https://www.netflix.com/title/80000603"
+    },
+    {
+     "site": "Bilibili",
+     "url": "https://www.bilibili.com/bangumi/media/md3287/"
+    },
+    {
+     "site": "Bilibili TV",
+     "url": "https://www.bilibili.tv/play/1005195"
+    },
+    {
+     "site": "Twitter",
+     "url": "https://twitter.com/NARUTOtoBORUTO"
+    },
+    {
+     "site": "Official Site",
+     "url": "https://www.tv-tokyo.co.jp/anime/naruto/index2.html"
+    },
+    {
+     "site": "YouTube",
+     "url": "https://www.youtube.com/@NARUTO_BORUTO_officialchannel"
+    },
+    {
+     "site": "Official Site",
+     "url": "https://naruto-official.com/"
+    }
+   ]
+  }
+ }
+}

--- a/neodb/test_data/anilist_media_199
+++ b/neodb/test_data/anilist_media_199
@@ -1,0 +1,305 @@
+{
+ "data": {
+  "Media": {
+   "id": 199,
+   "idMal": 199,
+   "type": "ANIME",
+   "format": "MOVIE",
+   "status": "FINISHED",
+   "siteUrl": "https://anilist.co/anime/199",
+   "description": "On the way to their new home, 10-year-old Chihiro Ogino's family stumbles upon a deserted theme park. Intrigued, the family investigates the park, though unbeknownst to them, it is secretly inhabited by spirits who sleep by day and appear at night. When Chihiro's mother and father eat food from a restaurant in the street, angry spirits turn them into pigs. Furthermore, a wide sea has appeared between the spirit world and the human one, trapping Chihiro, the sole human, in a land of spirits. Luckily for her though, a mysterious boy named Haku appears, claiming to know her from the past. Under his instructions, Chihiro secures a job in the bathhouse where Haku works. With only her courage and some new found friends to aid her, Chihiro embarks on a journey to turn her parents back to their original forms and return home.\n",
+   "episodes": 1,
+   "duration": 125,
+   "chapters": null,
+   "volumes": null,
+   "countryOfOrigin": "JP",
+   "startDate": {
+    "year": 2001,
+    "month": 7,
+    "day": 20
+   },
+   "genres": [
+    "Adventure",
+    "Drama",
+    "Fantasy",
+    "Supernatural"
+   ],
+   "synonyms": [
+    "Le Voyage de Chihiro",
+    "La Città Incantata",
+    "El Viaje de Chihiro",
+    "Chihiros Reise ins Zauberland",
+    "Ruhların Kaçışı",
+    "המסע המופלא",
+    "Călătoria lui Chihiro",
+    "Spirited Away: W krainie bogów",
+    "Chihiro Szellemországban",
+    "A Viagem de Chihiro",
+    "千与千寻",
+    "Унесённые призраками",
+    "Chihiro og heksene",
+    "Ταξίδι στην Χώρα των Θαυμάτων",
+    "มิติวิญญาณมหัศจรรย์",
+    "Henkien kätkemä",
+    "Chihiro ilmmiid gaskkas",
+    "Vaimudest viidud",
+    "Chihiro og álögin"
+   ],
+   "title": {
+    "romaji": "Sen to Chihiro no Kamikakushi",
+    "english": "Spirited Away",
+    "native": "千と千尋の神隠し"
+   },
+   "coverImage": {
+    "extraLarge": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/large/bx199-sWefXJvXkDOb.jpg",
+    "large": "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/bx199-sWefXJvXkDOb.jpg"
+   },
+   "studios": {
+    "edges": [
+     {
+      "isMain": true,
+      "node": {
+       "name": "Studio Ghibli"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "Studio Hibari"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "Walt Disney Studios"
+      }
+     },
+     {
+      "isMain": false,
+      "node": {
+       "name": "GKIDS"
+      }
+     }
+    ]
+   },
+   "staff": {
+    "edges": [
+     {
+      "role": "Original Creator",
+      "node": {
+       "name": {
+        "full": "Hayao Miyazaki"
+       }
+      }
+     },
+     {
+      "role": "Director",
+      "node": {
+       "name": {
+        "full": "Hayao Miyazaki"
+       }
+      }
+     },
+     {
+      "role": "Assistant Director",
+      "node": {
+       "name": {
+        "full": "Masayuki Miyaji"
+       }
+      }
+     },
+     {
+      "role": "Assistant Director",
+      "node": {
+       "name": {
+        "full": "Atsushi Takahashi"
+       }
+      }
+     },
+     {
+      "role": "Title Logo Design",
+      "node": {
+       "name": {
+        "full": "Kaoru Mano"
+       }
+      }
+     },
+     {
+      "role": "Assistance",
+      "node": {
+       "name": {
+        "full": "Fumio Yamazaki"
+       }
+      }
+     },
+     {
+      "role": "Assistance",
+      "node": {
+       "name": {
+        "full": "Kino Arai"
+       }
+      }
+     },
+     {
+      "role": "Art Director",
+      "node": {
+       "name": {
+        "full": "Youji Takeshige"
+       }
+      }
+     },
+     {
+      "role": "Assistant Art Director",
+      "node": {
+       "name": {
+        "full": "Noboru Yoshida"
+       }
+      }
+     },
+     {
+      "role": "Color Design",
+      "node": {
+       "name": {
+        "full": "Michiyo Yasuda"
+       }
+      }
+     },
+     {
+      "role": "Director of Photography",
+      "node": {
+       "name": {
+        "full": "Atsushi Okui"
+       }
+      }
+     },
+     {
+      "role": "Editing",
+      "node": {
+       "name": {
+        "full": "Takeshi Seyama"
+       }
+      }
+     },
+     {
+      "role": "Sound Director",
+      "node": {
+       "name": {
+        "full": "Kazuhiro Wakabayashi"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects",
+      "node": {
+       "name": {
+        "full": "Tooru Noguchi"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects",
+      "node": {
+       "name": {
+        "full": "Michihiro Itou"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Eiko Morikawa"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Mayuka Miyazawa"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Daisuke Murakami"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Toshiaki Abe"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Fumiko Ueda"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Rie Komiya"
+       }
+      }
+     },
+     {
+      "role": "Sound Effects Assistance",
+      "node": {
+       "name": {
+        "full": "Kazuaki Narita"
+       }
+      }
+     },
+     {
+      "role": "Music",
+      "node": {
+       "name": {
+        "full": "Joe Hisaishi"
+       }
+      }
+     },
+     {
+      "role": "Music Producer",
+      "node": {
+       "name": {
+        "full": "Masayoshi Ookawa"
+       }
+      }
+     },
+     {
+      "role": "Music Production",
+      "node": {
+       "name": {
+        "full": "Kazumi Inaki"
+       }
+      }
+     }
+    ]
+   },
+   "externalLinks": [
+    {
+     "site": "Netflix",
+     "url": "https://www.netflix.com/title/60023642"
+    },
+    {
+     "site": "Max",
+     "url": "https://www.max.com/movies/3deab668-d0a4-4a8d-9bc8-0952a0ad836e"
+    },
+    {
+     "site": "Max",
+     "url": "https://www.max.com/movies/00ad6746-f3f0-4f6b-b8ea-0997f5880aa5"
+    }
+   ]
+  }
+ }
+}

--- a/neodb/test_data/anilist_media_30011
+++ b/neodb/test_data/anilist_media_30011
@@ -1,0 +1,305 @@
+{
+ "data": {
+  "Media": {
+   "id": 30011,
+   "idMal": 11,
+   "type": "MANGA",
+   "format": "MANGA",
+   "status": "FINISHED",
+   "siteUrl": "https://anilist.co/manga/30011",
+   "description": "Before Naruto's birth, a great demon fox had attacked the Hidden Leaf Village. A man known as the 4th Hokage sealed the demon inside the newly born Naruto, causing him to unknowingly grow up detested by his fellow villagers. Despite his lack of talent in many areas of ninjutsu, Naruto strives for only one goal: to gain the title of Hokage, the strongest ninja in his village. Desiring the respect he never received, Naruto works towards his dream with fellow friends Sasuke and Sakura and mentor Kakashi as they go through many trials and battles that come with being a ninja.",
+   "episodes": null,
+   "duration": null,
+   "chapters": 700,
+   "volumes": 72,
+   "countryOfOrigin": "JP",
+   "startDate": {
+    "year": 1999,
+    "month": 9,
+    "day": 21
+   },
+   "genres": [
+    "Action",
+    "Adventure",
+    "Supernatural"
+   ],
+   "synonyms": [
+    "נארוטו",
+    "Наруто",
+    "火影忍者",
+    "나루토",
+    "นินจาคาถา โอ้โฮเฮะ"
+   ],
+   "title": {
+    "romaji": "NARUTO",
+    "english": "Naruto",
+    "native": "NARUTO -ナルト-"
+   },
+   "coverImage": {
+    "extraLarge": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/large/nx30011-9yUF1dXWgDOx.jpg",
+    "large": "https://s4.anilist.co/file/anilistcdn/media/manga/cover/medium/nx30011-9yUF1dXWgDOx.jpg"
+   },
+   "studios": {
+    "edges": []
+   },
+   "staff": {
+    "edges": [
+     {
+      "role": "Story & Art",
+      "node": {
+       "name": {
+        "full": "Masashi Kishimoto"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Yuuichi Itakura"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Ryou Tasaka"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Akira Oukubo"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Kazuhiro Takahashi"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Osamu Kajisa"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Mikio Ikemoto"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Kenji Taira"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Masaru Matsubara"
+       }
+      }
+     },
+     {
+      "role": "Assistant",
+      "node": {
+       "name": {
+        "full": "Satou Atsuhiro"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vol 59)",
+      "node": {
+       "name": {
+        "full": "Alexis Kirsch"
+       }
+      }
+     },
+     {
+      "role": "Translator (Norwegian: vol 1-9)",
+      "node": {
+       "name": {
+        "full": "Annette Nordheim"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vols 20, 24)",
+      "node": {
+       "name": {
+        "full": "Joe Yamazaki"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vols 2-18, 22, 28, 32-72)",
+      "node": {
+       "name": {
+        "full": "Mari Morimoto"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vols 1, 2)",
+      "node": {
+       "name": {
+        "full": "Katy Bridges"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vol 21, 26-27, 30)",
+      "node": {
+       "name": {
+        "full": "Azurelore Korrigan"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vols 19, 23, 25, 29, 31)",
+      "node": {
+       "name": {
+        "full": "Kyoko Shapiro"
+       }
+      }
+     },
+     {
+      "role": "Translator (English: vol 21, 26-27, 30)",
+      "node": {
+       "name": {
+        "full": "Naomi Kokubo"
+       }
+      }
+     },
+     {
+      "role": "Translator (French: vols 1-10)",
+      "node": {
+       "name": {
+        "full": "Sylvain Chollet"
+       }
+      }
+     },
+     {
+      "role": "Translator (French: vols 55-58)",
+      "node": {
+       "name": {
+        "full": "Frederic Malet"
+       }
+      }
+     },
+     {
+      "role": "Translator (French: vols 11-54, 59-72)",
+      "node": {
+       "name": {
+        "full": "Sebastien Bigini"
+       }
+      }
+     },
+     {
+      "role": "Translator (Vietnamese, vols 50-72)",
+      "node": {
+       "name": {
+        "full": "Hằng Trần"
+       }
+      }
+     },
+     {
+      "role": "Translator (Vietnamese, vols 1-49)",
+      "node": {
+       "name": {
+        "full": "Việt"
+       }
+      }
+     },
+     {
+      "role": "Translator (Turkish: vols 1-4, 7-27)",
+      "node": {
+       "name": {
+        "full": "Tayfun Nitahara Haksöyliyen"
+       }
+      }
+     },
+     {
+      "role": "Translator (Turkish: vols 5-6)",
+      "node": {
+       "name": {
+        "full": "Sercan Sert"
+       }
+      }
+     }
+    ]
+   },
+   "externalLinks": [
+    {
+     "site": "MANGA Plus",
+     "url": "https://mangaplus.shueisha.co.jp/titles/100018"
+    },
+    {
+     "site": "VIZ",
+     "url": "https://www.viz.com/shonenjump/chapters/naruto"
+    },
+    {
+     "site": "Mangas.io",
+     "url": "https://www.mangas.io/lire/naruto"
+    },
+    {
+     "site": "MANGA Plus",
+     "url": "https://mangaplus.shueisha.co.jp/titles/200001"
+    },
+    {
+     "site": "Official Site",
+     "url": "https://naruto-official.com/"
+    },
+    {
+     "site": "Shonen Jump Plus",
+     "url": "https://shonenjumpplus.com/episode/10833519556325021854"
+    },
+    {
+     "site": "Official Site",
+     "url": "https://www.shueisha.co.jp/books/search/search.html?seriesid=35181"
+    },
+    {
+     "site": "KakaoPage",
+     "url": "https://page.kakao.com/content/46335136"
+    },
+    {
+     "site": "VIZ",
+     "url": "https://www.viz.com/manga-books/manga/naruto/all"
+    },
+    {
+     "site": "Official Site",
+     "url": "https://zebrack-comic.shueisha.co.jp/title/48"
+    },
+    {
+     "site": "ONO",
+     "url": "https://www.ono.live/manga/naruto"
+    },
+    {
+     "site": "Twitter",
+     "url": "https://x.com/NARUTO_kousiki"
+    },
+    {
+     "site": "Twitter",
+     "url": "https://x.com/NARUTO_info_en"
+    }
+   ]
+  }
+ }
+}

--- a/neodb/tests/catalog/test_anilist.py
+++ b/neodb/tests/catalog/test_anilist.py
@@ -1,0 +1,117 @@
+import pytest
+
+from catalog.common import SiteManager, use_local_response
+from catalog.models import Edition, IdType, Movie, TVSeason
+from catalog.sites.anilist import AniListAnime, AniListManga, _base_role
+
+
+class TestBaseRole:
+    def test_strips_episode_scope(self):
+        assert _base_role("Director (eps 1-479)") == "director"
+        assert _base_role("Series Composition (eps 1-289, 296-479)") == (
+            "series composition"
+        )
+        assert _base_role("Story & Art") == "story & art"
+
+    def test_keeps_qualified_roles_distinct(self):
+        # these must not collapse onto "director"
+        assert _base_role("Episode Director (ep 480)") == "episode director"
+        assert _base_role("ADR Director (Italian; eps 287-348)") == "adr director"
+        assert _base_role("Assistant Director") == "assistant director"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestAniListAnime:
+    def test_parse(self):
+        t_url = "https://anilist.co/anime/1735/NARUTO-Shippuuden/"
+        p1 = SiteManager.get_site_cls_by_id_type(IdType.AniList_Anime)
+        assert p1 is not None
+        assert p1.validate_url(t_url)
+        assert p1.validate_url("https://anilist.co/anime/1735")
+        # manga URLs belong to the other site class
+        assert not p1.validate_url("https://anilist.co/manga/30011")
+        p2 = SiteManager.get_site_by_url(t_url)
+        assert p2 is not None
+        assert isinstance(p2, AniListAnime)
+        assert p2.id_value == "1735"
+        assert p1.id_to_url("1735") == "https://anilist.co/anime/1735"
+
+    @use_local_response
+    def test_scrape_tv(self):
+        site = SiteManager.get_site_by_url("https://anilist.co/anime/1735")
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready
+        assert site.resource is not None
+        m = site.resource.metadata
+        assert m["preferred_model"] == "TVSeason"
+        assert m["episode_count"] == 500
+        assert m["single_episode_length"] == 23 * 60  # stored as seconds
+        assert m["release_date"] == "2007-02-15"
+        assert m["origin_country"] == ["JP"]
+        assert m["director"] == ["Hayato Date"]
+        assert m["playwright"] == ["Junki Takegami"]
+        assert m["producer"] == ["Studio Pierrot"]
+        assert "Action" in m["genre"]
+        titles = {t["text"] for t in m["localized_title"]}
+        assert "NARUTO: Shippuuden" in titles
+        assert "Naruto: Shippuden" in titles
+        assert "NARUTO -ナルト- 疾風伝" in titles
+        assert m["orig_title"] == "NARUTO -ナルト- 疾風伝"
+        # description markup is flattened, not passed through
+        assert "<br>" not in m["brief"]
+        assert site.resource.get_all_lookup_ids().get(IdType.MAL_Anime) == "1735"
+        assert isinstance(site.resource.item, TVSeason)
+
+    @use_local_response
+    def test_scrape_movie(self):
+        site = SiteManager.get_site_by_url("https://anilist.co/anime/199")
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready
+        assert site.resource is not None
+        m = site.resource.metadata
+        assert m["preferred_model"] == "Movie"
+        assert m["length"] == 125 * 60
+        assert m["director"] == ["Hayao Miyazaki"]
+        assert m["release_date"] == "2001-07-20"
+        assert "episode_count" not in m
+        assert site.resource.get_all_lookup_ids().get(IdType.MAL_Anime) == "199"
+        assert isinstance(site.resource.item, Movie)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestAniListManga:
+    def test_parse(self):
+        t_url = "https://anilist.co/manga/30011/NARUTO/"
+        p1 = SiteManager.get_site_cls_by_id_type(IdType.AniList_Manga)
+        assert p1 is not None
+        assert p1.validate_url(t_url)
+        assert not p1.validate_url("https://anilist.co/anime/1735")
+        p2 = SiteManager.get_site_by_url(t_url)
+        assert p2 is not None
+        assert isinstance(p2, AniListManga)
+        assert p2.id_value == "30011"
+        assert p1.id_to_url("30011") == "https://anilist.co/manga/30011"
+
+    @use_local_response
+    def test_scrape(self):
+        site = SiteManager.get_site_by_url("https://anilist.co/manga/30011")
+        assert site is not None
+        site.get_resource_ready()
+        assert site.ready
+        assert site.resource is not None
+        m = site.resource.metadata
+        assert m["preferred_model"] == "Edition"
+        assert m["author"] == ["Masashi Kishimoto"]
+        assert m["pub_year"] == 1999
+        assert m["pub_month"] == 9
+        assert m["orig_title"] == "NARUTO -ナルト-"
+        # Edition permits exactly one localized title; the rest go to other_title
+        assert len(m["localized_title"]) == 1
+        assert m["localized_title"][0]["text"] == "Naruto"
+        assert "NARUTO -ナルト-" in m["other_title"]
+        # AniList's manga id and MyAnimeList's differ; both must be kept straight
+        assert site.resource.id_value == "30011"
+        assert site.resource.get_all_lookup_ids().get(IdType.MAL_Manga) == "11"
+        assert isinstance(site.resource.item, Edition)

--- a/neodb/tests/catalog/test_anilist.py
+++ b/neodb/tests/catalog/test_anilist.py
@@ -1,8 +1,55 @@
+import json
+
 import pytest
 
-from catalog.common import SiteManager, use_local_response
+from catalog.common import ParseError, SiteManager, use_local_response
 from catalog.models import Edition, IdType, Movie, TVSeason
-from catalog.sites.anilist import AniListAnime, AniListManga, _base_role
+from catalog.sites.anilist import (
+    AniListAnime,
+    AniListManga,
+    _base_role,
+    _localized,
+    _titles,
+)
+
+
+def _fixture(media_id: int) -> dict:
+    with open(f"test_data/anilist_media_{media_id}") as f:
+        return json.load(f)["data"]["Media"]
+
+
+class TestTitleLanguages:
+    def test_romaji_language_is_assigned_not_detected(self):
+        # langdetect reads "NARUTO: Shippuuden" as Finnish and "Sen to Chihiro
+        # no Kamikakushi" as Swahili, so romaji must never be detected.
+        for media_id, romaji in (
+            (1735, "NARUTO: Shippuuden"),
+            (199, "Sen to Chihiro no Kamikakushi"),
+        ):
+            entries = _localized(_titles(_fixture(media_id)))
+            lang = next(e["lang"] for e in entries if e["text"] == romaji)
+            assert lang == "x"  # English title exists, so romaji is unknown
+
+    def test_english_title_owns_en(self):
+        entries = _localized(_titles(_fixture(1735)))
+        assert entries[0] == {"lang": "en", "text": "Naruto: Shippuden"}
+
+    def test_romaji_stands_in_for_en_without_english_title(self):
+        media = _fixture(1735)
+        media["title"]["english"] = None
+        entries = _localized(_titles(media))
+        assert entries[0] == {"lang": "en", "text": "NARUTO: Shippuuden"}
+
+    def test_no_two_titles_claim_the_same_language(self):
+        for media_id in (1735, 199, 30011):
+            entries = _localized(_titles(_fixture(media_id)))
+            langs = [e["lang"] for e in entries if e["lang"] != "x"]
+            assert len(langs) == len(set(langs))
+
+    def test_native_title_uses_country_of_origin(self):
+        entries = _localized(_titles(_fixture(199)))
+        lang = next(e["lang"] for e in entries if e["text"] == "千と千尋の神隠し")
+        assert lang == "ja"
 
 
 class TestBaseRole:
@@ -18,6 +65,23 @@ class TestBaseRole:
         assert _base_role("Episode Director (ep 480)") == "episode director"
         assert _base_role("ADR Director (Italian; eps 287-348)") == "adr director"
         assert _base_role("Assistant Director") == "assistant director"
+
+
+class TestAuthorRoles:
+    def test_only_exact_author_roles_count(self):
+        from catalog.sites.anilist import _AUTHOR_ROLES, _staff_names
+
+        media = {
+            "staff": {
+                "edges": [
+                    {"role": "Story & Art", "node": {"name": {"full": "Real Author"}}},
+                    {"role": "Art Director", "node": {"name": {"full": "Not Author"}}},
+                    {"role": "Story Editor", "node": {"name": {"full": "Also Not"}}},
+                    {"role": "Art Assistant", "node": {"name": {"full": "Nope"}}},
+                ]
+            }
+        }
+        assert _staff_names(media, lambda r: r in _AUTHOR_ROLES) == ["Real Author"]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -78,6 +142,19 @@ class TestAniListAnime:
         assert "episode_count" not in m
         assert site.resource.get_all_lookup_ids().get(IdType.MAL_Anime) == "199"
         assert isinstance(site.resource.item, Movie)
+
+    @use_local_response
+    def test_rejects_a_manga_id_under_the_anime_path(self):
+        """anilist.co/anime/30011 is really a manga id.
+
+        AniList keeps anime and manga in one id space, so without a type check
+        this would build a TVSeason from manga data and file the manga's
+        idMal (11) as IdType.MAL_Anime, corrupting MyAnimeList dedupe.
+        """
+        site = SiteManager.get_site_by_url("https://anilist.co/anime/30011")
+        assert isinstance(site, AniListAnime)
+        with pytest.raises(ParseError):
+            site.scrape()
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION

Two site classes sharing `SiteName.AniList`:

- `AniListAnime` — `anilist.co/anime/{id}` to `TVSeason`, or `Movie` for the `MOVIE`/`MUSIC` formats. OVA/ONA/SPECIAL become seasons, matching how `bangumi.py` already treats OVA.
- `AniListManga` — `anilist.co/manga/{id}` to `Edition`, covering manga, manhwa, manhua and light novels.

Both support external search. Anime and manga need separate id types because AniList shares one numeric id space across the two.

`idMal` is stored as a lookup id (`MAL_Anime`/`MAL_Manga`). No MyAnimeList fetcher is added — the ids are carried so a future MAL integration and Wikidata's P4086/P4087 land on existing items instead of creating duplicates. The four matching Wikidata properties are wired into `WikiData.IdTypeMapping`, which is what makes the new ids usable as cross-references (AniList and MAL ids co-occur on ~96% of the Wikidata items that carry either).

## Two AniList API details worth knowing

- The `staff` connection is paginated at 25 edges and is **not** ordered by prominence by default. Without `sort: RELEVANCE` a long-running series returns incidental staff and no real director — Naruto: Shippuuden yielded a 4-episode fill-in director instead of Hayato Date.
- Staff roles carry a trailing scope, e.g. `"Director (eps 1-479)"`. The scope is stripped before matching so the base role can be compared exactly, which still excludes `"Episode Director"` and `"ADR Director"`.

## Known limitation

AniList manga is series-level while NeoDB's book identity is edition-level ISBN, so manga lands as ISBN-less `Edition`s and `volumes`/`chapters` have nowhere to go (`Series` is still a `proxy = True` stub and `Work.to_indexable_doc` returns `{}`). This matches how `bangumi.py` already handles manga; giving manga series a real home looks like a separate modeling change. Relatedly, `Edition` permits exactly one localized title, so manga keeps a single readable title and pushes the rest into `other_title`.
