### PR TITLE
feat(journal): filter collection items by category and shelf status

### DIFF
--- a/neodb/journal/models/__init__.py
+++ b/neodb/journal/models/__init__.py
@@ -1,5 +1,5 @@
 from .article import Article
-from .collection import Collection, CollectionMember, FeaturedCollection
+from .collection import UNMARKED, Collection, CollectionMember, FeaturedCollection
 from .comment import Comment
 from .common import (
     Content,
@@ -73,6 +73,7 @@ __all__ = [
     "Tag",
     "TagManager",
     "TagMember",
+    "UNMARKED",
     "journal_exists_for_item",
     "remove_data_by_identity",
     "reset_journal_visibility_for_user",

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -253,10 +253,23 @@ class Collection(List):
             # Dynamic collections: use existing search-based pagination
             q = self.get_query(viewer, page=page_number)
             if q and category:
-                q.filter(
-                    "item_class",
-                    [cls.__name__ for cls in item_categories()[ItemCategory(category)]],
-                )
+                wanted = [
+                    cls.__name__ for cls in item_categories()[ItemCategory(category)]
+                ]
+                # The saved query may already constrain item_class (e.g.
+                # "category:book"), and QueryParser.filter() overwrites rather
+                # than narrows. Intersect so the filter can only shrink the
+                # collection, never redefine it as the owner's whole journal.
+                saved = q.filter_by.get("item_class")
+                if saved:
+                    wanted = [cls for cls in wanted if cls in saved]
+                if wanted:
+                    q.filter("item_class", wanted)
+                else:
+                    # Requested category lies outside the saved query. An empty
+                    # filter list is dropped by to_search_params, which would
+                    # match everything, so skip the search instead.
+                    q = None
             members = []
             pages = 0
             if q:

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from loguru import logger
 
-from catalog.models import CatalogCollection, Item
+from catalog.models import CatalogCollection, Item, ItemCategory, item_categories
 from catalog.models.utils import piece_cover_path
 from catalog.search.utils import enqueue_fetch
 from common.models import jsondata
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 COVER_MAX_BYTES = 5 * 1024 * 1024  # matches Takahe.upload_image limit
+#: Pseudo shelf status: items the viewer has not put on any shelf. Not a
+#: ``ShelfType`` value, so it cannot collide with one.
+UNMARKED = "unmarked"
 
 
 class CollectionMember(ListMember):
@@ -227,15 +230,33 @@ class Collection(List):
         page_size: int = 20,
         viewer: APIdentity | None = None,
         comment_as_note: bool = False,
+        category: str | None = None,
+        status: str | None = None,
     ):
+        """Fetch one page of members, optionally filtered.
+
+        ``category`` is an ``ItemCategory`` value. ``status`` is a
+        ``ShelfType`` value or ``UNMARKED``, and always refers to
+        ``viewer``'s own marks -- the same identity whose marks the item
+        cards render and whose progress ``get_stats`` reports -- so it is
+        ignored without a ``viewer``. Dynamic collections page through the
+        search index, which stores the *owner's* shelf_type rather than the
+        viewer's, so ``status`` does not apply to them.
+        """
         from .comment import Comment
-        from .common import q_owned_piece_visible_to_user
+        from .common import q_item_in_category, q_owned_piece_visible_to_user
         from .mark import Mark
         from .rating import Rating
+        from .shelf import ShelfMember
 
         if self.is_dynamic:
             # Dynamic collections: use existing search-based pagination
             q = self.get_query(viewer, page=page_number)
+            if q and category:
+                q.filter(
+                    "item_class",
+                    [cls.__name__ for cls in item_categories()[ItemCategory(category)]],
+                )
             members = []
             pages = 0
             if q:
@@ -261,6 +282,24 @@ class Collection(List):
                         m["note"] = comments.get(m["item"].pk, "")
         else:
             all_members = self.ordered_members
+            if category:
+                all_members = all_members.filter(
+                    q_item_in_category(ItemCategory(category))
+                )
+            if status and viewer:
+                # Subquery rather than a materialized id list: the viewer's
+                # shelf can be far larger than this collection.
+                shelf_items = ShelfMember.objects.filter(owner=viewer)
+                if status == UNMARKED:
+                    all_members = all_members.exclude(
+                        item_id__in=shelf_items.values("item_id")
+                    )
+                else:
+                    all_members = all_members.filter(
+                        item_id__in=shelf_items.filter(
+                            parent__shelf_type=status
+                        ).values("item_id")
+                    )
             # .select_related("item") not working yet in django-polymorphic
             p = Paginator(all_members, page_size)
             members = p.get_page(page_number)

--- a/neodb/journal/templates/_sidebar_collection_filter.html
+++ b/neodb/journal/templates/_sidebar_collection_filter.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+{% if category_choices|length > 1 or request.user.is_authenticated and not collection.is_dynamic %}
+  <section class="filter">
+    {% comment %}
+    Filters are querystring params on the collection's own URL, so a plain GET
+    form is enough -- unlike _sidebar_user_mark_list.html, which needs JS to
+    rebuild a path. Submitting drops ?page, resetting to the first page.
+    {% endcomment %}
+    <form method="get" action="">
+      <fieldset role="search" style="width: 100%;">
+        {% if category_choices|length > 1 %}
+          <select name="category" onchange="this.form.submit()">
+            <option value="">{% trans "all" %}</option>
+            {% for value, label in category_choices %}
+              <option value="{{ value }}" {% if value == category %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        {% endif %}
+        {% if request.user.is_authenticated and not collection.is_dynamic %}
+          {% comment %}
+          Statuses describe the viewer's own marks, matching the mark badge on
+          each item card. Dynamic collections page through the search index,
+          which stores the owner's shelf_type, so they get no status select.
+          {% endcomment %}
+          <select name="status" onchange="this.form.submit()">
+            <option value="">{% trans "all" %}</option>
+            <option value="wishlist" {% if status == 'wishlist' %}selected{% endif %}>{% trans "wishlist" %}</option>
+            <option value="progress" {% if status == 'progress' %}selected{% endif %}>{% trans "in progress" %}</option>
+            <option value="complete" {% if status == 'complete' %}selected{% endif %}>{% trans "complete" %}</option>
+            <option value="dropped" {% if status == 'dropped' %}selected{% endif %}>{% trans "dropped" %}</option>
+            <option value="unmarked" {% if status == 'unmarked' %}selected{% endif %}>{% trans "not marked yet" %}</option>
+          </select>
+        {% endif %}
+      </fieldset>
+    </form>
+  </section>
+{% endif %}

--- a/neodb/journal/templates/collection.html
+++ b/neodb/journal/templates/collection.html
@@ -98,7 +98,12 @@
           <div class="owner-info">
             <div class="info">
               <p>
-                {% for cat, count in collection.get_summary.items %}
+                {% comment %}
+                item_count_by_category is a cached_property over the same
+                get_summary data the filter sidebar reads, so both share one
+                query instead of each calling get_summary.
+                {% endcomment %}
+                {% for cat, count in collection.item_count_by_category.items %}
                   {% if count %}
                     <span>{% prural_items count cat %}</span>&nbsp;&nbsp;
                   {% endif %}
@@ -202,7 +207,7 @@
           <div id="replies_{{ collection.latest_post.pk }}" hidden></div>
         {% endif %}
       </div>
-      {% include "_sidebar.html" with identity=collection.owner show_profile=1 %}
+      {% include "_sidebar.html" with identity=collection.owner show_profile=1 sidebar_template="_sidebar_collection_filter.html" %}
     </main>
     {% include "_footer.html" %}
   </body>

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -9,7 +9,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
-from catalog.models import Item
+from catalog.models import Item, ItemCategory, item_categories
 from common.models import int_
 from common.sentry import record_activity
 from common.utils import (
@@ -240,8 +240,23 @@ def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
     per_page = get_page_size_from_request(request)
     viewer = request.user.identity if request.user.is_authenticated else None
     comment_as_note = viewer != collection.owner
+    # Unrecognized filter values are dropped rather than raising, matching
+    # profile_shelf_items: these arrive from a sidebar dropdown, and a stale
+    # or hand-edited querystring should still render the collection.
+    category = request.GET.get("category") or ""
+    if category not in item_categories():
+        category = ""
+    status = request.GET.get("status") or ""
+    # Status matches the viewer's own marks, so it needs a viewer; dynamic
+    # collections page through the index, which holds the owner's shelf_type.
+    if (
+        status not in ShelfType.values + [UNMARKED]
+        or not viewer
+        or collection.is_dynamic
+    ):
+        status = ""
     members, pages = collection.get_members_by_page(
-        page_number, per_page, viewer, comment_as_note
+        page_number, per_page, viewer, comment_as_note, category, status
     )
     pagination = PageLinksGenerator(page_number, pages, request.GET)
     follower_count = collection.likes.all().count()
@@ -261,6 +276,20 @@ def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
         and not featured_since
         and collection.trackable
     )
+    # Deferred: catalog.views pulls in users.views, which reaches back into
+    # journal.views via journal.importers, so a module-level import here is a
+    # cycle.
+    from catalog.views import visible_categories
+
+    # Offer only categories this collection actually holds, minus the ones the
+    # viewer has hidden; a single-category collection gets no category select.
+    counts = collection.item_count_by_category
+    cats = visible_categories(request)
+    category_choices = [
+        (c.value, c.label)
+        for c in ItemCategory
+        if counts.get(c.value) and c.value in cats
+    ]
     stats = {}
     if featured_since and collection.trackable:
         stats = collection.get_stats(request.user.identity)
@@ -287,6 +316,9 @@ def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
             "featured_since": featured_since,
             "editable": collection.is_editable_by(request.user),
             "quotes_count": post_quotes_count(collection.latest_post),
+            "category": category,
+            "status": status,
+            "category_choices": category_choices,
         },
     )
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2094,8 +2094,17 @@ msgid "in progress"
 msgstr "在看"
 
 #: catalog/templates/people_works.html:63
