### PR TITLE
fix(takahe): reject non-ASCII OAuth credentials, guard pollless Questions

### DIFF
--- a/takahe/activities/templatetags/activity_tags.py
+++ b/takahe/activities/templatetags/activity_tags.py
@@ -4,6 +4,8 @@ from urllib.parse import urlencode
 from django import template
 from django.utils import timezone
 
+from activities.models.post_types import QuestionData
+
 register = template.Library()
 
 
@@ -65,7 +67,18 @@ def urlparams(context, **kwargs):
 
 @register.simple_tag(takes_context=True)
 def poll_vote_context(context, post):
-    """Return browser-session voting state for a Question post."""
+    """
+    Return browser-session voting state for a Question post, or None when the
+    post carries no usable poll data.
+
+    A Question whose type_data is missing or not a QuestionData (legacy rows, a
+    partially-applied ingest) must not raise: unlike ``{{ }}`` resolution, an
+    exception in a template tag is not swallowed, so it would take down every
+    page the post appears on rather than just the one post.
+    """
+    if not isinstance(post.type_data, QuestionData):
+        return None
+
     request = context.get("request")
     identity = None
     identities = []

--- a/takahe/api/views/oauth.py
+++ b/takahe/api/views/oauth.py
@@ -150,6 +150,19 @@ def extract_client_info_from_basic_auth(request):
     return None, None
 
 
