### PR TITLE
fix(journal): show star rating on review page

### DIFF
--- a/neodb/common/static/scss/_common.scss
+++ b/neodb/common/static/scss/_common.scss
@@ -15,6 +15,11 @@
   color: var(--pico-muted-color, #888);
 }
 
+// A <div>, not a <p>, so restore the paragraph spacing Pico would have given it.
+.article-summary {
+  margin-bottom: var(--pico-typography-spacing-vertical);
+}
+
 // Compact timeline-teaser layout shared by review / article / post-only
 // article cards. Replaces inline ``style="margin-bottom:0.2em"`` /
 // ``style="margin:0 0 0.4em 0"`` that used to live on each template.

--- a/neodb/journal/templates/article.html
+++ b/neodb/journal/templates/article.html
@@ -116,14 +116,14 @@
                 <span id="{{ article.classname }}_{{ article.uuid }}_title">{{ article.title }}</span>
               </h1>
             </hgroup>
-            <p class="piece-summary article-summary">
+            <div class="piece-summary article-summary">
               {% if article.classname == "article" %}
                 {{ article.display_summary|default:'' }}
               {% else %}
                 <a href="{{ article.item.url }}">{{ article.item.display_title }}</a> - {% trans 'Review' %}
                 {% if article.rating_grade %}{{ article.rating_grade | rating_star }}{% endif %}
               {% endif %}
-            </p>
+            </div>
           </header>
           {% if article.classname == "article" and article.sensitive %}
             <p id="article_{{ article.uuid }}_reveal_wrap"


### PR DESCRIPTION
## Problem

The star rating on the review page always renders as zero.

## Cause

`rating_star` (`neodb/common/templatetags/duration.py`) emits a `<div>` overlay inside a `<span>`:

```html
<span class="rating-star" data-rating="8.0"><div style="width:80%;"></div></span>
```

`article.html` placed that inside a `<p>`. `<div>` is not allowed in `<p>`, so the HTML parser closes the paragraph — and closing a `<p>` pops the open `<span>` with it, hoisting the overlay out of `.rating-star`:

```html
<p class="piece-summary article-summary"><a href="#">Item</a> - Review <span class="rating-star" data-rating="8.0"></span></p>
<div style="width:80%;"></div>
<p></p>
```

`.rating-star > div:before` (the solid stars) then no longer matches, leaving only `.rating-star:before` (five outline stars) — i.e. always zero. The server-side data and HTML are correct (`data-rating="8.0"`, `width:80%`); this is purely a markup-nesting bug.

`article.html` was the only `rating_star` call site inside a `<p>`; the other 15 sit in `<div>`/`<span>`/`<button>`, which is why only the review page was affected.

## Fix

Make the summary line a `<div>`, and restore the bottom margin Pico gave the `<p>` so the header spacing is unchanged.

Verified by parsing the real rendered page with html5lib: before the fix the overlay is stripped out of `.rating-star`; after, it stays nested.