### PR TITLE
fix(catalog): route BooksTW through ScrapDownloader to bypass bot challenge

### DIFF
--- a/neodb/catalog/common/downloaders.py
+++ b/neodb/catalog/common/downloaders.py
@@ -939,6 +939,9 @@ class ScrapDownloader(BasicDownloader):
         # Try each configured provider
         for provider in providers:
             resp, resp_type = self._scrape_with_provider(provider)
+            if resp_type == RESPONSE_OK and resp is not None:
+                # let subclasses reject challenge/error pages served with HTTP 200
+                resp_type = self.validate_response(resp)
 
             if resp_type == RESPONSE_OK and resp is not None:
                 self.response_type = resp_type
@@ -956,6 +959,8 @@ class ScrapDownloader(BasicDownloader):
         if backup and backup not in providers:
             logger.debug(f"Trying backup provider: {backup}")
             resp, resp_type = self._scrape_with_provider(backup)
+            if resp_type == RESPONSE_OK and resp is not None:
+                resp_type = self.validate_response(resp)
 
         self.response_type = resp_type
         if self.response_type == RESPONSE_OK and resp:

--- a/neodb/catalog/sites/bookstw.py
+++ b/neodb/catalog/sites/bookstw.py
@@ -4,6 +4,29 @@ from catalog.models.utils import *
 from common.models import normalize_price
 
 
+class BooksTWDownloader(ScrapDownloader):
+    def __init__(
+        self,
+        url: str,
+        headers: dict | None = None,
+        timeout: float | None = None,
+    ):
+        super().__init__(url, headers, timeout, "div.type02_p002")
+
+    def validate_response(self, response) -> int:
+        if response is None:
+            return RESPONSE_NETWORK_ERROR
+        if response.status_code == 404:
+            return RESPONSE_INVALID_CONTENT
+        if response.status_code == 200:
+            content = response.content.decode("utf-8", errors="ignore")
+            if "type02_p002" not in content:
+                # Cloudflare challenge or error page, try next provider
+                return RESPONSE_NETWORK_ERROR
+            return RESPONSE_OK
+        return RESPONSE_INVALID_CONTENT
+
+
 @SiteManager.register
 class BooksTW(AbstractSite):
     SITE_NAME = SiteName.BooksTW
@@ -20,7 +43,7 @@ class BooksTW(AbstractSite):
 
     def scrape(self):
         assert self.url
-        content = BasicDownloader(self.url).download().html()
+        content = BooksTWDownloader(self.url).download().html()
 
         isbn_elem = content.xpath(
             "//div[@class='bd']/ul/li[starts-with(text(),'ISBN：')]/text()"

--- a/neodb/catalog/sites/rateyourmusic.py
+++ b/neodb/catalog/sites/rateyourmusic.py
@@ -55,7 +55,8 @@ class RateYourMusicDownloader(ScrapDownloader):
             return RESPONSE_INVALID_CONTENT
         content = response.content.decode("utf-8", errors="ignore")
         if "page_release" not in content and 'id="tracks"' not in content:
-            return RESPONSE_INVALID_CONTENT
+            # likely a bot challenge page, retryable with next provider
+            return RESPONSE_NETWORK_ERROR
         return RESPONSE_OK
 
 


### PR DESCRIPTION
## Problem

books.com.tw now serves a Cloudflare JS challenge (HTTP 403, "Enable JavaScript and cookies to continue") to plain HTTP clients, so `BasicDownloader` fetches fail for every product page. The page DOM itself is unchanged - all existing xpaths in the parser still work once the rendered page is obtained. The cover image CDN (`im1.book.com.tw`) is not gated.

## Fix

- Add `BooksTWDownloader(ScrapDownloader)` and use it in `BooksTW.scrape()`, following the same pattern as StoryGraph / RateYourMusic / IMDB. It waits for `div.type02_p002` (the product info block) and rejects responses missing that marker so challenge/error pages are not parsed.
- Make `ScrapDownloader.download()` run `validate_response` on provider results. Previously the per-site `validate_response` overrides (StoryGraph, RateYourMusic, IMDB, Douban) were only effective in mock/no-provider mode; a provider returning challenge HTML with HTTP 200 was treated as success. Now such responses fall through to the next configured provider.

## Testing

- Live: `neodb-manage cat https://www.books.com.tw/products/0011049848` with providers configured - all fields parse correctly (title, orig_title, authors, translator, publisher, pub date, binding, pages, price, ISBN, cover).
- `pytest tests/catalog/test_book.py test_movie.py test_music.py test_tv.py` passes (existing mock fixture already contains the new content marker).
- `pre-commit run -a` passes.

Note: like StoryGraph/RYM, BooksTW now requires at least one scraping provider configured (`NEODB_DOWNLOADER_PROVIDERS` + key) to fetch live pages.