+def constant_time_equal(expected: str | None, provided: str | None) -> bool:
+    """
+    Constant-time comparison of two credential strings.
+
+    hmac.compare_digest raises TypeError for str arguments holding non-ASCII
+    characters, so compare the encoded bytes instead: a client sending a
+    non-ASCII client_id/secret must get a clean auth failure rather than a 500.
+    """
+    return hmac.compare_digest(
+        (expected or "").encode("utf-8"), (provided or "").encode("utf-8")
+    )
+
+
 @method_decorator(csrf_exempt, name="dispatch")
 class TokenView(View):
     def verify_code(
@@ -158,8 +171,8 @@ class TokenView(View):
         application = authorization.application
         # Use constant-time comparison on secrets to prevent timing attacks
         return (
-            hmac.compare_digest(application.client_id, client_id or "")
-            and hmac.compare_digest(application.client_secret, client_secret or "")
+            constant_time_equal(application.client_id, client_id)
+            and constant_time_equal(application.client_secret, client_secret)
             and authorization.redirect_uri == redirect_uri
         )
 

--- a/takahe/templates/activities/_type_question.html
+++ b/takahe/templates/activities/_type_question.html
@@ -1,7 +1,6 @@
 {% load activity_tags %}
 {{ sanitized_content }}
 {% poll_vote_context post as vote %}
-{# vote is None when the post has no usable poll data; render the body only #}
 {% if vote %}
 <div class="poll">
   <h3 class="screenreader-text">

--- a/takahe/templates/activities/_type_question.html
+++ b/takahe/templates/activities/_type_question.html
@@ -1,6 +1,8 @@
 {% load activity_tags %}
 {{ sanitized_content }}
 {% poll_vote_context post as vote %}
+{# vote is None when the post has no usable poll data; render the body only #}
+{% if vote %}
 <div class="poll">
   <h3 class="screenreader-text">
     Options:
@@ -74,3 +76,4 @@
     </form>
   {% endif %}
 </div>
+{% endif %}

--- a/takahe/tests/activities/views/test_poll_voting.py
+++ b/takahe/tests/activities/views/test_poll_voting.py
@@ -182,3 +182,24 @@ def test_question_page_allows_additive_multiple_choice_votes(
     assert poll["own_votes"] == [0, 1]
     assert poll["votes_count"] == 2
     assert poll["voters_count"] == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("type_data", [None, {"object": {"name": "not a poll"}}])
+def test_question_without_poll_data_still_renders(
+    config_system, identity, client, type_data
+):
+    """
+    A Question row whose type_data is missing or the wrong shape (legacy data,
+    a partially-applied ingest) must not raise out of the template tag: that
+    would 500 every page the post appears on instead of degrading one post.
+    """
+    post = make_poll(identity)
+    Post.objects.filter(pk=post.pk).update(type_data=type_data)
+
+    page = client.get(post_path(post))
+
+    assert page.status_code == 200
+    # The note body survives; only the poll widget is dropped
+    assert b"Choose a route" in page.content
+    assert b'class="poll"' not in page.content

--- a/takahe/tests/api/test_tokens.py
+++ b/takahe/tests/api/test_tokens.py
@@ -47,3 +47,58 @@ def test_authorization_code_single_use(client, identity):
 
     response = client.post("/oauth/token", data)
     assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_token_non_ascii_credentials_rejected(client, identity):
+    """
+    A non-ASCII client_id/client_secret must fail authentication cleanly.
+    hmac.compare_digest raises TypeError on non-ASCII str arguments, which
+    turned a bad credential into a 500 instead of an access_denied.
+    """
+    application = Application.objects.create(
+        name="Unicode App",
+        client_id="tk-unicode-test",
+        client_secret="unicodesecret",
+        redirect_uris="https://example.com/callback",
+    )
+    Authorization.objects.create(
+        application=application,
+        user=identity.users.first(),
+        identity=identity,
+        code="unicodeauthcode",
+        redirect_uri="https://example.com/callback",
+        scopes=["read"],
+    )
+
+    for client_id, client_secret in [
+        ("tk-unicode-tëst", "unicodesecret"),
+        ("tk-unicode-test", "unicodesécret"),
+        ("クライアント", "秘密"),
+    ]:
+        response = client.post(
+            "/oauth/token",
+            {
+                "grant_type": "authorization_code",
+                "code": "unicodeauthcode",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": "https://example.com/callback",
+            },
+        )
+        assert response.status_code == 401
+        assert response.json() == {"error": "access_denied"}
+
+    # The rejected attempts must not have consumed the code
+    response = client.post(
+        "/oauth/token",
+        {
+            "grant_type": "authorization_code",
+            "code": "unicodeauthcode",
+            "client_id": "tk-unicode-test",
+            "client_secret": "unicodesecret",
+            "redirect_uri": "https://example.com/callback",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["access_token"]


### PR DESCRIPTION
Two defects found while reviewing the takahe fork. Both turn bad or unusual input into a 500 rather than a handled response.

### Non-ASCII OAuth credentials return 500 instead of `access_denied`

`hmac.compare_digest` raises `TypeError: comparing strings with non-ASCII characters is not supported` for `str` arguments outside ASCII. A token request carrying a non-ASCII `client_id` or `client_secret` — as a form field, or decoded out of the Basic auth header by `extract_client_info_from_basic_auth` — therefore raised inside the `transaction.atomic()` block in `TokenView.post` instead of returning `{"error": "access_denied"}`, 401.

Fixed by comparing the UTF-8 encoded bytes through a shared `constant_time_equal()` helper, which keeps the constant-time property while accepting any input.

### A Question with no usable poll data 500s every page it appears on

`poll_vote_context` is a template *tag*, so unlike `{{ }}` variable resolution its exceptions are not swallowed. A `Question` whose `type_data` is absent or is not a `QuestionData` (legacy rows, a partially-applied ingest) raised `AttributeError: 'dict' object has no attribute 'to_mastodon_json'` and took down the whole rendered page rather than degrading that one post.

The other poll code paths (`PostStates.needs_question_tracking`, `handle_question_open`, `PostInteraction.create_votes`) already guard with `isinstance(..., QuestionData)`, which is what suggested these values do occur in practice. This does the same, returning `None` so `_type_question.html` still renders the note body and drops only the poll widget.

### Tests

One regression test per fix. Both were verified to fail without their fix:

- non-ASCII credentials: asserts 401 + `access_denied` for three combinations, and that the rejected attempts do not consume the authorization code (they run before the single-use marking, so this could regress silently).
- pollless Question: parametrized over `type_data=None` and a wrong-shape dict, asserting 200, body preserved, no poll markup.

### Verification

`takahe` suite: 478 passed, 3 of them new. `ruff` and `ruff format` clean on the changed files.

Nine pre-existing failures remain in `test_announced_activities.py`, `test_inbox_forwarding.py` and `test_post.py::test_fetch_post`. They are unrelated to this change — I confirmed the identical 9 on a pristine tree — and look environmental: `.test` TLDs do not resolve locally, so `check_url_safety`'s `getaddrinfo` fails before `pytest_httpx` can intercept and the mocks go unrequested. They should pass in CI.

The same two fixes are also applied to `neodb-social/neodb-incarnator` on `contribute-to-incarnator`.
