### PR TITLE
feat(users): show follow counts on other users' profiles

### DIFF
--- a/neodb/common/templates/_sidebar.html
+++ b/neodb/common/templates/_sidebar.html
@@ -68,9 +68,10 @@
               {% include 'users/profile_actions.html' %}
             {% endif %}
           </span>
-          {% if identity.user == request.user %}
-            <div>
-              <small>
+          {% current_user_relationship identity as sidebar_relationship %}
+          <div>
+            <small>
+              {% if identity.user == request.user or sidebar_relationship.mutual %}
                 <a href="{% url 'journal:user_follow_list' identity.handle 'following' %}">
                   {{ identity.following_count }} {% trans "following" %}
                 </a>
@@ -78,9 +79,13 @@
                 <a href="{% url 'journal:user_follow_list' identity.handle 'followers' %}">
                   {{ identity.follower_count }} {% trans "followers" %}
                 </a>
-              </small>
-            </div>
-          {% endif %}
+              {% else %}
+                {{ identity.following_count }} {% trans "following" %}
+                &nbsp;·&nbsp;
+                {{ identity.follower_count }} {% trans "followers" %}
+              {% endif %}
+            </small>
+          </div>
           {% if identity.safe_metadata %}
             <dl>
               {% for entry in identity.safe_metadata %}

--- a/neodb/common/templatetags/mastodon.py
+++ b/neodb/common/templatetags/mastodon.py
@@ -26,6 +26,7 @@ def current_user_relationship(context, target_identity: "APIdentity"):
         "following": False,
         "muting": False,
         "rejecting": False,
+        "mutual": False,
         "status": "",
     }
     if target_identity and current_identity and not target_identity.restricted:
@@ -39,14 +40,14 @@ def current_user_relationship(context, target_identity: "APIdentity"):
                 r["requested"] = current_identity.is_requested(target_identity)
                 r["muting"] = current_identity.is_muting(target_identity)
                 r["following"] = current_identity.is_following(target_identity)
-                if r["following"]:
-                    if current_identity.is_followed_by(target_identity):
-                        r["status"] = _("mutual followed")
-                    else:
-                        r["status"] = _("followed")
-                else:
-                    if current_identity.is_followed_by(target_identity):
-                        r["status"] = _("following you")
+                followed_by = current_identity.is_followed_by(target_identity)
+                r["mutual"] = r["following"] and followed_by
+                if r["mutual"]:
+                    r["status"] = _("mutual followed")
+                elif r["following"]:
+                    r["status"] = _("followed")
+                elif followed_by:
+                    r["status"] = _("following you")
         else:
             r["unavailable"] = True
             r["status"] = _("you")

--- a/neodb/tests/journal/test_pages.py
+++ b/neodb/tests/journal/test_pages.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from catalog.models import Edition, Movie
 from journal.models import Article, Collection, Mark, Review, ShelfType, Tag
+from takahe.utils import Takahe
 from users.models import User
 
 
@@ -176,3 +177,46 @@ def test_profile_articles_shelf_hidden_from_anonymous_when_not_viewable():
     response = Client().get(preview_url)
     assert response.status_code == 200
     assert response.content == b""
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_profile_follow_counts():
+    alice = User.register(email="alicefc@example.com", username="alicefc").identity
+    bob = User.register(email="bobfc@example.com", username="bobfc").identity
+    following_url = reverse(
+        "journal:user_follow_list", args=[alice.handle, "following"]
+    )
+    followers_url = reverse(
+        "journal:user_follow_list", args=[alice.handle, "followers"]
+    )
+
+    # An anonymous visitor sees the counts but no links to the lists.
+    content = Client().get(alice.url).content.decode()
+    assert "0 following" in content
+    assert "0 followers" in content
+    assert following_url not in content
+    assert followers_url not in content
+
+    # A one-way follower sees the counts but no links either.
+    bob.follow(alice)
+    Takahe._force_state_cycle()
+    client = Client()
+    client.force_login(bob.user, backend="mastodon.auth.OAuth2Backend")
+    content = client.get(alice.url).content.decode()
+    assert "1 followers" in content
+    assert following_url not in content
+    assert followers_url not in content
+
+    # A mutual follower gets links to the lists.
+    alice.follow(bob)
+    Takahe._force_state_cycle()
+    content = client.get(alice.url).content.decode()
+    assert following_url in content
+    assert followers_url in content
+
+    # The owner always gets links to the lists.
+    owner_client = Client()
+    owner_client.force_login(alice.user, backend="mastodon.auth.OAuth2Backend")
+    content = owner_client.get(alice.url).content.decode()
+    assert following_url in content
+    assert followers_url in content


### PR DESCRIPTION
## Summary
- Follow counts in the profile sidebar were previously only visible on one's own profile. Show them on every profile (including for anonymous visitors).
- The counts only link to the following/followers list pages when the viewer is the profile owner or a mutual follow, matching the access rule already enforced by `user_follow_list` (non-mutual visitors get plain text and would be denied by that view anyway).
- Adds an explicit `mutual` key to the `current_user_relationship` template tag (no extra queries; reuses the follow checks it already makes).

Note: for remote identities the counts reflect follows known to this server, same as the list pages themselves.

## Test plan
- Added `test_profile_follow_counts` covering anonymous, one-way follower, mutual follower, and owner views.
- `pytest tests/journal/test_pages.py tests/core/test_users.py tests/social/test_pages.py tests/users/` passes (121 tests).