### PR TITLE
fix(nginx): serve takahe uploads from disk so they can be cached

### DIFF
--- a/misc/nginx.conf.d/neodb-dev.conf
+++ b/misc/nginx.conf.d/neodb-dev.conf
@@ -41,7 +41,17 @@ server {
     location ~* ^/media/(album|book|game|item|movie)/(.+)$ {
         return 302 https://$host/m/$1/$2;
     }
-    # Proxies media and remote media with caching
+    # Takahe uploads; filenames are random per upload, so cache them forever
+    location ~* ^/media/ {
+        root /www;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        try_files $uri @takahe_media;
+    }
+    # Fallback for remote media backends
+    location @takahe_media {
+        proxy_pass http://takahe;
+    }
+    # Proxies remote media with caching
     location ~* ^/(media|proxy) {
         # Cache media and proxied resources
         proxy_cache takahe;

--- a/misc/nginx.conf.d/neodb.conf
+++ b/misc/nginx.conf.d/neodb.conf
@@ -54,7 +54,17 @@ server {
     location ~* ^/media/(album|book|game|item|movie)/(.+)$ {
         return 302 https://$host/m/$1/$2;
     }
-    # Proxies media and remote media with caching
+    # Takahe uploads; filenames are random per upload, so cache them forever
+    location ~* ^/media/ {
+        root /www;
+        add_header Cache-Control "public, max-age=604800, immutable";
+        try_files $uri @takahe_media;
+    }
+    # Fallback for remote media backends
+    location @takahe_media {
+        proxy_pass http://takahe;
+    }
+    # Proxies remote media with caching
     location ~* ^/(media|proxy) {
         # Cache media and proxied resources
         proxy_cache takahe;


### PR DESCRIPTION
## Problem

Local uploads served under `/media/` are never cached, anywhere. Every avatar is refetched in full on every page load:

```
$ curl -sI https://<instance>/media/profile_images/2025/9/9/<name>.PNG
cache-control: no-store, max-age=0
vary: Cookie, origin
x-cache: MISS
cf-cache-status: BYPASS
content-length: 631224
```

The chain:

1. `misc/nginx.conf.d/neodb.conf` routes `/media/*` to takahe via `location ~* ^/(media|proxy)` rather than serving it from disk.
2. takahe serves the file through `core.custom_static_serve` (`django.views.static.serve`), which sets `Last-Modified` but no `Cache-Control`.
3. `core.middleware.HeadersMiddleware` then stamps `Cache-Control: no-store, max-age=0` on any response lacking the header. That is a reasonable default for logged-in HTML, but `/media/` inherits it too.

`no-store` defeats three cache layers at once: the browser, nginx's own `proxy_cache takahe` on that location (nginx will not store a `no-store` response, hence `X-Cache: MISS` forever), and any CDN in front.

There is no revalidation path either. A conditional request carrying the exact `Last-Modified` still returns a full `200`, because nginx clears `If-Modified-Since` / `If-None-Match` on locations with `proxy_cache` enabled, so takahe never sees the condition.

Separately, `ConfigLoadingMiddleware` touches `request.user` and `request.identity`, which trips `SessionMiddleware` into adding `Vary: Cookie`. That alone would keep the response out of shared caches even with a correct `Cache-Control`, and it means every avatar hit runs session, identity and config queries.

For contrast, `/static/`, `/s/` and `/m/` are already served straight off disk with `public, max-age=604800, immutable`. Local profile images, headers, attachments and custom emoji are the only image classes that go through Django.

## Fix

Serve `/media/` from disk in nginx, exactly as `/m/` already is. The takahe media volume is already mounted into the nginx container at `/www/media` (`compose.yml`), so this is config-only.

```nginx
location ~* ^/media/ {
    root /www;
    add_header Cache-Control "public, max-age=604800, immutable";
    try_files $uri @takahe_media;
}
location @takahe_media {
    proxy_pass http://takahe;
}
```

It is placed between the legacy `/media/<category>/` redirect and the `^/(media|proxy)` block so regex ordering preserves both. Unknown paths fall back to takahe, so setups on an S3/GCS media backend are unaffected.

`immutable` is safe here: `core/uploads.py:upload_namer` names uploads with `secrets.token_urlsafe(20)`, so a replaced image always gets a brand-new URL.

## Verification

`nginx -t` passes on both configs. Exercised against a local dev cluster:

| Case | Before | After |
| --- | --- | --- |
| Avatar PNG | `no-store, max-age=0` | `public, max-age=604800, immutable`, ETag, no `Vary: Cookie` |
| Conditional GET | `200` with full body | `304` |
| WebP avatar | n/a | `Content-Type: image/webp` (nginx 1.26.3 ships it in `mime.types`) |
| `/media/book/...` legacy path | `302` to `/m/` | unchanged |
| Missing file | takahe `404` | falls back to takahe, still `404` |
| `/proxy/` remote avatars | takahe, `public, max-age=3600` | unchanged |
| Range request | n/a | `206 Partial Content` |

Django is now out of the path for local uploads, which also removes the per-request session/identity/config queries each avatar was triggering.
