### PR TITLE
perf(journal): keep idx-sync --remote from stalling Typesense

### DIFF
--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -775,7 +775,7 @@ def reindex_people_20260417():
         logger.error("People index is not ready, people reindex aborted.")
         return
 
-    purged = catalog_index.delete_docs("item_class", "People")
+    purged = catalog_index.delete_docs("item_class", "People", bulk=True)
     if purged:
         logger.warning(f"Purged {purged} legacy People docs from catalog index.")
 

--- a/neodb/catalog/management/commands/catalog.py
+++ b/neodb/catalog/management/commands/catalog.py
@@ -996,7 +996,7 @@ class Command(SiteCommand):
                     c += r
                 self.stdout.write(self.style.SUCCESS(f"indexed {c} of {t} docs."))
                 # Purge any People docs that were indexed before the split.
-                purged = index.delete_docs("item_class", "People")
+                purged = index.delete_docs("item_class", "People", bulk=True)
                 if purged:
                     self.stdout.write(
                         self.style.WARNING(f"purged {purged} People docs.")

--- a/neodb/catalog/search/index.py
+++ b/neodb/catalog/search/index.py
@@ -247,7 +247,7 @@ class CatalogIndex(Index):
         return [d for d in docs if d]
 
     def delete_all(self):
-        return self.delete_docs("id", "*")
+        return self.delete_docs("id", "*", bulk=True)
 
     def delete(self, item_ids):
         return self.delete_docs("id", item_ids)

--- a/neodb/catalog/search/people_index.py
+++ b/neodb/catalog/search/people_index.py
@@ -198,7 +198,7 @@ class PeopleIndex(Index):
         return doc
 
     def delete_all(self):
-        return self.delete_docs("id", "*")
+        return self.delete_docs("id", "*", bulk=True)
 
     def delete(self, item_ids):
         return self.delete_docs("id", item_ids)

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -41,11 +41,15 @@ TYPESENSE_ERRORS = (
 # https://typesense.org/docs/latest/api/documents.html#delete-by-query
 DELETE_BATCH_SIZE = 100
 
-# Export streams the whole matched set in a single response and is the one
-# operation here with no useful upper bound on duration. Give it a timeout of
-# its own rather than the search-sized connection_timeout_seconds; see
-# Index.export_docs().
-EXPORT_TIMEOUT_SECONDS = 600
+# Export streams the whole matched set in a single response, so it needs a
+# timeout of its own rather than the search-sized connection_timeout_seconds;
+# see Index.export_docs(). A filtered per-owner export comes back in
+# milliseconds on a healthy server and is run once per identity in a loop, so
+# it gets the short bound: a Typesense that still accepts connections but has
+# stopped answering must not hold up each identity in turn for minutes. Only
+# the full-collection export, run once per sync, gets the long one.
+EXPORT_TIMEOUT_SECONDS = 30
+FULL_EXPORT_TIMEOUT_SECONDS = 600
 EXPORT_CONNECT_TIMEOUT_SECONDS = 5
 
 
@@ -385,7 +389,9 @@ class Index:
                 c += 1
         return c
 
-    def export_docs(self, params: dict) -> Iterator[str]:
+    def export_docs(
+        self, params: dict, timeout: float = EXPORT_TIMEOUT_SECONDS
+    ) -> Iterator[str]:
         """Stream the export endpoint, yielding one non-empty JSONL line at a time.
 
         This bypasses the shared client on purpose. That client applies
@@ -410,9 +416,7 @@ class Index:
             url,
             params=params,
             headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_CONNECTION["api_key"]},
-            timeout=httpx.Timeout(
-                EXPORT_TIMEOUT_SECONDS, connect=EXPORT_CONNECT_TIMEOUT_SECONDS
-            ),
+            timeout=httpx.Timeout(timeout, connect=EXPORT_CONNECT_TIMEOUT_SECONDS),
         ) as r:
             if r.status_code < 200 or r.status_code >= 300:
                 r.read()

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -2,7 +2,7 @@ import re
 from functools import cached_property
 from json import JSONDecodeError
 from time import sleep
-from typing import Iterable, List, Self, cast
+from typing import Iterable, Iterator, List, Self, cast
 
 import httpx
 from django.conf import settings
@@ -33,6 +33,20 @@ TYPESENSE_ERRORS = (
     httpx.HTTPError,
     JSONDecodeError,
 )
+
+# Typesense deletes by filter synchronously, and a large match set can hold up
+# every other operation on the server for minutes; batch_size bounds how much
+# it does at a time. The server default is tuned for speed, not for sharing the
+# box with live indexing, so always pass one.
+# https://typesense.org/docs/latest/api/documents.html#delete-by-query
+DELETE_BATCH_SIZE = 100
+
+# Export streams the whole matched set in a single response and is the one
+# operation here with no useful upper bound on duration. Give it a timeout of
+# its own rather than the search-sized connection_timeout_seconds; see
+# Index.export_docs().
+EXPORT_TIMEOUT_SECONDS = 600
+EXPORT_CONNECT_TIMEOUT_SECONDS = 5
 
 
 def _backtick(s: str | int) -> str:
@@ -371,14 +385,59 @@ class Index:
                 c += 1
         return c
 
-    def delete_docs(self, field: str, values: Iterable[int | str] | int | str) -> int:
+    def export_docs(self, params: dict) -> Iterator[str]:
+        """Stream the export endpoint, yielding one non-empty JSONL line at a time.
+
+        This bypasses the shared client on purpose. That client applies
+        connection_timeout_seconds -- sized for search, a few seconds -- as the
+        httpx read timeout of every request including this one, and the write
+        client retries twice with no pause in between (typesense-python reads
+        retry_interval_seconds from the config and then never sleeps on it). An
+        export that stalls once therefore re-runs the entire scan up to three
+        times back to back, with every abandoned attempt still churning on the
+        server. It also buffers the whole response into one string, which for a
+        full-collection export is hundreds of MB.
+
+        Raises the underlying error (all within TYPESENSE_ERRORS) on failure.
+        """
+        node = settings.TYPESENSE_CONNECTION["nodes"][0]
+        url = (
+            f"{node['protocol']}://{node['host']}:{node['port']}"
+            f"/collections/{self.write_collection.name}/documents/export"
+        )
+        with httpx.stream(
+            "GET",
+            url,
+            params=params,
+            headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_CONNECTION["api_key"]},
+            timeout=httpx.Timeout(
+                EXPORT_TIMEOUT_SECONDS, connect=EXPORT_CONNECT_TIMEOUT_SECONDS
+            ),
+        ) as r:
+            if r.status_code < 200 or r.status_code >= 300:
+                r.read()
+                raise TypesenseClientError(
+                    f"export failed: {r.status_code} {r.text[:200]}"
+                )
+            for line in r.iter_lines():
+                if line:
+                    yield line
+
+    def delete_docs(
+        self,
+        field: str,
+        values: Iterable[int | str] | int | str,
+        batch_size: int = DELETE_BATCH_SIZE,
+    ) -> int:
         v: str = (
             str(values)
             if isinstance(values, (str, int))
             else ("[" + ",".join(str(x) for x in values) + "]")
         )
         try:
-            r = self.write_collection.documents.delete({"filter_by": f"{field}:{v}"})
+            r = self.write_collection.documents.delete(
+                {"filter_by": f"{field}:{v}", "batch_size": batch_size}
+            )
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return 0

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -299,6 +299,18 @@ class Index:
     def write_collection(self) -> Collection:
         return self._get_collection(True)
 
+    @cached_property
+    def _export_client(self) -> httpx.Client:
+        """Long-lived client for streamed exports; see export_docs().
+
+        Held for the life of the index so a sync that exports once per identity
+        reuses the connection rather than opening a fresh socket per owner and
+        leaving each in TIME_WAIT -- over a large remote estate that is both
+        needless handshake load on the server and a way to run the client out
+        of ephemeral ports. Timeouts are per request, not on the client.
+        """
+        return httpx.Client()
+
     @classmethod
     def get_schema(cls) -> CollectionCreateSchema:
         cname = SiteConfig.system.index_aliases.get(
@@ -411,7 +423,7 @@ class Index:
             f"{node['protocol']}://{node['host']}:{node['port']}"
             f"/collections/{self.write_collection.name}/documents/export"
         )
-        with httpx.stream(
+        with self._export_client.stream(
             "GET",
             url,
             params=params,

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -47,12 +47,16 @@ DELETE_BATCH_SIZE = 100
 # each identity in turn for minutes.
 EXPORT_TIMEOUT_SECONDS = 30
 
-# Operations that answer only once the server has finished the whole job --
-# delete-by-filter and the full-collection export -- take minutes on a large
-# collection, against the few seconds the shared clients allow for search.
+# Operations that answer only once the server has finished the whole job -- a
+# bulk delete-by-filter and the full-collection export -- take minutes on a
+# large collection, against the few seconds the shared clients allow for
+# search.
 LONG_OP_TIMEOUT_SECONDS = 600
 
-EXPORT_CONNECT_TIMEOUT_SECONDS = 5
+# Connecting is not what takes a long time, so it stays short even for the long
+# operations: a host that is down must fail in seconds rather than holding the
+# caller for the full read timeout.
+CONNECT_TIMEOUT_SECONDS = 5
 
 
 def _backtick(s: str | int) -> str:
@@ -278,41 +282,16 @@ class Index:
             }
         )
 
-    @classmethod
-    def get_bulk_client(cls) -> Client:
-        """Client for writes that answer only once the server is done.
-
-        Delete-by-filter returns its count when the whole match set is gone,
-        minutes on a large collection. Under the shared write client's
-        search-sized timeout such a delete is abandoned and reissued twice with
-        no pause (typesense-python parses retry_interval_seconds and never
-        sleeps on it), so the server ends up running overlapping copies of the
-        same delete while the caller is told 0 documents went. Retries are off
-        here for the same reason: a delete that timed out is very likely still
-        running, and firing another is precisely what must not happen. A delete
-        that never lands is recoverable -- the next sync still sees the docs.
-        """
-        return Client(
-            {
-                **settings.TYPESENSE_CONNECTION,
-                "connection_timeout_seconds": LONG_OP_TIMEOUT_SECONDS,
-                "num_retries": 0,
-            }
-        )
-
     def __init__(self):
         self._read_client = self.get_client()
         self._write_client = self.get_client(for_write=True)
-        self._bulk_client = self.get_bulk_client()
 
-    def _get_collection(
-        self, for_write=False, client: Client | None = None
-    ) -> Collection:
+    def _get_collection(self, for_write=False) -> Collection:
         collection_id = self.name + ("_write" if for_write else "_read")
         cname = SiteConfig.system.index_aliases.get(
             collection_id
         ) or SiteConfig.system.index_aliases.get(self.name, self.name)
-        client = client or (self._write_client if for_write else self._read_client)
+        client = self._write_client if for_write else self._read_client
         collection = client.collections[cname]
         if not collection:
             raise KeyError(f"Typesense: collection {collection_id} not found")
@@ -327,21 +306,30 @@ class Index:
         return self._get_collection(True)
 
     @cached_property
-    def bulk_write_collection(self) -> Collection:
-        """Write collection on the long-timeout, no-retry client."""
-        return self._get_collection(True, self._bulk_client)
+    def _http_client(self) -> httpx.Client:
+        """Long-lived client for the raw-HTTP maintenance calls below.
 
-    @cached_property
-    def _export_client(self) -> httpx.Client:
-        """Long-lived client for streamed exports; see export_docs().
-
-        Held for the life of the index so a sync that exports once per identity
-        reuses the connection rather than opening a fresh socket per owner and
-        leaving each in TIME_WAIT -- over a large remote estate that is both
-        needless handshake load on the server and a way to run the client out
-        of ephemeral ports. Timeouts are per request, not on the client.
+        Used where typesense-python cannot express what is needed: it derives
+        both the connect and the read timeout from the single
+        connection_timeout_seconds, and export/bulk-delete need those to
+        differ. Held for the life of the index so a sync that calls once per
+        identity reuses the connection rather than opening a fresh socket per
+        owner and leaving each in TIME_WAIT -- over a large remote estate that
+        is both needless handshake load on the server and a way to run the
+        client out of ephemeral ports. Timeouts are per request.
         """
         return httpx.Client()
+
+    def _node_url(self, path: str) -> str:
+        node = settings.TYPESENSE_CONNECTION["nodes"][0]
+        return (
+            f"{node['protocol']}://{node['host']}:{node['port']}"
+            f"/collections/{self.write_collection.name}/{path}"
+        )
+
+    @property
+    def _api_key_header(self) -> dict[str, str]:
+        return {"X-TYPESENSE-API-KEY": settings.TYPESENSE_CONNECTION["api_key"]}
 
     @classmethod
     def get_schema(cls) -> CollectionCreateSchema:
@@ -450,17 +438,12 @@ class Index:
 
         Raises the underlying error (all within TYPESENSE_ERRORS) on failure.
         """
-        node = settings.TYPESENSE_CONNECTION["nodes"][0]
-        url = (
-            f"{node['protocol']}://{node['host']}:{node['port']}"
-            f"/collections/{self.write_collection.name}/documents/export"
-        )
-        with self._export_client.stream(
+        with self._http_client.stream(
             "GET",
-            url,
+            self._node_url("documents/export"),
             params=params,
-            headers={"X-TYPESENSE-API-KEY": settings.TYPESENSE_CONNECTION["api_key"]},
-            timeout=httpx.Timeout(timeout, connect=EXPORT_CONNECT_TIMEOUT_SECONDS),
+            headers=self._api_key_header,
+            timeout=httpx.Timeout(timeout, connect=CONNECT_TIMEOUT_SECONDS),
         ) as r:
             if r.status_code < 200 or r.status_code >= 300:
                 r.read()
@@ -471,24 +454,57 @@ class Index:
                 if line:
                     yield line
 
+    def _delete_by_filter_bulk(self, filter_by: str, batch_size: int) -> int:
+        """Delete by filter over raw HTTP, for large maintenance filters.
+
+        Delete-by-filter answers only once the whole match set is gone, minutes
+        on a large collection, so it needs a long read timeout -- but a host
+        that is down must still fail in seconds rather than hanging the caller,
+        and typesense-python derives both from one setting. Hence raw httpx.
+
+        No retry: a delete that timed out is very likely still running on the
+        server, so reissuing it piles a second copy onto an already-struggling
+        node, which is exactly what the caller was trying to avoid.
+        """
+        r = self._http_client.request(
+            "DELETE",
+            self._node_url("documents"),
+            params={"filter_by": filter_by, "batch_size": batch_size},
+            headers=self._api_key_header,
+            timeout=httpx.Timeout(
+                LONG_OP_TIMEOUT_SECONDS, connect=CONNECT_TIMEOUT_SECONDS
+            ),
+        )
+        if r.status_code < 200 or r.status_code >= 300:
+            raise TypesenseClientError(f"delete failed: {r.status_code} {r.text[:200]}")
+        return r.json().get("num_deleted", 0)
+
     def delete_docs(
         self,
         field: str,
         values: Iterable[int | str] | int | str,
         batch_size: int = DELETE_BATCH_SIZE,
+        bulk: bool = False,
     ) -> int:
+        """Delete every doc matching field:values.
+
+        Set bulk for maintenance filters that may match a large number of docs
+        (whole-collection wipes, per-owner purges, reconciliation sweeps). The
+        default path is the shared write client, which is right for the point
+        deletes on the save path: those match a doc or two, so they want the
+        short timeout and the retries rather than a ten-minute ceiling.
+        """
         v: str = (
             str(values)
             if isinstance(values, (str, int))
             else ("[" + ",".join(str(x) for x in values) + "]")
         )
+        filter_by = f"{field}:{v}"
         try:
-            # bulk client, not the shared write one: batch_size makes the
-            # server yield between batches but the response still waits for the
-            # whole filter, so a short timeout here would abandon and reissue a
-            # delete that is still running
-            r = self.bulk_write_collection.documents.delete(
-                {"filter_by": f"{field}:{v}", "batch_size": batch_size}
+            if bulk:
+                return self._delete_by_filter_bulk(filter_by, batch_size)
+            r = self.write_collection.documents.delete(
+                {"filter_by": filter_by, "batch_size": batch_size}
             )
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -305,7 +305,9 @@ class Index:
         self._write_client = self.get_client(for_write=True)
         self._bulk_client = self.get_bulk_client()
 
-    def _get_collection(self, for_write=False, client: Client | None = None):
+    def _get_collection(
+        self, for_write=False, client: Client | None = None
+    ) -> Collection:
         collection_id = self.name + ("_write" if for_write else "_read")
         cname = SiteConfig.system.index_aliases.get(
             collection_id

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -41,15 +41,17 @@ TYPESENSE_ERRORS = (
 # https://typesense.org/docs/latest/api/documents.html#delete-by-query
 DELETE_BATCH_SIZE = 100
 
-# Export streams the whole matched set in a single response, so it needs a
-# timeout of its own rather than the search-sized connection_timeout_seconds;
-# see Index.export_docs(). A filtered per-owner export comes back in
-# milliseconds on a healthy server and is run once per identity in a loop, so
-# it gets the short bound: a Typesense that still accepts connections but has
-# stopped answering must not hold up each identity in turn for minutes. Only
-# the full-collection export, run once per sync, gets the long one.
+# A filtered per-owner export comes back in milliseconds on a healthy server
+# and is run once per identity in a loop, so it gets a short bound: a Typesense
+# that still accepts connections but has stopped answering must not hold up
+# each identity in turn for minutes.
 EXPORT_TIMEOUT_SECONDS = 30
-FULL_EXPORT_TIMEOUT_SECONDS = 600
+
+# Operations that answer only once the server has finished the whole job --
+# delete-by-filter and the full-collection export -- take minutes on a large
+# collection, against the few seconds the shared clients allow for search.
+LONG_OP_TIMEOUT_SECONDS = 600
+
 EXPORT_CONNECT_TIMEOUT_SECONDS = 5
 
 
@@ -276,16 +278,39 @@ class Index:
             }
         )
 
+    @classmethod
+    def get_bulk_client(cls) -> Client:
+        """Client for writes that answer only once the server is done.
+
+        Delete-by-filter returns its count when the whole match set is gone,
+        minutes on a large collection. Under the shared write client's
+        search-sized timeout such a delete is abandoned and reissued twice with
+        no pause (typesense-python parses retry_interval_seconds and never
+        sleeps on it), so the server ends up running overlapping copies of the
+        same delete while the caller is told 0 documents went. Retries are off
+        here for the same reason: a delete that timed out is very likely still
+        running, and firing another is precisely what must not happen. A delete
+        that never lands is recoverable -- the next sync still sees the docs.
+        """
+        return Client(
+            {
+                **settings.TYPESENSE_CONNECTION,
+                "connection_timeout_seconds": LONG_OP_TIMEOUT_SECONDS,
+                "num_retries": 0,
+            }
+        )
+
     def __init__(self):
         self._read_client = self.get_client()
         self._write_client = self.get_client(for_write=True)
+        self._bulk_client = self.get_bulk_client()
 
-    def _get_collection(self, for_write=False) -> Collection:
+    def _get_collection(self, for_write=False, client: Client | None = None):
         collection_id = self.name + ("_write" if for_write else "_read")
         cname = SiteConfig.system.index_aliases.get(
             collection_id
         ) or SiteConfig.system.index_aliases.get(self.name, self.name)
-        client = self._write_client if for_write else self._read_client
+        client = client or (self._write_client if for_write else self._read_client)
         collection = client.collections[cname]
         if not collection:
             raise KeyError(f"Typesense: collection {collection_id} not found")
@@ -298,6 +323,11 @@ class Index:
     @cached_property
     def write_collection(self) -> Collection:
         return self._get_collection(True)
+
+    @cached_property
+    def bulk_write_collection(self) -> Collection:
+        """Write collection on the long-timeout, no-retry client."""
+        return self._get_collection(True, self._bulk_client)
 
     @cached_property
     def _export_client(self) -> httpx.Client:
@@ -451,7 +481,11 @@ class Index:
             else ("[" + ",".join(str(x) for x in values) + "]")
         )
         try:
-            r = self.write_collection.documents.delete(
+            # bulk client, not the shared write one: batch_size makes the
+            # server yield between batches but the response still waits for the
+            # whole filter, so a short timeout here would abandon and reissue a
+            # delete that is still running
+            r = self.bulk_write_collection.documents.delete(
                 {"filter_by": f"{field}:{v}", "batch_size": batch_size}
             )
         except TYPESENSE_ERRORS as e:

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -46,8 +46,10 @@ idx-sync:       add missing docs, delete stale docs and rewrite docs still
                 deactivated identities (use --dry-run to preview, --remote to
                 sync remote pieces and identities instead). A --remote run
                 walks every remote identity and puts sustained load on the
-                index; use --offset/--limit to spread it over several
-                invocations and --throttle to pace it.
+                index; use --after-id/--limit to spread it over several
+                invocations and --throttle to pace it. A sliced run covers
+                only identities that still own pieces and does not purge, so
+                run once unsliced to reconcile the rest.
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -149,10 +151,10 @@ class Command(SiteCommand):
             help="report what idx-sync would change without writing to index",
         )
         parser.add_argument(
-            "--offset",
+            "--after-id",
             type=int,
             default=0,
-            help="idx-sync: skip this many identities (to run in slices)",
+            help="idx-sync: resume after this identity id (to run in slices)",
         )
         parser.add_argument(
             "--limit",
@@ -327,23 +329,28 @@ class Command(SiteCommand):
             added += index.replace_docs(index.pieces_to_docs(pieces))
         return added, deleted
 
-    def apply_slice(self, identity_ids: list[int]) -> tuple[list[int], bool]:
-        """Cut the identity list down to --offset/--limit.
+    def apply_cursor(self, identity_ids: list[int]) -> list[int]:
+        """Cut the ascending identity list down to --after-id/--limit.
 
-        A full --remote run walks every remote identity in one pass and cannot
-        be narrowed with --owner, so slicing is the only way to spread it over
-        several shorter invocations. Returns the slice and whether one was asked
-        for.
+        A --remote run walks every remote identity in one pass and cannot be
+        narrowed with --owner, so slicing is the only way to spread it over
+        several shorter invocations.
+
+        The cursor is an identity id rather than a list position because the
+        candidate list is recomputed per invocation and the run itself changes
+        it: syncing an owner whose docs were all stale leaves it with neither
+        docs nor pieces, so it drops out of the next run's candidates. A
+        positional offset would then shift left and step over an identity that
+        was never synced. Deactivations between slices do the same.
         """
-        if not self.offset and not self.limit:
-            return identity_ids, False
-        end = self.offset + self.limit if self.limit else None
-        sliced = identity_ids[self.offset : end]
+        ids = [i for i in identity_ids if i > self.after_id]
+        if self.limit:
+            ids = ids[: self.limit]
         self.stdout.write(
-            f"syncing identities {self.offset}..{self.offset + len(sliced)} "
-            f"of {len(identity_ids)}"
+            f"syncing {len(ids)} of {len(identity_ids)} candidate identities "
+            f"with id > {self.after_id}"
         )
-        return sliced, True
+        return ids
 
     def idx_sync(self, index: JournalIndex, owners: list[int], remote: bool = False):
         identities = APIdentity.objects.filter(local=not remote)
@@ -353,6 +360,7 @@ class Command(SiteCommand):
         active_q = Q(user__isnull=False, user__is_active=True) | Q(
             user__isnull=True, deleted__isnull=True
         )
+        sliced = bool(self.after_id or self.limit)
         indexed_owner_ids: set[int] | None = None
         if remote:
             # candidates: remote identities owning indexable pieces, plus
@@ -366,17 +374,32 @@ class Command(SiteCommand):
                     .values_list("owner_id", flat=True)
                     .distinct()
                 )
-            indexed_owner_ids = index.get_indexed_owner_ids()
-            if indexed_owner_ids is None:
+            if sliced:
+                # get_indexed_owner_ids() exports the whole collection, and it
+                # would run before the slice is applied -- so N slices would
+                # repeat the heaviest call N times, multiplying the very load
+                # slicing exists to spread out. A sliced run therefore covers
+                # only owners that still have pieces.
                 self.stdout.write(
                     self.style.WARNING(
-                        "failed to list indexed owners, stale docs of "
-                        "identities without pieces may be missed, and the "
-                        "purge of deactivated identities will be skipped"
+                        "sliced run: skipping the full-collection scan, so "
+                        "docs of owners with no remaining pieces are not "
+                        "reconciled; run once without --after-id/--limit to "
+                        "cover those"
                     )
                 )
             else:
-                candidate_ids |= indexed_owner_ids
+                indexed_owner_ids = index.get_indexed_owner_ids()
+                if indexed_owner_ids is None:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            "failed to list indexed owners, stale docs of "
+                            "identities without pieces may be missed, and the "
+                            "purge of deactivated identities will be skipped"
+                        )
+                    )
+                else:
+                    candidate_ids |= indexed_owner_ids
             active_ids = []
             for chunk in batched(sorted(candidate_ids), _SYNC_PK_CHUNK):
                 active_ids.extend(
@@ -389,7 +412,8 @@ class Command(SiteCommand):
             active_ids = list(
                 identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
             )
-        active_ids, sliced = self.apply_slice(active_ids)
+        if sliced:
+            active_ids = self.apply_cursor(active_ids)
         inactive_ids = list(
             identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
         )
@@ -406,8 +430,8 @@ class Command(SiteCommand):
             # each slice would just repeat the same work
             self.stdout.write(
                 self.style.WARNING(
-                    "--offset/--limit given, skipping purge of deactivated "
-                    "identities; run once without a slice to purge"
+                    "sliced run, skipping purge of deactivated identities; "
+                    "run once without --after-id/--limit to purge"
                 )
             )
             inactive_ids = []
@@ -443,6 +467,8 @@ class Command(SiteCommand):
                 f"{len(inactive_ids)} deactivated identities, {purged} docs {w}purged."
             )
         )
