### PR TITLE
fix(journal): correct NDJSON export/import data loss and crashes

### DIFF
--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -1,12 +1,13 @@
 import json
 import os
-import re
 import shutil
 import tempfile
 import uuid
+from typing import Any
 
 from django.conf import settings
 from django.core.files.storage import default_storage
+from django.db.models.fields.files import ImageFieldFile
 from django.utils import timezone
 from loguru import logger
 
@@ -15,16 +16,26 @@ from common.utils import GenerateDateUUIDMediaFilePath
 from journal.models import (
     Article,
     Collection,
-    Content,
+    Comment,
     Note,
+    Rating,
     Review,
     ShelfLogEntry,
     ShelfMember,
+    ShelfMemberProgress,
     Tag,
     TagMember,
 )
+from journal.models.renderers import RE_MD_IMAGE
 from takahe.models import Post
 from users.models import Task
+
+# Content subclasses carried on the journal stream, in the order they are
+# written. Enumerated rather than walked via ``Content.__subclasses__()``:
+# that also yields ``Debris`` (tombstones left by catalog item merges), which
+# has no ``ap_object`` and used to abort the whole export with
+# NotImplementedError for any user who had one.
+_CONTENT_CLASSES = (Rating, Comment, Review, Note)
 
 
 class NdjsonExporter(Task):
@@ -57,135 +68,201 @@ class NdjsonExporter(Task):
             "created_time": timezone.now().isoformat(),
         }
 
-    def run(self):
-        self.ref_items = []
-        user = self.user
-        temp_dir = tempfile.mkdtemp()
-        temp_folder_path = os.path.join(temp_dir, self.filename)
-        os.makedirs(temp_folder_path)
-        attachment_path = os.path.join(temp_folder_path, "attachments")
-        os.makedirs(attachment_path, exist_ok=True)
+    # --- bundling helpers -------------------------------------------------
+    #
+    # Every helper returns an archive-relative path ("attachments/xxx.png")
+    # so the importer can restore the file and repoint the record at it.
 
-        def _save_image(url):
-            if url.startswith("http"):
+    def _bundle_path(self, filename: str) -> tuple[str, str]:
+        """Absolute destination and archive-relative path for ``filename``,
+        uniquified so two sources with the same basename can't clobber."""
+        dest = os.path.join(self.attachment_path, filename)
+        if os.path.exists(dest):
+            filename = f"{uuid.uuid4()}-{filename}"
+            dest = os.path.join(self.attachment_path, filename)
+        return dest, f"attachments/{filename}"
+
+    def _save_image(self, url: str) -> str | None:
+        """Copy (local) or download (remote) an image into the bundle.
+
+        Returns its archive-relative path, or None when it can't be bundled.
+        Local media is checked first: MEDIA_URL may itself be an absolute
+        ``https://`` URL, and pulling our own files back over HTTP would be
+        both wasteful and unreliable behind an internal-only media host.
+        """
+        cached = self.bundled_images.get(url)
+        if cached is not None:
+            return cached or None
+        path = None
+        if url.startswith(settings.MEDIA_URL):
+            rel_path = url[len(settings.MEDIA_URL) :]
+            basename = os.path.basename(rel_path)
+            if basename:
+                dest, path = self._bundle_path(basename)
                 try:
-                    raw_img, ext = ProxiedImageDownloader.download_image(url, "")
-                    if raw_img:
-                        file = "%s/%s.%s" % (attachment_path, uuid.uuid4(), ext)
-                        with open(file, "wb") as binary_file:
-                            binary_file.write(raw_img)
-                        return file
-                except Exception:
-                    logger.debug(f"error downloading {url}")
-            elif url.startswith(settings.MEDIA_URL):
-                rel_path = url[len(settings.MEDIA_URL) :]
-                try:
-                    dest = os.path.join(attachment_path, os.path.basename(rel_path))
                     with default_storage.open(rel_path, "rb") as src:
                         with open(dest, "wb") as dst:
                             shutil.copyfileobj(src, dst)
                 except Exception:
-                    logger.error(f"error copying {url} to {attachment_path}")
-                return url
-            return url
+                    logger.error(f"error copying {url} to {self.attachment_path}")
+                    path = None
+        elif url.startswith("http"):
+            try:
+                raw_img, ext = ProxiedImageDownloader.download_image(url, "")
+                if raw_img:
+                    dest, path = self._bundle_path(f"{uuid.uuid4()}.{ext or 'jpg'}")
+                    with open(dest, "wb") as binary_file:
+                        binary_file.write(raw_img)
+            except Exception:
+                logger.debug(f"error downloading {url}")
+                path = None
+        # cache misses too, so a broken URL is only attempted once per export
+        self.bundled_images[url] = path or ""
+        return path
 
