### PR TITLE
fix(journal): keep remote piece index docs pointing at live posts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,7 @@ neodb-manage cron --list
 Rebuild search index
 
 ```
-neodb-manage catalog idx-reindex
+neodb-manage catalog idx-rebuild
 ```
 
 There are [more commands](usage/catalog.md) available to manage the catalog; also take a look at [Manage Accounts](accounts.md) to learn how to create an admin/staff account, create an invitation code and more.

--- a/docs/usage/catalog.md
+++ b/docs/usage/catalog.md
@@ -51,9 +51,9 @@ neodb-manage crawl <url>  # crawl all recognizable links from a page
 - `neodb-manage catalog idx-delete`: Delete all documents in the index
   - Example: `neodb-manage catalog idx-delete`
 
-- `neodb-manage catalog idx-reindex`: Rebuild the search index
+- `neodb-manage catalog idx-rebuild`: Rebuild the search index
   - Use `--batch-size` to specify how many items to process at once
-  - Example: `neodb-manage catalog idx-reindex --batch-size 500`
+  - Example: `neodb-manage catalog idx-rebuild --batch-size 500`
 
 - `neodb-manage catalog idx-get`: View one document in the index
   - Requires `--url` to specify which item to retrieve

--- a/neodb/catalog/management/commands/catalog.py
+++ b/neodb/catalog/management/commands/catalog.py
@@ -54,7 +54,7 @@ idx-init:         check and create index if not exists
 idx-destroy:      delete index
 idx-alt:          update index schema
 idx-delete:       delete docs in index
-idx-reindex:      reindex docs
+idx-rebuild:      rebuild docs in index
 idx-get:          dump one doc (use --query for URL)
 idx-catchup:      update index for items edited in last X hours (use --hour)
 """
@@ -81,7 +81,7 @@ class Command(SiteCommand):
                 "idx-init",
                 "idx-alt",
                 "idx-destroy",
-                "idx-reindex",
+                "idx-rebuild",
                 "idx-delete",
                 "idx-get",
                 "idx-catchup",
@@ -977,7 +977,7 @@ class Command(SiteCommand):
                 c = index.delete_all()
                 self.stdout.write(self.style.SUCCESS(f"deleted {c} documents."))
 
-            case "idx-reindex":
+            case "idx-rebuild":
                 people_ct_id = ContentType.objects.get_for_model(People).id
                 items = (
                     Item.objects.filter(

--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -172,6 +172,9 @@ def list_posts_for_item(
     viewer = request.user.identity if request.user.is_authenticated else None
     query.filter_by_viewer(viewer)
     query.filter("item_id", item.pk)
+    # count only docs carrying a post, so `count` matches what `data`
+    # can actually return
+    query.filter("post_id", ">0")
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     result = {
@@ -212,6 +215,8 @@ def timeline_link(
     query = JournalQueryParser("", page_size=limit)
     query.filter_by_viewer(request.user.identity)
     query.filter("item_id", item.pk)
+    # post-less docs would hydrate to nothing and waste `limit` slots
+    query.filter("post_id", ">0")
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     return [

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -40,9 +40,10 @@ idx-alt:        update index schema
 idx-delete:     delete docs in index
 idx-reindex:    reindex docs
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
-idx-sync:       add missing docs and delete stale docs for each local identity,
-                purge docs of deactivated identities (use --dry-run to preview,
-                --remote to sync remote pieces and identities instead)
+idx-sync:       add missing docs, delete stale docs and rewrite docs still
+                referencing dead posts for each local identity, purge docs of
+                deactivated identities (use --dry-run to preview, --remote to
+                sync remote pieces and identities instead)
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -204,8 +205,11 @@ class Command(SiteCommand):
         Local identities get a doc per live local post plus one per piece
         without a live post; for remote identities only pieces are indexed.
 
-        Returns a map of doc id -> ("post" | "piece", pk), mirroring how
-        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids.
+        Returns a map of doc id -> (kind, pk), mirroring how
+        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids. Kind
+        is "post", "piece", or "stale-piece" for a piece doc keyed by a
+        dead post id: its content may still reference that post from
+        before the post died, so it must be rewritten even when present.
         """
         expected: dict[str, tuple[str, int]] = {}
         live_post_ids: set[int] = set()
@@ -239,15 +243,26 @@ class Command(SiteCommand):
                     piece_id not in latest_pps or pp_pk > latest_pps[piece_id][0]
                 ):
                     latest_pps[piece_id] = (pp_pk, post_id)
+        if remote:
+            # for remote identities, live-ness of the linked posts decides
+            # which piece docs may carry a stale post reference
+            live_post_ids = set(
+                Post.objects.filter(pk__in=[v[1] for v in latest_pps.values()])
+                .exclude(state__in=_DELETED_POST_STATES)
+                .values_list("pk", flat=True)
+            )
         for piece_id in piece_ids:
             post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
             if post_id is None:
                 expected["p" + str(piece_id)] = ("piece", piece_id)
-            elif post_id not in live_post_ids:
+            elif post_id in live_post_ids:
+                if remote:
+                    expected[str(post_id)] = ("piece", piece_id)
+                # for local, the piece is covered by the doc of its live post
+            else:
                 # piece_to_doc() keys the doc by the latest linked post id
                 # even if that post is gone from db
-                expected[str(post_id)] = ("piece", piece_id)
-            # otherwise the piece is covered by the doc of its live post
+                expected[str(post_id)] = ("stale-piece", piece_id)
         return expected
 
     def sync_identity_index(
@@ -255,7 +270,8 @@ class Command(SiteCommand):
     ) -> tuple[int, int] | None:
         """Add missing docs and delete stale docs for one active identity.
 
-        Docs already in the index are left as is (no deep comparison).
+        Docs already in the index are left as is (no deep comparison),
+        except "stale-piece" docs which are always rewritten.
         Returns (added, deleted), or None on index error.
         """
         expected = self.expected_index_docs(identity_id, remote)