+        if sliced and active_ids:
+            self.stdout.write(f"resume the next slice with --after-id {active_ids[-1]}")
         if errors:
             self.stdout.write(
                 self.style.WARNING(f"{errors} identities skipped due to index errors.")
@@ -468,7 +494,7 @@ class Command(SiteCommand):
         self.fix = fix
         self.batch_size = int(batch_size)
         self.dry_run = kwargs.get("dry_run", False)
-        self.offset = kwargs.get("offset") or 0
+        self.after_id = kwargs.get("after_id") or 0
         self.limit = kwargs.get("limit") or 0
         self.throttle = kwargs.get("throttle") or 0.0
         index = JournalIndex.instance()

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -391,6 +391,9 @@ class Command(SiteCommand):
             # outlive their pieces); enumerating every known remote
             # identity instead would be pointlessly slow
             candidate_ids: set[int] = set()
+            # highest owner id below which every candidate is known to be in
+            # candidate_ids; None while no per-class scan has been cut short
+            frontier: int | None = None
             for cls in _INDEXABLE_PIECE_CLASSES:
                 pieces = cls.objects.filter(local=False)
                 if self.after_id:
@@ -398,20 +401,32 @@ class Command(SiteCommand):
                     # scans over the piece tables, and a slice that enumerates
                     # the whole estate first is not a shorter run
                     pieces = pieces.filter(owner_id__gt=self.after_id)
-                owner_ids = (
+                owner_q = (
                     pieces.values_list("owner_id", flat=True)
                     .distinct()
                     .order_by("owner_id")
                 )
                 if self.limit:
-                    # the globally smallest --limit owner ids are contained in
-                    # the per-class smallest --limit, so bounding each scan
-                    # keeps the union small without losing any of the ids this
-                    # slice is due. Otherwise every slice would materialise and
-                    # sort the whole remaining tail, which is quadratic over a
-                    # resumed run.
-                    owner_ids = owner_ids[: self.limit]
+                    # bound each scan, or every slice materialises and sorts
+                    # the whole remaining tail, which is quadratic over a
+                    # resumed run
+                    owner_q = owner_q[: self.limit]
+                owner_ids = list(owner_q)
                 candidate_ids.update(owner_ids)
+                if self.limit and len(owner_ids) == self.limit:
+                    # this class may hold more owners past its last returned
+                    # id, so nothing above that id is proven enumerated
+                    last = owner_ids[-1]
+                    frontier = last if frontier is None else min(frontier, last)
+            if frontier is not None:
+                # Beyond the frontier the candidate set is incomplete, and
+                # incomplete is dangerous rather than merely short: these caps
+                # are applied before active_q, so a class whose first --limit
+                # owners are all deactivated can hide a lower active owner.
+                # Syncing a higher active owner from another class would then
+                # advance the cursor past that hidden one and strand it for
+                # good. Only ids the scan actually proved are in play.
+                candidate_ids = {i for i in candidate_ids if i <= frontier}
             if sliced:
                 # get_indexed_owner_ids() exports the whole collection, and it
                 # would run before the slice is applied -- so N slices would

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -1,6 +1,7 @@
 from argparse import RawTextHelpFormatter
 from datetime import timedelta
 from itertools import batched
+from time import sleep
 
 from django.core.paginator import Paginator
 from django.db.models import Q
@@ -43,7 +44,10 @@ idx-catchup:    update index for journal items edited in last X hours (use --hou
 idx-sync:       add missing docs, delete stale docs and rewrite docs still
                 referencing dead posts for each local identity, purge docs of
                 deactivated identities (use --dry-run to preview, --remote to
-                sync remote pieces and identities instead)
+                sync remote pieces and identities instead). A --remote run
+                walks every remote identity and puts sustained load on the
+                index; use --offset/--limit to spread it over several
+                invocations and --throttle to pace it.
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -63,7 +67,7 @@ _INDEXABLE_PIECE_CLASSES: list[type[Piece]] = [
 _SYNC_DELETE_CHUNK = 200
 
 # stays well under postgres's 65535 query-parameter limit
-_SYNC_OWNER_CHUNK = 10000
+_SYNC_PK_CHUNK = 10000
 
 
 class Command(SiteCommand):
@@ -143,6 +147,25 @@ class Command(SiteCommand):
             "--dry-run",
             action="store_true",
             help="report what idx-sync would change without writing to index",
+        )
+        parser.add_argument(
+            "--offset",
+            type=int,
+            default=0,
+            help="idx-sync: skip this many identities (to run in slices)",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="idx-sync: sync at most this many identities (0 for all)",
+        )
+        parser.add_argument(
+            "--throttle",
+            type=float,
+            default=0.0,
+            help="idx-sync: seconds to pause after each identity, to keep a "
+            "long run from saturating the index",
         )
 
     def integrity(self):
@@ -246,11 +269,12 @@ class Command(SiteCommand):
         if remote:
             # for remote identities, live-ness of the linked posts decides
             # which piece docs may carry a stale post reference
-            live_post_ids = set(
-                Post.objects.filter(pk__in=[v[1] for v in latest_pps.values()])
-                .exclude(state__in=_DELETED_POST_STATES)
-                .values_list("pk", flat=True)
-            )
+            for chunk in batched({v[1] for v in latest_pps.values()}, _SYNC_PK_CHUNK):
+                live_post_ids.update(
+                    Post.objects.filter(pk__in=chunk)
+                    .exclude(state__in=_DELETED_POST_STATES)
+                    .values_list("pk", flat=True)
+                )
         for piece_id in piece_ids:
             post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
             if post_id is None:
@@ -303,6 +327,24 @@ class Command(SiteCommand):
             added += index.replace_docs(index.pieces_to_docs(pieces))
         return added, deleted
 
+    def apply_slice(self, identity_ids: list[int]) -> tuple[list[int], bool]:
+        """Cut the identity list down to --offset/--limit.
+
+        A full --remote run walks every remote identity in one pass and cannot
+        be narrowed with --owner, so slicing is the only way to spread it over
+        several shorter invocations. Returns the slice and whether one was asked
+        for.
+        """
+        if not self.offset and not self.limit:
+            return identity_ids, False
+        end = self.offset + self.limit if self.limit else None
+        sliced = identity_ids[self.offset : end]
+        self.stdout.write(
+            f"syncing identities {self.offset}..{self.offset + len(sliced)} "
+            f"of {len(identity_ids)}"
+        )
+        return sliced, True
+
     def idx_sync(self, index: JournalIndex, owners: list[int], remote: bool = False):
         identities = APIdentity.objects.filter(local=not remote)
         if owners:
@@ -329,13 +371,14 @@ class Command(SiteCommand):
                 self.stdout.write(
                     self.style.WARNING(
                         "failed to list indexed owners, stale docs of "
-                        "identities without pieces may be missed"
+                        "identities without pieces may be missed, and the "
+                        "purge of deactivated identities will be skipped"
                     )
                 )
             else:
                 candidate_ids |= indexed_owner_ids
             active_ids = []
-            for chunk in batched(sorted(candidate_ids), _SYNC_OWNER_CHUNK):
+            for chunk in batched(sorted(candidate_ids), _SYNC_PK_CHUNK):
                 active_ids.extend(
                     identities.filter(active_q, pk__in=chunk).values_list(
                         "pk", flat=True
@@ -346,15 +389,33 @@ class Command(SiteCommand):
             active_ids = list(
                 identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
             )
+        active_ids, sliced = self.apply_slice(active_ids)
         inactive_ids = list(
             identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
         )
         if indexed_owner_ids is not None:
             # purging owners holding no docs would be a no-op; skip them
             inactive_ids = [i for i in inactive_ids if i in indexed_owner_ids]
+        elif remote:
+            # without that list every deactivated remote identity gets its own
+            # delete-by-filter, nearly all matching nothing; that is a long
+            # stretch of pointless load on the index, so do not start it
+            inactive_ids = []
+        if sliced and inactive_ids:
+            # the purge is over the whole estate, not the slice; running it on
+            # each slice would just repeat the same work
+            self.stdout.write(
+                self.style.WARNING(
+                    "--offset/--limit given, skipping purge of deactivated "
+                    "identities; run once without a slice to purge"
+                )
+            )
+            inactive_ids = []
         added = deleted = errors = 0
         for identity_id in tqdm(active_ids, desc="Syncing active identities"):
             r = self.sync_identity_index(index, identity_id, remote)
+            if self.throttle:
+                sleep(self.throttle)
             if r is None:
                 errors += 1
                 continue
@@ -407,6 +468,9 @@ class Command(SiteCommand):
         self.fix = fix
         self.batch_size = int(batch_size)
         self.dry_run = kwargs.get("dry_run", False)
+        self.offset = kwargs.get("offset") or 0
+        self.limit = kwargs.get("limit") or 0
+        self.throttle = kwargs.get("throttle") or 0.0
         index = JournalIndex.instance()
 
         if owner and not remote:

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -1,6 +1,7 @@
 from argparse import RawTextHelpFormatter
 from datetime import timedelta
 from itertools import batched
+from math import isfinite
 from time import sleep
 
 from django.core.management.base import CommandError
@@ -388,10 +389,14 @@ class Command(SiteCommand):
             # identity instead would be pointlessly slow
             candidate_ids: set[int] = set()
             for cls in _INDEXABLE_PIECE_CLASSES:
+                pieces = cls.objects.filter(local=False)
+                if self.after_id:
+                    # narrow in the query, not after it: these are six distinct
+                    # scans over the piece tables, and a slice that enumerates
+                    # the whole estate first is not a shorter run
+                    pieces = pieces.filter(owner_id__gt=self.after_id)
                 candidate_ids.update(
-                    cls.objects.filter(local=False)
-                    .values_list("owner_id", flat=True)
-                    .distinct()
+                    pieces.values_list("owner_id", flat=True).distinct()
                 )
             if sliced:
                 # get_indexed_owner_ids() exports the whole collection, and it
@@ -420,31 +425,29 @@ class Command(SiteCommand):
                 else:
                     candidate_ids |= indexed_owner_ids
             active_ids = []
+            # candidate ids ascend, so a chunk is a range: once enough active
+            # ids are in hand the rest of the estate need not be resolved at
+            # all, which is what keeps a slice cheaper than a full run
             for chunk in batched(sorted(candidate_ids), _SYNC_PK_CHUNK):
                 active_ids.extend(
                     identities.filter(active_q, pk__in=chunk).values_list(
                         "pk", flat=True
                     )
                 )
+                if self.limit and len(active_ids) >= self.limit:
+                    break
             active_ids.sort()
         else:
-            active_ids = list(
-                identities.filter(active_q).order_by("pk").values_list("pk", flat=True)
-            )
+            local_q = identities.filter(active_q)
+            if self.after_id:
+                local_q = local_q.filter(pk__gt=self.after_id)
+            active_ids = list(local_q.order_by("pk").values_list("pk", flat=True))
         if sliced:
             active_ids = self.apply_cursor(active_ids)
-        inactive_ids = list(
-            identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
-        )
-        if indexed_owner_ids is not None:
-            # purging owners holding no docs would be a no-op; skip them
-            inactive_ids = [i for i in inactive_ids if i in indexed_owner_ids]
-        elif remote:
-            # without that list every deactivated remote identity gets its own
-            # delete-by-filter, nearly all matching nothing; that is a long
-            # stretch of pointless load on the index, so do not start it
-            inactive_ids = []
-        if sliced and inactive_ids:
+        # decide whether the purge runs before paying for its query: on a large
+        # federated instance enumerating every deactivated remote identity is a
+        # full scan, and both skip branches below would throw the result away
+        if sliced:
             # the purge is over the whole estate, not the slice; running it on
             # each slice would just repeat the same work
             self.stdout.write(
@@ -454,6 +457,18 @@ class Command(SiteCommand):
                 )
             )
             inactive_ids = []
+        elif remote and indexed_owner_ids is None:
+            # warned above: without that list every deactivated remote identity
+            # gets its own delete-by-filter, nearly all matching nothing; that
+            # is a long stretch of pointless load on the index
+            inactive_ids = []
+        else:
+            inactive_ids = list(
+                identities.exclude(active_q).order_by("pk").values_list("pk", flat=True)
+            )
+            if indexed_owner_ids is not None:
+                # purging owners holding no docs would be a no-op; skip them
+                inactive_ids = [i for i in inactive_ids if i in indexed_owner_ids]
         added = deleted = errors = 0
         # the resume cursor may only advance over an unbroken run of successes:
         # moving it past an identity that errored would drop that owner from
@@ -539,13 +554,14 @@ class Command(SiteCommand):
         self.after_id = kwargs.get("after_id") or 0
         self.limit = kwargs.get("limit") or 0
         self.throttle = kwargs.get("throttle") or 0.0
-        # a negative value here fails quietly and badly: --limit -1 drops the
-        # last identity of every slice, --throttle -1 raises from sleep() only
-        # after the first identity has already been synced
-        if self.after_id < 0 or self.limit < 0 or self.throttle < 0:
-            raise CommandError(
-                "--after-id, --limit and --throttle must not be negative"
-            )
+        # these fail quietly and badly rather than up front: --limit -1 drops
+        # the last identity of every slice, and --throttle -1/nan/inf raises
+        # from sleep() only once the first identity has already been synced,
+        # leaving a partial run with no resume cursor
+        if self.after_id < 0 or self.limit < 0:
+            raise CommandError("--after-id and --limit must not be negative")
+        if not isfinite(self.throttle) or self.throttle < 0:
+            raise CommandError("--throttle must be a non-negative finite number")
         index = JournalIndex.instance()
 
         if owner and not remote:

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -436,13 +436,21 @@ class Command(SiteCommand):
             )
             inactive_ids = []
         added = deleted = errors = 0
+        # the resume cursor may only advance over an unbroken run of successes:
+        # moving it past an identity that errored would drop that owner from
+        # every later slice, silently leaving it unreconciled for good
+        resume_id = self.after_id
+        contiguous = True
         for identity_id in tqdm(active_ids, desc="Syncing active identities"):
             r = self.sync_identity_index(index, identity_id, remote)
             if self.throttle:
                 sleep(self.throttle)
             if r is None:
                 errors += 1
+                contiguous = False
                 continue
+            if contiguous:
+                resume_id = identity_id
             a, d = r
             added += a
             deleted += d
@@ -467,8 +475,23 @@ class Command(SiteCommand):
                 f"{len(inactive_ids)} deactivated identities, {purged} docs {w}purged."
             )
         )