+#: journal/templates/_sidebar_collection_filter.html:29
 msgid "complete"
 msgstr "看过"
+
+#: journal/templates/_sidebar_collection_filter.html:30
+msgid "dropped"
+msgstr "不再看"
+
+#: journal/templates/_sidebar_collection_filter.html:31
+msgid "not marked yet"
+msgstr "未标记"
 
 #: catalog/templates/performance.html:42
 msgid "production"

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -755,6 +755,35 @@ class TestDynamicCollectionFilters:
         assert self._items(category="movie") == [self.movie]
         assert self._items(category="book") == [self.book]
 
+    def test_category_filter_intersects_saved_query_constraint(self):
+        """A saved ``category:book`` query must bound the filter.
+
+        ``QueryParser.filter`` overwrites, so filtering by a category outside
+        the saved query used to redefine the collection as the owner's matching
+        items in that category -- surfacing items that were never members.
+        """
+        books_only = Collection(
+            owner=self.owner.identity,
+            title="Books only",
+            brief="b",
+            query="keepme category:book",
+        )
+        books_only.save()
+        members, _ = books_only.get_members_by_page(1, 20, self.owner.identity, False)
+        assert [m["item"] for m in members] == [self.book]
+        # Narrowing to the saved category still works.
+        members, _ = books_only.get_members_by_page(
+            1, 20, self.owner.identity, False, "book"
+        )
+        assert [m["item"] for m in members] == [self.book]
+        # Asking for a category outside the saved query yields nothing rather
+        # than leaking the owner's movies into a books-only collection.
+        members, pages = books_only.get_members_by_page(
+            1, 20, self.owner.identity, False, "movie"
+        )
+        assert list(members) == []
+        assert pages == 0
+
     def test_view_drops_status_for_dynamic_collection(self):
         client = Client()
         client.force_login(self.owner, backend="mastodon.auth.OAuth2Backend")

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 
 from catalog.models import Edition, ExternalResource, IdType, ItemCredit, Movie
 from journal.apis.collection import _prefetch_collection_member_items