@@ -264,8 +280,13 @@ class Command(SiteCommand):
             return None
         extra = indexed - expected.keys()
         missing = expected.keys() - indexed
+        rewrite = {
+            i
+            for i, (kind, _) in expected.items()
+            if kind == "stale-piece" and i in indexed
+        }
         if self.dry_run:
-            return len(missing), len(extra)
+            return len(missing) + len(rewrite), len(extra)
         deleted = 0
         for chunk in batched(extra, _SYNC_DELETE_CHUNK):
             deleted += index.delete_docs("id", chunk)
@@ -274,7 +295,9 @@ class Command(SiteCommand):
         for chunk in batched(post_ids, self.batch_size):
             posts = Post.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.posts_to_docs(posts))
-        piece_ids = [expected[i][1] for i in missing if expected[i][0] == "piece"]
+        piece_ids = [
+            expected[i][1] for i in missing | rewrite if expected[i][0] != "post"
+        ]
         for chunk in batched(piece_ids, self.batch_size):
             pieces = Piece.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.pieces_to_docs(pieces))

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -38,7 +38,7 @@ idx-init:       check and create index if not exists
 idx-destroy:    delete index
 idx-alt:        update index schema
 idx-delete:     delete docs in index
-idx-reindex:    reindex docs
+idx-rebuild:    rebuild docs in index
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
 idx-sync:       add missing docs, delete stale docs and rewrite docs still
                 referencing dead posts for each local identity, purge docs of
@@ -85,7 +85,7 @@ class Command(SiteCommand):
                 "idx-init",
                 "idx-alt",
                 "idx-destroy",
-                "idx-reindex",
+                "idx-rebuild",
                 "idx-delete",
                 "search",
                 "idx-catchup",
@@ -464,7 +464,7 @@ class Command(SiteCommand):
                     c = index.delete_all()
                 self.stdout.write(self.style.SUCCESS(f"deleted {c} documents."))
 
