### PR TITLE
feat(api): resolve local item URLs, redirect merged items, allow progress on any marked item

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import List
+from urllib.parse import urlparse
 
 from django.core.cache import cache
 from django.core.paginator import Paginator
@@ -47,6 +48,7 @@ from .models import (
 )
 from .recommendation import blended_for_discover, can_show_reco, similar_items
 from .search.utils import enqueue_fetch, get_fetch_lock, query_index
+from .sites.fedi import FediverseInstance
 
 PAGE_SIZE = 20
 
@@ -250,7 +252,13 @@ def search_item(
 
 @api.get(
     "/catalog/fetch",
-    response={302: RedirectedResult, 202: Result, 422: Result, 429: Result},
+    response={
+        302: RedirectedResult,
+        202: Result,
+        404: Result,
+        422: Result,
+        429: Result,
+    },
     summary="Fetch item from URL of a supported site",
     auth=None,
     tags=["catalog"],
@@ -258,6 +266,10 @@ def search_item(
 def fetch_item(request, url: str, response: HttpResponse):
     """
     Convert a URL from a supported site (e.g. https://m.imdb.com/title/tt2852400/) to an item.
+
+    An item URL of this server (e.g. https://neodb.social/movie/4W2ZHSBFHfCbRhdBUlHhBS)
+    is also accepted, and resolved directly without fetching.
+    If such URL doesn't match an item here, HTTP 404 will be returned.
 
     If the URL is not supported by this server, HTTP 422 will be returned.
     If the item is available in the catalog, HTTP 302 will be returned.
@@ -267,6 +279,14 @@ def fetch_item(request, url: str, response: HttpResponse):
     If not getting the item after 120 seconds, please stop and consider the URL is not available.
     Frequent request may result with HTTP 429.
     """
+    if FediverseInstance.is_local_item_url(url):
+        # our own item URL: resolve it locally, no fetching or rate limit needed.
+        # match on path only, so the host can't fool the uuid search in get_by_url
+        item = Item.get_by_url(urlparse(url).path, resolve_merge=True)
+        if not item or item.is_deleted:
+            return Status(404, {"message": "Item not found"})
+        response["Location"] = item.api_url
+        return Status(302, {"message": "Item fetched", "url": item.api_url})
     site = SiteManager.get_site_by_url(url, detect_redirection=False)
     if not site:
         return Status(422, {"message": "URL not supported"})

--- a/neodb/catalog/sites/fedi.py
+++ b/neodb/catalog/sites/fedi.py
@@ -104,8 +104,15 @@ class FediverseInstance(AbstractSite):
     @classmethod
     def is_local_item_url(cls, url: str) -> bool:
         """Check if the given URL belongs to a local item"""
-        host = url.split("://", 1)[1].split("/", 1)[0].lower()
-        return host in settings.SITE_DOMAINS
+        parsed = urlparse(url)
+        if not parsed.hostname:
+            return False
+        # hostname drops any :port and userinfo; netloc keeps the port, which
+        # SITE_DOMAINS may carry in local setups
+        return (
+            parsed.hostname in settings.SITE_DOMAINS
+            or parsed.netloc.lower() in settings.SITE_DOMAINS
+        )
 
     def get_local_item_from_external_resources(self) -> Item | None:
         """if a local item is in the external_resources, return it"""

--- a/neodb/common/api.py
+++ b/neodb/common/api.py
@@ -2,12 +2,13 @@ from typing import Any, List
 
 from django.conf import settings
 from django.db.models import QuerySet
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
 from loguru import logger
 from ninja import NinjaAPI, Schema, Status
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
 from ninja.security import HttpBearer
 
+from catalog.models import Item
 from takahe.utils import Takahe
 from users.models.apidentity import APIdentity
 
@@ -119,3 +120,41 @@ NOT_FOUND = Status(404, {"message": "Not found"})
 OK = Status(200, {"message": "OK"})
 NO_DATA = {"data": [], "count": 0, "pages": 0}
 INVALID_PAGE = Status(400, {"message": "Invalid page number"})
+
+
+def _resolve_item(
+    item_uuid: str, api_path: str, response: HttpResponse, redirect_status: int
+) -> tuple[Item | None, Any]:
+    item = Item.get_by_url(item_uuid)
+    if not item or item.is_deleted:
+        return None, Status(404, {"message": "Item not found"})
+    if item.merged_to_item:
+        url = api_path.format(uuid=item.final_item.uuid)
+        response["Location"] = url
+        return None, Status(redirect_status, {"message": "Item merged", "url": url})
+    return item, None
+
+
+def resolve_item_for_read(
+    item_uuid: str, api_path: str, response: HttpResponse
+) -> tuple[Item | None, Any]:
+    """Resolve the item a read API is about, redirecting merged items.
+
+    `api_path` is this endpoint's path with `{uuid}` where the item uuid goes.
+    Returns `(item, None)` when the item can be read, otherwise `(None, status)`:
+    404 if the item is unknown or deleted, or 302 pointing at the item a merged
+    one was folded into.
+    """
+    return _resolve_item(item_uuid, api_path, response, 302)
+
+
+def resolve_item_for_write(
+    item_uuid: str, api_path: str, response: HttpResponse
+) -> tuple[Item | None, Any]:
+    """Resolve the item a write API is about, redirecting merged items.
+
+    Same as `resolve_item_for_read`, but a merged item gets 307 rather than 302,
+    so the client replays the same method and body instead of turning the write
+    into a GET.
+    """
+    return _resolve_item(item_uuid, api_path, response, 307)

--- a/neodb/journal/apis/note.py
+++ b/neodb/journal/apis/note.py
@@ -1,12 +1,21 @@
 from datetime import datetime
 from typing import List
 
-from django.http import Http404
-from ninja import Field, Schema, Status
+from django.http import HttpResponse
+from ninja import Field, Schema
 from ninja.pagination import paginate
 
-from catalog.models import Item, ItemSchema
-from common.api import NOT_FOUND, OK, PageNumberPagination, Result, api
+from catalog.models import ItemSchema
+from common.api import (
+    NOT_FOUND,
+    OK,
+    PageNumberPagination,
+    RedirectedResult,
+    Result,
+    api,
+    resolve_item_for_read,
+    resolve_item_for_write,
+)
 from common.sentry import record_activity
 
 from ..models import Note
@@ -37,33 +46,56 @@ class NoteInSchema(Schema):
 
 @api.get(
     "/me/note/item/{item_uuid}/",
-    response={200: List[NoteSchema], 401: Result, 403: Result},
+    response={
+        200: List[NoteSchema],
+        302: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["note"],
 )
 @paginate(PageNumberPagination)
-def list_notes_for_item(request, item_uuid):
+def list_notes_for_item(request, item_uuid: str, response: HttpResponse):
     """
     List notes by current user for an item
+
+    If the item was merged into another one, HTTP 302 is returned.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/me/note/item/{uuid}/", response
+    )
     if not item:
-        raise Http404("Item not found")
+        return redirect
     queryset = Note.objects.filter(owner=request.user.identity, item=item)
     return queryset.prefetch_related("item")
 
 
 @api.post(
     "/me/note/item/{item_uuid}/",
-    response={200: NoteSchema, 401: Result, 403: Result, 404: Result},
+    response={
+        200: NoteSchema,
+        307: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["note"],
 )
-def add_note_for_item(request, item_uuid: str, n_in: NoteInSchema):
+def add_note_for_item(
+    request, item_uuid: str, n_in: NoteInSchema, response: HttpResponse
+):
     """
     Add a note for an item
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/note/item/{uuid}/", response
+    )
     if not item:
-        return Status(404, {"message": "Item not found"})
+        return redirect
     note = Note()
     note.item = item
     note.owner = request.user.identity

--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -1,15 +1,17 @@
 from typing import List, Literal, Union
 
+from django.http import HttpResponse
 from ninja import Field, Schema
 
 from catalog.models import Item
 from common.api import (
     INVALID_PAGE,
-    NOT_FOUND,
     OAuthAccessTokenAuth,
     OptionalOAuthAccessTokenAuth,
+    RedirectedResult,
     Result,
     api,
+    resolve_item_for_read,
 )
 from journal.search import JournalIndex, JournalQueryParser
 
@@ -133,23 +135,37 @@ PostTypes = {"mark", "comment", "review", "collection", "note"}
 
 @api.get(
     "/item/{item_uuid}/posts/",
-    response={200: PaginatedPostList, 400: Result, 401: Result, 404: Result},
+    response={
+        200: PaginatedPostList,
+        302: RedirectedResult,
+        400: Result,
+        401: Result,
+        404: Result,
+    },
     tags=["catalog"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
 def list_posts_for_item(
-    request, item_uuid: str, type: str | None = None, page: int = 1
+    request,
+    item_uuid: str,
+    response: HttpResponse,
+    type: str | None = None,
+    page: int = 1,
 ):
     """
     Get posts for an item
 
     `type` is optional, can be a comma separated list of `comment`, `review`, `collection`, `note`, `mark`; default is `comment,review`
+
+    If the item was merged into another one, HTTP 302 is returned.
     """
     if page < 1 or page > 99:
         return INVALID_PAGE
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/item/{uuid}/posts/", response
+    )
     if not item:
-        return NOT_FOUND
+        return redirect
     types = [t for t in (type or "").split(",") if t in PostTypes]
     q = "type:" + ",".join(types or ["comment", "review"])
     query = JournalQueryParser(q, page)

--- a/neodb/journal/apis/review.py
+++ b/neodb/journal/apis/review.py
@@ -1,12 +1,21 @@
 from datetime import datetime
 from typing import List
 
+from django.http import HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
 from catalog.models import AvailableItemCategory, Item, ItemSchema
-from common.api import OptionalOAuthAccessTokenAuth, PageNumberPagination, Result, api
+from common.api import (
+    OptionalOAuthAccessTokenAuth,
+    PageNumberPagination,
+    RedirectedResult,
+    Result,
+    api,
+    resolve_item_for_read,
+    resolve_item_for_write,
+)
 from common.sentry import record_activity
 
 from ..models import (
@@ -55,16 +64,26 @@ def list_reviews(request, category: AvailableItemCategory | None = None):
 
 @api.get(
     "/me/review/item/{item_uuid}",
-    response={200: ReviewSchema, 401: Result, 403: Result, 404: Result},
+    response={
+        200: ReviewSchema,
+        302: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["review"],
 )
-def get_review_by_item(request, item_uuid: str):
+def get_review_by_item(request, item_uuid: str, response: HttpResponse):
     """
     Get review on current user's shelf by item uuid
+
+    If the item was merged into another one, HTTP 302 is returned.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/me/review/item/{uuid}", response
+    )
     if not item:
-        return Status(404, {"message": "Item not found"})
+        return redirect
     review = Review.objects.filter(owner=request.user.identity, item=item).first()
     if not review:
         return Status(404, {"message": "Review not found"})
@@ -73,20 +92,33 @@ def get_review_by_item(request, item_uuid: str):
 
 @api.post(
     "/me/review/item/{item_uuid}",
-    response={200: Result, 401: Result, 403: Result, 404: Result},
+    response={
+        200: Result,
+        307: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["review"],
 )
-def review_item(request, item_uuid: str, review: ReviewInSchema):
+def review_item(
+    request, item_uuid: str, review: ReviewInSchema, response: HttpResponse
+):
     """
     Create or update a review about an item for current user.
 
     `title`, `body` (markdown formatted) and`visibility` are required;
     `created_time` is optional, default to now.
     if the item is already reviewed, this will update the review.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/review/item/{uuid}", response
+    )
     if not item:
-        return Status(404, {"message": "Item not found"})
+        return redirect
     if review.created_time and review.created_time >= timezone.now():
         review.created_time = None
     Review.update_item_review(

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from django.core.cache import cache
 from django.db.models import QuerySet, prefetch_related_objects
-from django.http import Http404, HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
 from ninja.pagination import paginate
@@ -14,7 +14,14 @@ from catalog.models import (
     ItemCategory,
     ItemSchema,
 )
-from common.api import PageNumberPagination, Result, api
+from common.api import (
+    PageNumberPagination,
+    RedirectedResult,
+    Result,
+    api,
+    resolve_item_for_read,
+    resolve_item_for_write,
+)
 from common.sentry import record_activity
 from common.utils import get_uuid_or_404
 from journal.models.common import (
@@ -215,21 +222,26 @@ def list_marks_on_shelf(
 
 @api.get(
     "/me/shelf/item/{item_uuid}",
-    response={200: MarkSchema, 302: Result, 401: Result, 403: Result, 404: Result},
+    response={
+        200: MarkSchema,
+        302: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["shelf"],
 )
 def get_mark_by_item(request, item_uuid: str, response: HttpResponse):
     """
     Get holding mark on current user's shelf by item uuid
+
+    If the item was merged into another one, HTTP 302 is returned.
     """
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted:
-        return Status(404, {"message": "Item not found"})
-    if item.merged_to_item:
-        response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}"
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/me/shelf/item/{uuid}", response
+    )
+    if not item:
+        return redirect
     shelfmember = request.user.shelf_manager.locate_item(item)
     if not shelfmember:
         return Status(404, {"message": "Mark not found"})
@@ -240,7 +252,7 @@ def get_mark_by_item(request, item_uuid: str, response: HttpResponse):
     "/me/shelf/item/{item_uuid}/progress",
     response={
         200: ProgressSchema,
-        302: Result,
+        302: RedirectedResult,
         400: Result,
         401: Result,
         403: Result,
@@ -249,15 +261,15 @@ def get_mark_by_item(request, item_uuid: str, response: HttpResponse):
     tags=["shelf"],
 )
 def get_item_progress(request, item_uuid: str, response: HttpResponse):
-    """Get reading progress for an in-progress book."""
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted:
-        return Status(404, {"message": "Item not found"})
-    if item.merged_to_item:
-        response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/progress"
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+    """Get reading progress for an in-progress book.
+
+    If the item was merged into another one, HTTP 302 is returned.
+    """
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/me/shelf/item/{uuid}/progress", response
+    )
+    if not item:
+        return redirect
     mark = Mark(request.user.identity, item)
     if mark.shelf_type != ShelfType.PROGRESS:
         return Status(400, {"message": "Only in-progress items can have progress."})
@@ -271,7 +283,7 @@ def get_item_progress(request, item_uuid: str, response: HttpResponse):
     "/me/shelf/item/{item_uuid}/progress",
     response={
         200: ProgressSchema,
-        302: Result,
+        307: RedirectedResult,
         400: Result,
         401: Result,
         403: Result,
@@ -285,15 +297,16 @@ def set_item_progress(
     progress: ProgressInSchema,
     response: HttpResponse,
 ):
-    """Set or clear reading progress for an in-progress item."""
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted:
-        return Status(404, {"message": "Item not found"})
-    if item.merged_to_item:
-        response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/progress"
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+    """Set or clear reading progress for an in-progress item.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
+    """
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/shelf/item/{uuid}/progress", response
+    )
+    if not item:
+        return redirect
     mark = Mark(request.user.identity, item)
     try:
         mark.set_progress(progress.type, progress.value)
@@ -310,7 +323,7 @@ def set_item_progress(
     "/me/shelf/item/{item_uuid}/progress",
     response={
         200: Result,
-        302: Result,
+        307: RedirectedResult,
         400: Result,
         401: Result,
         403: Result,
@@ -319,15 +332,16 @@ def set_item_progress(
     tags=["shelf"],
 )
 def delete_item_progress(request, item_uuid: str, response: HttpResponse):
-    """Clear reading progress for an in-progress item."""
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted:
-        return Status(404, {"message": "Item not found"})
-    if item.merged_to_item:
-        response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/progress"
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+    """Clear reading progress for an in-progress item.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
+    """
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/shelf/item/{uuid}/progress", response
+    )
+    if not item:
+        return redirect
     mark = Mark(request.user.identity, item)
     try:
         mark.set_progress(None, None)
@@ -360,10 +374,16 @@ def get_marks_by_item_list(request, item_uuids: str, response: HttpResponse):
 
 @api.post(
     "/me/shelf/item/{item_uuid}",
-    response={200: Result, 401: Result, 403: Result, 404: Result},
+    response={
+        200: Result,
+        307: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["shelf"],
 )
-def mark_item(request, item_uuid: str, mark: MarkInSchema):
+def mark_item(request, item_uuid: str, mark: MarkInSchema, response: HttpResponse):
     """
     Create or update a holding mark about an item for current user.
 
@@ -371,10 +391,15 @@ def mark_item(request, item_uuid: str, mark: MarkInSchema):
     if the item is already marked, this will update the mark.
 
     updating mark without `rating_grade`, `comment_text` or `tags` field will clear them.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
     """
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted or item.merged_to_item:
-        return Status(404, {"message": "Item not found"})
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/shelf/item/{uuid}", response
+    )
+    if not item:
+        return redirect
     if mark.created_time:
         if mark.created_time.tzinfo is None:
             mark.created_time = timezone.make_aware(
@@ -418,7 +443,7 @@ def delete_mark(request, item_uuid: str):
     "/me/shelf/item/{item_uuid}/logs",
     response={
         200: List[MarkLogSchema],
-        302: Result,
+        302: RedirectedResult,
         401: Result,
         404: Result,
     },
@@ -428,13 +453,12 @@ def delete_mark(request, item_uuid: str):
 def get_mark_logs_by_item(request, item_uuid: str, response: HttpResponse):
     """
     Get holding mark on current user's shelf by item uuid
+
+    If the item was merged into another one, HTTP 302 is returned.
     """
-    item = Item.get_by_url(item_uuid)
-    if not item or item.is_deleted:
-        raise Http404("Item not found")
-    if item.merged_to_item:
-        response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/logs"
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+    item, redirect = resolve_item_for_read(
+        item_uuid, "/api/me/shelf/item/{uuid}/logs", response
+    )
+    if not item:
+        return redirect
     return Mark(request.user.identity, item).logs

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -261,7 +261,7 @@ def get_mark_by_item(request, item_uuid: str, response: HttpResponse):
     tags=["shelf"],
 )
 def get_item_progress(request, item_uuid: str, response: HttpResponse):
-    """Get reading progress for an in-progress book.
+    """Get progress of a marked item.
 
     If the item was merged into another one, HTTP 302 is returned.
     """
@@ -271,8 +271,8 @@ def get_item_progress(request, item_uuid: str, response: HttpResponse):
     if not item:
         return redirect
     mark = Mark(request.user.identity, item)
-    if mark.shelf_type != ShelfType.PROGRESS:
-        return Status(400, {"message": "Only in-progress items can have progress."})
+    if not mark.shelfmember:
+        return Status(404, {"message": "Mark not found"})
     return {
         "type": mark.progress_type,
         "value": mark.progress_value,
@@ -297,7 +297,7 @@ def set_item_progress(
     progress: ProgressInSchema,
     response: HttpResponse,
 ):
-    """Set or clear reading progress for an in-progress item.
+    """Set or clear progress of a marked item.
 
     If the item was merged into another one, HTTP 307 is returned; repeat the
     request against the returned url.
@@ -332,7 +332,7 @@ def set_item_progress(
     tags=["shelf"],
 )
 def delete_item_progress(request, item_uuid: str, response: HttpResponse):
-    """Clear reading progress for an in-progress item.
+    """Clear progress of a marked item.
 
     If the item was merged into another one, HTTP 307 is returned; repeat the
     request against the returned url.

--- a/neodb/journal/models/mark.py
+++ b/neodb/journal/models/mark.py
@@ -109,7 +109,7 @@ class Mark:
 
     @cached_property
     def current_progress(self) -> ShelfMemberProgress | None:
-        if not self.shelfmember or self.shelf_type != ShelfType.PROGRESS:
+        if not self.shelfmember:
             return None
         try:
             return self.shelfmember.current_progress
@@ -464,9 +464,9 @@ class Mark:
         progress_type: Note.ProgressType | str | None,
         progress_value: str | None,
     ) -> ShelfLogEntry | None:
-        """Set reading progress without creating or updating a timeline post."""
-        if self.item.class_name != "edition" or self.shelf_type != ShelfType.PROGRESS:
-            raise ValueError(_("Only in-progress books can have reading progress."))
+        """Set progress without creating or updating a timeline post."""
+        if not self.shelfmember:
+            raise ValueError(_("Please mark the item before setting progress."))
 
         normalized_value = progress_value.strip() if progress_value else None
         if normalized_value and len(normalized_value) > 500:
@@ -481,7 +481,6 @@ class Mark:
             if normalized_type not in Note.get_progress_types_by_item(self.item):
                 raise ValueError(_("Invalid progress type for this item."))
 
-        assert self.shelfmember is not None
         shelfmember = (
             ShelfMember.objects.select_for_update()
             .select_related("parent")
@@ -512,7 +511,7 @@ class Mark:
         log_entry = ShelfLogEntry(
             owner=self.owner,
             item=self.item,
-            shelf_type=ShelfType.PROGRESS,
+            shelf_type=shelfmember.parent.shelf_type,
             timestamp=timestamp,
             metadata=metadata,
         )

--- a/neodb/journal/views/note.py
+++ b/neodb/journal/views/note.py
@@ -112,16 +112,15 @@ def note_edit(
         )
 
     mark = Mark(owner, item)
-    can_update_progress = (
-        item.class_name == "edition" and mark.shelf_type == ShelfType.PROGRESS
-    )
+    # mark progress is editable and surfaced while the item is in progress
+    can_update_progress = mark.shelf_type == ShelfType.PROGRESS
     requested_mode = request.POST.get("mode") or request.GET.get("mode") or "note"
     if note:
         mode = "note"
     elif requested_mode == "progress" and can_update_progress:
         mode = "progress"
     elif requested_mode == "progress" and request.method == "POST":
-        raise BadRequest(_("Only in-progress books can have reading progress."))
+        raise BadRequest(_("Only in-progress items can have progress."))
     else:
         mode = "note"
 
@@ -129,8 +128,8 @@ def note_edit(
     if not note:
         initial.update(
             {
-                "progress_type": mark.progress_type,
-                "progress_value": mark.progress_value,
+                "progress_type": mark.progress_type if can_update_progress else None,
+                "progress_value": mark.progress_value if can_update_progress else None,
             }
         )
     form = NoteForm(
@@ -148,7 +147,7 @@ def note_edit(
         "form": form,
         "mode": mode,
         "can_update_progress": can_update_progress,
-        "has_current_progress": bool(mark.progress_value),
+        "has_current_progress": bool(can_update_progress and mark.progress_value),
     }
 
     if request.method == "GET":
@@ -181,7 +180,7 @@ def note_edit(
         return render(request, "note.html", context, status=400)
     if form.cleaned_data["update_progress"] and not can_update_progress:
         form.add_error(
-            "update_progress", _("Only in-progress books can have reading progress.")
+            "update_progress", _("Only in-progress items can have progress.")
         )
         return render(request, "note.html", context, status=400)
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-25 20:43+0000\n"
+"POT-Creation-Date: 2026-07-26 18:42+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:226
+#: boofilsic/settings.py:472 common/models/lang.py:230
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:473 common/models/lang.py:73
+#: boofilsic/settings.py:473 common/models/lang.py:77
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:474 common/models/lang.py:74
+#: boofilsic/settings.py:474 common/models/lang.py:78
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:475 common/models/lang.py:179
+#: boofilsic/settings.py:475 common/models/lang.py:183
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:476 common/models/lang.py:83
+#: boofilsic/settings.py:476 common/models/lang.py:87
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:477 common/models/lang.py:108
+#: boofilsic/settings.py:477 common/models/lang.py:112
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:478 common/models/lang.py:162
-#: common/models/lang.py:301
+#: boofilsic/settings.py:478 common/models/lang.py:166
+#: common/models/lang.py:305
 msgid "Portuguese"
 msgstr ""
 
@@ -51,11 +51,11 @@ msgstr ""
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:480 common/models/lang.py:312
+#: boofilsic/settings.py:480 common/models/lang.py:316
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:481 common/models/lang.py:313
+#: boofilsic/settings.py:481 common/models/lang.py:317
 msgid "Traditional Chinese"
 msgstr ""
 
@@ -170,7 +170,7 @@ msgstr ""
 msgid "imprint"
 msgstr ""
 
-#: catalog/models/common.py:26 common/models/lang.py:252
+#: catalog/models/common.py:26 common/models/lang.py:256
 msgid "Unknown"
 msgstr ""
 
@@ -2768,759 +2768,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr ""
 
-#: common/models/lang.py:50
+#: common/models/lang.py:54
 msgid "Afar"
 msgstr ""
 
-#: common/models/lang.py:51
+#: common/models/lang.py:55
 msgid "Afrikaans"
 msgstr ""
 
-#: common/models/lang.py:52
+#: common/models/lang.py:56
 msgid "Akan"
 msgstr ""
 
-#: common/models/lang.py:53
+#: common/models/lang.py:57
 msgid "Aragonese"
 msgstr ""
 
-#: common/models/lang.py:54
+#: common/models/lang.py:58
 msgid "Assamese"
 msgstr ""
 
-#: common/models/lang.py:55
+#: common/models/lang.py:59
 msgid "Avaric"
 msgstr ""
 
-#: common/models/lang.py:56
+#: common/models/lang.py:60
 msgid "Avestan"
 msgstr ""
 
-#: common/models/lang.py:57
+#: common/models/lang.py:61
 msgid "Aymara"
 msgstr ""
 
-#: common/models/lang.py:58
+#: common/models/lang.py:62
 msgid "Azerbaijani"
 msgstr ""
 
-#: common/models/lang.py:59
+#: common/models/lang.py:63
 msgid "Bashkir"
 msgstr ""
 
-#: common/models/lang.py:60
+#: common/models/lang.py:64
 msgid "Bambara"
 msgstr ""
 
-#: common/models/lang.py:61
+#: common/models/lang.py:65
 msgid "Bislama"
 msgstr ""
 
-#: common/models/lang.py:62
+#: common/models/lang.py:66
 msgid "Tibetan"
 msgstr ""
 
-#: common/models/lang.py:63
+#: common/models/lang.py:67
 msgid "Breton"
 msgstr ""
 
-#: common/models/lang.py:64
+#: common/models/lang.py:68
 msgid "Catalan"
 msgstr ""
 
-#: common/models/lang.py:65
+#: common/models/lang.py:69
 msgid "Czech"
 msgstr ""
 
-#: common/models/lang.py:66
+#: common/models/lang.py:70
 msgid "Chechen"
 msgstr ""
 
-#: common/models/lang.py:67
+#: common/models/lang.py:71
 msgid "Slavic"
 msgstr ""
 
-#: common/models/lang.py:68
+#: common/models/lang.py:72
 msgid "Chuvash"
 msgstr ""
 
-#: common/models/lang.py:69
+#: common/models/lang.py:73
 msgid "Cornish"
 msgstr ""
 
-#: common/models/lang.py:70
+#: common/models/lang.py:74
 msgid "Corsican"
 msgstr ""
 
-#: common/models/lang.py:71
+#: common/models/lang.py:75
 msgid "Cree"
 msgstr ""
 
-#: common/models/lang.py:72
+#: common/models/lang.py:76
 msgid "Welsh"
 msgstr ""
 
-#: common/models/lang.py:75
+#: common/models/lang.py:79
 msgid "Divehi"
 msgstr ""
 
-#: common/models/lang.py:76
+#: common/models/lang.py:80
 msgid "Dzongkha"
 msgstr ""
 
-#: common/models/lang.py:77
+#: common/models/lang.py:81
 msgid "Esperanto"
 msgstr ""
 
-#: common/models/lang.py:78
+#: common/models/lang.py:82
 msgid "Estonian"
 msgstr ""
 
-#: common/models/lang.py:79
+#: common/models/lang.py:83
 msgid "Basque"
 msgstr ""
 
-#: common/models/lang.py:80
+#: common/models/lang.py:84
 msgid "Faroese"
 msgstr ""
 
-#: common/models/lang.py:81
+#: common/models/lang.py:85
 msgid "Fijian"
 msgstr ""
 
-#: common/models/lang.py:82
+#: common/models/lang.py:86
 msgid "Finnish"
 msgstr ""
 
-#: common/models/lang.py:84
+#: common/models/lang.py:88
 msgid "Frisian"
 msgstr ""
 
-#: common/models/lang.py:85
+#: common/models/lang.py:89
 msgid "Fulah"
 msgstr ""
 
-#: common/models/lang.py:86
+#: common/models/lang.py:90
 msgid "Gaelic"
 msgstr ""
 
-#: common/models/lang.py:87
+#: common/models/lang.py:91
 msgid "Irish"
 msgstr ""
 
-#: common/models/lang.py:88
+#: common/models/lang.py:92
 msgid "Galician"
 msgstr ""
 
-#: common/models/lang.py:89
+#: common/models/lang.py:93
 msgid "Manx"
 msgstr ""
 
-#: common/models/lang.py:90
+#: common/models/lang.py:94
 msgid "Guarani"
 msgstr ""
 
-#: common/models/lang.py:91
+#: common/models/lang.py:95
 msgid "Gujarati"
 msgstr ""
 
-#: common/models/lang.py:92
+#: common/models/lang.py:96
 msgid "Haitian; Haitian Creole"
 msgstr ""
 
-#: common/models/lang.py:93
+#: common/models/lang.py:97
 msgid "Hausa"
 msgstr ""
 
-#: common/models/lang.py:94
+#: common/models/lang.py:98
 msgid "Serbo-Croatian"
 msgstr ""
 
-#: common/models/lang.py:95
+#: common/models/lang.py:99
 msgid "Herero"
 msgstr ""
 
-#: common/models/lang.py:96
+#: common/models/lang.py:100
 msgid "Hiri Motu"
 msgstr ""
 
-#: common/models/lang.py:97
+#: common/models/lang.py:101
 msgid "Croatian"
 msgstr ""
 
-#: common/models/lang.py:98
+#: common/models/lang.py:102
 msgid "Hungarian"
 msgstr ""
 
-#: common/models/lang.py:99
+#: common/models/lang.py:103
 msgid "Igbo"
 msgstr ""
 
-#: common/models/lang.py:100
+#: common/models/lang.py:104
 msgid "Ido"
 msgstr ""
 
-#: common/models/lang.py:101
+#: common/models/lang.py:105
 msgid "Yi"
 msgstr ""
 
-#: common/models/lang.py:102
+#: common/models/lang.py:106
 msgid "Inuktitut"
 msgstr ""
 
-#: common/models/lang.py:103
+#: common/models/lang.py:107
 msgid "Interlingue"
 msgstr ""
 
-#: common/models/lang.py:104
+#: common/models/lang.py:108
 msgid "Interlingua"
 msgstr ""
 
-#: common/models/lang.py:105
+#: common/models/lang.py:109
 msgid "Indonesian"
 msgstr ""
 
-#: common/models/lang.py:106
+#: common/models/lang.py:110
 msgid "Inupiaq"
 msgstr ""
 
-#: common/models/lang.py:107
+#: common/models/lang.py:111
 msgid "Icelandic"
 msgstr ""
 
-#: common/models/lang.py:109
+#: common/models/lang.py:113
 msgid "Javanese"
 msgstr ""
 
-#: common/models/lang.py:110
+#: common/models/lang.py:114
 msgid "Japanese"
 msgstr ""
 
-#: common/models/lang.py:111
+#: common/models/lang.py:115
 msgid "Kalaallisut"
 msgstr ""
 
-#: common/models/lang.py:112
+#: common/models/lang.py:116
 msgid "Kannada"
 msgstr ""
 
-#: common/models/lang.py:113
+#: common/models/lang.py:117
 msgid "Kashmiri"
 msgstr ""
 
-#: common/models/lang.py:114
+#: common/models/lang.py:118
 msgid "Kanuri"
 msgstr ""
 
-#: common/models/lang.py:115
+#: common/models/lang.py:119
 msgid "Kazakh"
 msgstr ""
 
-#: common/models/lang.py:116
+#: common/models/lang.py:120
 msgid "Khmer"
 msgstr ""
 
-#: common/models/lang.py:117
+#: common/models/lang.py:121
 msgid "Kikuyu"
 msgstr ""
 
-#: common/models/lang.py:118
+#: common/models/lang.py:122
 msgid "Kinyarwanda"
 msgstr ""
 
-#: common/models/lang.py:119
+#: common/models/lang.py:123
 msgid "Kirghiz"
 msgstr ""
 
-#: common/models/lang.py:120
+#: common/models/lang.py:124
 msgid "Komi"
 msgstr ""
 
-#: common/models/lang.py:121
+#: common/models/lang.py:125
 msgid "Kongo"
 msgstr ""
 
-#: common/models/lang.py:122
+#: common/models/lang.py:126
 msgid "Korean"
 msgstr ""
 
-#: common/models/lang.py:123
+#: common/models/lang.py:127
 msgid "Kuanyama"
 msgstr ""
 
-#: common/models/lang.py:124
+#: common/models/lang.py:128
 msgid "Kurdish"
 msgstr ""
 
-#: common/models/lang.py:125
+#: common/models/lang.py:129
 msgid "Lao"
 msgstr ""
 
-#: common/models/lang.py:126
+#: common/models/lang.py:130
 msgid "Latin"
 msgstr ""
 
-#: common/models/lang.py:127
+#: common/models/lang.py:131
 msgid "Latvian"
 msgstr ""
 
-#: common/models/lang.py:128
+#: common/models/lang.py:132
 msgid "Limburgish"
 msgstr ""
 
-#: common/models/lang.py:129
+#: common/models/lang.py:133
 msgid "Lingala"
 msgstr ""
 
-#: common/models/lang.py:130
+#: common/models/lang.py:134
 msgid "Lithuanian"
 msgstr ""
 
-#: common/models/lang.py:131
+#: common/models/lang.py:135
 msgid "Letzeburgesch"
 msgstr ""
 
-#: common/models/lang.py:132
+#: common/models/lang.py:136
 msgid "Luba-Katanga"
 msgstr ""
 
-#: common/models/lang.py:133
+#: common/models/lang.py:137
 msgid "Ganda"
 msgstr ""
 
-#: common/models/lang.py:134
+#: common/models/lang.py:138
 msgid "Marshall"
 msgstr ""
 
-#: common/models/lang.py:135
+#: common/models/lang.py:139
 msgid "Malayalam"
 msgstr ""
 
-#: common/models/lang.py:136
+#: common/models/lang.py:140
 msgid "Marathi"
 msgstr ""
 
-#: common/models/lang.py:137
+#: common/models/lang.py:141
 msgid "Malagasy"
 msgstr ""
 
-#: common/models/lang.py:138
+#: common/models/lang.py:142
 msgid "Maltese"
 msgstr ""
 
-#: common/models/lang.py:139
+#: common/models/lang.py:143
 msgid "Moldavian"
 msgstr ""
 
-#: common/models/lang.py:140
+#: common/models/lang.py:144
 msgid "Mongolian"
 msgstr ""
 
-#: common/models/lang.py:141
+#: common/models/lang.py:145
 msgid "Maori"
 msgstr ""
 
-#: common/models/lang.py:142
+#: common/models/lang.py:146
 msgid "Malay"
 msgstr ""
 
-#: common/models/lang.py:143
+#: common/models/lang.py:147
 msgid "Burmese"
 msgstr ""
 
-#: common/models/lang.py:144
+#: common/models/lang.py:148
 msgid "Nauru"
 msgstr ""
 
-#: common/models/lang.py:145
+#: common/models/lang.py:149
 msgid "Navajo"
 msgstr ""
 
-#: common/models/lang.py:146 common/models/lang.py:147
+#: common/models/lang.py:150 common/models/lang.py:151
 msgid "Ndebele"
 msgstr ""
 
-#: common/models/lang.py:148
+#: common/models/lang.py:152
 msgid "Ndonga"
 msgstr ""
 
-#: common/models/lang.py:149
+#: common/models/lang.py:153
 msgid "Nepali"
 msgstr ""
 
-#: common/models/lang.py:150
+#: common/models/lang.py:154
 msgid "Dutch"
 msgstr ""
 
-#: common/models/lang.py:151
+#: common/models/lang.py:155
 msgid "Norwegian Nynorsk"
 msgstr ""
 
-#: common/models/lang.py:152
+#: common/models/lang.py:156
 msgid "Norwegian Bokmål"
 msgstr ""
 
-#: common/models/lang.py:153
+#: common/models/lang.py:157
 msgid "Norwegian"
 msgstr ""
 
-#: common/models/lang.py:154
+#: common/models/lang.py:158
 msgid "Chichewa; Nyanja"
 msgstr ""
 
-#: common/models/lang.py:155
+#: common/models/lang.py:159
 msgid "Occitan"
 msgstr ""
 
-#: common/models/lang.py:156
+#: common/models/lang.py:160
 msgid "Ojibwa"
 msgstr ""
 
-#: common/models/lang.py:157
+#: common/models/lang.py:161
 msgid "Oriya"
 msgstr ""
 
-#: common/models/lang.py:158
+#: common/models/lang.py:162
 msgid "Oromo"
 msgstr ""
 
-#: common/models/lang.py:159
+#: common/models/lang.py:163
 msgid "Ossetian; Ossetic"
 msgstr ""
 
-#: common/models/lang.py:160
+#: common/models/lang.py:164
 msgid "Pali"
 msgstr ""
 
-#: common/models/lang.py:161
+#: common/models/lang.py:165
 msgid "Polish"
 msgstr ""
 
-#: common/models/lang.py:163
+#: common/models/lang.py:167
 msgid "Quechua"
 msgstr ""
 
-#: common/models/lang.py:164
+#: common/models/lang.py:168
 msgid "Raeto-Romance"
 msgstr ""
 
-#: common/models/lang.py:165
+#: common/models/lang.py:169
 msgid "Romanian"
 msgstr ""
 
-#: common/models/lang.py:166
+#: common/models/lang.py:170
 msgid "Rundi"
 msgstr ""
 
-#: common/models/lang.py:167
+#: common/models/lang.py:171
 msgid "Russian"
 msgstr ""
 
-#: common/models/lang.py:168
+#: common/models/lang.py:172
 msgid "Sango"
 msgstr ""
 
-#: common/models/lang.py:169
+#: common/models/lang.py:173
 msgid "Sanskrit"
 msgstr ""
 
-#: common/models/lang.py:170
+#: common/models/lang.py:174
 msgid "Sinhalese"
 msgstr ""
 
-#: common/models/lang.py:171
+#: common/models/lang.py:175
 msgid "Slovak"
 msgstr ""
 
-#: common/models/lang.py:172
+#: common/models/lang.py:176
 msgid "Slovenian"
 msgstr ""
 
-#: common/models/lang.py:173
+#: common/models/lang.py:177
 msgid "Northern Sami"
 msgstr ""
 
-#: common/models/lang.py:174
+#: common/models/lang.py:178
 msgid "Samoan"
 msgstr ""
 
-#: common/models/lang.py:175
+#: common/models/lang.py:179
 msgid "Shona"
 msgstr ""
 
-#: common/models/lang.py:176
+#: common/models/lang.py:180
 msgid "Sindhi"
 msgstr ""
 
-#: common/models/lang.py:177
+#: common/models/lang.py:181
 msgid "Somali"
 msgstr ""
 
-#: common/models/lang.py:178
+#: common/models/lang.py:182
 msgid "Sotho"
 msgstr ""
 
-#: common/models/lang.py:180
+#: common/models/lang.py:184
 msgid "Albanian"
 msgstr ""
 
-#: common/models/lang.py:181
+#: common/models/lang.py:185
 msgid "Sardinian"
 msgstr ""
 
-#: common/models/lang.py:182
+#: common/models/lang.py:186
 msgid "Serbian"
 msgstr ""
 
-#: common/models/lang.py:183
+#: common/models/lang.py:187
 msgid "Swati"
 msgstr ""
 
-#: common/models/lang.py:184
+#: common/models/lang.py:188
 msgid "Sundanese"
 msgstr ""
 
-#: common/models/lang.py:185
+#: common/models/lang.py:189
 msgid "Swahili"
 msgstr ""
 
-#: common/models/lang.py:186
+#: common/models/lang.py:190
 msgid "Swedish"
 msgstr ""
 
-#: common/models/lang.py:187
+#: common/models/lang.py:191
 msgid "Tahitian"
 msgstr ""
 
-#: common/models/lang.py:188
+#: common/models/lang.py:192
 msgid "Tamil"
 msgstr ""
 
-#: common/models/lang.py:189
+#: common/models/lang.py:193
 msgid "Tatar"
 msgstr ""
 
-#: common/models/lang.py:190
+#: common/models/lang.py:194
 msgid "Telugu"
 msgstr ""
 
-#: common/models/lang.py:191
+#: common/models/lang.py:195
 msgid "Tajik"
 msgstr ""
 
-#: common/models/lang.py:192
+#: common/models/lang.py:196
 msgid "Tagalog"
 msgstr ""
 
-#: common/models/lang.py:193
+#: common/models/lang.py:197
 msgid "Thai"
 msgstr ""
 
-#: common/models/lang.py:194
+#: common/models/lang.py:198
 msgid "Tigrinya"
 msgstr ""
 
-#: common/models/lang.py:195
+#: common/models/lang.py:199
 msgid "Tonga"
 msgstr ""
 
-#: common/models/lang.py:196
+#: common/models/lang.py:200
 msgid "Tswana"
 msgstr ""
 
-#: common/models/lang.py:197
+#: common/models/lang.py:201
 msgid "Tsonga"
 msgstr ""
 
-#: common/models/lang.py:198
+#: common/models/lang.py:202
 msgid "Turkmen"
 msgstr ""
 
-#: common/models/lang.py:199
+#: common/models/lang.py:203
 msgid "Turkish"
 msgstr ""
 
-#: common/models/lang.py:200
+#: common/models/lang.py:204
 msgid "Twi"
 msgstr ""
 
-#: common/models/lang.py:201
+#: common/models/lang.py:205
 msgid "Uighur"
 msgstr ""
 
-#: common/models/lang.py:202
+#: common/models/lang.py:206
 msgid "Ukrainian"
 msgstr ""
 
-#: common/models/lang.py:203
+#: common/models/lang.py:207
 msgid "Urdu"
 msgstr ""
 
-#: common/models/lang.py:204
+#: common/models/lang.py:208
 msgid "Uzbek"
 msgstr ""
 
-#: common/models/lang.py:205
+#: common/models/lang.py:209
 msgid "Venda"
 msgstr ""
 
-#: common/models/lang.py:206
+#: common/models/lang.py:210
 msgid "Vietnamese"
 msgstr ""
 
-#: common/models/lang.py:207
+#: common/models/lang.py:211
 msgid "Volapük"
 msgstr ""
 
-#: common/models/lang.py:208
+#: common/models/lang.py:212
 msgid "Walloon"
 msgstr ""
 
-#: common/models/lang.py:209
+#: common/models/lang.py:213
 msgid "Wolof"
 msgstr ""
 
-#: common/models/lang.py:210
+#: common/models/lang.py:214
 msgid "Xhosa"
 msgstr ""
 
-#: common/models/lang.py:211
+#: common/models/lang.py:215
 msgid "Yiddish"
 msgstr ""
 
-#: common/models/lang.py:212
+#: common/models/lang.py:216
 msgid "Zhuang"
 msgstr ""
 
-#: common/models/lang.py:213
+#: common/models/lang.py:217
 msgid "Zulu"
 msgstr ""
 
-#: common/models/lang.py:214
+#: common/models/lang.py:218
 msgid "Abkhazian"
 msgstr ""
 
-#: common/models/lang.py:215
+#: common/models/lang.py:219
 msgid "Chinese"
 msgstr ""
 
-#: common/models/lang.py:216
+#: common/models/lang.py:220
 msgid "Pushto"
 msgstr ""
 
-#: common/models/lang.py:217
+#: common/models/lang.py:221
 msgid "Amharic"
 msgstr ""
 
-#: common/models/lang.py:218
+#: common/models/lang.py:222
 msgid "Arabic"
 msgstr ""
 
-#: common/models/lang.py:219
+#: common/models/lang.py:223
 msgid "Bulgarian"
 msgstr ""
 
-#: common/models/lang.py:220
+#: common/models/lang.py:224
 msgid "Macedonian"
 msgstr ""
 
-#: common/models/lang.py:221
+#: common/models/lang.py:225
 msgid "Greek"
 msgstr ""
 
-#: common/models/lang.py:222
+#: common/models/lang.py:226
 msgid "Persian"
 msgstr ""
 
-#: common/models/lang.py:223
+#: common/models/lang.py:227
 msgid "Hebrew"
 msgstr ""
 
-#: common/models/lang.py:224
+#: common/models/lang.py:228
 msgid "Hindi"
 msgstr ""
 
-#: common/models/lang.py:225
+#: common/models/lang.py:229
 msgid "Armenian"
 msgstr ""
 
-#: common/models/lang.py:227
+#: common/models/lang.py:231
 msgid "Ewe"
 msgstr ""
 
-#: common/models/lang.py:228
+#: common/models/lang.py:232
 msgid "Georgian"
 msgstr ""
 
-#: common/models/lang.py:229
+#: common/models/lang.py:233
 msgid "Punjabi"
 msgstr ""
 
-#: common/models/lang.py:230
+#: common/models/lang.py:234
 msgid "Bengali"
 msgstr ""
 
-#: common/models/lang.py:231
+#: common/models/lang.py:235
 msgid "Bosnian"
 msgstr ""
 
-#: common/models/lang.py:232
+#: common/models/lang.py:236
 msgid "Chamorro"
 msgstr ""
 
-#: common/models/lang.py:233
+#: common/models/lang.py:237
 msgid "Belarusian"
 msgstr ""
 
-#: common/models/lang.py:234
+#: common/models/lang.py:238
 msgid "Yoruba"
 msgstr ""
 
-#: common/models/lang.py:296
+#: common/models/lang.py:300
 msgid "Simplified Chinese (Mainland)"
 msgstr ""
 
-#: common/models/lang.py:297
+#: common/models/lang.py:301
 msgid "Traditional Chinese (Taiwan)"
 msgstr ""
 
-#: common/models/lang.py:298
+#: common/models/lang.py:302
 msgid "Traditional Chinese (Hongkong)"
 msgstr ""
 
-#: common/models/lang.py:306
+#: common/models/lang.py:310
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: common/models/lang.py:309
+#: common/models/lang.py:313
 msgid "Simplified Chinese (Singapore)"
 msgstr ""
 
-#: common/models/lang.py:310
+#: common/models/lang.py:314
 msgid "Simplified Chinese (Malaysia)"
 msgstr ""
 
-#: common/models/lang.py:311
+#: common/models/lang.py:315
 msgid "Traditional Chinese (Macau)"
 msgstr ""
 
-#: common/models/lang.py:319
+#: common/models/lang.py:323
 msgid "Mandarin Chinese"
 msgstr ""
 
-#: common/models/lang.py:320
+#: common/models/lang.py:324
 msgid "Yue Chinese"
 msgstr ""
 
-#: common/models/lang.py:324
+#: common/models/lang.py:328
 msgid "Min Nan Chinese"
 msgstr ""
 
-#: common/models/lang.py:325
+#: common/models/lang.py:329
 msgid "Wu Chinese"
 msgstr ""
 
-#: common/models/lang.py:326
+#: common/models/lang.py:330
 msgid "Hakka Chinese"
 msgstr ""
 
@@ -5011,9 +5011,8 @@ msgstr ""
 msgid "Retrying"
 msgstr ""
 
-#: journal/models/mark.py:469 journal/views/note.py:124
-#: journal/views/note.py:184
-msgid "Only in-progress books can have reading progress."
+#: journal/models/mark.py:469
+msgid "Please mark the item before setting progress."
 msgstr ""
 
 #: journal/models/mark.py:473
@@ -6164,7 +6163,7 @@ msgid "Invalid input"
 msgstr ""
 
 #: journal/views/mark.py:225 journal/views/mark.py:279
-#: journal/views/note.py:176 journal/views/profile.py:42
+#: journal/views/note.py:175 journal/views/profile.py:42
 #: journal/views/review.py:50 journal/views/review.py:67
 msgid "Content not found"
 msgstr ""
@@ -6191,6 +6190,10 @@ msgstr ""
 
 #: journal/views/note.py:85
 msgid "Progress Type (optional)"
+msgstr ""
+
+#: journal/views/note.py:123 journal/views/note.py:183
+msgid "Only in-progress items can have progress."
 msgstr ""
 
 #: journal/views/post.py:98 journal/views/post.py:387

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-25 20:43+0000\n"
+"POT-Creation-Date: 2026-07-26 18:42+0800\n"
 "PO-Revision-Date: 2026-07-02 15:01+0000\n"
 "Last-Translator: Hosted Weblate user 54392 <hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: boofilsic/settings.py:472 common/models/lang.py:226
+#: boofilsic/settings.py:472 common/models/lang.py:230
 msgid "English"
 msgstr "英语"
 
-#: boofilsic/settings.py:473 common/models/lang.py:73
+#: boofilsic/settings.py:473 common/models/lang.py:77
 msgid "Danish"
 msgstr "丹麦语"
 
-#: boofilsic/settings.py:474 common/models/lang.py:74
+#: boofilsic/settings.py:474 common/models/lang.py:78
 msgid "German"
 msgstr "德语"
 
-#: boofilsic/settings.py:475 common/models/lang.py:179
+#: boofilsic/settings.py:475 common/models/lang.py:183
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: boofilsic/settings.py:476 common/models/lang.py:83
+#: boofilsic/settings.py:476 common/models/lang.py:87
 msgid "French"
 msgstr "法语"
 
-#: boofilsic/settings.py:477 common/models/lang.py:108
+#: boofilsic/settings.py:477 common/models/lang.py:112
 msgid "Italian"
 msgstr "意大利语"
 
-#: boofilsic/settings.py:478 common/models/lang.py:162
-#: common/models/lang.py:301
+#: boofilsic/settings.py:478 common/models/lang.py:166
+#: common/models/lang.py:305
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
@@ -50,11 +50,11 @@ msgstr "葡萄牙语"
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: boofilsic/settings.py:480 common/models/lang.py:312
+#: boofilsic/settings.py:480 common/models/lang.py:316
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: boofilsic/settings.py:481 common/models/lang.py:313
+#: boofilsic/settings.py:481 common/models/lang.py:317
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
@@ -169,7 +169,7 @@ msgstr "价格"
 msgid "imprint"
 msgstr "出品方"
 
-#: catalog/models/common.py:26 common/models/lang.py:252
+#: catalog/models/common.py:26 common/models/lang.py:256
 msgid "Unknown"
 msgstr "未知"
 
@@ -2767,759 +2767,759 @@ msgctxt "genre"
 msgid "Health"
 msgstr "健康"
 
-#: common/models/lang.py:50
+#: common/models/lang.py:54
 msgid "Afar"
 msgstr "阿法尔语"
 
-#: common/models/lang.py:51
+#: common/models/lang.py:55
 msgid "Afrikaans"
 msgstr "南非荷兰语"
 
-#: common/models/lang.py:52
+#: common/models/lang.py:56
 msgid "Akan"
 msgstr "阿坎语"
 
-#: common/models/lang.py:53
+#: common/models/lang.py:57
 msgid "Aragonese"
 msgstr "阿拉贡语"
 
-#: common/models/lang.py:54
+#: common/models/lang.py:58
 msgid "Assamese"
 msgstr "阿萨姆语"
 
-#: common/models/lang.py:55
+#: common/models/lang.py:59
 msgid "Avaric"
 msgstr "阿瓦尔语"
 
-#: common/models/lang.py:56
+#: common/models/lang.py:60
 msgid "Avestan"
 msgstr "阿维斯陀语"
 
-#: common/models/lang.py:57
+#: common/models/lang.py:61
 msgid "Aymara"
 msgstr "艾马拉语"
 
-#: common/models/lang.py:58
+#: common/models/lang.py:62
 msgid "Azerbaijani"
 msgstr "阿塞拜疆"
 
-#: common/models/lang.py:59
+#: common/models/lang.py:63
 msgid "Bashkir"
 msgstr "巴什基尔语"
 
-#: common/models/lang.py:60
+#: common/models/lang.py:64
 msgid "Bambara"
 msgstr "班巴拉语"
 
-#: common/models/lang.py:61
+#: common/models/lang.py:65
 msgid "Bislama"
 msgstr "比斯拉马语"
 
-#: common/models/lang.py:62
+#: common/models/lang.py:66
 msgid "Tibetan"
 msgstr "藏语"
 
-#: common/models/lang.py:63
+#: common/models/lang.py:67
 msgid "Breton"
 msgstr "布列塔尼语"
 
-#: common/models/lang.py:64
+#: common/models/lang.py:68
 msgid "Catalan"
 msgstr "加泰罗尼亚"
 
-#: common/models/lang.py:65
+#: common/models/lang.py:69
 msgid "Czech"
 msgstr "捷克语"
 
-#: common/models/lang.py:66
+#: common/models/lang.py:70
 msgid "Chechen"
 msgstr "车臣"
 
-#: common/models/lang.py:67
+#: common/models/lang.py:71
 msgid "Slavic"
 msgstr "斯拉夫"
 
-#: common/models/lang.py:68
+#: common/models/lang.py:72
 msgid "Chuvash"
 msgstr "楚瓦什语"
 
-#: common/models/lang.py:69
+#: common/models/lang.py:73
 msgid "Cornish"
 msgstr "康沃尔语"
 
-#: common/models/lang.py:70
+#: common/models/lang.py:74
 msgid "Corsican"
 msgstr "科西嘉语"
 
-#: common/models/lang.py:71
+#: common/models/lang.py:75
 msgid "Cree"
 msgstr "克里语"
 
-#: common/models/lang.py:72
+#: common/models/lang.py:76
 msgid "Welsh"
 msgstr "威尔士语"
 
-#: common/models/lang.py:75
+#: common/models/lang.py:79
 msgid "Divehi"
 msgstr "迪维希语"
 
-#: common/models/lang.py:76
+#: common/models/lang.py:80
 msgid "Dzongkha"
 msgstr "宗喀语"
 
-#: common/models/lang.py:77
+#: common/models/lang.py:81
 msgid "Esperanto"
 msgstr "世界语"
 
-#: common/models/lang.py:78
+#: common/models/lang.py:82
 msgid "Estonian"
 msgstr "爱沙尼亚语"
 
-#: common/models/lang.py:79
+#: common/models/lang.py:83
 msgid "Basque"
 msgstr "巴斯克语"
 
-#: common/models/lang.py:80
+#: common/models/lang.py:84
 msgid "Faroese"
 msgstr "法罗语"
 
-#: common/models/lang.py:81
+#: common/models/lang.py:85
 msgid "Fijian"
 msgstr "斐济语"
 
-#: common/models/lang.py:82
+#: common/models/lang.py:86
 msgid "Finnish"
 msgstr "芬兰语"
 
-#: common/models/lang.py:84
+#: common/models/lang.py:88
 msgid "Frisian"
 msgstr "弗里西语"
 
-#: common/models/lang.py:85
+#: common/models/lang.py:89
 msgid "Fulah"
 msgstr "富拉语"
 
-#: common/models/lang.py:86
+#: common/models/lang.py:90
 msgid "Gaelic"
 msgstr "盖尔语"
 
-#: common/models/lang.py:87
+#: common/models/lang.py:91
 msgid "Irish"
 msgstr "爱尔兰语"
 
-#: common/models/lang.py:88
+#: common/models/lang.py:92
 msgid "Galician"
 msgstr "加利西亚语"
 
-#: common/models/lang.py:89
+#: common/models/lang.py:93
 msgid "Manx"
 msgstr "马恩语"
 
-#: common/models/lang.py:90
+#: common/models/lang.py:94
 msgid "Guarani"
 msgstr "瓜拉尼语"
 
-#: common/models/lang.py:91
+#: common/models/lang.py:95
 msgid "Gujarati"
 msgstr "古吉拉特语"
 
-#: common/models/lang.py:92
+#: common/models/lang.py:96
 msgid "Haitian; Haitian Creole"
 msgstr "海地语; 海地克里奥尔语"
 
-#: common/models/lang.py:93
+#: common/models/lang.py:97
 msgid "Hausa"
 msgstr "豪萨语"
 
-#: common/models/lang.py:94
+#: common/models/lang.py:98
 msgid "Serbo-Croatian"
 msgstr "塞尔维亚-克罗地亚语"
 
-#: common/models/lang.py:95
+#: common/models/lang.py:99
 msgid "Herero"
 msgstr "赫雷罗语"
 
-#: common/models/lang.py:96
+#: common/models/lang.py:100
 msgid "Hiri Motu"
 msgstr "希里莫图语"
 
-#: common/models/lang.py:97
+#: common/models/lang.py:101
 msgid "Croatian"
 msgstr "克罗地亚语"
 
-#: common/models/lang.py:98
+#: common/models/lang.py:102
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: common/models/lang.py:99
+#: common/models/lang.py:103
 msgid "Igbo"
 msgstr "伊博语"
 
-#: common/models/lang.py:100
+#: common/models/lang.py:104
 msgid "Ido"
 msgstr "伊多语"
 
-#: common/models/lang.py:101
+#: common/models/lang.py:105
 msgid "Yi"
 msgstr "彝语"
 
-#: common/models/lang.py:102
+#: common/models/lang.py:106
 msgid "Inuktitut"
 msgstr "因纽特语"
 
-#: common/models/lang.py:103
+#: common/models/lang.py:107
 msgid "Interlingue"
 msgstr "西方国际语"
 
-#: common/models/lang.py:104
+#: common/models/lang.py:108
 msgid "Interlingua"
 msgstr "国际语"
 
-#: common/models/lang.py:105
+#: common/models/lang.py:109
 msgid "Indonesian"
 msgstr "印度尼西亚语"
 
-#: common/models/lang.py:106
+#: common/models/lang.py:110
 msgid "Inupiaq"
 msgstr "伊努皮克语"
 
-#: common/models/lang.py:107
+#: common/models/lang.py:111
 msgid "Icelandic"
 msgstr "冰岛语"
 
-#: common/models/lang.py:109
+#: common/models/lang.py:113
 msgid "Javanese"
 msgstr "爪哇语"
 
-#: common/models/lang.py:110
+#: common/models/lang.py:114
 msgid "Japanese"
 msgstr "日语"
 
-#: common/models/lang.py:111
+#: common/models/lang.py:115
 msgid "Kalaallisut"
 msgstr "格陵兰语"
 
-#: common/models/lang.py:112
+#: common/models/lang.py:116
 msgid "Kannada"
 msgstr "卡纳达语"
 
-#: common/models/lang.py:113
+#: common/models/lang.py:117
 msgid "Kashmiri"
 msgstr "克什米尔语"
 
-#: common/models/lang.py:114
+#: common/models/lang.py:118
 msgid "Kanuri"
 msgstr "卡努里语"
 
-#: common/models/lang.py:115
+#: common/models/lang.py:119
 msgid "Kazakh"
 msgstr "哈萨克语"
 
-#: common/models/lang.py:116
+#: common/models/lang.py:120
 msgid "Khmer"
 msgstr "高棉语"
 
-#: common/models/lang.py:117
+#: common/models/lang.py:121
 msgid "Kikuyu"
 msgstr "基库尤语"
 
-#: common/models/lang.py:118
+#: common/models/lang.py:122
 msgid "Kinyarwanda"
 msgstr "卢旺达语"
 
-#: common/models/lang.py:119
+#: common/models/lang.py:123
 msgid "Kirghiz"
 msgstr "吉尔吉斯语"
 
-#: common/models/lang.py:120
+#: common/models/lang.py:124
 msgid "Komi"
 msgstr "科米语"
 
-#: common/models/lang.py:121
+#: common/models/lang.py:125
 msgid "Kongo"
 msgstr "刚果语"
 
-#: common/models/lang.py:122
+#: common/models/lang.py:126
 msgid "Korean"
 msgstr "韩语"
 
-#: common/models/lang.py:123
+#: common/models/lang.py:127
 msgid "Kuanyama"
 msgstr "宽亚玛语"
 
-#: common/models/lang.py:124
+#: common/models/lang.py:128
 msgid "Kurdish"
 msgstr "库尔德语"
 
-#: common/models/lang.py:125
+#: common/models/lang.py:129
 msgid "Lao"
 msgstr "老挝语"
 
-#: common/models/lang.py:126
+#: common/models/lang.py:130
 msgid "Latin"
 msgstr "拉丁"
 
-#: common/models/lang.py:127
+#: common/models/lang.py:131
 msgid "Latvian"
 msgstr "拉脱维亚语"
 
-#: common/models/lang.py:128
+#: common/models/lang.py:132
 msgid "Limburgish"
 msgstr "林堡语"
 
-#: common/models/lang.py:129
+#: common/models/lang.py:133
 msgid "Lingala"
 msgstr "林加拉语"
 
-#: common/models/lang.py:130
+#: common/models/lang.py:134
 msgid "Lithuanian"
 msgstr "立陶宛语"
 
-#: common/models/lang.py:131
+#: common/models/lang.py:135
 msgid "Letzeburgesch"
 msgstr "卢森堡语"
 
-#: common/models/lang.py:132
+#: common/models/lang.py:136
 msgid "Luba-Katanga"
 msgstr "卢巴-加丹加语"
 
-#: common/models/lang.py:133
+#: common/models/lang.py:137
 msgid "Ganda"
 msgstr "干达语"
 
-#: common/models/lang.py:134
+#: common/models/lang.py:138
 msgid "Marshall"
 msgstr "马绍尔语"
 
-#: common/models/lang.py:135
+#: common/models/lang.py:139
 msgid "Malayalam"
 msgstr "马拉雅拉姆语"
 
-#: common/models/lang.py:136
+#: common/models/lang.py:140
 msgid "Marathi"
 msgstr "马拉地语"
 
-#: common/models/lang.py:137
+#: common/models/lang.py:141
 msgid "Malagasy"
 msgstr "马达加斯加语"
 
-#: common/models/lang.py:138
+#: common/models/lang.py:142
 msgid "Maltese"
 msgstr "马耳他语"
 
-#: common/models/lang.py:139
+#: common/models/lang.py:143
 msgid "Moldavian"
 msgstr "摩尔多瓦语"
 
-#: common/models/lang.py:140
+#: common/models/lang.py:144
 msgid "Mongolian"
 msgstr "蒙古语"
 
-#: common/models/lang.py:141
+#: common/models/lang.py:145
 msgid "Maori"
 msgstr "毛利语"
 
-#: common/models/lang.py:142
+#: common/models/lang.py:146
 msgid "Malay"
 msgstr "马来语"
 
-#: common/models/lang.py:143
+#: common/models/lang.py:147
 msgid "Burmese"
 msgstr "缅甸语"
 
-#: common/models/lang.py:144
+#: common/models/lang.py:148
 msgid "Nauru"
 msgstr "瑙鲁语"
 
-#: common/models/lang.py:145
+#: common/models/lang.py:149
 msgid "Navajo"
 msgstr "纳瓦霍语"
 
-#: common/models/lang.py:146 common/models/lang.py:147
+#: common/models/lang.py:150 common/models/lang.py:151
 msgid "Ndebele"
 msgstr "恩德贝莱语"
 
-#: common/models/lang.py:148
+#: common/models/lang.py:152
 msgid "Ndonga"
 msgstr "恩东加语"
 
-#: common/models/lang.py:149
+#: common/models/lang.py:153
 msgid "Nepali"
 msgstr "尼泊尔语"
 
-#: common/models/lang.py:150
+#: common/models/lang.py:154
 msgid "Dutch"
 msgstr "荷兰语"
 
-#: common/models/lang.py:151
+#: common/models/lang.py:155
 msgid "Norwegian Nynorsk"
 msgstr "挪威尼诺斯克语"
 
-#: common/models/lang.py:152
+#: common/models/lang.py:156
 msgid "Norwegian Bokmål"
 msgstr "挪威博克马尔语"
 
-#: common/models/lang.py:153
+#: common/models/lang.py:157
 msgid "Norwegian"
 msgstr "挪威语"
 
-#: common/models/lang.py:154
+#: common/models/lang.py:158
 msgid "Chichewa; Nyanja"
 msgstr "奇切瓦语; 尼扬贾语"
 
-#: common/models/lang.py:155
+#: common/models/lang.py:159
 msgid "Occitan"
 msgstr "奥克语"
 
-#: common/models/lang.py:156
+#: common/models/lang.py:160
 msgid "Ojibwa"
 msgstr "奥吉布瓦语"
 
-#: common/models/lang.py:157
+#: common/models/lang.py:161
 msgid "Oriya"
 msgstr "奥里亚语"
 
-#: common/models/lang.py:158
+#: common/models/lang.py:162
 msgid "Oromo"
 msgstr "奥罗莫语"
 
-#: common/models/lang.py:159
+#: common/models/lang.py:163
 msgid "Ossetian; Ossetic"
 msgstr "奥塞梯语"
 
-#: common/models/lang.py:160
+#: common/models/lang.py:164
 msgid "Pali"
 msgstr "巴利语"
 
-#: common/models/lang.py:161
+#: common/models/lang.py:165
 msgid "Polish"
 msgstr "波兰语"
 
-#: common/models/lang.py:163
+#: common/models/lang.py:167
 msgid "Quechua"
 msgstr "克丘亚语"
 
-#: common/models/lang.py:164
+#: common/models/lang.py:168
 msgid "Raeto-Romance"
 msgstr "罗曼什语"
 
-#: common/models/lang.py:165
+#: common/models/lang.py:169
 msgid "Romanian"
 msgstr "罗马尼亚语"
 
-#: common/models/lang.py:166
+#: common/models/lang.py:170
 msgid "Rundi"
 msgstr "基隆迪语"
 
-#: common/models/lang.py:167
+#: common/models/lang.py:171
 msgid "Russian"
 msgstr "俄语"
 
-#: common/models/lang.py:168
+#: common/models/lang.py:172
 msgid "Sango"
 msgstr "桑戈语"
 
-#: common/models/lang.py:169
+#: common/models/lang.py:173
 msgid "Sanskrit"
 msgstr "梵语"
 
-#: common/models/lang.py:170
+#: common/models/lang.py:174
 msgid "Sinhalese"
 msgstr "僧伽罗语"
 
-#: common/models/lang.py:171
+#: common/models/lang.py:175
 msgid "Slovak"
 msgstr "斯洛伐克语"
 
-#: common/models/lang.py:172
+#: common/models/lang.py:176
 msgid "Slovenian"
 msgstr "斯洛文尼亚语"
 
-#: common/models/lang.py:173
+#: common/models/lang.py:177
 msgid "Northern Sami"
 msgstr "北萨米语"
 
-#: common/models/lang.py:174
+#: common/models/lang.py:178
 msgid "Samoan"
 msgstr "萨摩亚语"
 
-#: common/models/lang.py:175
+#: common/models/lang.py:179
 msgid "Shona"
 msgstr "绍纳语"
 
-#: common/models/lang.py:176
+#: common/models/lang.py:180
 msgid "Sindhi"
 msgstr "信德语"
 
-#: common/models/lang.py:177
+#: common/models/lang.py:181
 msgid "Somali"
 msgstr "索马里语"
 
-#: common/models/lang.py:178
+#: common/models/lang.py:182
 msgid "Sotho"
 msgstr "索托语"
 
-#: common/models/lang.py:180
+#: common/models/lang.py:184
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
-#: common/models/lang.py:181
+#: common/models/lang.py:185
 msgid "Sardinian"
 msgstr "萨丁尼亚语"
 
-#: common/models/lang.py:182
+#: common/models/lang.py:186
 msgid "Serbian"
 msgstr "塞尔维亚语"
 
-#: common/models/lang.py:183
+#: common/models/lang.py:187
 msgid "Swati"
 msgstr "斯瓦特语"
 
-#: common/models/lang.py:184
+#: common/models/lang.py:188
 msgid "Sundanese"
 msgstr "巽他语"
 
-#: common/models/lang.py:185
+#: common/models/lang.py:189
 msgid "Swahili"
 msgstr "斯瓦希里语"
 
-#: common/models/lang.py:186
+#: common/models/lang.py:190
 msgid "Swedish"
 msgstr "瑞典语"
 
-#: common/models/lang.py:187
+#: common/models/lang.py:191
 msgid "Tahitian"
 msgstr "塔希提语"
 
-#: common/models/lang.py:188
+#: common/models/lang.py:192
 msgid "Tamil"
 msgstr "泰米尔语"
 
-#: common/models/lang.py:189
+#: common/models/lang.py:193
 msgid "Tatar"
 msgstr "鞑靼语"
 
-#: common/models/lang.py:190
+#: common/models/lang.py:194
 msgid "Telugu"
 msgstr "泰卢固语"
 
-#: common/models/lang.py:191
+#: common/models/lang.py:195
 msgid "Tajik"
 msgstr "塔吉克语"
 
-#: common/models/lang.py:192
+#: common/models/lang.py:196
 msgid "Tagalog"
 msgstr "他加禄语"
 
-#: common/models/lang.py:193
+#: common/models/lang.py:197
 msgid "Thai"
 msgstr "泰语"
 
-#: common/models/lang.py:194
+#: common/models/lang.py:198
 msgid "Tigrinya"
 msgstr "提格利尼亚语"
 
-#: common/models/lang.py:195
+#: common/models/lang.py:199
 msgid "Tonga"
 msgstr "汤加语"
 
-#: common/models/lang.py:196
+#: common/models/lang.py:200
 msgid "Tswana"
 msgstr "茨瓦纳语"
 
-#: common/models/lang.py:197
+#: common/models/lang.py:201
 msgid "Tsonga"
 msgstr "聪加语"
 
-#: common/models/lang.py:198
+#: common/models/lang.py:202
 msgid "Turkmen"
 msgstr "土库曼语"
 
-#: common/models/lang.py:199
+#: common/models/lang.py:203
 msgid "Turkish"
 msgstr "土耳其语"
 
-#: common/models/lang.py:200
+#: common/models/lang.py:204
 msgid "Twi"
 msgstr "契维语"
 
-#: common/models/lang.py:201
+#: common/models/lang.py:205
 msgid "Uighur"
 msgstr "维吾尔语"
 
-#: common/models/lang.py:202
+#: common/models/lang.py:206
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: common/models/lang.py:203
+#: common/models/lang.py:207
 msgid "Urdu"
 msgstr "乌尔都语"
 
-#: common/models/lang.py:204
+#: common/models/lang.py:208
 msgid "Uzbek"
 msgstr "乌兹别克语"
 
-#: common/models/lang.py:205
+#: common/models/lang.py:209
 msgid "Venda"
 msgstr "文达语"
 
-#: common/models/lang.py:206
+#: common/models/lang.py:210
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: common/models/lang.py:207
+#: common/models/lang.py:211
 msgid "Volapük"
 msgstr "沃拉普克语"
 
-#: common/models/lang.py:208
+#: common/models/lang.py:212
 msgid "Walloon"
 msgstr "瓦隆语"
 
-#: common/models/lang.py:209
+#: common/models/lang.py:213
 msgid "Wolof"
 msgstr "沃洛夫语"
 
-#: common/models/lang.py:210
+#: common/models/lang.py:214
 msgid "Xhosa"
 msgstr "科萨语"
 
-#: common/models/lang.py:211
+#: common/models/lang.py:215
 msgid "Yiddish"
 msgstr "意第绪语"
 
-#: common/models/lang.py:212
+#: common/models/lang.py:216
 msgid "Zhuang"
 msgstr "壮语"
 
-#: common/models/lang.py:213
+#: common/models/lang.py:217
 msgid "Zulu"
 msgstr "祖鲁语"
 
-#: common/models/lang.py:214
+#: common/models/lang.py:218
 msgid "Abkhazian"
 msgstr "阿布哈兹语"
 
-#: common/models/lang.py:215
+#: common/models/lang.py:219
 msgid "Chinese"
 msgstr "中文"
 
-#: common/models/lang.py:216
+#: common/models/lang.py:220
 msgid "Pushto"
 msgstr "普什图语"
 
-#: common/models/lang.py:217
+#: common/models/lang.py:221
 msgid "Amharic"
 msgstr "阿姆哈拉语"
 
-#: common/models/lang.py:218
+#: common/models/lang.py:222
 msgid "Arabic"
 msgstr "阿拉伯语"
 
-#: common/models/lang.py:219
+#: common/models/lang.py:223
 msgid "Bulgarian"
 msgstr "保加利亚语"
 
-#: common/models/lang.py:220
+#: common/models/lang.py:224
 msgid "Macedonian"
 msgstr "马其顿语"
 
-#: common/models/lang.py:221
+#: common/models/lang.py:225
 msgid "Greek"
 msgstr "希腊语"
 
-#: common/models/lang.py:222
+#: common/models/lang.py:226
 msgid "Persian"
 msgstr "波斯语"
 
-#: common/models/lang.py:223
+#: common/models/lang.py:227
 msgid "Hebrew"
 msgstr "希伯来语"
 
-#: common/models/lang.py:224
+#: common/models/lang.py:228
 msgid "Hindi"
 msgstr "印度语"
 
-#: common/models/lang.py:225
+#: common/models/lang.py:229
 msgid "Armenian"
 msgstr "亚美尼亚语"
 
-#: common/models/lang.py:227
+#: common/models/lang.py:231
 msgid "Ewe"
 msgstr "埃维语"
 
-#: common/models/lang.py:228
+#: common/models/lang.py:232
 msgid "Georgian"
 msgstr "格鲁吉亚语"
 
-#: common/models/lang.py:229
+#: common/models/lang.py:233
 msgid "Punjabi"
 msgstr "旁遮普语"
 
-#: common/models/lang.py:230
+#: common/models/lang.py:234
 msgid "Bengali"
 msgstr "孟加拉语"
 
-#: common/models/lang.py:231
+#: common/models/lang.py:235
 msgid "Bosnian"
 msgstr "波斯尼亚语"
 
-#: common/models/lang.py:232
+#: common/models/lang.py:236
 msgid "Chamorro"
 msgstr "查莫罗语"
 
-#: common/models/lang.py:233
+#: common/models/lang.py:237
 msgid "Belarusian"
 msgstr "白俄罗斯语"
 
-#: common/models/lang.py:234
+#: common/models/lang.py:238
 msgid "Yoruba"
 msgstr "约鲁巴语"
 
-#: common/models/lang.py:296
+#: common/models/lang.py:300
 msgid "Simplified Chinese (Mainland)"
 msgstr "简体中文(大陆)"
 
-#: common/models/lang.py:297
+#: common/models/lang.py:301
 msgid "Traditional Chinese (Taiwan)"
 msgstr "正体中文(台湾)"
 
-#: common/models/lang.py:298
+#: common/models/lang.py:302
 msgid "Traditional Chinese (Hongkong)"
 msgstr "繁体中文(香港)"
 
-#: common/models/lang.py:306
+#: common/models/lang.py:310
 msgid "Portuguese (Brazil)"
 msgstr "葡萄牙语(巴西)"
 
-#: common/models/lang.py:309
+#: common/models/lang.py:313
 msgid "Simplified Chinese (Singapore)"
 msgstr "简体中文(新加坡)"
 
-#: common/models/lang.py:310
+#: common/models/lang.py:314
 msgid "Simplified Chinese (Malaysia)"
 msgstr "简体中文(马来西亚)"
 
-#: common/models/lang.py:311
+#: common/models/lang.py:315
 msgid "Traditional Chinese (Macau)"
 msgstr "繁体中文(澳门)"
 
-#: common/models/lang.py:319
+#: common/models/lang.py:323
 msgid "Mandarin Chinese"
 msgstr "普通话"
 
-#: common/models/lang.py:320
+#: common/models/lang.py:324
 msgid "Yue Chinese"
 msgstr "粤语"
 
-#: common/models/lang.py:324
+#: common/models/lang.py:328
 msgid "Min Nan Chinese"
 msgstr "闽南语"
 
-#: common/models/lang.py:325
+#: common/models/lang.py:329
 msgid "Wu Chinese"
 msgstr "吴语"
 
-#: common/models/lang.py:326
+#: common/models/lang.py:330
 msgid "Hakka Chinese"
 msgstr "客家话"
 
@@ -5031,10 +5031,9 @@ msgstr "失败"
 msgid "Retrying"
 msgstr "重试中"
 
-#: journal/models/mark.py:469 journal/views/note.py:124
-#: journal/views/note.py:184
-msgid "Only in-progress books can have reading progress."
-msgstr "只有正在阅读的书籍可以设置阅读进度。"
+#: journal/models/mark.py:469
+msgid "Please mark the item before setting progress."
+msgstr "请先标记条目再设置进度。"
 
 #: journal/models/mark.py:473
 msgid "Progress must be 500 characters or fewer."
@@ -6229,7 +6228,7 @@ msgid "Invalid input"
 msgstr "无效输入"
 
 #: journal/views/mark.py:225 journal/views/mark.py:279
-#: journal/views/note.py:176 journal/views/profile.py:42
+#: journal/views/note.py:175 journal/views/profile.py:42
 #: journal/views/review.py:50 journal/views/review.py:67
 msgid "Content not found"
 msgstr "内容未找到"
@@ -6257,6 +6256,10 @@ msgstr "剧透或敏感内容提示（选填）"
 #: journal/views/note.py:85
 msgid "Progress Type (optional)"
 msgstr "进度类型（选填）"
+
+#: journal/views/note.py:123 journal/views/note.py:183
+msgid "Only in-progress items can have progress."
+msgstr "只有进行中的条目可以设置进度。"
 
 #: journal/views/post.py:98 journal/views/post.py:387
 msgid "Post not found"

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -2,6 +2,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 import requests
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -124,6 +125,94 @@ def test_catalog_fetch_endpoint_returns_accepted_when_queued(live_server):
 
     assert response.status_code == 202
     enqueue_fetch.assert_called_once_with("http://example.com/queued", False, ANY)
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_catalog_fetch_endpoint_resolves_local_url(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Local Movie")
+
+    with patch("catalog.apis.enqueue_fetch") as enqueue_fetch:
+        response = requests.get(
+            f"{live_server.url}/api/catalog/fetch",
+            params={"url": movie.absolute_url},
+            timeout=5,
+            allow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == movie.api_url
+    assert response.json()["url"] == movie.api_url
+    enqueue_fetch.assert_not_called()
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_catalog_fetch_endpoint_resolves_local_alternative_url(live_server):
+    """The federated `/~neodb~/` prefix and the API path resolve too."""
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Local Movie")
+
+    site_url = settings.SITE_INFO["site_url"]
+    for url in [
+        f"{site_url}/~neodb~{movie.url}",
+        f"{site_url}{movie.api_url}",
+        f"{site_url}{movie.url}/",
+    ]:
+        response = requests.get(
+            f"{live_server.url}/api/catalog/fetch",
+            params={"url": url},
+            timeout=5,
+            allow_redirects=False,
+        )
+        assert response.status_code == 302, url
+        assert response.headers["Location"] == movie.api_url
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_catalog_fetch_endpoint_resolves_merged_local_url(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Local Movie")
+        merged = Movie.objects.create(title="Merged Movie", merged_to_item=movie)
+
+    response = requests.get(
+        f"{live_server.url}/api/catalog/fetch",
+        params={"url": merged.absolute_url},
+        timeout=5,
+        allow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == movie.api_url
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+@pytest.mark.parametrize("path", ["/movie/nonexistentitemuuid1", "/users/someone/"])
+def test_catalog_fetch_endpoint_returns_not_found_for_local_url(live_server, path):
+    response = requests.get(
+        f"{live_server.url}/api/catalog/fetch",
+        params={"url": f"{settings.SITE_INFO['site_url']}{path}"},
+        timeout=5,
+        allow_redirects=False,
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_catalog_fetch_endpoint_returns_not_found_for_deleted_local_item(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Deleted Movie")
+        movie.is_deleted = True
+        movie.save()
+
+    response = requests.get(
+        f"{live_server.url}/api/catalog/fetch",
+        params={"url": movie.absolute_url},
+        timeout=5,
+        allow_redirects=False,
+    )
+
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)

--- a/neodb/tests/catalog/test_fedi.py
+++ b/neodb/tests/catalog/test_fedi.py
@@ -128,6 +128,34 @@ class TestFediverseInstance:
                 FediverseInstance.is_local_item_url("https://external.com/movie/789")
                 is False
             )
+            # a hostname-less or malformed URL is not local, and must not raise
+            assert FediverseInstance.is_local_item_url("neodb.social") is False
+            assert FediverseInstance.is_local_item_url("") is False
+            # userinfo must not be mistaken for the host
+            assert (
+                FediverseInstance.is_local_item_url(
+                    "https://neodb.social@external.com/movie/789"
+                )
+                is False
+            )
+            assert (
+                FediverseInstance.is_local_item_url(
+                    "https://external.com@neodb.social/movie/789"
+                )
+                is True
+            )
+
+    def test_is_local_item_url_with_port(self):
+        """A SITE_DOMAINS entry may carry a port in local setups"""
+        with patch("catalog.sites.fedi.settings.SITE_DOMAINS", ["localhost:8000"]):
+            assert (
+                FediverseInstance.is_local_item_url("http://localhost:8000/movie/123")
+                is True
+            )
+            assert (
+                FediverseInstance.is_local_item_url("http://localhost/movie/123")
+                is False
+            )
 
     @patch("catalog.sites.fedi.CachedDownloader")
     @patch("catalog.sites.fedi.Item.get_by_url")

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1182,10 +1182,50 @@ def test_book_progress_api_get_set_clear_and_logs():
     assert latest_log["comment_text"] is None
     assert latest_log["rating_grade"] is None
 
+    # progress is not restricted to items on the in-progress shelf
     Mark(user.identity, item).update(ShelfType.COMPLETE, visibility=0)
     response = client.post(
         f"/api/me/shelf/item/{item.uuid}/progress",
         data=json.dumps({"type": "page", "value": "126"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "type": "page",
+        "value": "126",
+    }
+
+    response = client.get(
+        f"/api/me/shelf/item/{item.uuid}/progress",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "type": "page",
+        "value": "126",
+    }
+
+    response = client.get(
+        f"/api/me/shelf/item/{item.uuid}/logs",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    latest_log = response.json()["data"][-1]
+    assert latest_log["shelf_type"] == "complete"
+    assert latest_log["progress_value"] == "126"
+
+    # progress belongs to a mark, so an unmarked item has none
+    unmarked = Edition.objects.create(title="Unmarked Progress Book")
+    response = client.get(
+        f"/api/me/shelf/item/{unmarked.uuid}/progress",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 404
+
+    response = client.post(
+        f"/api/me/shelf/item/{unmarked.uuid}/progress",
+        data=json.dumps({"type": "page", "value": "1"}),
         content_type="application/json",
         HTTP_AUTHORIZATION=authorization,
     )

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -1251,7 +1251,7 @@ def test_shelf_api_list_delete_and_logs():
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_shelf_api_logs_on_merged_item_redirects():
+def test_read_apis_on_merged_item_redirect_with_302():
     user = User.register(email="shelf-merged@example.com", username="shelfuser3")
     merged_item = Edition.objects.create(title="Merged Away Book")
     target_item = Edition.objects.create(title="Surviving Book")
@@ -1266,14 +1266,121 @@ def test_shelf_api_logs_on_merged_item_redirects():
     token = Takahe.refresh_token(app, user.identity.pk, user.pk)
     client = Client()
 
-    response = client.get(
-        f"/api/me/shelf/item/{merged_item.uuid}/logs",
-        HTTP_AUTHORIZATION=f"Bearer {token}",
-    )
+    paths = [
+        "/api/me/shelf/item/{}",
+        "/api/me/shelf/item/{}/progress",
+        "/api/me/shelf/item/{}/logs",
+        "/api/me/review/item/{}",
+        "/api/me/note/item/{}/",
+        "/api/item/{}/posts/",
+    ]
+    for path in paths:
+        location = path.format(target_item.uuid)
+        response = client.get(
+            path.format(merged_item.uuid),
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
-    assert response.status_code == 302
-    assert response["Location"] == f"/api/me/shelf/item/{target_item.uuid}/logs"
-    assert response.json() == {"message": "Item merged"}
+        assert response.status_code == 302, path
+        assert response["Location"] == location
+        assert response.json() == {"message": "Item merged", "url": location}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_write_apis_on_merged_item_redirect_with_307():
+    """Writes get 307, so the client can replay method and body as-is."""
+    user = User.register(email="merged-write@example.com", username="mergeduser")
+    merged_item = Edition.objects.create(title="Merged Away Book 2")
+    target_item = Edition.objects.create(title="Surviving Book 2")
+    merged_item.merge_to(target_item)
+
+    app = Takahe.get_or_create_app(
+        "Merged Write API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    authorization = f"Bearer {token}"
+    client = Client()
+
+    cases = [
+        ("post", "/api/me/shelf/item/{}", {"shelf_type": "complete", "visibility": 0}),
+        (
+            "post",
+            "/api/me/shelf/item/{}/progress",
+            {"type": "page", "value": "10"},
+        ),
+        ("delete", "/api/me/shelf/item/{}/progress", None),
+        (
+            "post",
+            "/api/me/review/item/{}",
+            {"title": "Title", "body": "Body", "visibility": 0},
+        ),
+        (
+            "post",
+            "/api/me/note/item/{}/",
+            {"title": "Title", "content": "Content", "visibility": 0},
+        ),
+    ]
+    for method, path, payload in cases:
+        url = path.format(merged_item.uuid)
+        location = path.format(target_item.uuid)
+        kwargs = {"HTTP_AUTHORIZATION": authorization}
+        if payload is not None:
+            kwargs["data"] = json.dumps(payload)
+            kwargs["content_type"] = "application/json"
+        response = getattr(client, method)(url, **kwargs)
+        assert response.status_code == 307, url
+        assert response["Location"] == location
+        assert response.json() == {"message": "Item merged", "url": location}
+
+    # nothing was written to the merged-away item
+    assert Mark(user.identity, merged_item).shelf_type is None
+    assert not Review.objects.filter(item=merged_item).exists()
+    assert not Note.objects.filter(item=merged_item).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_write_apis_on_deleted_item_return_404():
+    user = User.register(email="deleted-write@example.com", username="deleteduser")
+    item = Edition.objects.create(title="Deleted Write Book")
+    item.is_deleted = True
+    item.save()
+
+    app = Takahe.get_or_create_app(
+        "Deleted Write API Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    authorization = f"Bearer {token}"
+    client = Client()
+
+    response = client.post(
+        f"/api/me/shelf/item/{item.uuid}",
+        data=json.dumps({"shelf_type": "complete", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 404
+
+    response = client.post(
+        f"/api/me/review/item/{item.uuid}",
+        data=json.dumps({"title": "Title", "body": "Body", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 404
+
+    response = client.post(
+        f"/api/me/note/item/{item.uuid}/",
+        data=json.dumps({"title": "Title", "content": "Content", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_mark.py
+++ b/neodb/tests/journal/test_mark.py
@@ -184,6 +184,38 @@ def test_set_book_progress_logs_change_without_new_post():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_set_progress_allows_any_item_type_and_shelf():
+    user = User.register(email="progress-any@example.com", username="progressany")
+    podcast = Podcast.objects.create(title="Progress Podcast")
+    book = Edition.objects.create(title="Completed Progress Book")
+    podcast_mark = Mark(user.identity, podcast)
+    podcast_mark.update(ShelfType.PROGRESS, visibility=0)
+    book_mark = Mark(user.identity, book)
+    book_mark.update(ShelfType.COMPLETE, visibility=0)
+
+    podcast_log = podcast_mark.set_progress(Note.ProgressType.EPISODE, "12")
+    assert podcast_log is not None
+    assert podcast_log.shelf_type == ShelfType.PROGRESS
+    assert podcast_mark.progress_value == "12"
+
+    # progress on another shelf is logged under that shelf, not as in-progress
+    book_log = book_mark.set_progress(Note.ProgressType.PAGE, "42")
+    assert book_log is not None
+    assert book_log.shelf_type == ShelfType.COMPLETE
+    assert book_mark.progress_value == "42"
+    assert Mark(user.identity, book).progress_value == "42"
+
+    # progress types still have to match the item type
+    with pytest.raises(ValueError):
+        podcast_mark.set_progress(Note.ProgressType.PAGE, "3")
+
+    # progress hangs off a mark, so an unmarked item cannot have any
+    unmarked = Mark(user.identity, Edition.objects.create(title="Unmarked Book"))
+    with pytest.raises(ValueError):
+        unmarked.set_progress(Note.ProgressType.PAGE, "1")
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_progress_shelf_renders_progress_bar(client):
     user = User.register(email="progressbar@example.com", username="progressbar")
     book = Edition.objects.create(title="Bar Book")
@@ -503,6 +535,32 @@ def test_note_and_progress_dialog_modes(client):
     response = client.get(reverse("journal:note", args=[book.uuid, note.uuid]))
     assert response.status_code == 200
     assert 'id="note-mode-selector"' not in response.content.decode()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_note_dialog_offers_progress_for_nonbook_item(client):
+    user = User.register(email="note-podcast@example.com", username="notepodcast")
+    podcast = Podcast.objects.create(title="Note Progress Podcast")
+    Mark(user.identity, podcast).update(ShelfType.PROGRESS, visibility=0)
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    note_url = reverse("journal:note", args=[podcast.uuid])
+
+    response = client.get(f"{note_url}?mode=progress")
+    assert response.status_code == 200
+    assert response.context["mode"] == "progress"
+    assert response.context["can_update_progress"] is True
+
+    response = client.post(
+        note_url,
+        {
+            "mode": "progress",
+            "progress_type": "episode",
+            "progress_value": "9",
+        },
+    )
+    assert response.status_code == 302
+    assert Mark(user.identity, podcast).progress_value == "9"
+    assert Note.objects.filter(owner=user.identity, item=podcast).count() == 0
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Three related fixes to how item-scoped API endpoints resolve the item they are about.

### `/catalog/fetch` accepts this server's own item URLs

Every URL went through `SiteManager`, which rejects local URLs by design, so pasting an item URL from this very server returned `422 URL not supported`. Local URLs now resolve directly: `302` to the item's `api_url` (following the merge chain), `404` when the URL is not a live item here. No fetch job is queued and no rate limit is spent, since nothing is fetched. Accepts `/movie/<uuid>`, `/~neodb~/…`, `/api/…` and trailing-slash forms; matching uses the URL path only, so a long hostname cannot satisfy the uuid search in `Item.get_by_url`.

This also hardens `FediverseInstance.is_local_item_url`, which the new path depends on. It sliced on `"://"`, so a scheme-less `url` query param raised `IndexError` (a 500), and it treated userinfo as the host, so `https://ourdomain@evil.com/…` counted as local.

### Merged items redirect instead of 404-ing or writing to the wrong item

Handling was inconsistent: marking a merged item returned 404, reviewing or noting one silently wrote to the merged-away item, and its posts came back as an empty list. All of them now go through one resolver:

| endpoint | before | after |
| --- | --- | --- |
| `GET /me/shelf/item/{uuid}` | 302, body without `url` | 302 |
| `GET /me/shelf/item/{uuid}/progress` | 302, body without `url` | 302 |
| `GET /me/shelf/item/{uuid}/logs` | 302, body without `url` | 302 |
| `GET /me/review/item/{uuid}` | 404 | 302 |
| `GET /me/note/item/{uuid}/` | listed the merged-away item's notes | 302 |
| `GET /item/{uuid}/posts/` | empty list | 302 |
| `POST /me/shelf/item/{uuid}` | 404 | **307** |
| `POST`/`DELETE /me/shelf/item/{uuid}/progress` | 302 | **307** |
| `POST /me/review/item/{uuid}` | wrote to the merged-away item | **307** |
| `POST /me/note/item/{uuid}/` | wrote to the merged-away item | **307** |

Writes get 307 rather than 302 so the client replays method and body instead of degrading the write into a GET. `Location` and the body `url` both point at the same endpoint for the surviving item, resolved through the whole merge chain in one hop. Unknown or deleted items are 404 everywhere, which is new behavior for review and note writes and for `/item/{uuid}/posts/`.

The three endpoints that already redirected declared `302: Result`, so the `url` they passed was dropped before serialization; they now declare `RedirectedResult` and actually return it. That is additive: no field was removed.

### Progress on any marked item

Progress was restricted to editions on the in-progress shelf, so a podcast being listened to or a book already finished could not record where the reader is. It now hangs off the mark: `Mark.set_progress` only requires a shelfmember and logs the entry under whichever shelf the item is currently on, `Mark.current_progress` no longer hides progress off the in-progress shelf, and `GET`/`POST .../progress` return `404 Mark not found` for an unmarked item instead of `400 Only in-progress items can have progress`. Progress types are still validated against the item type, and the note dialog still only prefills and edits progress while the item is in progress.

### Testing

`tests/journal` + `tests/catalog` pass on a fresh database (1394 passed; the upstream baseline for the same command is 1383, the difference being the tests added here). New coverage: local-URL fetch (plain, `/~neodb~/`, `/api/`, trailing slash, merged, unknown, deleted), `is_local_item_url` edge cases (scheme-less, userinfo, port-carrying `SITE_DOMAINS`), all six read redirects and all five write redirects in one place, deleted-item 404s, and progress across item types and shelves.

Note for reviewers: the three commits are stacked, so the progress commit's `shelf.py` hunks build on the redirect refactor of the same functions. Happy to split into separate PRs if you would rather review them independently.