### PR TITLE
fix(search): drop post_id range filter from item post queries

### DIFF
--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -172,9 +172,9 @@ def list_posts_for_item(
     viewer = request.user.identity if request.user.is_authenticated else None
     query.filter_by_viewer(viewer)
     query.filter("item_id", item.pk)
-    # count only docs carrying a post, so `count` matches what `data`
-    # can actually return
-    query.filter("post_id", ">0")
+    # NB: no `post_id:>0` filter to align `count` with `data`: post_id has no
+    # range index and millions of distinct values, so it scans the whole
+    # numeric tree and saturates Typesense (NEODB-SOCIAL-7NF)
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     result = {
@@ -215,8 +215,6 @@ def timeline_link(
     query = JournalQueryParser("", page_size=limit)
     query.filter_by_viewer(request.user.identity)
     query.filter("item_id", item.pk)
-    # post-less docs would hydrate to nothing and waste `limit` slots
-    query.filter("post_id", ">0")
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     return [

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -131,7 +131,6 @@ class TestRemotePieceIndex:
         q = JournalQueryParser(f"type:{piece_type}", 1)
         q.filter_by_viewer(None)
         q.filter("item_id", self.book.pk)
-        q.filter("post_id", ">0")
         q.sort(["created:desc"])
         return self.index.search(q)
 
@@ -280,8 +279,9 @@ class TestRemotePieceIndex:
 
 @pytest.mark.django_db(databases="__all__")
 class TestLocalPostDeleted:
-    """A local mark whose post is deleted from a Mastodon client is kept,
-    but its index doc must stop counting toward item post listings."""
+    """A local mark whose post is deleted from a Mastodon client is kept and
+    stays searchable by its owner, but its index doc must stop referencing the
+    dead post so item post listings never try to return it."""
 
     @pytest.fixture(autouse=True)
     def setup_data(self):
@@ -291,7 +291,7 @@ class TestLocalPostDeleted:
         self.user = User.register(email="pd@y.com", username="pduser")
         self.identity = self.user.identity
 
-    def test_deleted_post_stops_counting(self):
+    def test_deleted_post_is_dropped_from_doc(self):
         from takahe.ap_handlers import post_deleted
 
         mark = Mark(self.identity, self.book)
@@ -306,10 +306,9 @@ class TestLocalPostDeleted:
         q = JournalQueryParser("fine")
         q.filter_by_owner(self.identity)
         assert self.index.search(q).total == 1
-        # but item post listings no longer count it
+        # item post listings return no post for it, but still count the doc
         q = JournalQueryParser("type:mark", 1)
         q.filter_by_viewer(None)
         q.filter("item_id", self.book.pk)
-        q.filter("post_id", ">0")
         r = self.index.search(q)
-        assert r.total == len(list(r.posts)) == 0
+        assert len(list(r.posts)) == 0


### PR DESCRIPTION
## Problem

Sentry [NEODB-SOCIAL-7NF](https://neodb.sentry.io/issues/NEODB-SOCIAL-7NF) (`Typesense: error timed out`) went from a couple hundred events per release to **9,976 in the last 24 hours**, all on `0.17.5-260d21b-20260808204851`.

By transaction over the last 14 days:

| transaction | count |
| --- | --- |
| `/api/item/{item_uuid}/posts/` | 8052 |
| `/mark/{item_uuid}` | 1344 |
| `takahe.ap_handlers.post_fetched` | 218 |
| background index writes, misc | rest |

The write-side timeouts are collateral: once Typesense is saturated by the read path, `replace_docs` / `delete_docs` in mark saves and AP handlers blow the 4s client timeout too.

## Cause

c364195b added `query.filter("post_id", ">0")` to `/api/item/{uuid}/posts/` and `/v1/timelines/link` so `count` would match what `data` can hydrate.

`post_id` is declared `int64[]` with no `range_index` and has roughly one distinct value per post, so `post_id:>0` makes Typesense walk the entire numeric tree and OR together millions of posting lists — maximum work for zero selectivity, since it matches nearly every document anyway. `/api/item/{uuid}/posts/` is the hottest search path on the instance (crawlers on item pages), so this saturates the server.

## Fix

Drop the filter from both endpoints. Post-less docs are rare, `idx-sync` (same commit) repairs them properly, and an occasionally optimistic `count` is far cheaper than the scan.

Not done here, and deliberately:

- **Raising `connection_timeout_seconds` again** (already 2 → 4 in 800845b7) would only hold gunicorn workers longer against the 30s worker timeout and deepen the pileup.
- **`range_index: true` on `post_id`** needs a schema update plus reindex and would not help much — the filter still matches nearly every document. If the `count`/`data` invariant is worth keeping, a low-cardinality marker (a `has_post` bool) is the shape that can actually be indexed cheaply, since cost here tracks distinct values rather than documents.

## Tests

`tests/journal/test_search.py` mirrored the API query, so the filter is dropped there too. `TestLocalPostDeleted` now asserts what the reverted behaviour guarantees — the doc stops referencing the dead post, so the listing returns no post for it — instead of asserting a `total` that the filter used to suppress.

Full suite green on the fork: neodb 2060 passed, takahe 500 passed.

## Follow-up, not in this PR

On the same path, `filter_by_viewer` builds `owner_id:!=[...]` from every identity with `restriction > 0` for anonymous viewers (`neodb/journal/search/index.py:186`). Large negation lists are expensive in Typesense and that list only grows with moderation actions — worth checking its size on neodb.social.