-        if sliced and active_ids:
-            self.stdout.write(f"resume the next slice with --after-id {active_ids[-1]}")
+        if sliced:
+            if resume_id > self.after_id:
+                self.stdout.write(
+                    f"resume the next slice with --after-id {resume_id}"
+                    + (
+                        ", which stops before the first identity that errored"
+                        if not contiguous
+                        else ""
+                    )
+                )
+            elif active_ids:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "no resume cursor: the first identity of this slice "
+                        "errored, so rerun the same --after-id"
+                    )
+                )
         if errors:
             self.stdout.write(
                 self.style.WARNING(f"{errors} identities skipped due to index errors.")

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from itertools import batched
 from time import sleep
 
+from django.core.management.base import CommandError
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.utils import timezone
@@ -298,7 +299,13 @@ class Command(SiteCommand):
 
         Docs already in the index are left as is (no deep comparison),
         except "stale-piece" docs which are always rewritten.
-        Returns (added, deleted), or None on index error.
+
+        Returns (added, deleted), or None if the index could not be read or a
+        write did not fully land. Callers must not treat an identity that
+        returned None as reconciled: advancing the resume cursor past it would
+        drop it from every later slice. A partly-written identity reports None
+        and so loses its counts from the totals, which is the cheaper wrong
+        answer next to a silently skipped owner.
         """
         expected = self.expected_index_docs(identity_id, remote)
         indexed = index.get_doc_ids_by_owner(identity_id)
@@ -313,21 +320,33 @@ class Command(SiteCommand):
         }
         if self.dry_run:
             return len(missing) + len(rewrite), len(extra)
+        # delete_docs()/replace_docs() log Typesense errors and return a count
+        # rather than raising, so a short count is the only signal that the
+        # write did not land
+        complete = True
         deleted = 0
         for chunk in batched(extra, _SYNC_DELETE_CHUNK):
-            deleted += index.delete_docs("id", chunk)
+            n = index.delete_docs("id", chunk)
+            deleted += n
+            complete = complete and n == len(chunk)
         added = 0
         post_ids = [expected[i][1] for i in missing if expected[i][0] == "post"]
         for chunk in batched(post_ids, self.batch_size):
             posts = Post.objects.filter(pk__in=chunk)
-            added += index.replace_docs(index.posts_to_docs(posts))
+            docs = [d for d in index.posts_to_docs(posts) if d]
+            n = index.replace_docs(docs)
+            added += n
+            complete = complete and n == len(docs)
         piece_ids = [
             expected[i][1] for i in missing | rewrite if expected[i][0] != "post"
         ]
         for chunk in batched(piece_ids, self.batch_size):
             pieces = Piece.objects.filter(pk__in=chunk)
-            added += index.replace_docs(index.pieces_to_docs(pieces))
-        return added, deleted
+            docs = [d for d in index.pieces_to_docs(pieces) if d]
+            n = index.replace_docs(docs)
+            added += n
+            complete = complete and n == len(docs)
+        return (added, deleted) if complete else None
 
     def apply_cursor(self, identity_ids: list[int]) -> list[int]:
         """Cut the ascending identity list down to --after-id/--limit.
@@ -520,6 +539,13 @@ class Command(SiteCommand):
         self.after_id = kwargs.get("after_id") or 0
         self.limit = kwargs.get("limit") or 0
         self.throttle = kwargs.get("throttle") or 0.0
+        # a negative value here fails quietly and badly: --limit -1 drops the
+        # last identity of every slice, --throttle -1 raises from sleep() only
+        # after the first identity has already been synced
+        if self.after_id < 0 or self.limit < 0 or self.throttle < 0:
+            raise CommandError(
+                "--after-id, --limit and --throttle must not be negative"
+            )
         index = JournalIndex.instance()
 
         if owner and not remote:

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -363,13 +363,13 @@ class Command(SiteCommand):
         positional offset would then shift left and step over an identity that
         was never synced. Deactivations between slices do the same.
         """
+        # both bounds are already pushed into the candidate queries; these are
+        # the backstop for the remote path, whose per-class limits can union to
+        # more than --limit
         ids = [i for i in identity_ids if i > self.after_id]
         if self.limit:
             ids = ids[: self.limit]
-        self.stdout.write(
-            f"syncing {len(ids)} of {len(identity_ids)} candidate identities "
-            f"with id > {self.after_id}"
-        )
+        self.stdout.write(f"syncing {len(ids)} identities with id > {self.after_id}")
         return ids
 
     def idx_sync(self, index: JournalIndex, owners: list[int], remote: bool = False):
@@ -381,6 +381,9 @@ class Command(SiteCommand):
             user__isnull=True, deleted__isnull=True
         )
         sliced = bool(self.after_id or self.limit)
+        # highest identity id this slice looked at, whether or not it was
+        # active; 0 when the slice stopped early and so did not clear a range
+        scanned_to = 0
         indexed_owner_ids: set[int] | None = None
         if remote:
             # candidates: remote identities owning indexable pieces, plus
@@ -395,9 +398,20 @@ class Command(SiteCommand):
                     # scans over the piece tables, and a slice that enumerates
                     # the whole estate first is not a shorter run
                     pieces = pieces.filter(owner_id__gt=self.after_id)
-                candidate_ids.update(
-                    pieces.values_list("owner_id", flat=True).distinct()
+                owner_ids = (
+                    pieces.values_list("owner_id", flat=True)
+                    .distinct()
+                    .order_by("owner_id")
                 )
+                if self.limit:
+                    # the globally smallest --limit owner ids are contained in
+                    # the per-class smallest --limit, so bounding each scan
+                    # keeps the union small without losing any of the ids this
+                    # slice is due. Otherwise every slice would materialise and
+                    # sort the whole remaining tail, which is quadratic over a
+                    # resumed run.
+                    owner_ids = owner_ids[: self.limit]
+                candidate_ids.update(owner_ids)
             if sliced:
                 # get_indexed_owner_ids() exports the whole collection, and it
                 # would run before the slice is applied -- so N slices would
@@ -436,12 +450,20 @@ class Command(SiteCommand):
                 )
                 if self.limit and len(active_ids) >= self.limit:
                     break
+            else:
+                # no early break, so every candidate was resolved: this is how
+                # far the slice actually looked, which lets the cursor move on
+                # even when none of them turned out to be active
+                scanned_to = max(candidate_ids) if candidate_ids else 0
             active_ids.sort()
         else:
             local_q = identities.filter(active_q)
             if self.after_id:
                 local_q = local_q.filter(pk__gt=self.after_id)
-            active_ids = list(local_q.order_by("pk").values_list("pk", flat=True))
+            local_q = local_q.order_by("pk").values_list("pk", flat=True)
+            if self.limit:
+                local_q = local_q[: self.limit]
+            active_ids = list(local_q)
         if sliced:
             active_ids = self.apply_cursor(active_ids)
         # decide whether the purge runs before paying for its query: on a large
@@ -511,13 +533,31 @@ class Command(SiteCommand):
         )
         if sliced:
             if resume_id > self.after_id:
-                self.stdout.write(
-                    f"resume the next slice with --after-id {resume_id}"
-                    + (
-                        ", which stops before the first identity that errored"
-                        if not contiguous
-                        else ""
+                note = (
+                    ", which stops before the first identity that errored"
+                    if not contiguous
+                    else ""
+                )
+                if self.dry_run:
+                    # nothing was written, so this cursor only continues the
+                    # preview; a real run started from it would leave every
+                    # identity previewed here unreconciled
+                    self.stdout.write(
+                        f"continue previewing with --after-id {resume_id}{note}; "
+                        f"a real run must still start from --after-id "
+                        f"{self.after_id}, nothing was written"
                     )
+                else:
+                    self.stdout.write(
+                        f"resume the next slice with --after-id {resume_id}{note}"
+                    )
+            elif not active_ids and scanned_to > self.after_id:
+                # nothing was attempted, so nothing errored: the slice resolved
+                # only deactivated identities and the operator would otherwise
+                # be stuck rescanning the same range forever
+                self.stdout.write(
+                    f"no active identity in this slice; "
+                    f"resume with --after-id {scanned_to}"
                 )
             elif active_ids:
                 self.stdout.write(

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -326,7 +326,7 @@ class Command(SiteCommand):
         complete = True
         deleted = 0
         for chunk in batched(extra, _SYNC_DELETE_CHUNK):
-            n = index.delete_docs("id", chunk)
+            n = index.delete_docs("id", chunk, bulk=True)
             deleted += n
             complete = complete and n == len(chunk)
         added = 0
@@ -485,7 +485,7 @@ class Command(SiteCommand):
                     purged += len(ids)
         else:
             for chunk in batched(inactive_ids, 100):
-                purged += index.delete_by_owner(chunk)
+                purged += index.delete_by_owner(chunk, bulk=True)
         w = "would be " if self.dry_run else ""
         self.stdout.write(
             self.style.SUCCESS(
@@ -598,7 +598,7 @@ class Command(SiteCommand):
 
             case "idx-delete":
                 if owners:
-                    c = index.delete_by_owner(owners)
+                    c = index.delete_by_owner(owners, bulk=True)
                 else:
                     c = index.delete_all()
                 self.stdout.write(self.style.SUCCESS(f"deleted {c} documents."))

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -460,19 +460,27 @@ class JournalIndex(Index):
     def get_doc_ids_by_owner(self, owner_id: int) -> set[str] | None:
         """Return ids of all docs owned by the identity, or None on error."""
         try:
-            r = self.write_collection.documents.export(
-                {"filter_by": f"owner_id:{owner_id}", "include_fields": "id"}
-            )
-            return {json.loads(line)["id"] for line in r.splitlines() if line}
+            return {
+                json.loads(line)["id"]
+                for line in self.export_docs(
+                    {"filter_by": f"owner_id:{owner_id}", "include_fields": "id"}
+                )
+            }
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return None
 
     def get_indexed_owner_ids(self) -> set[int] | None:
-        """Return distinct owner_id over all docs, or None on error."""
+        """Return distinct owner_id over all docs, or None on error.
+
+        This exports every doc in the collection, so it is by far the heaviest
+        call in the index; keep it to one-off maintenance, never a request path.
+        """
         try:
-            r = self.write_collection.documents.export({"include_fields": "owner_id"})
-            return {json.loads(line)["owner_id"] for line in r.splitlines() if line}
+            return {
+                json.loads(line)["owner_id"]
+                for line in self.export_docs({"include_fields": "owner_id"})
+            }
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
             return None

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -12,7 +12,7 @@ from loguru import logger
 from catalog.models import Item, item_categories
 from common.models import int_, uniq
 from common.search import Index, QueryParser, SearchResult
-from common.search.index import TYPESENSE_ERRORS
+from common.search.index import FULL_EXPORT_TIMEOUT_SECONDS, TYPESENSE_ERRORS
 from takahe.models import Identity as TakaheIdentity
 from takahe.models import Post
 from takahe.utils import Takahe
@@ -479,7 +479,9 @@ class JournalIndex(Index):
         try:
             return {
                 json.loads(line)["owner_id"]
-                for line in self.export_docs({"include_fields": "owner_id"})
+                for line in self.export_docs(
+                    {"include_fields": "owner_id"}, FULL_EXPORT_TIMEOUT_SECONDS
+                )
             }
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -12,7 +12,7 @@ from loguru import logger
 from catalog.models import Item, item_categories
 from common.models import int_, uniq
 from common.search import Index, QueryParser, SearchResult
-from common.search.index import FULL_EXPORT_TIMEOUT_SECONDS, TYPESENSE_ERRORS
+from common.search.index import LONG_OP_TIMEOUT_SECONDS, TYPESENSE_ERRORS
 from takahe.models import Identity as TakaheIdentity
 from takahe.models import Post
 from takahe.utils import Takahe
@@ -480,7 +480,7 @@ class JournalIndex(Index):
             return {
                 json.loads(line)["owner_id"]
                 for line in self.export_docs(
-                    {"include_fields": "owner_id"}, FULL_EXPORT_TIMEOUT_SECONDS
+                    {"include_fields": "owner_id"}, LONG_OP_TIMEOUT_SECONDS
                 )
             }
         except TYPESENSE_ERRORS as e:

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -455,7 +455,7 @@ class JournalIndex(Index):
         return [cls.post_to_doc(p) for p in posts]
 
     def delete_all(self):
-        return self.delete_docs("owner_id", ">0")
+        return self.delete_docs("owner_id", ">0", bulk=True)
 
     def get_doc_ids_by_owner(self, owner_id: int) -> set[str] | None:
         """Return ids of all docs owned by the identity, or None on error."""
@@ -487,8 +487,8 @@ class JournalIndex(Index):
             logger.error(f"Typesense: error {e}")
             return None
 
-    def delete_by_owner(self, owner_ids):
-        return self.delete_docs("owner_id", owner_ids)
+    def delete_by_owner(self, owner_ids, bulk: bool = False):
+        return self.delete_docs("owner_id", owner_ids, bulk=bulk)
 
     def delete_by_piece(self, piece_ids):
         return self.delete_docs("piece_id", piece_ids)

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -6,6 +6,7 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 
 from catalog.models import Edition
+from common.search.index import TYPESENSE_ERRORS
 from journal.management.commands import journal as journal_command
 from journal.models import Comment, Mark, Review, ShelfType
 from journal.search import JournalIndex, JournalQueryParser
@@ -182,6 +183,14 @@ class TestIdxSync:
         output = self.run_sync("--limit", "2")
         assert "no resume cursor" in output
         assert "2 identities skipped due to index errors" in output
+
+    def test_export_docs_raises_on_error_response(self):
+        # export_docs is a generator, so the request is only made once it is
+        # iterated; a rejected export must surface as a TYPESENSE_ERRORS member
+        # so get_doc_ids_by_owner() can turn it into None rather than an
+        # empty-and-therefore-"delete-everything" result
+        with pytest.raises(TYPESENSE_ERRORS):
+            list(self.index.export_docs({"filter_by": "no_such_field:1"}))
 
     def test_negative_slice_values_rejected(self):
         for arg in ("--limit", "--after-id", "--throttle"):

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -147,6 +147,31 @@ class TestIdxSync:
         self.run_sync("--after-id", str(first), "--limit", "1")
         assert self.doc_ids(second)
 
+    def test_resume_cursor_stops_before_failed_identity(self, monkeypatch):
+        # advancing the cursor past an identity that errored would drop that
+        # owner from every later slice and leave it unreconciled for good
+        first, second = sorted([self.identity1.pk, self.identity2.pk])
+        monkeypatch.setattr(
+            JournalIndex,
+            "get_doc_ids_by_owner",
+            lambda self, owner_id: None if owner_id == first else set(),
+        )
+        output = self.run_sync("--limit", "2")
+        assert f"--after-id {first}" not in output
+        assert "no resume cursor" in output
+        assert "1 identities skipped due to index errors" in output
+
+    def test_resume_cursor_reports_partial_progress(self, monkeypatch):
+        first, second = sorted([self.identity1.pk, self.identity2.pk])
+        monkeypatch.setattr(
+            JournalIndex,
+            "get_doc_ids_by_owner",
+            lambda self, owner_id: None if owner_id == second else set(),
+        )
+        output = self.run_sync("--limit", "2")
+        assert f"--after-id {first}" in output
+        assert "stops before the first identity that errored" in output
+
     def test_slice_skips_purge(self):
         self.user2.is_active = False
         self.user2.save()

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -197,6 +197,13 @@ class TestIdxSync:
             with pytest.raises(CommandError):
                 self.run_sync(arg, "-1")
 
+    def test_non_finite_throttle_rejected(self):
+        # argparse takes these as floats and they pass a bare < 0 check, then
+        # blow up inside sleep() after the first identity has already synced
+        for value in ("nan", "inf"):
+            with pytest.raises(CommandError):
+                self.run_sync("--throttle", value)
+
     def test_slice_skips_purge(self):
         self.user2.is_active = False
         self.user2.save()

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -2,6 +2,7 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.utils import timezone
 
 from catalog.models import Edition
@@ -171,6 +172,21 @@ class TestIdxSync:
         output = self.run_sync("--limit", "2")
         assert f"--after-id {first}" in output
         assert "stops before the first identity that errored" in output
+
+    def test_failed_write_blocks_resume_cursor(self, monkeypatch):
+        # replace_docs() logs Typesense errors and returns a count, so a short
+        # count is the only sign the write did not land; the cursor must not
+        # move past an owner whose docs never made it in
+        self.index.delete_by_owner([self.identity1.pk, self.identity2.pk])
+        monkeypatch.setattr(JournalIndex, "replace_docs", lambda self, docs: 0)
+        output = self.run_sync("--limit", "2")
+        assert "no resume cursor" in output
+        assert "2 identities skipped due to index errors" in output
+
+    def test_negative_slice_values_rejected(self):
+        for arg in ("--limit", "--after-id", "--throttle"):
+            with pytest.raises(CommandError):
+                self.run_sync(arg, "-1")
 
     def test_slice_skips_purge(self):
         self.user2.is_active = False

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -127,7 +127,7 @@ class TestIdxSync:
         first, second = sorted([self.identity1.pk, self.identity2.pk])
         self.index.delete_by_owner([first, second])
         output = self.run_sync("--limit", "1")
-        assert "syncing 1 of 2 candidate identities with id > 0" in output
+        assert "syncing 1 identities with id > 0" in output
         assert f"--after-id {first}" in output
         assert self.doc_ids(first)
         assert self.doc_ids(second) == set()
@@ -196,6 +196,13 @@ class TestIdxSync:
         for arg in ("--limit", "--after-id", "--throttle"):
             with pytest.raises(CommandError):
                 self.run_sync(arg, "-1")
+
+    def test_dry_run_cursor_is_marked_preview_only(self):
+        # a dry run treats every identity as successful, so the cursor it
+        # prints must not be usable to skip ahead in a real run
+        output = self.run_sync("--dry-run", "--limit", "1")
+        assert "continue previewing with --after-id" in output
+        assert "a real run must still start from --after-id 0" in output
 
     def test_non_finite_throttle_rejected(self):
         # argparse takes these as floats and they pass a bare < 0 check, then

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from catalog.models import Edition
+from journal.management.commands import journal as journal_command
 from journal.models import Comment, Mark, Review, ShelfType
 from journal.search import JournalIndex, JournalQueryParser
 from takahe.models import Domain, Post
@@ -120,6 +121,32 @@ class TestIdxSync:
         assert self.doc_ids(self.identity1.pk)
         assert self.doc_ids(self.identity2.pk) == set()
 
+    def test_offset_limit_slices_run(self):
+        first, second = sorted([self.identity1.pk, self.identity2.pk])
+        self.index.delete_by_owner([first, second])
+        output = self.run_sync("--limit", "1")
+        assert "syncing identities 0..1 of 2" in output
+        assert self.doc_ids(first)
+        assert self.doc_ids(second) == set()
+        self.run_sync("--offset", "1", "--limit", "1")
+        assert self.doc_ids(second)
+
+    def test_slice_skips_purge(self):
+        self.user2.is_active = False
+        self.user2.save()
+        before = self.doc_ids(self.identity2.pk)
+        assert before
+        output = self.run_sync("--limit", "1")
+        assert "skipping purge of deactivated identities" in output
+        # the purge covers the whole estate, so a sliced run must not start it
+        assert self.doc_ids(self.identity2.pk) == before
+
+    def test_throttle_pauses_between_identities(self, monkeypatch):
+        pauses = []
+        monkeypatch.setattr(journal_command, "sleep", pauses.append)
+        self.run_sync("--throttle", "0.01")
+        assert pauses == [0.01, 0.01]
+
 
 def _make_remote_identity(username: str, domain_name: str = "remote.example"):
     domain, _ = Domain.objects.get_or_create(
@@ -220,6 +247,20 @@ class TestIdxSyncRemote:
     def test_local_sync_leaves_remote_docs(self):
         self.run_sync()
         assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+
+    def test_purge_skipped_when_indexed_owners_unavailable(self, monkeypatch):
+        before = self.doc_ids(self.owner.pk)
+        assert before
+        self.owner.deleted = timezone.now()
+        self.owner.save()
+        monkeypatch.setattr(JournalIndex, "get_indexed_owner_ids", lambda self: None)
+        output = self.run_sync("--remote")
+        assert "purge of deactivated identities will be skipped" in output
+        assert "0 deactivated identities" in output
+        # without the indexed-owner list the purge would issue one
+        # delete-by-filter per deactivated remote identity, nearly all of them
+        # matching nothing; leaving the docs is the cheaper wrong answer
+        assert self.doc_ids(self.owner.pk) == before
 
     def test_remote_dry_run(self):
         self.index.delete_by_owner([self.owner.pk])

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -280,6 +280,57 @@ class TestIdxSyncRemote:
         assert ids is not None
         return ids
 
+    def _make_remote_piece(self, owner, uri: str, review: bool):
+        obj = {
+            "id": uri,
+            "type": "Review" if review else "Comment",
+            "content": "body",
+            "published": "2026-01-01T00:00:00+00:00",
+        }
+        if review:
+            obj["name"] = "title"
+            obj["mediaType"] = "text/markdown"
+        post = Post.objects.create(
+            author_id=owner.pk,
+            local=False,
+            object_uri=uri,
+            content=obj["content"],
+            type="Article" if review else "Note",
+            type_data={"object": {"relatedWith": [obj]}},
+            visibility=Post.Visibilities.public,
+            state="fanned_out",
+        )
+        cls = Review if review else Comment
+        piece = cls.update_by_ap_object(owner, self.book, obj, post)
+        assert piece is not None
+        return piece
+
+    def test_sliced_cursor_does_not_skip_owner_capped_out_of_a_class(self):
+        # the per-class --limit cap is applied before active_q, so a class
+        # whose first --limit owners are deactivated can hide a lower active
+        # owner. Syncing a higher active owner from another class and taking
+        # it as the cursor would strand the hidden one for good.
+        deactivated = self.owner  # lowest id, owns a Review
+        deactivated.deleted = timezone.now()
+        deactivated.save()
+        mid = _make_remote_identity("midreader")
+        self._make_remote_piece(mid, "https://remote.example/review/2", review=True)
+        high = _make_remote_identity("highreader")
+        self._make_remote_piece(high, "https://remote.example/comment/2", review=False)
+        assert deactivated.pk < mid.pk < high.pk
+        self.index.delete_all()
+
+        output = self.run_sync("--remote", "--limit", "1")
+
+        # Review's first (and only, under the cap) owner is the deactivated
+        # one, so nothing above it is proven enumerated: the cursor must stop
+        # there rather than jump to high and skip mid
+        assert f"--after-id {deactivated.pk}" in output
+        assert self.doc_ids(high.pk) == set()
+        # and resuming from that cursor still reaches mid
+        self.run_sync("--remote", "--after-id", str(deactivated.pk), "--limit", "1")
+        assert self.doc_ids(mid.pk)
+
     def test_add_missing_remote_docs(self):
         assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
         self.index.delete_by_owner([self.owner.pk])

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -121,14 +121,30 @@ class TestIdxSync:
         assert self.doc_ids(self.identity1.pk)
         assert self.doc_ids(self.identity2.pk) == set()
 
-    def test_offset_limit_slices_run(self):
+    def test_after_id_limit_slices_run(self):
         first, second = sorted([self.identity1.pk, self.identity2.pk])
         self.index.delete_by_owner([first, second])
         output = self.run_sync("--limit", "1")
-        assert "syncing identities 0..1 of 2" in output
+        assert "syncing 1 of 2 candidate identities with id > 0" in output
+        assert f"--after-id {first}" in output
         assert self.doc_ids(first)
         assert self.doc_ids(second) == set()
-        self.run_sync("--offset", "1", "--limit", "1")
+        self.run_sync("--after-id", str(first), "--limit", "1")
+        assert self.doc_ids(second)
+
+    def test_cursor_survives_shrinking_candidate_list(self):
+        # the cursor is an id, not a position, so an identity dropping out of
+        # the candidate list between slices must not shift the next slice past
+        # an identity that was never synced
+        first, second = sorted([self.identity1.pk, self.identity2.pk])
+        self.index.delete_by_owner([first, second])
+        self.run_sync("--limit", "1")
+        user = User.objects.get(identity=first)
+        user.is_active = False
+        user.save()
+        # first is gone from the candidate list now; a positional offset of 1
+        # would land past second and skip it
+        self.run_sync("--after-id", str(first), "--limit", "1")
         assert self.doc_ids(second)
 
     def test_slice_skips_purge(self):
@@ -247,6 +263,23 @@ class TestIdxSyncRemote:
     def test_local_sync_leaves_remote_docs(self):
         self.run_sync()
         assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+
+    def test_sliced_remote_run_skips_full_collection_scan(self, monkeypatch):
+        # the full scan runs before the slice would be applied, so paying it
+        # per slice would multiply the load slicing exists to spread out
+        calls = []
+        original = JournalIndex.get_indexed_owner_ids
+
+        def counted(self):
+            calls.append(1)
+            return original(self)
+
+        monkeypatch.setattr(JournalIndex, "get_indexed_owner_ids", counted)
+        output = self.run_sync("--remote", "--limit", "1")
+        assert "skipping the full-collection scan" in output
+        assert calls == []
+        self.run_sync("--remote")
+        assert calls == [1]
 
     def test_purge_skipped_when_indexed_owners_unavailable(self, monkeypatch):
         before = self.doc_ids(self.owner.pk)


### PR DESCRIPTION
`journal idx-sync --remote` walks every remote identity in one pass and leans on Typesense far harder than the local path does. This started as a review of what in it could stall the index, and turned into fixing what that review found.

## What could stall Typesense

**The full-collection export.** `get_indexed_owner_ids()` exported every doc in the collection through the shared client. That client applies `connection_timeout_seconds` — sized for search, a few seconds — as httpx's read timeout on every request including this one, and the write client retries twice with no pause (typesense-python parses `retry_interval_seconds` and then never sleeps on it). One stall therefore re-ran the entire scan up to three times back to back, each abandoned attempt still churning on the server, and buffered the whole response into a single string. Export now streams over a request with its own long read timeout, a short connect timeout, and no retry.

**A safeguard that needed the riskiest call to succeed.** When that export failed, the check that skips deactivated identities holding no docs was silently disabled, degrading the purge into one delete-by-filter per deactivated remote identity — nearly all matching nothing. The purge is now skipped instead of running at full scale.

**Delete-by-filter with no `batch_size`.** Typesense's docs note a larger batch "will impact performance of other operations running on the server", and deletes on large collections are [documented as pathologically slow](https://github.com/typesense/typesense/issues/515) — 150k documents taking hours, a single delete-by-id blocking 20s meanwhile. Bulk deletes now pass an explicit batch size and run on a long read timeout with no retry, since a delete that timed out is probably still running and reissuing it piles a second copy onto a struggling node.

**No way to run it in pieces.** `--remote` could not be narrowed with `--owner`, so it was the whole estate or nothing. Added `--after-id`/`--limit` slicing and `--throttle` pacing.

## Slicing, and keeping it honest

Slicing turned out to be the hard part, and most of the work here is making it impossible to silently skip an identity:

- The cursor is an **identity id, not a list position**. The candidate list is recomputed per invocation and the run itself changes it — syncing an owner whose docs were all stale leaves it with neither docs nor pieces, so it drops out of the next run's candidates and a positional offset would step over an identity that was never synced.
- The cursor **only advances over an unbroken run of successes**. `delete_docs()`/`replace_docs()` log Typesense errors and return a count rather than raising, so a short count is the only signal a write did not land; an identity whose writes were rejected is reported as failed rather than reconciled.
- Both bounds are **pushed into the SQL**, not applied afterwards — otherwise each slice re-materialised and sorted the whole remaining tail, which is quadratic across a resumed run.
- Bounding the per-class scans by `--limit` then created a trap: the cap runs *before* the active-identity filter, so a class whose first N owners are all deactivated hides a lower active owner, and syncing a higher active owner from another class would take that id as the cursor and strand the hidden one for good. The command now tracks a **proven scan frontier** — the lowest last-returned id among classes that hit their cap — and only advances the cursor over ids the scan actually accounted for.
- A sliced run skips the full-collection scan and the purge (paying either per slice would multiply the load slicing exists to spread out) and says so.
- `--dry-run` labels its cursor as preview-only; a dry run counts every identity as successful, so feeding that cursor to a real run would skip every owner the preview covered.

## Scope note

`delete_docs()` also backs `Piece.update_index()`/`delete_index()` and the catalog item deletes, which run while a user is saving a mark. The long-timeout, no-retry path is therefore **opt-in via `bulk=True`** — used by whole-collection wipes, per-owner purges and the idx-sync sweep. Everything else keeps the shared write client with its short timeout and its retries: those match a doc or two, so they want fast failure and recovery rather than a ten-minute ceiling.

Also chunked the one unbounded `pk__in`, which could exceed postgres's parameter limit and crash a long run partway through.

## Not addressed

Two things surfaced during review and deliberately left out of scope:

- `journal_piece.local` has no index, so the remote candidate scan does near-full scans across six polymorphic subclass tables. Fixing it needs a migration on a large table.
- `Post.piece` and `to_indexable_doc()` are N+1-heavy. Pre-existing and shared with `idx-rebuild`.

## Testing

`neodb/tests/journal/test_idx_sync.py` grows from 14 to 28 tests, covering the cursor semantics (including that it survives a shrinking candidate list, stops before a failed identity, and does not skip an owner capped out of a class), the purge-skip paths, write-failure handling, argument validation, and the export error path. The frontier regression test was verified to fail with the fix disabled.

Full suite passes (2039). Three failures in `tests/mastodon/test_lexicons.py` are pre-existing and environmental — `compose.yml` does not mount `docs/` into the dev container, so `/docs/lexicons/publish.py` is not importable; nothing in this diff is on that path. `uv run pre-commit run -a` is clean, including `ty`.