-        filename = os.path.join(temp_folder_path, "journal.ndjson")
+    def _bundle_body_images(self, body: str) -> list[dict[str, str]]:
+        """Bundle every inline markdown image in ``body``.
+
+        Returns ``[{"src": <original>, "file": <archive path>}]`` for the
+        images that were archived; the importer uses this to rewrite the
+        body, without which local images 404 on the destination server.
+        """
+        images: list[dict[str, str]] = []
+        seen: set[str] = set()
+        # RE_MD_IMAGE is the renderer's own pattern; the previous local one
+        # only matched an empty alt text, silently skipping ``![alt](url)``
+        for m in RE_MD_IMAGE.finditer(body or ""):
+            src = m.group(2).strip()
+            if not src or src in seen:
+                continue
+            seen.add(src)
+            path = self._save_image(src)
+            if path:
+                images.append({"src": src, "file": path})
+        return images
+
+    def _bundle_cover(self, cover: ImageFieldFile) -> str | None:
+        """Bundle a piece's cover image file (Article / Collection).
+
+        The ap_object only carries a URL that may be unreachable after
+        migration, so the bytes travel in the archive.
+        """
+        if not cover or str(cover) == settings.DEFAULT_ITEM_COVER:
+            return None
+        basename = os.path.basename(str(cover))
+        if not basename:
+            return None
+        dest, path = self._bundle_path(basename)
+        try:
+            with cover.open("rb") as src:
+                with open(dest, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        except Exception as e:
+            logger.error(
+                f"error copying cover {basename} to {dest}", extra={"exception": e}
+            )
+            return None
+        return path
+
+    def _bundle_post_attachments(self, post: Post) -> list[dict[str, str]]:
+        attachments = []
+        for a in post.attachments.all():
+            basename = os.path.basename(a.file.name or "")
+            if not basename:
+                continue
+            dest, path = self._bundle_path(basename)
+            try:
+                with a.file.open("rb") as src:
+                    with open(dest, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+            except Exception as e:
+                logger.error(
+                    f"error copying attachment {basename} to {dest}",
+                    extra={"exception": e},
+                )
+                continue
+            attachments.append({"file": path, "mimetype": a.mimetype})
+        return attachments
+
+    def _bundle_note_attachments(self, note: Note) -> list[dict[str, str]]:
+        """Attachment records for a Note.
+
+        Preferred source is the linked post, which holds the actual files.
+        Takahe prunes posts though, so fall back to the Note's own stored
+        ``attachments`` JSON rather than dropping the media silently; the
+        file is bundled too when its URL still resolves to local storage.
+        """
+        if note.latest_post:
+            attachments = self._bundle_post_attachments(note.latest_post)
+            if attachments:
+                return attachments
+        attachments = []
+        for a in note.attachments or []:
+            url = a.get("url")
+            if not url:
+                continue
+            entry = {"mimetype": a.get("mimetype", ""), "url": url}
+            path = self._save_image(url)
+            if path:
+                entry["file"] = path
+            attachments.append(entry)
+        return attachments
+
+    def run(self):
+        self.ref_items = []
+        self.bundled_images: dict[str, str] = {}
+        user = self.user
+        temp_dir = tempfile.mkdtemp()
+        temp_folder_path = os.path.join(temp_dir, self.filename)
+        os.makedirs(temp_folder_path)
+        self.attachment_path = os.path.join(temp_folder_path, "attachments")
+        os.makedirs(self.attachment_path, exist_ok=True)
+
+        journal_file = os.path.join(temp_folder_path, "journal.ndjson")
         total = 0
-        with open(filename, "w") as f:
+        with open(journal_file, "w") as f:
             f.write(json.dumps(self.get_header()) + "\n")
 
-            for cls in list(Content.__subclasses__()):
-                pieces = cls.objects.filter(owner=user.identity)
-                for p in pieces:
+            for cls in _CONTENT_CLASSES:
+                for p in cls.objects.filter(owner=user.identity):
                     total += 1
                     self.ref(p.item)
-                    o = {
+                    o: dict[str, Any] = {
                         "type": p.__class__.__name__,
                         "content": p.ap_object,
                         "visibility": p.visibility,
                         "metadata": p.metadata,
                     }
-                    if cls == Review:
-                        for url in re.findall(r"(?<=!\[\]\()([^)]+)(?=\))", p.body):
-                            _save_image(url)
-                    elif cls == Note and p.latest_post:
-                        note_attachments = []
-                        for a in p.latest_post.attachments.all():
-                            filename = os.path.basename(a.file.name or "")
-                            if not filename:
-                                continue
-                            dest = os.path.join(attachment_path, filename)
-                            try:
-                                with a.file.open("rb") as src:
-                                    with open(dest, "wb") as dst:
-                                        shutil.copyfileobj(src, dst)
-                                note_attachments.append(
-                                    {
-                                        "file": f"attachments/{filename}",
-                                        "mimetype": a.mimetype,
-                                    }
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    f"error copying attachment {filename} to {dest}",
-                                    extra={"exception": e},
-                                )
-                        if note_attachments:
-                            o["attachments"] = note_attachments
+                    if isinstance(p, Review):
+                        images = self._bundle_body_images(p.body)
+                        if images:
+                            o["images"] = images
+                    elif isinstance(p, Note):
+                        attachments = self._bundle_note_attachments(p)
+                        if attachments:
+                            o["attachments"] = attachments
                     f.write(json.dumps(o, default=str) + "\n")
 
             # Articles are item-less so they don't fall under
-            # Content.__subclasses__(). Mirror Review's body-image side-effect
-            # (downloads referenced inline images into the bundle) and
-            # serialize via the same {type, content, visibility, metadata}
-            # envelope the importer expects.
+            # _CONTENT_CLASSES. Serialized via the same
+            # {type, content, visibility, metadata} envelope the importer
+            # expects, plus the bundled body images and featured image.
             for art in Article.objects.filter(owner=user.identity):
                 total += 1
-                for url in re.findall(r"(?<=!\[\]\()([^)]+)(?=\))", art.body):
-                    _save_image(url)
-                # bundle the featured image file (the ap_object only carries a
-                # URL that may be unreachable after migration), mirroring how
-                # Collection covers are archived and restored on import
-                cover_file = None
-                if art.cover and str(art.cover) != settings.DEFAULT_ITEM_COVER:
-                    cover_filename = os.path.basename(str(art.cover))
-                    cover_dest = os.path.join(attachment_path, cover_filename)
-                    try:
-                        with art.cover.open("rb") as src:
-                            with open(cover_dest, "wb") as dst:
-                                shutil.copyfileobj(src, dst)
-                        cover_file = f"attachments/{cover_filename}"
-                    except Exception as e:
-                        logger.error(
-                            f"error copying cover {cover_filename} to {cover_dest}",
-                            extra={"exception": e},
-                        )
                 o = {
                     "type": "Article",
                     "content": art.ap_object,
                     "visibility": art.visibility,
                     "metadata": art.metadata,
-                    "cover": cover_file,
+                    "cover": self._bundle_cover(art.cover),
                 }
+                images = self._bundle_body_images(art.body)
+                if images:
+                    o["images"] = images
                 f.write(json.dumps(o, default=str) + "\n")
 
-            collections = Collection.objects.filter(owner=user.identity)
-            for c in collections:
+            for c in Collection.objects.filter(owner=user.identity):
                 total += 1
-                cover_file = None
-                if c.cover and str(c.cover) != settings.DEFAULT_ITEM_COVER:
-                    cover_filename = os.path.basename(str(c.cover))
-                    cover_dest = os.path.join(attachment_path, cover_filename)
-                    try:
-                        with c.cover.open("rb") as src:
-                            with open(cover_dest, "wb") as dst:
-                                shutil.copyfileobj(src, dst)
-                        cover_file = f"attachments/{cover_filename}"
-                    except Exception as e:
-                        logger.error(
-                            f"error copying cover {cover_filename} to {cover_dest}",
-                            extra={"exception": e},
-                        )
                 o = {
                     "type": "Collection",
                     "content": c.ap_object,
@@ -193,16 +270,19 @@ class NdjsonExporter(Task):
                     "metadata": c.metadata,
                     "collaborative": c.collaborative,
                     "query": c.query,
-                    "cover": cover_file,
+                    "cover": self._bundle_cover(c.cover),
                     "items": [
                         {"item": self.ref(m.item), "metadata": m.metadata}
                         for m in c.ordered_members
                     ],
                 }
+                # the description is markdown and may embed images too
+                images = self._bundle_body_images(c.brief)
+                if images:
+                    o["images"] = images
                 f.write(json.dumps(o, default=str) + "\n")
 
-            tags = Tag.objects.filter(owner=user.identity)
-            for t in tags:
+            for t in Tag.objects.filter(owner=user.identity):
                 total += 1
                 o = {
                     "type": "Tag",
@@ -212,8 +292,7 @@ class NdjsonExporter(Task):
                 }
                 f.write(json.dumps(o, default=str) + "\n")
 
-            tags = TagMember.objects.filter(owner=user.identity)
-            for t in tags:
+            for t in TagMember.objects.filter(owner=user.identity):
                 total += 1
                 self.ref(t.item)
                 o = {
@@ -223,24 +302,41 @@ class NdjsonExporter(Task):
                     "metadata": t.metadata,
                 }
                 f.write(json.dumps(o, default=str) + "\n")
-            marks = ShelfMember.objects.filter(owner=user.identity)
-            for m in marks:
+
+            progress_by_member = {
+                p.shelf_member_id: p
+                for p in ShelfMemberProgress.objects.filter(
+                    shelf_member__owner=user.identity
+                )
+            }
+            for m in ShelfMember.objects.filter(owner=user.identity):
                 total += 1
+                # a mark whose item has no comment/rating/log would otherwise
+                # never reach catalog.ndjson, and fail to import
+                self.ref(m.item)
                 o = {
                     "type": "ShelfMember",
                     "content": m.ap_object,
                     "visibility": m.visibility,
                     "metadata": m.metadata,
                 }
+                progress = progress_by_member.get(m.pk)
+                if progress and progress.progress_value:
+                    o["progress"] = {
+                        "type": progress.progress_type or "",
+                        "value": progress.progress_value,
+                    }
                 f.write(json.dumps(o, default=str) + "\n")
 
-            logs = ShelfLogEntry.objects.filter(owner=user.identity)
-            for log in logs:
+            for log in ShelfLogEntry.objects.filter(owner=user.identity):
                 total += 1
                 o = {
                     "type": "ShelfLog",
                     "item": self.ref(log.item),
                     "status": log.shelf_type,
+                    # jsondata fields (comment_text, rating_grade, progress_*)
+                    # live in metadata; without it the history reimports blank
+                    "metadata": log.metadata,
                     "posts": list(log.all_post_ids()),
                     "timestamp": log.timestamp,
                 }
@@ -249,35 +345,23 @@ class NdjsonExporter(Task):
             posts = Post.objects.filter(author_id=user.identity.pk).exclude(
                 type_data__has_key="object"
             )
-
             for p in posts:
                 total += 1
                 o = {"type": "post", "post": p.to_mastodon_json()}
-                for a in p.attachments.all():
-                    filename = os.path.basename(a.file.name or "")
-                    if not filename:
-                        continue
-                    dest = os.path.join(attachment_path, filename)
-                    try:
-                        with a.file.open("rb") as src:
-                            with open(dest, "wb") as dst:
-                                shutil.copyfileobj(src, dst)
-                    except Exception as e:
-                        logger.error(
-                            f"error copying attachment {filename} to {dest}",
-                            extra={"exception": e},
-                        )
+                attachments = self._bundle_post_attachments(p)
+                if attachments:
+                    o["attachments"] = attachments
                 f.write(json.dumps(o, default=str) + "\n")
 
-        filename = os.path.join(temp_folder_path, "catalog.ndjson")
-        with open(filename, "w") as f:
+        catalog_file = os.path.join(temp_folder_path, "catalog.ndjson")
+        with open(catalog_file, "w") as f:
             f.write(json.dumps(self.get_header()) + "\n")
             for item in self.ref_items:
                 f.write(json.dumps(item.ap_object, default=str) + "\n")
 
         # Export actor.ndjson with Takahe identity data
-        filename = os.path.join(temp_folder_path, "actor.ndjson")
-        with open(filename, "w") as f:
+        actor_file = os.path.join(temp_folder_path, "actor.ndjson")
+        with open(actor_file, "w") as f:
             f.write(json.dumps(self.get_header()) + "\n")
             takahe_identity = self.user.identity.takahe_identity
             identity_data = {
@@ -300,6 +384,9 @@ class NdjsonExporter(Task):
         if not os.path.exists(os.path.dirname(filename)):
             os.makedirs(os.path.dirname(filename))
         shutil.make_archive(filename[:-4], "zip", temp_folder_path)
+        # the staging copy holds every attachment we just bundled; drop it
+        # so exports don't accumulate in the system temp dir
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
         self.metadata["file"] = filename
         self.metadata["total"] = total

--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -26,7 +26,7 @@ from journal.models import (
     Tag,
     TagMember,
 )
-from journal.models.renderers import RE_MD_IMAGE
+from journal.models.renderers import RE_MD_IMAGE, normalize_image_src
 from takahe.models import Post
 from users.models import Task
 
@@ -86,16 +86,19 @@ class NdjsonExporter(Task):
         """Copy (local) or download (remote) an image into the bundle.
 
         Returns its archive-relative path, or None when it can't be bundled.
-        Local media is checked first: MEDIA_URL may itself be an absolute
-        ``https://`` URL, and pulling our own files back over HTTP would be
-        both wasteful and unreliable behind an internal-only media host.
+        Local media is resolved first, via the renderer's normalizer so that
+        an absolute URL on our own site (how import_note records restored
+        attachments) is recognised as local: pulling our own files back over
+        HTTP is wasteful, and is_valid_url blocks it outright when the site
+        or media host is internal.
         """
         cached = self.bundled_images.get(url)
         if cached is not None:
             return cached or None
         path = None
-        if url.startswith(settings.MEDIA_URL):
-            rel_path = url[len(settings.MEDIA_URL) :]
+        normalized = normalize_image_src(url) or url
+        if normalized.startswith(settings.MEDIA_URL):
+            rel_path = normalized[len(settings.MEDIA_URL) :]
             basename = os.path.basename(rel_path)
             if basename:
                 dest, path = self._bundle_path(basename)
@@ -106,9 +109,9 @@ class NdjsonExporter(Task):
                 except Exception:
                     logger.error(f"error copying {url} to {self.attachment_path}")
                     path = None
-        elif url.startswith("http"):
+        elif normalized.startswith("http"):
             try:
-                raw_img, ext = ProxiedImageDownloader.download_image(url, "")
+                raw_img, ext = ProxiedImageDownloader.download_image(normalized, "")
                 if raw_img:
                     dest, path = self._bundle_path(f"{uuid.uuid4()}.{ext or 'jpg'}")
                     with open(dest, "wb") as binary_file:
@@ -321,11 +324,17 @@ class NdjsonExporter(Task):
                     "metadata": m.metadata,
                 }
                 progress = progress_by_member.get(m.pk)
-                if progress and progress.progress_value:
-                    o["progress"] = {
+                # always written, null included: a later import has to tell
+                # "this mark has no progress" from "this archive predates the
+                # field", or clearing progress could never be replayed
+                o["progress"] = (
+                    {
                         "type": progress.progress_type or "",
                         "value": progress.progress_value,
                     }
+                    if progress and progress.progress_value
+                    else None
+                )
                 f.write(json.dumps(o, default=str) + "\n")
 
             for log in ShelfLogEntry.objects.filter(owner=user.identity):

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -64,7 +64,7 @@ class NdjsonImporter(BaseImporter):
         """Copy a file out of the extracted bundle into media storage.
 
         Returns the stored file's media URL, which is MEDIA_URL-prefixed and
-        therefore accepted by ``renderers._normalize_image_src``. Returns
+        therefore accepted by ``renderers.normalize_image_src``. Returns
         None when the bundle carries no such file.
         """
         src = self._store_path(rel_path)
@@ -177,27 +177,37 @@ class NdjsonImporter(BaseImporter):
                 metadata=metadata,
                 created_time=published_dt,
             )
-            self.restore_progress(owner, item, data.get("progress") or {})
+            self.restore_progress(owner, item, data)
             return "imported"
         except Exception:
             logger.exception("Error importing shelf member")
             return "failed"
 
     def restore_progress(
-        self, owner: APIdentity, item: Item, progress: Dict[str, Any]
+        self, owner: APIdentity, item: Item, data: Dict[str, Any]
     ) -> None:
-        """Restore a mark's current reading progress.
+        """Restore — or clear — a mark's current reading progress.
+
+        Tri-state on the ``progress`` key, so that a newer archive in which
+        the user cleared their progress can replay that: an absent key is a
+        legacy archive that never carried progress and is left alone, a value
+        restores it, and an explicit null clears it. Only reached once the
+        archive has been found newer than the destination mark.
 
         Written straight to ``ShelfMemberProgress`` rather than through
         ``Mark.set_progress``: that would append a fresh log entry stamped
         with the import time, polluting the history the ShelfLog records
         restore separately.
         """
-        value = progress.get("value")
-        if not value:
+        if "progress" not in data:
             return
         shelfmember = ShelfMember.objects.filter(owner=owner, item=item).first()
         if not shelfmember:
+            return
+        progress = data.get("progress") or {}
+        value = progress.get("value")
+        if not value:
+            ShelfMemberProgress.objects.filter(shelf_member=shelfmember).delete()
             return
         ShelfMemberProgress.objects.update_or_create(
             shelf_member=shelfmember,
@@ -223,15 +233,19 @@ class NdjsonImporter(BaseImporter):
                 # IntegrityError and break the enclosing transaction
                 raise ValueError(f"Shelf log without timestamp: {data.get('item', '')}")
             # comment_text / rating_grade / progress_* are jsondata fields
-            # stored inside metadata. Only overwrite when the bundle carries
-            # them, so older exports don't blank what the mark import wrote.
-            metadata = data.get("metadata") or {}
+            # stored inside metadata. Keyed on presence, not truthiness: an
+            # archive that carries the key is authoritative even when it is
+            # empty, while a legacy archive without it must not blank what
+            # the mark import already wrote.
+            defaults = (
+                {"metadata": data.get("metadata") or {}} if "metadata" in data else {}
+            )
             _, created = ShelfLogEntry.objects.update_or_create(
                 owner=owner,
                 item=item,
                 shelf_type=shelf_type,
                 timestamp=timestamp_dt,
-                defaults={"metadata": metadata} if metadata else {},
+                defaults=defaults,
             )
             # return "imported" if created else "skipped"
             # count skip as success otherwise it may confuse user

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import tempfile
 import uuid
 import zipfile
@@ -8,8 +9,10 @@ from typing import Any, Callable, Dict
 from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import default_storage
+from django.utils import timezone
 from loguru import logger
 
+from catalog.models import Item
 from journal.models import (
     Article,
     Collection,
@@ -19,11 +22,15 @@ from journal.models import (
     Rating,
     Review,
     ShelfLogEntry,
+    ShelfMember,
+    ShelfMemberProgress,
     ShelfType,
     Tag,
     TagMember,
 )
+from journal.models.renderers import RE_MD_IMAGE
 from takahe.utils import Takahe
+from users.models import APIdentity
 
 from .base import BaseImporter
 
@@ -53,6 +60,56 @@ class NdjsonImporter(BaseImporter):
             return None
         return resolved
 
+    def _store_bundled_file(self, rel_path: str | None) -> str | None:
+        """Copy a file out of the extracted bundle into media storage.
+
+        Returns the stored file's media URL, which is MEDIA_URL-prefixed and
+        therefore accepted by ``renderers._normalize_image_src``. Returns
+        None when the bundle carries no such file.
+        """
+        src = self._store_path(rel_path)
+        if not src:
+            return None
+        ext = os.path.splitext(src)[1]
+        # same layout as journal.views.common.generate_upload_path, so
+        # restored images sit where the rest of the app expects uploads
+        name = f"upload/{self.user.identity.pk}/{timezone.now():%Y}/{uuid.uuid4()}{ext}"
+        with open(src, "rb") as f:
+            name = default_storage.save(name, File(f))
+        return default_storage.url(name)
+
+    def _store_path(self, rel_path: str | None) -> str | None:
+        """Resolved path of a regular file inside the bundle, else None."""
+        src = self._resolve_temp_path(rel_path)
+        return src if src and os.path.isfile(src) else None
+
+    def _restore_body_images(self, body: str, data: Dict[str, Any]) -> str:
+        """Repoint inline markdown images at copies restored from the bundle.
+
+        Without this a migrated review / article / collection keeps pointing
+        at the source server's media, which 404s for every reader on the
+        destination server.
+        """
+        images = data.get("images") or []
+        if not body or not images:
+            return body
+        mapping: Dict[str, str] = {}
+        for entry in images:
+            if not isinstance(entry, dict):
+                continue
+            src = entry.get("src")
+            url = self._store_bundled_file(entry.get("file"))
+            if src and url:
+                mapping[src] = url
+        if not mapping:
+            return body
+
+        def _replace(m: "re.Match[str]") -> str:
+            src = m.group(2).strip()
+            return f"![{m.group(1)}]({mapping.get(src, src)})"
+
+        return RE_MD_IMAGE.sub(_replace, body)
+
     def import_collection(self, data: Dict[str, Any]) -> BaseImporter.ImportResult:
         """Import a collection from NDJSON data."""
         try:
@@ -69,15 +126,17 @@ class NdjsonImporter(BaseImporter):
             collection = Collection.objects.create(
                 owner=owner,
                 title=name,
-                brief=content,
+                brief=self._restore_body_images(content, data),
                 visibility=visibility,
-                metadata=data.get("metadata", {}),
-                created_time=published_dt,
+                metadata=data.get("metadata") or {},
                 collaborative=data.get("collaborative", 0),
                 query=data.get("query"),
+                # created_time is not nullable; let the model default stand
+                # when a bundle carries no published timestamp
+                **({"created_time": published_dt} if published_dt else {}),
             )
-            cover_src = self._resolve_temp_path(data.get("cover"))
-            if cover_src and os.path.isfile(cover_src):
+            cover_src = self._store_path(data.get("cover"))
+            if cover_src:
                 with open(cover_src, "rb") as f:
                     collection.cover.save(
                         os.path.basename(cover_src), File(f), save=True
@@ -102,7 +161,7 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {})
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             item = self.items.get(content_data.get("withRegardTo", ""))
@@ -118,10 +177,35 @@ class NdjsonImporter(BaseImporter):
                 metadata=metadata,
                 created_time=published_dt,
             )
+            self.restore_progress(owner, item, data.get("progress") or {})
             return "imported"
         except Exception:
             logger.exception("Error importing shelf member")
             return "failed"
+
+    def restore_progress(
+        self, owner: APIdentity, item: Item, progress: Dict[str, Any]
+    ) -> None:
+        """Restore a mark's current reading progress.
+
+        Written straight to ``ShelfMemberProgress`` rather than through
+        ``Mark.set_progress``: that would append a fresh log entry stamped
+        with the import time, polluting the history the ShelfLog records
+        restore separately.
+        """
+        value = progress.get("value")
+        if not value:
+            return
+        shelfmember = ShelfMember.objects.filter(owner=owner, item=item).first()
+        if not shelfmember:
+            return
+        ShelfMemberProgress.objects.update_or_create(
+            shelf_member=shelfmember,
+            defaults={
+                "progress_type": progress.get("type") or None,
+                "progress_value": value,
+            },
+        )
 
     def import_shelf_log(self, data: Dict[str, Any]) -> BaseImporter.ImportResult:
         """Import a shelf log entry from NDJSON data."""
@@ -134,11 +218,20 @@ class NdjsonImporter(BaseImporter):
             # posts = data.get("posts", [])  # TODO but will be tricky
             timestamp = data.get("timestamp")
             timestamp_dt = self.parse_datetime(timestamp) if timestamp else None
+            if not timestamp_dt:
+                # timestamp is not nullable; inserting would raise
+                # IntegrityError and break the enclosing transaction
+                raise ValueError(f"Shelf log without timestamp: {data.get('item', '')}")
+            # comment_text / rating_grade / progress_* are jsondata fields
+            # stored inside metadata. Only overwrite when the bundle carries
+            # them, so older exports don't blank what the mark import wrote.
+            metadata = data.get("metadata") or {}
             _, created = ShelfLogEntry.objects.update_or_create(
                 owner=owner,
                 item=item,
                 shelf_type=shelf_type,
                 timestamp=timestamp_dt,
+                defaults={"metadata": metadata} if metadata else {},
             )
             # return "imported" if created else "skipped"
             # count skip as success otherwise it may confuse user
@@ -157,7 +250,7 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {}) or {}
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {}) or {}
             published_dt = self.parse_datetime(content_data.get("published"))
             title = (content_data.get("name") or "")[:500]
@@ -180,13 +273,14 @@ class NdjsonImporter(BaseImporter):
                 owner=owner, title=title, created_time=published_dt
             ).exists():
                 return "skipped"
+            body = self._restore_body_images(body, data)
             # Restore the bundled featured image (if any) as part of the
             # initial create so the federated post carries it too. Keep the
             # handle open across the create — the ImageField reads it on save.
-            cover_src = self._resolve_temp_path(data.get("cover"))
+            cover_src = self._store_path(data.get("cover"))
             cover_arg = None
             cover_fh = None
-            if cover_src and os.path.isfile(cover_src):
+            if cover_src:
                 cover_fh = open(cover_src, "rb")
                 cover_arg = File(cover_fh, name=os.path.basename(cover_src))
             try:
@@ -232,7 +326,7 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {})
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             item = self.items.get(content_data.get("withRegardTo", ""))
@@ -252,7 +346,7 @@ class NdjsonImporter(BaseImporter):
                     return "skipped"
                 # a newer export updates the existing review in place;
                 # creating another row would duplicate (owner, item, title)
-                existing_review.body = content
+                existing_review.body = self._restore_body_images(content, data)
                 if published_dt:
                     existing_review.created_time = published_dt
                 existing_review.visibility = visibility
@@ -263,10 +357,10 @@ class NdjsonImporter(BaseImporter):
                 owner=owner,
                 item=item,
                 title=name,
-                body=content,
-                created_time=published_dt,
+                body=self._restore_body_images(content, data),
                 visibility=visibility,
                 metadata=metadata,
+                **({"created_time": published_dt} if published_dt else {}),
             )
             return "imported"
         except Exception:
@@ -301,44 +395,41 @@ class NdjsonImporter(BaseImporter):
                 sensitive=sensitive,
                 progress_type=progress_type,
                 progress_value=progress_value,
-                created_time=published_dt,
                 visibility=visibility,
-                metadata=data.get("metadata", {}),
+                metadata=data.get("metadata") or {},
+                **({"created_time": published_dt} if published_dt else {}),
             )
-            attachments_data = data.get("attachments", [])
-            if attachments_data and hasattr(self, "temp_dir"):
-                note_attachments = []
-                for atta in attachments_data:
-                    file_rel = atta.get("file")
-                    mimetype = atta.get("mimetype", "")
-                    src = self._resolve_temp_path(file_rel)
-                    if not src or not os.path.isfile(src):
-                        continue
-                    ext = os.path.splitext(src)[1]
-                    storage_name = f"journal/attachments/{uuid.uuid4()}{ext}"
-                    with open(src, "rb") as f:
-                        storage_name = default_storage.save(storage_name, File(f))
-                    storage_url = default_storage.url(storage_name)
-                    url = (
-                        settings.SITE_INFO["site_url"].rstrip("/") + storage_url
-                        if storage_url.startswith("/")
-                        else storage_url
-                    )
-                    note_attachments.append(
-                        {
-                            "type": (mimetype or "unknown").split("/")[0],
-                            "mimetype": mimetype,
-                            "url": url,
-                            "preview_url": "",
-                        }
-                    )
-                if note_attachments:
-                    note.attachments = note_attachments
-                    note.save(
-                        update_fields=["attachments"],
-                        post_when_save=False,
-                        index_when_save=False,
-                    )
+            note_attachments = []
+            for atta in data.get("attachments") or []:
+                if not isinstance(atta, dict):
+                    continue
+                mimetype = atta.get("mimetype", "")
+                url = self._store_bundled_file(atta.get("file"))
+                if url:
+                    if url.startswith("/"):
+                        url = settings.SITE_INFO["site_url"].rstrip("/") + url
+                else:
+                    # the exporter could not bundle the file (post pruned or
+                    # media held elsewhere); keep its recorded URL rather
+                    # than dropping the attachment entirely
+                    url = atta.get("url")
+                if not url:
+                    continue
+                note_attachments.append(
+                    {
+                        "type": (mimetype or "unknown").split("/")[0],
+                        "mimetype": mimetype,
+                        "url": url,
+                        "preview_url": "",
+                    }
+                )
+            if note_attachments:
+                note.attachments = note_attachments
+                note.save(
+                    update_fields=["attachments"],
+                    post_when_save=False,
+                    index_when_save=False,
+                )
             return "imported"
         except Exception:
             logger.exception("Error importing note")
@@ -349,7 +440,7 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {})
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             item = self.items.get(content_data.get("withRegardTo", ""))
@@ -378,9 +469,9 @@ class NdjsonImporter(BaseImporter):
                 owner=owner,
                 item=item,
                 text=content,
-                created_time=published_dt,
                 visibility=visibility,
                 metadata=metadata,
+                **({"created_time": published_dt} if published_dt else {}),
             )
             return "imported"
         except Exception:
@@ -392,28 +483,42 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {})
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             item = self.items.get(content_data.get("withRegardTo", ""))
             if not item:
                 raise KeyError(f"Could not find item: {data.get('item', '')}")
-            rating_grade = int(float(content_data.get("value", 0)))
-            existing_rating = Rating.objects.filter(owner=owner, item=item).first()
-            if (
-                existing_rating
-                and existing_rating.created_time
-                and published_dt
-                and existing_rating.created_time >= published_dt
-            ):
+            rating_grade = int(float(content_data.get("value") or 0))
+            if not rating_grade:
+                # a rating with no grade carries nothing to restore, and
+                # Rating.update_item_rating treats it as a deletion
                 return "skipped"
+            existing_rating = Rating.objects.filter(owner=owner, item=item).first()
+            if existing_rating:
+                if (
+                    existing_rating.created_time
+                    and published_dt
+                    and existing_rating.created_time >= published_dt
+                ):
+                    return "skipped"
+                # (owner, item) is unique on Rating: inserting a second row
+                # raises IntegrityError, which marks the surrounding
+                # transaction for rollback and fails every later record too
+                existing_rating.grade = rating_grade
+                if published_dt:
+                    existing_rating.created_time = published_dt
+                existing_rating.visibility = visibility
+                existing_rating.metadata = metadata
+                existing_rating.save()
+                return "imported"
             Rating.objects.create(
                 owner=owner,
                 item=item,
                 grade=rating_grade,
-                created_time=published_dt,
                 visibility=visibility,
                 metadata=metadata,
+                **({"created_time": published_dt} if published_dt else {}),
             )
             return "imported"
         except Exception:
@@ -445,7 +550,7 @@ class NdjsonImporter(BaseImporter):
         try:
             owner = self.user.identity
             visibility = data.get("visibility", self.metadata.get("visibility", 0))
-            metadata = data.get("metadata", {})
+            metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             item = self.items.get(content_data.get("withRegardTo", ""))
@@ -478,13 +583,16 @@ class NdjsonImporter(BaseImporter):
             logger.exception("Error importing tag member")
             return "failed"
 
-    def process_journal(self, file_path: str) -> None:
-        """Process a NDJSON file and import all items."""
-        logger.debug(f"Processing {file_path}")
-        lines_error = 0
-        import_funcs: dict[
-            str, Callable[[Dict[str, Any]], BaseImporter.ImportResult]
-        ] = {
+    def import_funcs(
+        self,
+    ) -> dict[str, Callable[[Dict[str, Any]], BaseImporter.ImportResult]]:
+        """Handler per journal record ``type``, in dependency order.
+
+        Keys must cover every ``type`` NdjsonExporter writes; iteration order
+        is the import order (Tag before TagMember, Rating/Comment before
+        ShelfMember, which reads them back through Mark).
+        """
+        return {
             "Tag": self.import_tag,
             "TagMember": self.import_tag_member,
             "Rating": self.import_rating,
@@ -494,9 +602,18 @@ class NdjsonImporter(BaseImporter):
             "Note": self.import_note,
             "Collection": self.import_collection,
             "ShelfLog": self.import_shelf_log,
+            # the exporter writes lowercase "post"; "Post" is accepted too so
+            # the two never silently drift apart again
+            "post": self.import_post,
             "Post": self.import_post,
             "Article": self.import_article,
         }
+
+    def process_journal(self, file_path: str) -> None:
+        """Process a NDJSON file and import all items."""
+        logger.debug(f"Processing {file_path}")
+        lines_error = 0
+        import_funcs = self.import_funcs()
         journal: dict[str, list[Dict[str, Any]]] = {k: [] for k in import_funcs.keys()}
         with open(file_path, "r") as jsonfile:
             # Skip header line
@@ -523,10 +640,19 @@ class NdjsonImporter(BaseImporter):
         if lines_error:
             logger.error(f"Error processing journal.ndjson: {lines_error} lines")
 
-        for typ, func in import_funcs.items():
-            for data in journal.get(typ, []):
-                result = func(data)
-                self.progress(result)
+        # journal is seeded from import_funcs, so iterating it preserves the
+        # dependency order (Tag before TagMember, Rating/Comment before
+        # ShelfMember) and puts unrecognised types last. Every record is
+        # accounted for, including unrecognised ones — otherwise processed
+        # never reaches total and progress stalls short of 100%.
+        for typ, entries in journal.items():
+            func = import_funcs.get(typ)
+            for data in entries:
+                if func is None:
+                    logger.debug(f"Skipping unsupported record type {typ}")
+                    self.progress("skipped")
+                else:
+                    self.progress(func(data))
         logger.info(
             f"Imported {self.metadata['imported']}, skipped {self.metadata['skipped']}, failed {self.metadata['failed']}"
         )
@@ -538,18 +664,24 @@ class NdjsonImporter(BaseImporter):
         try:
             with open(file_path, "r") as jsonfile:
                 for line in jsonfile:
+                    # the whole body is guarded, not just the parse: a single
+                    # unresolvable entry must not abort the catalog, or every
+                    # later piece fails to find its item
                     try:
                         i = json.loads(line)
-                    except json.JSONDecodeError, Exception:
+                        u = i.get("id")
+                        if not u:
+                            continue
+                        # self.catalog_items[u] = i
+                        item_count += 1
+                        links = [u] + [
+                            r["url"]
+                            for r in i.get("external_resources") or []
+                            if isinstance(r, dict) and r.get("url")
+                        ]
+                        self.items[u] = self.get_item_by_info_and_links("", "", links)
+                    except Exception:
                         logger.exception("Error processing catalog item")
-                        continue
-                    u = i.get("id")
-                    if not u:
-                        continue
-                    # self.catalog_items[u] = i
-                    item_count += 1
-                    links = [u] + [r["url"] for r in i.get("external_resources", [])]
-                    self.items[u] = self.get_item_by_info_and_links("", "", links)
             logger.info(f"Loaded {item_count} items from catalog")
             self.metadata["catalog_processed"] = item_count
         except Exception:

--- a/neodb/journal/management/commands/migrate_images.py
+++ b/neodb/journal/management/commands/migrate_images.py
@@ -7,8 +7,7 @@ from tqdm import tqdm
 
 from common.management.base import SiteCommand
 from journal.models import Collection, Review
-
-_RE_MD_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+from journal.models.renderers import RE_MD_IMAGE
 
 
 def _migrate_image(src: str, identity_id: int, created_year: str) -> str | None:
@@ -73,7 +72,7 @@ def _process_content(text: str, identity_id: int, created_year: str) -> str | No
             return f"![{alt}]({new_src})"
         return m.group(0)
 
-    result = _RE_MD_IMAGE.sub(_replace, text)
+    result = RE_MD_IMAGE.sub(_replace, text)
     return result if changed else None
 
 

--- a/neodb/journal/models/renderers.py
+++ b/neodb/journal/models/renderers.py
@@ -41,7 +41,11 @@ def render_md(s: str) -> str:
     return cast(str, _markdown(s))
 
 
-_RE_MD_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+# Public: the NDJSON exporter/importer and the image migration command all
+# need to agree with the renderer on what counts as an inline image, so they
+# share this pattern instead of keeping their own copies. Group 1 is the alt
+# text, group 2 the src.
+RE_MD_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
 
 def _normalize_image_src(src: str) -> str | None:
@@ -94,7 +98,7 @@ def sanitize_md_images(md_text: str) -> str:
             return f"![{alt}]({normalized})"
         return f"==[invalid image: {src}]=="
 
-    return _RE_MD_IMAGE.sub(_replace, md_text)
+    return RE_MD_IMAGE.sub(_replace, md_text)
 
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")

--- a/neodb/journal/models/renderers.py
+++ b/neodb/journal/models/renderers.py
@@ -48,12 +48,17 @@ def render_md(s: str) -> str:
 RE_MD_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
 
-def _normalize_image_src(src: str) -> str | None:
+def normalize_image_src(src: str) -> str | None:
     """Normalize an image src. Return normalized src or None if invalid.
 
     Convert to full URL for checking. If on our server or media host,
     must be under MEDIA_URL prefix. External URLs are allowed as-is.
     Relative paths are always invalid.
+
+    Public because the NDJSON exporter needs the same "is this our own
+    media?" decision: an absolute URL on our site normalizes to a
+    MEDIA_URL-prefixed one, which is what tells it to copy the file out of
+    storage instead of fetching it back over HTTP.
     """
     parsed = urlparse(src)
     media_parsed = urlparse(settings.MEDIA_URL)
@@ -93,7 +98,7 @@ def sanitize_md_images(md_text: str) -> str:
     def _replace(m: re.Match[str]) -> str:
         alt = m.group(1)
         src = m.group(2).strip()
-        normalized = _normalize_image_src(src)
+        normalized = normalize_image_src(src)
         if normalized is not None:
             return f"![{alt}]({normalized})"
         return f"==[invalid image: {src}]=="

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -6,6 +6,8 @@ from tempfile import TemporaryDirectory
 
 import pytest
 from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.utils.dateparse import parse_datetime
@@ -25,6 +27,8 @@ from catalog.models import (
 from journal.exporters import NdjsonExporter
 from journal.importers import NdjsonImporter
 from journal.models import *
+from journal.models.common import Debris
+from takahe.utils import Takahe
 from users.models import User
 
 
@@ -821,3 +825,288 @@ class TestNdjsonExportImport:
                 owner=self.user2.identity, title="Cover Directory Skipped"
             )
             assert not coll.cover.name or coll.cover.name == settings.DEFAULT_ITEM_COVER
+
+    def test_ndjson_export_skips_debris(self):
+        """A Debris tombstone must not abort the export.
+
+        Debris is a Content subclass with no ap_object, so walking
+        Content.__subclasses__() blew the whole export up with
+        NotImplementedError for anyone who had survived an item merge.
+        """
+        comment = Comment.objects.create(
+            item=self.book1, owner=self.user1.identity, text="hi", visibility=0
+        )
+        Debris.create_from_piece(comment)
+
+        exporter = NdjsonExporter.create(user=self.user1)
+        exporter.run()
+        with zipfile.ZipFile(exporter.metadata["file"]) as zf:
+            journal = zf.read("journal.ndjson").decode()
+        types = {json.loads(line)["type"] for line in journal.splitlines()[1:]}
+        assert "Comment" in types
+        assert "Debris" not in types
+
+    def test_ndjson_catalog_covers_shelf_only_items(self):
+        """A mark whose item has no comment/rating/log still round-trips.
+
+        Only ShelfMember referenced such an item, and ShelfMember was the one
+        piece type that never ref()'d its item into catalog.ndjson, so the
+        mark failed to import with "Could not find item".
+        """
+        mark = Mark(self.user1.identity, self.book1)
+        mark.update(ShelfType.WISHLIST, created_time=self.dt)
+        mark.delete_all_logs()
+
+        exporter = NdjsonExporter.create(user=self.user1)
+        exporter.run()
+        with zipfile.ZipFile(exporter.metadata["file"]) as zf:
+            catalog = zf.read("catalog.ndjson").decode()
+        assert self.book1.absolute_url in catalog
+
+        importer = NdjsonImporter.create(
+            user=self.user2, file=exporter.metadata["file"], visibility=0
+        )
+        importer.run()
+        assert importer.metadata["failed"] == 0
+        assert Mark(self.user2.identity, self.book1).shelf_type == ShelfType.WISHLIST
+
+    def test_ndjson_rating_newer_import_updates_in_place(self):
+        """(owner, item) is unique on Rating, so a newer import must update.
+
+        Inserting a second row raised IntegrityError, which marks the
+        surrounding transaction for rollback and fails every later record.
+        """
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        owner = self.user2.identity
+        Rating.objects.create(
+            item=self.book1, owner=owner, grade=5, visibility=0, created_time=self.dt
+        )
+
+        result = importer.import_rating(
+            {
+                "visibility": 0,
+                "content": {
+                    "withRegardTo": self.book1.absolute_url,
+                    "value": 9,
+                    "published": "2021-02-01T00:00:00Z",
+                },
+            }
+        )
+        assert result == "imported"
+        rating = Rating.objects.get(owner=owner, item=self.book1)
+        assert rating.grade == 9
+        assert rating.created_time == self.dt2
+        # the transaction is still usable — the old failure poisoned it
+        assert Rating.objects.filter(owner=owner).count() == 1
+
+    def test_ndjson_every_exported_type_has_an_importer(self):
+        """The two sides must agree on every record type name.
+
+        The exporter writes type "post" while the importer dispatched on
+        "Post", so posts were counted in total but never processed and the
+        progress percentage never reached 100%.
+        """
+        Takahe.post(self.user1.identity.pk, "hello world", Takahe.Visibilities.public)
+        Mark(self.user1.identity, self.book1).update(
+            ShelfType.COMPLETE, "done", 8, ["tagged"], 0, created_time=self.dt
+        )
+        Review.update_item_review(
+            self.book1, self.user1.identity, "R", "body", visibility=0
+        )
+        Note.objects.create(
+            item=self.book1, owner=self.user1.identity, content="n", visibility=0
+        )
+        Collection.objects.create(
+            owner=self.user1.identity, title="C", brief="", visibility=0
+        )
+        Article.update_local_article(
+            owner=self.user1.identity, title="A", body="b", visibility=0
+        )
+
+        exporter = NdjsonExporter.create(user=self.user1)
+        exporter.run()
+        export_path = exporter.metadata["file"]
+        with zipfile.ZipFile(export_path) as zf:
+            journal = zf.read("journal.ndjson").decode()
+        exported_types = {
+            json.loads(line)["type"]
+            for line in journal.splitlines()[1:]
+            if "type" in json.loads(line)
+        }
+        # covers every branch of the exporter, so a new record type added
+        # without a matching handler fails here rather than in production
+        assert exported_types >= {
+            "Rating",
+            "Comment",
+            "Review",
+            "Note",
+            "Article",
+            "Collection",
+            "Tag",
+            "TagMember",
+            "ShelfMember",
+            "ShelfLog",
+            "post",
+        }
+
+        importer = NdjsonImporter.create(
+            user=self.user2, file=export_path, visibility=0
+        )
+        assert exported_types <= set(importer.import_funcs())
+
+        importer.run()
+        m = importer.metadata
+        assert m["total"] == exporter.metadata["total"]
+        assert m["processed"] == m["total"]
+        assert m["imported"] + m["skipped"] + m["failed"] == m["total"]
+
+    def test_ndjson_unrecognised_records_are_counted(self, tmp_path):
+        """A record type this version doesn't know still reaches the counters."""
+        path = tmp_path / "journal.ndjson"
+        path.write_text(
+            json.dumps({"server": "x"})
+            + "\n"
+            + json.dumps({"type": "SomethingFromTheFuture"})
+            + "\n"
+        )
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.process_journal(str(path))
+        assert importer.metadata["total"] == 1
+        assert importer.metadata["processed"] == 1
+        assert importer.metadata["skipped"] == 1
+
+    def test_ndjson_review_inline_images_round_trip(self, tmp_path):
+        """Inline images are bundled and the body repointed at the restored copy.
+
+        Previously the exporter downloaded them into the archive but nothing
+        mapped them back, so every local image 404'd after a server move.
+        Images carrying alt text were not even bundled.
+        """
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            buf = BytesIO()
+            Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+            name = default_storage.save(
+                "upload/1/2026/pic.png", ContentFile(buf.getvalue())
+            )
+            src = default_storage.url(name)
+            Review.update_item_review(
+                self.book1,
+                self.user1.identity,
+                "Illustrated",
+                f"before ![alt text]({src}) after",
+                visibility=0,
+            )
+
+            exporter = NdjsonExporter.create(user=self.user1)
+            exporter.run()
+            export_path = exporter.metadata["file"]
+            with zipfile.ZipFile(export_path) as zf:
+                assert any(
+                    n.startswith("attachments/") and n.endswith(".png")
+                    for n in zf.namelist()
+                )
+
+            importer = NdjsonImporter.create(
+                user=self.user2, file=export_path, visibility=0
+            )
+            importer.run()
+            assert importer.metadata["failed"] == 0
+
+            body = Review.objects.get(owner=self.user2.identity, item=self.book1).body
+            assert src not in body, "body still points at the source server's media"
+            new_src = body.split("![alt text](")[1].split(")")[0]
+            assert new_src.startswith(settings.MEDIA_URL)
+            assert default_storage.exists(new_src[len(settings.MEDIA_URL) :])
+
+    def test_ndjson_progress_round_trips(self):
+        """Reading progress survives export/import.
+
+        ShelfMemberProgress was never exported and ShelfLogEntry.metadata
+        (comment_text / rating_grade / progress_*) was dropped on both sides,
+        so a restored journal lost its whole progress history.
+        """
+        mark = Mark(self.user1.identity, self.book1)
+        mark.update(ShelfType.PROGRESS, "reading it", 7, [], 0, created_time=self.dt)
+        mark.set_progress(Note.ProgressType.PAGE, "42")
+
+        exporter = NdjsonExporter.create(user=self.user1)
+        exporter.run()
+        importer = NdjsonImporter.create(
+            user=self.user2, file=exporter.metadata["file"], visibility=0
+        )
+        importer.run()
+        assert importer.metadata["failed"] == 0
+
+        imported = Mark(self.user2.identity, self.book1)
+        assert imported.progress_type == Note.ProgressType.PAGE
+        assert imported.progress_value == "42"
+
+        def _logs(owner):
+            return [
+                (
+                    log.shelf_type,
+                    log.comment_text,
+                    log.rating_grade,
+                    log.progress_type,
+                    log.progress_value,
+                )
+                for log in ShelfLogEntry.objects.filter(owner=owner).order_by(
+                    "timestamp", "item_id"
+                )
+            ]
+
+        assert _logs(self.user2.identity) == _logs(self.user1.identity)
+
+    def test_ndjson_catalog_survives_bad_entries(self, tmp_path):
+        """One unparseable catalog entry must not strand every later piece.
+
+        parse_catalog only guarded json.loads, so a malformed
+        external_resources entry raised out of the loop and aborted the
+        whole catalog — every piece then failed with "Could not find item".
+        """
+        path = tmp_path / "catalog.ndjson"
+        path.write_text(
+            json.dumps({"server": "x"})
+            + "\nnot json at all\n"
+            + json.dumps(
+                {
+                    "id": "https://example.org/nowhere",
+                    "external_resources": [{"missing_url_key": 1}],
+                }
+            )
+            + "\n"
+            + json.dumps({"id": self.book1.absolute_url})
+            + "\n"
+        )
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.parse_catalog(str(path))
+        assert importer.items.get(self.book1.absolute_url) == self.book1
+
+    def test_ndjson_import_without_published_timestamp(self):
+        """created_time is not nullable; a bundle without `published` must
+        fall back to the model default instead of raising IntegrityError."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        owner = self.user2.identity
+
+        assert (
+            importer.import_comment(
+                {
+                    "content": {
+                        "withRegardTo": self.book1.absolute_url,
+                        "content": "no timestamp",
+                    }
+                }
+            )
+            == "imported"
+        )
+        assert Comment.objects.get(owner=owner, item=self.book1).created_time
+
+        assert (
+            importer.import_collection(
+                {"content": {"name": "No Timestamp"}, "items": []}
+            )
+            == "imported"
+        )
+        assert Collection.objects.get(owner=owner, title="No Timestamp").created_time

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1058,6 +1058,143 @@ class TestNdjsonExportImport:
 
         assert _logs(self.user2.identity) == _logs(self.user1.identity)
 
+    def test_ndjson_cleared_progress_round_trips(self):
+        """A newer archive in which progress was cleared clears it on import.
+
+        The exporter only emitted `progress` when a value existed, so a
+        cleared mark looked exactly like a legacy archive and the
+        destination silently kept stale progress.
+        """
+        # destination already holds progress for this item. set_progress
+        # re-dates the mark to now, so wind it back explicitly — the archive
+        # has to be the newer side for the import to touch the mark at all.
+        dest_mark = Mark(self.user2.identity, self.book1)
+        dest_mark.update(ShelfType.PROGRESS, created_time=self.dt)
+        dest_mark.set_progress(Note.ProgressType.PAGE, "10")
+        ShelfMember.objects.filter(owner=self.user2.identity, item=self.book1).update(
+            created_time=self.dt
+        )
+        assert Mark(self.user2.identity, self.book1).progress_value == "10"
+
+        # source is strictly newer and carries no progress
+        src_mark = Mark(self.user1.identity, self.book1)
+        src_mark.update(ShelfType.PROGRESS, created_time=self.dt2)
+
+        exporter = NdjsonExporter.create(user=self.user1)
+        exporter.run()
+        with zipfile.ZipFile(exporter.metadata["file"]) as zf:
+            journal = zf.read("journal.ndjson").decode()
+        shelf_members = [
+            json.loads(line)
+            for line in journal.splitlines()[1:]
+            if json.loads(line).get("type") == "ShelfMember"
+        ]
+        # the key is present-and-null, which is what makes clearing replayable
+        assert "progress" in shelf_members[0]
+        assert shelf_members[0]["progress"] is None
+
+        importer = NdjsonImporter.create(
+            user=self.user2, file=exporter.metadata["file"], visibility=0
+        )
+        importer.run()
+        assert importer.metadata["failed"] == 0
+        assert Mark(self.user2.identity, self.book1).progress_value is None
+
+    def test_ndjson_legacy_archive_keeps_progress(self):
+        """A record with no `progress` key must leave existing progress alone."""
+        mark = Mark(self.user2.identity, self.book1)
+        mark.update(ShelfType.PROGRESS, created_time=self.dt)
+        mark.set_progress(Note.ProgressType.PAGE, "10")
+
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.restore_progress(self.user2.identity, self.book1, {})
+        assert Mark(self.user2.identity, self.book1).progress_value == "10"
+
+    def test_ndjson_bundles_absolute_local_media(self, tmp_path):
+        """An absolute URL on our own site is copied from storage, not fetched.
+
+        import_note records restored attachments as site_url + MEDIA_URL, so
+        a re-export saw a URL that did not start with a relative MEDIA_URL
+        and fell through to the HTTP downloader — which is_valid_url blocks
+        for an internal host, silently dropping the file from the bundle.
+        """
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            buf = BytesIO()
+            Image.new("RGB", (2, 2), "green").save(buf, format="PNG")
+            name = default_storage.save(
+                "upload/1/2026/abs.png", ContentFile(buf.getvalue())
+            )
+            absolute = settings.SITE_INFO["site_url"].rstrip("/") + default_storage.url(
+                name
+            )
+            assert not absolute.startswith(settings.MEDIA_URL)
+
+            # a note whose media is only reachable through its stored
+            # attachments JSON — exactly what import_note writes back
+            note = Note.objects.create(
+                item=self.book1,
+                owner=self.user1.identity,
+                content="see attached",
+                visibility=0,
+            )
+            note.attachments = [
+                {
+                    "type": "image",
+                    "mimetype": "image/png",
+                    "url": absolute,
+                    "preview_url": "",
+                }
+            ]
+            note.save(
+                update_fields=["attachments"],
+                post_when_save=False,
+                index_when_save=False,
+            )
+
+            exporter = NdjsonExporter.create(user=self.user1)
+            exporter.run()
+            with zipfile.ZipFile(exporter.metadata["file"]) as zf:
+                names = zf.namelist()
+                journal = zf.read("journal.ndjson").decode()
+            assert any(
+                n.startswith("attachments/") and n.endswith(".png") for n in names
+            )
+            record = next(
+                r
+                for r in (json.loads(line) for line in journal.splitlines()[1:])
+                if r.get("type") == "Note"
+            )
+            assert record["attachments"][0]["file"].startswith("attachments/")
+
+    def test_ndjson_shelf_log_empty_metadata_is_authoritative(self):
+        """An explicit empty metadata overwrites; an absent key does not."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        owner = self.user2.identity
+        stale = ShelfLogEntry.objects.create(
+            owner=owner,
+            item=self.book1,
+            shelf_type=ShelfType.COMPLETE,
+            timestamp=self.dt,
+            metadata={"comment_text": "stale", "rating_grade": 3},
+        )
+        record = {
+            "item": self.book1.absolute_url,
+            "status": ShelfType.COMPLETE,
+            "timestamp": "2021-01-01T00:00:00Z",
+        }
+
+        # legacy archive (no metadata key): leave the row alone
+        assert importer.import_shelf_log(record) == "imported"
+        stale.refresh_from_db()
+        assert stale.comment_text == "stale"
+
+        # new archive that says the entry carries nothing: overwrite
+        assert importer.import_shelf_log({**record, "metadata": {}}) == "imported"
+        stale.refresh_from_db()
+        assert stale.comment_text is None
+        assert stale.rating_grade is None
+
     def test_ndjson_catalog_survives_bad_entries(self, tmp_path):
         """One unparseable catalog entry must not strand every later piece.
 

--- a/neodb/tests/journal/test_renderers.py
+++ b/neodb/tests/journal/test_renderers.py
@@ -3,7 +3,7 @@ import pytest
 from catalog.models import Edition
 from journal.models.renderers import (
     _linkify,
-    _normalize_image_src,
+    normalize_image_src,
     convert_leading_space_in_md,
     has_spoiler,
     html_to_text,
@@ -322,51 +322,51 @@ class TestRenderPostWithMacro:
 
 
 class TestNormalizeImageSrc:
-    """Tests for _normalize_image_src with default MEDIA_URL='/m/'."""
+    """Tests for normalize_image_src with default MEDIA_URL='/m/'."""
 
     def test_valid_media_path(self):
-        result = _normalize_image_src("/m/upload/1/2025/abc.jpg")
+        result = normalize_image_src("/m/upload/1/2025/abc.jpg")
         assert result == "/m/upload/1/2025/abc.jpg"
 
     def test_external_url_allowed(self):
-        result = _normalize_image_src("https://example.com/photo.jpg")
+        result = normalize_image_src("https://example.com/photo.jpg")
         assert result == "https://example.com/photo.jpg"
 
     def test_relative_path_invalid(self):
-        assert _normalize_image_src("relative/path.jpg") is None
+        assert normalize_image_src("relative/path.jpg") is None
 
     def test_absolute_path_not_under_media_invalid(self):
-        assert _normalize_image_src("/static/secret.txt") is None
+        assert normalize_image_src("/static/secret.txt") is None
 
     def test_data_scheme_invalid(self):
-        assert _normalize_image_src("data:image/png;base64,abc") is None
+        assert normalize_image_src("data:image/png;base64,abc") is None
 
     def test_ftp_scheme_invalid(self):
-        assert _normalize_image_src("ftp://example.com/file.jpg") is None
+        assert normalize_image_src("ftp://example.com/file.jpg") is None
 
     def test_our_domain_media_path_valid(self, settings):
         settings.SITE_DOMAINS = ["mysite.local"]
-        result = _normalize_image_src("https://mysite.local/m/upload/1/abc.jpg")
+        result = normalize_image_src("https://mysite.local/m/upload/1/abc.jpg")
         assert result == "/m/upload/1/abc.jpg"
 
     def test_our_domain_non_media_path_invalid(self, settings):
         settings.SITE_DOMAINS = ["mysite.local"]
-        assert _normalize_image_src("https://mysite.local/admin/") is None
+        assert normalize_image_src("https://mysite.local/admin/") is None
 
     def test_alt_domain_media_path_valid(self, settings):
         settings.SITE_DOMAINS = ["mysite.local", "alt.mysite.local"]
-        result = _normalize_image_src("https://alt.mysite.local/m/upload/1/abc.jpg")
+        result = normalize_image_src("https://alt.mysite.local/m/upload/1/abc.jpg")
         assert result == "/m/upload/1/abc.jpg"
 
     def test_empty_src_invalid(self):
-        assert _normalize_image_src("") is None
+        assert normalize_image_src("") is None
 
     def test_bare_filename_invalid(self):
-        assert _normalize_image_src("image.jpg") is None
+        assert normalize_image_src("image.jpg") is None
 
 
 class TestNormalizeImageSrcS3:
-    """Tests for _normalize_image_src with S3 MEDIA_URL."""
+    """Tests for normalize_image_src with S3 MEDIA_URL."""
 
     @pytest.fixture(autouse=True)
     def setup_s3(self, settings):
@@ -374,31 +374,31 @@ class TestNormalizeImageSrcS3:
 
     def test_s3_url_valid(self):
         src = "https://cdn.example.com/m/upload/1/2025/abc.jpg"
-        result = _normalize_image_src(src)
+        result = normalize_image_src(src)
         assert result == src
 
     def test_s3_host_wrong_path_invalid(self):
-        assert _normalize_image_src("https://cdn.example.com/other/file.jpg") is None
+        assert normalize_image_src("https://cdn.example.com/other/file.jpg") is None
 
     def test_absolute_path_under_media_normalized_to_s3(self):
-        result = _normalize_image_src("/m/upload/1/2025/abc.jpg")
+        result = normalize_image_src("/m/upload/1/2025/abc.jpg")
         assert result == "https://cdn.example.com/m/upload/1/2025/abc.jpg"
 
     def test_absolute_path_not_under_media_invalid(self):
-        assert _normalize_image_src("/static/file.jpg") is None
+        assert normalize_image_src("/static/file.jpg") is None
 
     def test_external_url_allowed(self):
-        result = _normalize_image_src("https://other.com/photo.jpg")
+        result = normalize_image_src("https://other.com/photo.jpg")
         assert result == "https://other.com/photo.jpg"
 
     def test_our_domain_media_path_normalized(self, settings):
         settings.SITE_DOMAINS = ["mysite.local"]
-        result = _normalize_image_src("https://mysite.local/m/upload/1/abc.jpg")
+        result = normalize_image_src("https://mysite.local/m/upload/1/abc.jpg")
         assert result == "https://cdn.example.com/m/upload/1/abc.jpg"
 
     def test_our_domain_non_media_invalid(self, settings):
         settings.SITE_DOMAINS = ["mysite.local"]
-        assert _normalize_image_src("https://mysite.local/admin/") is None
+        assert normalize_image_src("https://mysite.local/admin/") is None
 
 
 class TestSanitizeMdImages:


### PR DESCRIPTION
Reviewed the NDJSON journal export/import round trip end to end and fixed the problems found. Every fix has a regression test that fails without it.

## Crashes and failed imports

- **A `Debris` row aborted the entire export.** The exporter walked `Content.__subclasses__()`, which also yields `Debris` — the tombstone left behind when a catalog item merge hits a duplicate. `Debris` has no `ap_object`, so any user who had ever survived an item merge got `NotImplementedError` instead of an archive. The exported classes are now enumerated explicitly.
- **`import_rating` inserted a duplicate row** against the unique `(owner, item)` constraint whenever an older rating existed. The resulting `IntegrityError` marks the enclosing transaction for rollback, so it also failed every record processed after it. It now updates in place, as `Comment` and `Review` already did.
- **Items referenced only by a `ShelfMember` never reached `catalog.ndjson`.** `ShelfMember` was the one piece type that never `ref()`'d its item, so a mark on an item with no comment, rating or log entry failed to import with "Could not find item".
- **One bad catalog line stranded every later piece.** `parse_catalog` only guarded `json.loads`, so anything else raising — e.g. an `external_resources` entry without a `url` — escaped the loop and aborted the whole catalog. Guarded per line.
- **`created_time=None` was passed straight into `create()`** for bundles without a `published` timestamp, violating the non-null column. It now falls back to the model default, and a shelf log entry without a timestamp fails just that record rather than poisoning the transaction.

## Silent data loss

- **Inline body images never survived a server move.** The exporter downloaded them into `attachments/` but nothing mapped them back, so the body kept pointing at the source server's media. (The rewritten string was discarded even in the original `re.sub` version; 5c3cfc91 only made that explicit.) The bundle now records `{src, file}` per piece and the importer repoints the body at the restored copy. `Collection.brief` is covered as well.
- **Images with alt text were not bundled at all** — the pattern only matched `![](url)`, never `![alt](url)`. All three copies of that regex (renderer, exporter, `migrate_images`) now share the renderer's own `RE_MD_IMAGE`.
- **Reading progress was lost.** `ShelfMemberProgress` was never exported, and `ShelfLogEntry.metadata` — which holds the `comment_text` / `rating_grade` / `progress_*` jsondata fields — was dropped on both sides, so restored history came back blank.
- **Note attachments were read only from the linked post.** Takahé prunes posts, and the note's own `attachments` JSON was then silently dropped.

## Accounting and hygiene

- **The exporter writes `type: "post"` while the importer dispatched on `"Post"`**, so plain posts were counted in `total` but never processed: progress never reached 100% and the completion message under-reported. Both spellings are accepted, and unrecognised record types are now counted so `processed` always reaches `total`.
- **The export staging directory under `/tmp` was never removed**, leaving a full copy of every bundled attachment behind after each run.
- Local media is resolved before falling back to the HTTP downloader, and an absolute URL on the instance's own site is recognised as local — otherwise `is_valid_url` blocks it outright when the site or media host is internal.

## Format compatibility

The new keys (`images`, `progress`, shelf-log `metadata`, note attachment `url`) are additive: an older importer reads a new archive, and a new importer reads an old one. Two of them are deliberately tri-state on *presence* rather than truthiness, so that a newer archive can replay a cleared value (progress cleared by the user, a log entry with no comment or rating) without a legacy archive blanking data it simply never carried.

## Testing

- `tests/journal/test_ndjson.py`: 23 tests, up from 10.
- Each new test was confirmed to fail against the pre-fix code.
- Full suite green apart from the pre-existing `tests/mastodon/test_lexicons.py` failures, which are environmental (the dev container does not mount `docs/`) and fail identically on a clean tree.
- `pre-commit run -a` clean.