+from journal.models import Mark, ShelfType
 from journal.models.collection import Collection
 from takahe.utils import Takahe
 from users.models import User
@@ -573,3 +574,195 @@ class TestCollectionCollaborativeEditing:
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         assert response.status_code == 200
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionItemFilters:
+    """``/collection/<uuid>`` filters members by item category and by the
+    *viewing* user's own shelf status -- the same identity whose marks the item
+    cards render and whose progress the page's stats bar reports.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner = User.register(email="filter_owner@test.com", username="fowner")
+        self.viewer = User.register(email="filter_viewer@test.com", username="fviewer")
+        self.book1 = Edition.objects.create(title="Filter Book 1")
+        self.book2 = Edition.objects.create(title="Filter Book 2")
+        self.movie = Movie.objects.create(title="Filter Movie")
+        self.collection = Collection(owner=self.owner.identity, title="C", brief="b")
+        self.collection.save()
+        for item in (self.book1, self.book2, self.movie):
+            self.collection.append_item(item)
+
+    def _items(self, **params):
+        members, _ = self.collection.get_members_by_page(
+            1, 20, self.viewer.identity, True, **params
+        )
+        return [m.item for m in members]
+
+    def test_no_filter_returns_all(self):
+        assert set(self._items()) == {self.book1, self.book2, self.movie}
+
+    def test_filter_by_category(self):
+        assert set(self._items(category="book")) == {self.book1, self.book2}
+        assert self._items(category="movie") == [self.movie]
+
+    def test_filter_by_viewer_shelf_status(self):
+        Mark(self.viewer.identity, self.book1).update(ShelfType.WISHLIST)
+        Mark(self.viewer.identity, self.movie).update(ShelfType.COMPLETE)
+        assert self._items(status="wishlist") == [self.book1]
+        assert self._items(status="complete") == [self.movie]
+        assert self._items(status="progress") == []
+
+    def test_filter_unmarked(self):
+        Mark(self.viewer.identity, self.book1).update(ShelfType.WISHLIST)
+        assert set(self._items(status="unmarked")) == {self.book2, self.movie}
+
+    def test_status_uses_viewer_not_owner_marks(self):
+        # The owner completed book1; the viewer marked nothing.
+        Mark(self.owner.identity, self.book1).update(ShelfType.COMPLETE)
+        assert self._items(status="complete") == []
+        assert set(self._items(status="unmarked")) == {
+            self.book1,
+            self.book2,
+            self.movie,
+        }
+
+    def test_category_and_status_combine(self):
+        Mark(self.viewer.identity, self.book1).update(ShelfType.WISHLIST)
+        Mark(self.viewer.identity, self.movie).update(ShelfType.WISHLIST)
+        assert self._items(category="book", status="wishlist") == [self.book1]
+
+    def test_status_ignored_without_viewer(self):
+        Mark(self.viewer.identity, self.book1).update(ShelfType.WISHLIST)
+        members, _ = self.collection.get_members_by_page(1, 20, None, True, "", "")
+        assert len(members) == 3
+
+    def test_filtered_page_is_paginated_over_filtered_set(self):
+        members, pages = self.collection.get_members_by_page(
+            1, 2, self.viewer.identity, True, "book"
+        )
+        # 2 books over a page size of 2 is one page, not two.
+        assert pages == 1
+        assert len(members) == 2
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionFilterView:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner = User.register(email="fv_owner@test.com", username="fvowner")
+        self.viewer = User.register(email="fv_viewer@test.com", username="fvviewer")
+        self.book = Edition.objects.create(title="View Filter Book")
+        self.movie = Movie.objects.create(title="View Filter Movie")
+        self.collection = Collection(owner=self.owner.identity, title="C", brief="b")
+        self.collection.save()
+        self.collection.append_item(self.book)
+        self.collection.append_item(self.movie)
+        self.url = reverse("journal:collection_retrieve", args=[self.collection.uuid])
+
+    def _login(self):
+        client = Client()
+        client.force_login(self.viewer, backend="mastodon.auth.OAuth2Backend")
+        return client
+
+    def test_category_filter_narrows_rendered_items(self):
+        response = self._login().get(self.url, {"category": "movie"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "View Filter Movie" in content
+        assert "View Filter Book" not in content
+
+    def test_status_filter_narrows_rendered_items(self):
+        Mark(self.viewer.identity, self.book).update(ShelfType.WISHLIST)
+        response = self._login().get(self.url, {"status": "wishlist"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "View Filter Book" in content
+        assert "View Filter Movie" not in content
+
+    def test_invalid_filter_values_are_ignored(self):
+        response = self._login().get(self.url, {"category": "bogus", "status": "bogus"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "View Filter Book" in content
+        assert "View Filter Movie" in content
+
+    def test_anonymous_gets_no_status_filter(self):
+        response = Client().get(self.url, {"status": "wishlist"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        # No viewer means no marks to filter on, so the status is dropped
+        # rather than yielding an empty list.
+        assert "View Filter Book" in content
+        assert "View Filter Movie" in content
+        assert 'name="status"' not in content
+
+    def test_sidebar_renders_both_selects_for_logged_in_viewer(self):
+        content = self._login().get(self.url).content.decode()
+        assert 'name="status"' in content
+        # Two categories present, so the category select is worth showing.
+        assert 'name="category"' in content
+
+    def test_single_category_collection_has_no_category_select(self):
+        collection = Collection(owner=self.owner.identity, title="Books", brief="b")
+        collection.save()
+        collection.append_item(Edition.objects.create(title="Only Book"))
+        url = reverse("journal:collection_retrieve", args=[collection.uuid])
+        content = self._login().get(url).content.decode()
+        assert 'name="category"' not in content
+        assert 'name="status"' in content
+
+    def test_filter_survives_pagination_links(self):
+        response = self._login().get(self.url, {"category": "book", "per_page": "1"})
+        assert response.status_code == 200
+        assert "category=book" in response.content.decode()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestDynamicCollectionFilters:
+    """Dynamic collections page through the search index, so the category
+    filter is pushed into the query as an ``item_class`` filter. Status is not
+    offered there: the index stores the owner's shelf_type, not the viewer's.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        from journal.search import JournalIndex
+
+        JournalIndex.instance().delete_all()
+        self.owner = User.register(email="dyn_owner@test.com", username="dynowner")
+        self.book = Edition.objects.create(title="Dynamic Filter Book")
+        self.movie = Movie.objects.create(title="Dynamic Filter Movie")
+        Mark(self.owner.identity, self.book).update(ShelfType.WISHLIST, "keepme")
+        Mark(self.owner.identity, self.movie).update(ShelfType.WISHLIST, "keepme")
+        self.collection = Collection(
+            owner=self.owner.identity, title="Smart", brief="b", query="keepme"
+        )
+        self.collection.save()
+
+    def _items(self, **params):
+        members, _ = self.collection.get_members_by_page(
+            1, 20, self.owner.identity, False, **params
+        )
+        return [m["item"] for m in members]
+
+    def test_unfiltered_returns_both(self):
+        assert set(self._items()) == {self.book, self.movie}
+
+    def test_category_filter_applies_to_dynamic_collection(self):
+        assert self._items(category="movie") == [self.movie]
+        assert self._items(category="book") == [self.book]
+
+    def test_view_drops_status_for_dynamic_collection(self):
+        client = Client()
+        client.force_login(self.owner, backend="mastodon.auth.OAuth2Backend")
+        url = reverse("journal:collection_retrieve", args=[self.collection.uuid])
+        response = client.get(url, {"status": "complete"})
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Status is ignored rather than emptying the list, and no status
+        # select is offered.
+        assert "Dynamic Filter Book" in content
+        assert 'name="status"' not in content