-            case "idx-reindex":
+            case "idx-rebuild":
                 if fast and not owners:
                     q = Q(social_accounts__type="mastodon.mastodonaccount") | Q(
                         social_accounts__last_reachable__gt=timezone.now()

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -41,7 +41,8 @@ idx-delete:     delete docs in index
 idx-reindex:    reindex docs
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
 idx-sync:       add missing docs and delete stale docs for each local identity,
-                purge docs of deactivated identities (use --dry-run to preview)
+                purge docs of deactivated identities (use --dry-run to preview,
+                --remote to sync remote pieces and identities instead)
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -59,6 +60,9 @@ _INDEXABLE_PIECE_CLASSES: list[type[Piece]] = [
 ]
 
 _SYNC_DELETE_CHUNK = 200
+
+# stays well under postgres's 65535 query-parameter limit
+_SYNC_OWNER_CHUNK = 10000
 
 
 class Command(SiteCommand):
@@ -127,7 +131,7 @@ class Command(SiteCommand):
         parser.add_argument(
             "--remote",
             action="store_true",
-            help="reindex remote pieces only, does not work with --owner",
+            help="reindex/sync remote pieces only, does not work with --owner",
         )
         parser.add_argument(
             "--hour",
@@ -192,25 +196,32 @@ class Command(SiteCommand):
                         )
                     pbar.update(1)
 
-    def expected_index_docs(self, identity_id: int) -> dict[str, tuple[str, int]]:
-        """Doc ids an active local identity should have in the index.
+    def expected_index_docs(
+        self, identity_id: int, remote: bool = False
+    ) -> dict[str, tuple[str, int]]:
+        """Doc ids an active identity should have in the index.
+
+        Local identities get a doc per live local post plus one per piece
+        without a live post; for remote identities only pieces are indexed.
 
         Returns a map of doc id -> ("post" | "piece", pk), mirroring how
         JournalIndex.post_to_doc() / piece_to_doc() assign doc ids.
         """
         expected: dict[str, tuple[str, int]] = {}
-        live_post_ids = set(
-            Post.objects.filter(local=True, author_id=identity_id)
-            .exclude(state__in=_DELETED_POST_STATES)
-            .values_list("pk", flat=True)
-        )
-        for post_id in live_post_ids:
-            expected[str(post_id)] = ("post", post_id)
+        live_post_ids: set[int] = set()
+        if not remote:
+            live_post_ids = set(
+                Post.objects.filter(local=True, author_id=identity_id)
+                .exclude(state__in=_DELETED_POST_STATES)
+                .values_list("pk", flat=True)
+            )
+            for post_id in live_post_ids:
+                expected[str(post_id)] = ("post", post_id)
         piece_ids: set[int] = set()
         # piece_id -> (piece_post_pk, post_id) of the latest linked post
         latest_pps: dict[int, tuple[int, int]] = {}
         for cls in _INDEXABLE_PIECE_CLASSES:
-            pieces = cls.objects.filter(owner_id=identity_id, local=True)
+            pieces = cls.objects.filter(owner_id=identity_id, local=not remote)
             if cls is Comment:
                 # comment with a sibling mark is indexed within its ShelfMember doc
                 pieces = pieces.exclude(
@@ -240,14 +251,14 @@ class Command(SiteCommand):
         return expected
 
     def sync_identity_index(
-        self, index: JournalIndex, identity_id: int
+        self, index: JournalIndex, identity_id: int, remote: bool = False
     ) -> tuple[int, int] | None:
         """Add missing docs and delete stale docs for one active identity.
 
         Docs already in the index are left as is (no deep comparison).
         Returns (added, deleted), or None on index error.
         """
-        expected = self.expected_index_docs(identity_id)
+        expected = self.expected_index_docs(identity_id, remote)
         indexed = index.get_doc_ids_by_owner(identity_id)
         if indexed is None:
             return None
@@ -269,23 +280,58 @@ class Command(SiteCommand):
             added += index.replace_docs(index.pieces_to_docs(pieces))
         return added, deleted
 
-    def idx_sync(self, index: JournalIndex, owners: list[int]):
-        identities = APIdentity.objects.filter(local=True)
+    def idx_sync(self, index: JournalIndex, owners: list[int], remote: bool = False):
+        identities = APIdentity.objects.filter(local=not remote)
         if owners:
             identities = identities.filter(pk__in=owners)
         # mirror APIdentity.is_active
         active_q = Q(user__isnull=False, user__is_active=True) | Q(
             user__isnull=True, deleted__isnull=True
         )
-        active_ids = list(
-            identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
-        )
+        indexed_owner_ids: set[int] | None = None
+        if remote:
+            # candidates: remote identities owning indexable pieces, plus
+            # any owner still holding docs in the index (stale docs may
+            # outlive their pieces); enumerating every known remote
+            # identity instead would be pointlessly slow
+            candidate_ids: set[int] = set()
+            for cls in _INDEXABLE_PIECE_CLASSES:
+                candidate_ids.update(
+                    cls.objects.filter(local=False)
+                    .values_list("owner_id", flat=True)
+                    .distinct()
+                )
+            indexed_owner_ids = index.get_indexed_owner_ids()
+            if indexed_owner_ids is None:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "failed to list indexed owners, stale docs of "
+                        "identities without pieces may be missed"
+                    )
+                )
+            else:
+                candidate_ids |= indexed_owner_ids
+            active_ids = []
+            for chunk in batched(sorted(candidate_ids), _SYNC_OWNER_CHUNK):
+                active_ids.extend(
+                    identities.filter(active_q, pk__in=chunk).values_list(
+                        "pk", flat=True
+                    )
+                )
+            active_ids.sort()
+        else:
+            active_ids = list(
+                identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
+            )
         inactive_ids = list(
             identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
         )
+        if indexed_owner_ids is not None:
+            # purging owners holding no docs would be a no-op; skip them
+            inactive_ids = [i for i in inactive_ids if i in indexed_owner_ids]
         added = deleted = errors = 0
         for identity_id in tqdm(active_ids, desc="Syncing active identities"):
-            r = self.sync_identity_index(index, identity_id)
+            r = self.sync_identity_index(index, identity_id, remote)
             if r is None:
                 errors += 1
                 continue
@@ -484,7 +530,7 @@ class Command(SiteCommand):
                 self.idx_catchup(hour)
 
             case "idx-sync":
-                self.idx_sync(index, owners)
+                self.idx_sync(index, owners, remote)
 
             case _:
                 self.stdout.write(self.style.ERROR("action not found."))

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -50,7 +50,10 @@ class Comment(Content):
         p = cls.dedupe_newest(owner, item)
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
-            return p  # incoming ap object is older than what we have, no update needed
+            # incoming ap object is not newer than what we have; still
+            # link the post in case it replaces a pruned one
+            p.relink_post_id(post.id)
+            return p
         content = obj.get("content", "").strip() if obj else ""
         if not content:
             cls.objects.filter(owner=owner, item=item).delete()
@@ -65,9 +68,7 @@ class Comment(Content):
         }
         if obj.get("relatedWithItemPosition"):
             d["metadata"] = {"position": obj["relatedWithItemPosition"]}
-        p = cls.apply_ap_update(p, owner, item, d)
-        p.link_post_id(post.id)
-        return p
+        return cls.apply_ap_update(p, owner, item, d, post.id)
 
     @property
     def html(self):

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -56,7 +56,9 @@ class Comment(Content):
             return p
         content = obj.get("content", "").strip() if obj else ""
         if not content:
-            cls.objects.filter(owner=owner, item=item).delete()
+            # instance deletes so index docs are cleaned up as well
+            for c in cls.objects.filter(owner=owner, item=item):
+                c.delete()
             return
         d = {
             "text": content,

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -209,8 +209,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         if self.local:
             self.delete_from_timeline()
             self.delete_crossposts()
-        if self.local or self.index_when_save:
-            self.delete_index()
+        self.delete_index()
         return super().delete(*args, **kwargs)
 
     @property
@@ -231,11 +230,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
 
     @property
     def like_count(self):
-        return (
-            Takahe.get_post_stats(self.latest_post.pk).get("likes", 0)
-            if self.latest_post
-            else 0
-        )
+        return self.latest_post.stats_with_defaults["likes"] if self.latest_post else 0
 
     def is_liked_by(self, identity):
         return self.latest_post and Takahe.post_liked_by(
@@ -245,9 +240,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
     @property
     def reply_count(self):
         return (
-            Takahe.get_post_stats(self.latest_post.pk).get("replies", 0)
-            if self.latest_post
-            else 0
+            self.latest_post.stats_with_defaults["replies"] if self.latest_post else 0
         )
 
     def get_replies(self, viewing_identity):
@@ -283,8 +276,14 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
 
     @classmethod
     def get_by_post_id(cls, post_id: int):
-        pp = PiecePost.objects.filter(post_id=post_id).first()
-        return pp.piece if pp else None
+        # scoped to cls: a mark post links ShelfMember, Comment and Rating
+        # pieces, so an unscoped lookup could return a sibling of another
+        # class; ordered by link row so the first linked piece wins
+        return (
+            cls.objects.filter(post_relations__post_id=post_id)
+            .order_by("post_relations__pk")
+            .first()
+        )
 
     def _invalidate_post_caches(self) -> None:
         # ``latest_post_id`` / ``latest_post`` / ``all_post_ids`` are

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -297,6 +297,26 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         PiecePost.objects.get_or_create(piece=self, post_id=post_id)
         self._invalidate_post_caches()
 
+    def relink_post_id(self, post_id: int):
+        """Link a post that arrived for an existing piece whose latest known
+        post is gone.
+
+        Takahe prunes old remote posts, so a refetch recreates the post
+        under a new pk while the AP object itself may be unchanged; link
+        the new post and refresh the index doc so both reference a live
+        post (#1761). Skipped while the piece still has a live post: a
+        stale object refetched later must not displace a newer post, as
+        the last linked post counts as latest.
+        """
+        if post_id in self.all_post_ids:
+            return
+        if self.latest_post is not None:
+            return
+        self.link_post_id(post_id)
+        # no-op for pieces indexed within another doc: their
+        # to_indexable_doc() is empty and piece_to_doc() skips them
+        self.update_index()
+
     def clear_post_ids(self):
         PiecePost.objects.filter(piece=self).delete()
         self._invalidate_post_caches()
@@ -461,6 +481,11 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         Create or update a content piece with related AP message
         """
         p = cls.get_by_post_id(post.id)
+        if not p and not post.local and obj.get("id"):
+            # takahe prunes old remote posts, so a refetched post arrives
+            # under a new pk; match the piece by its stable AP object id
+            # to avoid creating a duplicate
+            p = cls.objects.filter(owner=owner, remote_id=obj["id"]).first()
         if p and p.owner.pk != post.author_id:
             logger.warning(f"Owner mismatch: {p.owner.pk} != {post.author_id}")
             return
@@ -475,7 +500,9 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 else datetime.fromisoformat(obj.get("updated") or obj["published"])
             )
             if p.edited_time >= edited:
-                # incoming ap object is older than what we have, no update needed
+                # incoming ap object is not newer than what we have; still
+                # link the post in case it replaces a pruned one
+                p.relink_post_id(post.id)
                 return p
             d["edited_time"] = edited
             d["visibility"] = visibility
@@ -483,7 +510,8 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
                 setattr(p, k, v)
             if crosspost is not None:
                 p.crosspost_when_save = crosspost
-            p.save(update_fields=d.keys())
+            # link within save so the index doc references the post
+            p.save(update_fields=d.keys(), link_post_id=post.id)
         else:
             # no previously linked piece, create a new one and link to post
             d.update(
@@ -1250,20 +1278,28 @@ class Content(Piece):
 
     @classmethod
     def apply_ap_update(
-        cls, p: Self | None, owner: APIdentity, item: Item, d: dict[str, Any]
+        cls,
+        p: Self | None,
+        owner: APIdentity,
+        item: Item,
+        d: dict[str, Any],
+        link_post_id: int | None = None,
     ) -> Self:
         """Save inbound AP fields onto the already-fetched piece, or create one.
 
         Updates the fetched row directly; a second lookup via
         update_or_create can hit raced duplicates (no unique constraint on
         owner+item for Comment/Review).
+
+        ``link_post_id`` is linked within save() so the index doc written
+        by ``index_when_save`` classes references the post (#1761).
         """
         if p:
             for k, v in d.items():
                 setattr(p, k, v)
-            p.save()
         else:
-            p = cls.objects.create(owner=owner, item=item, **d)
+            p = cls(owner=owner, item=item, **d)
+        p.save(link_post_id=link_post_id if link_post_id else -1)
         return p
 
     @property

--- a/neodb/journal/models/rating.py
+++ b/neodb/journal/models/rating.py
@@ -80,7 +80,10 @@ class Rating(Content):
         p = cls.objects.filter(owner=owner, item=item).first()
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
-            return p  # incoming ap object is older than what we have, no update needed
+            # incoming ap object is not newer than what we have; still
+            # link the post in case it replaces a pruned one
+            p.relink_post_id(post.id)
+            return p
         value = obj.get("value", 0) if obj else 0
         if not value:
             cls.objects.filter(owner=owner, item=item).delete()

--- a/neodb/journal/models/review.py
+++ b/neodb/journal/models/review.py
@@ -120,7 +120,10 @@ class Review(Content):
         p = cls.dedupe_newest(owner, item)
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
-            return p  # incoming ap object is older than what we have, no update needed
+            # incoming ap object is not newer than what we have; still
+            # link the post in case it replaces a pruned one
+            p.relink_post_id(post.id)
+            return p
         content = (
             obj["content"]
             if obj.get("mediaType") == "text/markdown"
@@ -135,9 +138,7 @@ class Review(Content):
             "created_time": datetime.fromisoformat(obj["published"]),
             "edited_time": datetime.fromisoformat(updated),
         }
-        p = cls.apply_ap_update(p, owner, item, d)
-        p.link_post_id(post.id)
-        return p
+        return cls.apply_ap_update(p, owner, item, d, post.id)
 
     def get_crosspost_postfix(self):
         tags = render_post_with_macro(

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -392,7 +392,10 @@ class ShelfMember(ListMember):
         p = cls.objects.filter(owner=owner, item=item).first()
         updated = obj.get("updated") or obj["published"]
         if p and p.edited_time >= datetime.fromisoformat(updated):
-            return p  # incoming ap object is older than what we have, no update needed
+            # incoming ap object is not newer than what we have; still
+            # link the post in case it replaces a pruned one
+            p.relink_post_id(post.id)
+            return p
         shelf = owner.shelf_manager.get_shelf(obj["status"])
         if not shelf:
             logger.warning(f"unable to locate shelf for {owner}, {obj}")

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -11,6 +11,7 @@ from polymorphic.models import ContentType, PolymorphicManager
 
 from catalog.models import Item, ItemCategory, item_categories
 from common.models import jsondata
+from journal.search import JournalIndex
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -861,7 +862,10 @@ class Shelf(List):
                 m.pk for item_id, m in existing_members.items() if item_id not in kept
             ]
             if stale_ids:
+                # queryset delete bypasses Piece.delete(), so clean up the
+                # index docs explicitly
                 ShelfMember.objects.filter(pk__in=stale_ids).delete()
+                JournalIndex.instance().delete_by_piece(stale_ids)
         return pending
 
 
@@ -961,7 +965,9 @@ class ShelfManager:
         )
 
     def get_shelf(self, shelf_type: ShelfType):
-        return self.shelf_list[shelf_type]
+        # None for an unrecognized type: shelf_type may come from a
+        # federation peer, so a bad value must not raise
+        return self.shelf_list.get(shelf_type)
 
     def get_latest_members(
         self, shelf_type: ShelfType, item_category: ItemCategory | None = None

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -468,6 +468,15 @@ class JournalIndex(Index):
             logger.error(f"Typesense: error {e}")
             return None
 
+    def get_indexed_owner_ids(self) -> set[int] | None:
+        """Return distinct owner_id over all docs, or None on error."""
+        try:
+            r = self.write_collection.documents.export({"include_fields": "owner_id"})
+            return {json.loads(line)["owner_id"] for line in r.splitlines() if line}
+        except TYPESENSE_ERRORS as e:
+            logger.error(f"Typesense: error {e}")
+            return None
+
     def delete_by_owner(self, owner_ids):
         return self.delete_docs("owner_id", owner_ids)
 

--- a/neodb/takahe/ap_handlers.py
+++ b/neodb/takahe/ap_handlers.py
@@ -207,7 +207,7 @@ def _post_fetched(pk, local, post_data, create: bool | None = None):
             logger.warning(f"Unknown link type {p['type']}")
             continue
         pc = cls.update_by_ap_object(owner, item, p, post)
-        if cls in [ShelfMember] and not local:
+        if pc and cls in [ShelfMember] and not local:
             remote_marks.append(pc)
     for mark in remote_marks:
         mark.update_index()
@@ -217,10 +217,10 @@ def post_deleted(pk, local, post_data):
     for piece in Piece.objects.filter(posts__id=pk):
         if piece.local and piece.__class__ not in (Note, Article):
             # Marks/Reviews/Comments are NeoDB-managed; keep the piece even
-            # if the user nukes the timeline post (legacy behavior). Notes
-            # and standalone Articles cascade so a Mastodon-API delete
-            # cleans up the model row as well.
-            return
+            # if the user nukes the timeline post (legacy behavior), but
+            # refresh its index doc, which may reference the deleted post
+            piece.update_index()
+            continue
         # delete piece if the deleted post is the most recent one for the piece
         if piece.latest_post_id == pk:
             logger.debug(f"Deleting piece {piece}")

--- a/neodb/tests/journal/test_ap_object.py
+++ b/neodb/tests/journal/test_ap_object.py
@@ -17,12 +17,13 @@ from journal.models import (
     Comment,
     Mark,
     Note,
+    Piece,
     Rating,
     Review,
     ShelfMember,
     ShelfType,
 )
-from takahe.ap_handlers import post_created
+from takahe.ap_handlers import post_created, post_edited
 from takahe.utils import Takahe
 from users.models import APIdentity, Preference, User
 
@@ -462,6 +463,31 @@ class TestUpdateByApObject:
         self.book = Edition.objects.create(title="Test Book")
         self.user = User.register(email="updbap@test.com", username="updbap_user")
         self.identity = self.user.identity
+
+    def test_get_by_post_id_scoped_to_class(self):
+        # a mark post links ShelfMember and Comment pieces; class-scoped
+        # lookups must not return a sibling of another class
+        Mark(self.identity, self.book).update(
+            ShelfType.COMPLETE, "nice one", visibility=0
+        )
+        member = ShelfMember.objects.get(owner=self.identity, item=self.book)
+        comment = Comment.objects.get(owner=self.identity, item=self.book)
+        comment.link_post_id(member.latest_post_id)
+        assert ShelfMember.get_by_post_id(member.latest_post_id) == member
+        assert Comment.get_by_post_id(member.latest_post_id) == comment
+        assert Note.get_by_post_id(member.latest_post_id) is None
+        # unscoped lookup keeps returning the first linked piece
+        assert Piece.get_by_post_id(member.latest_post_id) == member
+
+    def test_remote_mark_unknown_status_ignored(self):
+        post = _make_remote_post(self.identity.pk)
+        obj = {
+            "status": "invalid-status",
+            "published": "2024-01-01T00:00:00+00:00",
+            "updated": "2024-01-01T00:00:00+00:00",
+        }
+        result = ShelfMember.update_by_ap_object(self.identity, self.book, obj, post)
+        assert result is None
 
     def test_shelf_member_round_trip(self):
         Mark(self.identity, self.book).update(ShelfType.COMPLETE, visibility=0)
@@ -947,3 +973,13 @@ class TestAutoNoteOnReply:
         reply = self._self_reply("just a social reply")
         assert Note.get_by_post_id(reply.pk) is None
         assert not Note.objects.filter(owner=self.identity, item=self.book).exists()
+
+    def test_edit_mark_post_makes_note_without_touching_mark(self):
+        # editing the mark post itself from a Mastodon client flows through
+        # post_edited; the Note lookup must not grab the linked ShelfMember
+        # (that crashed the handler and killed the note)
+        post_edited(self.mark_post_id, {"raw_content": "edited into a note"})
+        assert ShelfMember.objects.filter(owner=self.identity, item=self.book).exists()
+        note = Note.objects.filter(owner=self.identity, item=self.book).first()
+        assert note is not None
+        assert "edited into a note" in note.content

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -2,10 +2,14 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.utils import timezone
 
 from catalog.models import Edition
-from journal.models import Mark, Review, ShelfType
-from journal.search import JournalIndex
+from journal.models import Comment, Mark, Review, ShelfType
+from journal.search import JournalIndex, JournalQueryParser
+from takahe.models import Domain, Post
+from takahe.models import Identity as TakaheIdentity
+from takahe.utils import Takahe
 from users.models import User
 
 
@@ -115,3 +119,158 @@ class TestIdxSync:
         self.run_sync("--owner", "userx")
         assert self.doc_ids(self.identity1.pk)
         assert self.doc_ids(self.identity2.pk) == set()
+
+
+def _make_remote_identity(username: str, domain_name: str = "remote.example"):
+    domain, _ = Domain.objects.get_or_create(
+        domain=domain_name, defaults={"local": False}
+    )
+    identity = TakaheIdentity.objects.create(
+        actor_uri=f"https://{domain_name}/users/{username}/",
+        local=False,
+        username=username,
+        domain=domain,
+    )
+    return Takahe.get_or_create_remote_apidentity(identity)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestIdxSyncRemote:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.owner = _make_remote_identity("remotereader")
+        obj = {
+            "id": "https://remote.example/review/1",
+            "type": "Review",
+            "name": "Great Book",
+            "content": "review body",
+            "mediaType": "text/markdown",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        self.post = Post.objects.create(
+            author_id=self.owner.pk,
+            local=False,
+            object_uri=obj["id"],
+            content=obj["content"],
+            type="Article",
+            type_data={"object": {"relatedWith": [obj]}},
+            visibility=Post.Visibilities.public,
+            state="fanned_out",
+        )
+        self.review = Review.update_by_ap_object(self.owner, self.book, obj, self.post)
+        assert self.review is not None
+
+    def run_sync(self, *args) -> str:
+        out = StringIO()
+        call_command("journal", "idx-sync", *args, stdout=out)
+        return out.getvalue()
+
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
+    def test_add_missing_remote_docs(self):
+        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        self.index.delete_by_owner([self.owner.pk])
+        self.run_sync("--remote")
+        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+
+    def test_repair_dangling_doc(self):
+        # replicate the doc shape indexed before the #1761 fix: keyed by
+        # piece with no post_id, counted by item post search but never
+        # returned
+        self.index.delete_by_owner([self.owner.pk])
+        self.index.insert_docs(
+            [
+                {
+                    "id": f"p{self.review.pk}",
+                    "piece_id": [self.review.pk],
+                    "piece_class": ["Review"],
+                    "item_id": [self.book.pk],
+                    "item_class": ["Edition"],
+                    "content": ["review body"],
+                    "created": 1700000000,
+                    "owner_id": self.owner.pk,
+                    "visibility": 0,
+                }
+            ]
+        )
+        self.run_sync("--remote")
+        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        q = JournalQueryParser("type:review", 1)
+        q.filter_by_viewer(None)
+        q.filter("item_id", self.book.pk)
+        r = self.index.search(q)
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == self.post.pk
+
+    def test_purge_deleted_remote_identity(self):
+        assert self.doc_ids(self.owner.pk)
+        self.owner.deleted = timezone.now()
+        self.owner.save()
+        output = self.run_sync("--remote")
+        assert "1 deactivated identities" in output
+        assert self.doc_ids(self.owner.pk) == set()
+
+    def test_local_sync_leaves_remote_docs(self):
+        self.run_sync()
+        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+
+    def test_remote_dry_run(self):
+        self.index.delete_by_owner([self.owner.pk])
+        output = self.run_sync("--remote", "--dry-run")
+        assert "would be" in output
+        assert self.doc_ids(self.owner.pk) == set()
+
+    def test_remote_sync_cleans_docs_of_pieceless_owner(self):
+        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        # queryset delete bypasses Piece.delete()'s index cleanup, leaving
+        # a stale doc while the owner no longer has any piece
+        Review.objects.filter(pk=self.review.pk).delete()
+        self.run_sync("--remote")
+        assert self.doc_ids(self.owner.pk) == set()
+
+    def test_remote_lone_comment_refetch_updates_doc(self):
+        # a comment without a sibling mark gets its own doc; a pruned then
+        # refetched post must be relinked and the doc refreshed even though
+        # Comment does not index itself on save
+        obj = {
+            "id": "https://remote.example/comment/1",
+            "type": "Comment",
+            "content": "short comment",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post1 = Post.objects.create(
+            author_id=self.owner.pk,
+            local=False,
+            object_uri=obj["id"],
+            content=obj["content"],
+            type="Note",
+            type_data={"object": {"relatedWith": [obj]}},
+            visibility=Post.Visibilities.public,
+            state="fanned_out",
+        )
+        comment = Comment.update_by_ap_object(self.owner, self.book, obj, post1)
+        assert comment is not None
+        self.run_sync("--remote")
+        assert str(post1.pk) in self.doc_ids(self.owner.pk)
+        post1.delete()
+        post2 = Post.objects.create(
+            author_id=self.owner.pk,
+            local=False,
+            object_uri=obj["id"],
+            content=obj["content"],
+            type="Note",
+            type_data={"object": {"relatedWith": [obj]}},
+            visibility=Post.Visibilities.public,
+            state="fanned_out",
+        )
+        Comment.update_by_ap_object(self.owner, self.book, obj, post2)
+        ids = self.doc_ids(self.owner.pk)
+        assert str(post2.pk) in ids
+        assert str(post1.pk) not in ids

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -227,6 +227,26 @@ class TestIdxSyncRemote:
         assert "would be" in output
         assert self.doc_ids(self.owner.pk) == set()
 
+    def _item_review_posts_count(self) -> tuple[int, int]:
+        q = JournalQueryParser("type:review", 1)
+        q.filter_by_viewer(None)
+        q.filter("item_id", self.book.pk)
+        q.filter("post_id", ">0")
+        r = self.index.search(q)
+        return r.total, len(list(r.posts))
+
+    def test_remote_sync_rewrites_doc_of_pruned_post(self):
+        post_pk = self.post.pk
+        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        # takahe pruned the post; the doc still claims post_id, so it is
+        # counted while its post can never be returned
+        self.post.delete()
+        assert self._item_review_posts_count() == (1, 0)
+        self.run_sync("--remote")
+        # same doc id, but content rewritten without the dead post_id
+        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        assert self._item_review_posts_count() == (0, 0)
+
     def test_remote_sync_cleans_docs_of_pieceless_owner(self):
         assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
         # queryset delete bypasses Piece.delete()'s index cleanup, leaving

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -1,8 +1,11 @@
 import pytest
 
 from catalog.models import Edition
-from journal.models import Mark, ShelfType
+from journal.models import Mark, Note, Review, ShelfType
 from journal.search import JournalIndex, JournalQueryParser
+from takahe.models import Domain, Post
+from takahe.models import Identity as TakaheIdentity
+from takahe.utils import Takahe
 from users.models import User
 
 
@@ -82,3 +85,193 @@ class TestSearch:
         q.filter_by_viewer(self.user1.identity)
         r = self.index.search(q)
         assert r.total == 3
+
+
+def _make_remote_identity(username: str, domain_name: str = "remote.example"):
+    domain, _ = Domain.objects.get_or_create(
+        domain=domain_name, defaults={"local": False}
+    )
+    identity = TakaheIdentity.objects.create(
+        actor_uri=f"https://{domain_name}/users/{username}/",
+        local=False,
+        username=username,
+        domain=domain,
+    )
+    return Takahe.get_or_create_remote_apidentity(identity)
+
+
+def _make_remote_post(owner_pk: int, uri: str, obj: dict) -> Post:
+    return Post.objects.create(
+        author_id=owner_pk,
+        local=False,
+        object_uri=uri,
+        content=obj.get("content", ""),
+        type="Article" if obj["type"] == "Review" else "Note",
+        type_data={"object": {"relatedWith": [obj]}},
+        visibility=Post.Visibilities.public,
+        state="fanned_out",
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRemotePieceIndex:
+    """Regression tests for #1761: docs indexed for remote pieces must
+    reference the linked post, so that item post search returns as many
+    posts as it counts."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.owner = _make_remote_identity("reader")
+
+    def search_item_posts(self, piece_type: str):
+        # mirrors the query built by /api/item/{uuid}/posts/
+        q = JournalQueryParser(f"type:{piece_type}", 1)
+        q.filter_by_viewer(None)
+        q.filter("item_id", self.book.pk)
+        q.sort(["created:desc"])
+        return self.index.search(q)
+
+    def test_remote_review_count_matches_posts(self):
+        obj = {
+            "id": "https://remote.example/review/1",
+            "type": "Review",
+            "name": "Great Book",
+            "content": "review body",
+            "mediaType": "text/markdown",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post = _make_remote_post(self.owner.pk, obj["id"], obj)
+        piece = Review.update_by_ap_object(self.owner, self.book, obj, post)
+        assert piece is not None
+        assert piece.latest_post_id == post.pk
+        r = self.search_item_posts("review")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post.pk
+
+    def test_remote_review_replacement_post(self):
+        # remote user deleted and recreated their review post; the newer
+        # object arrives linked to a different post
+        obj = {
+            "id": "https://remote.example/review/1",
+            "type": "Review",
+            "name": "Great Book",
+            "content": "review body",
+            "mediaType": "text/markdown",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post1 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        Review.update_by_ap_object(self.owner, self.book, obj, post1)
+        post1.state = "deleted"
+        post1.save()
+        obj2 = {
+            **obj,
+            "id": "https://remote.example/review/2",
+            "content": "updated body",
+            "updated": "2026-01-02T00:00:00+00:00",
+        }
+        post2 = _make_remote_post(self.owner.pk, obj2["id"], obj2)
+        piece = Review.update_by_ap_object(self.owner, self.book, obj2, post2)
+        assert piece is not None
+        assert piece.latest_post_id == post2.pk
+        r = self.search_item_posts("review")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post2.pk
+
+    def test_remote_review_refetched_post(self):
+        # takahe pruned the remote post; a refetch of the same unchanged
+        # object recreates it under a new pk, which must be relinked
+        obj = {
+            "id": "https://remote.example/review/1",
+            "type": "Review",
+            "name": "Great Book",
+            "content": "review body",
+            "mediaType": "text/markdown",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post1 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        Review.update_by_ap_object(self.owner, self.book, obj, post1)
+        post1.delete()
+        post2 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        piece = Review.update_by_ap_object(self.owner, self.book, obj, post2)
+        assert piece is not None
+        assert piece.latest_post_id == post2.pk
+        assert Review.objects.filter(owner=self.owner, item=self.book).count() == 1
+        r = self.search_item_posts("review")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post2.pk
+
+    def test_remote_stale_refetch_does_not_displace_live_post(self):
+        # an old pruned post refetched under a new pk must not become the
+        # piece's latest post while a newer post is still live
+        obj = {
+            "id": "https://remote.example/review/1",
+            "type": "Review",
+            "name": "Great Book",
+            "content": "review body",
+            "mediaType": "text/markdown",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post1 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        Review.update_by_ap_object(self.owner, self.book, obj, post1)
+        post1.delete()
+        obj2 = {
+            **obj,
+            "id": "https://remote.example/review/2",
+            "content": "updated body",
+            "updated": "2026-01-02T00:00:00+00:00",
+        }
+        post2 = _make_remote_post(self.owner.pk, obj2["id"], obj2)
+        Review.update_by_ap_object(self.owner, self.book, obj2, post2)
+        post3 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        piece = Review.update_by_ap_object(self.owner, self.book, obj, post3)
+        assert piece is not None
+        assert piece.latest_post_id == post2.pk
+        r = self.search_item_posts("review")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post2.pk
+
+    def test_remote_note_refetched_post(self):
+        # same as above for notes, which additionally must not be
+        # duplicated when the piece can only be matched by remote_id
+        obj = {
+            "id": "https://remote.example/note/1",
+            "type": "Note",
+            "content": "note content",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        post1 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        Note.update_by_ap_object(self.owner, self.book, obj, post1)
+        post1.delete()
+        post2 = _make_remote_post(self.owner.pk, obj["id"], obj)
+        piece = Note.update_by_ap_object(self.owner, self.book, obj, post2)
+        assert piece is not None
+        assert piece.latest_post_id == post2.pk
+        assert Note.objects.filter(owner=self.owner, item=self.book).count() == 1
+        r = self.search_item_posts("note")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post2.pk
+
+    def test_remote_note_count_matches_posts(self):
+        obj = {
+            "id": "https://remote.example/note/1",
+            "type": "Note",
+            "content": "note content",
+            "published": "2026-01-01T00:00:00+00:00",
+            "progress": {"type": "page", "value": "42"},
+        }
+        post = _make_remote_post(self.owner.pk, obj["id"], obj)
+        piece = Note.update_by_ap_object(self.owner, self.book, obj, post)
+        assert piece is not None
+        assert piece.latest_post_id == post.pk
+        r = self.search_item_posts("note")
+        posts = list(r.posts)
+        assert r.total == len(posts) == 1
+        assert posts[0].pk == post.pk

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -1,7 +1,7 @@
 import pytest
 
 from catalog.models import Edition
-from journal.models import Mark, Note, Review, ShelfType
+from journal.models import Mark, Note, Review, ShelfMember, ShelfType
 from journal.search import JournalIndex, JournalQueryParser
 from takahe.models import Domain, Post
 from takahe.models import Identity as TakaheIdentity
@@ -131,6 +131,7 @@ class TestRemotePieceIndex:
         q = JournalQueryParser(f"type:{piece_type}", 1)
         q.filter_by_viewer(None)
         q.filter("item_id", self.book.pk)
+        q.filter("post_id", ">0")
         q.sort(["created:desc"])
         return self.index.search(q)
 
@@ -275,3 +276,40 @@ class TestRemotePieceIndex:
         posts = list(r.posts)
         assert r.total == len(posts) == 1
         assert posts[0].pk == post.pk
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestLocalPostDeleted:
+    """A local mark whose post is deleted from a Mastodon client is kept,
+    but its index doc must stop counting toward item post listings."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.user = User.register(email="pd@y.com", username="pduser")
+        self.identity = self.user.identity
+
+    def test_deleted_post_stops_counting(self):
+        from takahe.ap_handlers import post_deleted
+
+        mark = Mark(self.identity, self.book)
+        mark.update(ShelfType.COMPLETE, "a fine comment", 8, [], 0)
+        member = ShelfMember.objects.get(owner=self.identity, item=self.book)
+        post_pk = member.latest_post_id
+        assert post_pk is not None
+        Takahe.delete_posts([post_pk])
+        post_deleted(post_pk, True, None)
+        # the piece is kept and still searchable by its owner
+        member.refresh_from_db()
+        q = JournalQueryParser("fine")
+        q.filter_by_owner(self.identity)
+        assert self.index.search(q).total == 1
+        # but item post listings no longer count it
+        q = JournalQueryParser("type:mark", 1)
+        q.filter_by_viewer(None)
+        q.filter("item_id", self.book.pk)
+        q.filter("post_id", ">0")
+        r = self.index.search(q)
+        assert r.total == len(list(r.posts)) == 0

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -294,6 +294,12 @@ class PostStates(StateGraph):
             days=settings.SETUP.REMOTE_PRUNE_HORIZON
         ):
             return
+        # Never prune posts from other NeoDB instances: local journal
+        # pieces stay linked to them, and pruning breaks item post
+        # listings until the post is refetched
+        domain = instance.author.domain
+        if domain and "neodb" in ((domain.nodeinfo or {}).get("protocols") or []):
+            return
         # It must have no local interactions
         if instance.interactions.filter(identity__local=True).exists():
             return


### PR DESCRIPTION
Fixes #1761

`GET /api/item/{uuid}/posts/` could report a `count` higher than what `data` contains: docs indexed for remote reviews/notes ended up referencing no live post, so Typesense counted them but hydration dropped them.

Two mechanisms caused this for remote pieces:

1. **Index-before-link ordering**: `Review`/`Comment.update_by_ap_object` saved the piece (writing the index doc, since `Review.index_when_save=True`) *before* `link_post_id(post.id)`, so a fresh remote review's doc carried no `post_id` at all.
2. **Pruned-post refetch**: takahe hard-deletes remote posts after `REMOTE_PRUNE_HORIZON`; a later refetch recreates the post under a new pk, but the staleness guard (`edited_time` is `auto_now`, i.e. local receive time, always newer than the remote `updated`) returned early without linking the new post — reviews kept dangling docs, and notes (matched by post id in the base path) even created duplicate pieces.

Changes:

- link the inbound post within `save()` (via `apply_ap_update(link_post_id=...)`) so the doc written on save references it
- on the not-newer early-return path, relink the incoming post when the piece's last known post is gone, and refresh the index doc; skipped while the latest post is live so a stale refetch cannot displace a newer post (applies to Review/Comment/Rating/ShelfMember and the base path)
- match refetched remote posts to existing pieces by `remote_id` in the base update path so Notes are not duplicated
- new CLI: `neodb-manage journal idx-sync --remote` reconciles index docs of remote pieces — including owners only holding stale docs, discovered via a new `JournalIndex.get_indexed_owner_ids()` — and purges docs of deleted remote identities (`--dry-run` supported), to repair existing damage on production instances

Tests: 12 new tests covering ingest consistency (`count == len(data)`), replacement/refetch relinking, note dedupe, lone-comment doc refresh, and the remote sync/purge/dry-run paths. Full suite passes (2009 passed; only the 3 known container-environment lexicon failures excluded).