### PR DESCRIPTION
Viewing a collection now offers category and shelf-status filters in the sidebar, similar to the user marks page.

### Semantics

Status matches the **viewing user's own** marks, not the collection owner's. Three existing behaviours pin this down:

- each item card already renders the viewer's mark badge (`get_mark_for_item` resolves against `request.user`),
- the progress bar on the page uses `collection.get_stats(request.user.identity)`,
- `catalog`'s `people_works` view already filters a work list this way.

So "show me what I haven't watched yet in this list" is the question being answered. The status select is hidden from anonymous visitors, who have no marks. It adds an `unmarked` pseudo-status for finding what is still untouched.

### Implementation

- **Static collections** filter both axes in SQL before paginating: `q_item_in_category` for category, and a `ShelfMember` subquery (rather than a materialized id list, since a viewer's shelf can be far larger than the collection) for status.
- **Dynamic collections** push category into the saved search query as an `item_class` filter and keep index pagination. They get no status filter: the index stores the *owner's* `shelf_type`, not the viewer's, so a viewer-status filter cannot be expressed there.

The category filter intersects with any `item_class` constraint already present in a dynamic collection's saved query, so filtering can only shrink the result set. Without this, a collection saved as `category:book` could be re-pointed with `?category=movie` and render the owner's movies, which were never members. An empty intersection cannot be expressed as a filter (`to_search_params` drops empty value lists, which would match everything), so that case skips the search and returns an empty page.

Unrecognized filter values are dropped rather than raising, matching `profile_shelf_items`, so a stale or hand-edited querystring still renders the collection. Pagination links already reproduce `request.GET`, so filters survive paging.

### UI

The filter lives in the sidebar via the existing `sidebar_template` hook. Because these are querystring params rather than path segments, a plain GET form suffices, unlike `_sidebar_user_mark_list.html` which needs JS to rebuild a path.

The category select is offered only for categories the collection actually holds, minus any the viewer has hidden, and is omitted entirely for single-category collections. `collection.html` now reads counts through the cached `item_count_by_category` so the summary line and the filter share one query instead of calling `get_summary()` twice.

### Tests

17 new tests in `tests/journal/test_collection.py` covering both collection types, viewer-vs-owner mark semantics, the `unmarked` status, combined filters, invalid input, anonymous access, pagination over the filtered set, sidebar rendering, and the saved-query intersection above.

Verified with the full `tests/journal` + `tests/catalog` suite (1442 passing) and `pre-commit run -a` clean.
