### PR TITLE
fix(federation): take the FeatureRequest requester from the delivery signature

### DIFF
--- a/takahe/tests/users/models/test_feature_authorization.py
+++ b/takahe/tests/users/models/test_feature_authorization.py
@@ -1,8 +1,14 @@
+import base64
 import json
+from email.utils import format_datetime
 
 import pytest
 from core.ld import canonicalise
+from core.signatures import HttpSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from django.test import Client
+from django.utils import timezone
 
 from users.models import (
     FeatureAuthorization,
@@ -23,14 +29,21 @@ def _enable_federation(settings):
     settings.SETUP.NO_FEDERATION = original
 
 
-def _feature_request(actor_uri: str, object_uri: str) -> dict:
-    return {
+def _feature_request(object_uri: str, actor_uri: str | None = None) -> dict:
+    """
+    A FeatureRequest as it arrives: Mastodon's FeatureRequestSerializer emits no
+    `actor` at all, so `actor_uri` here stands for what the inbox fills in from
+    the signature before handing the message on.
+    """
+    request = {
         "type": "FeatureRequest",
         "id": REQUEST_URI,
-        "actor": actor_uri,
         "object": object_uri,
         "instrument": COLLECTION_URI,
     }
+    if actor_uri:
+        request["actor"] = actor_uri
+    return request
 
 
 ### Actor policy ###
@@ -182,7 +195,7 @@ def test_handle_feature_request_accepts_when_discoverable(
     monkeypatch.setattr(Identity, "signed_request", fake_signed_request)
 
     Identity.handle_feature_request_ap(
-        _feature_request(remote_identity.actor_uri, identity.actor_uri)
+        _feature_request(identity.actor_uri, actor_uri=remote_identity.actor_uri)
     )
 
     auth = FeatureAuthorization.objects.get(identity=identity)
@@ -218,7 +231,7 @@ def test_handle_feature_request_rejects_when_not_discoverable(
     monkeypatch.setattr(Identity, "signed_request", fake_signed_request)
 
     Identity.handle_feature_request_ap(
-        _feature_request(remote_identity.actor_uri, identity.actor_uri)
+        _feature_request(identity.actor_uri, actor_uri=remote_identity.actor_uri)
     )
 
     assert not FeatureAuthorization.objects.filter(identity=identity).exists()
@@ -239,7 +252,9 @@ def test_handle_feature_request_ignores_remote_target(
     )
 
     Identity.handle_feature_request_ap(
-        _feature_request(remote_identity2.actor_uri, remote_identity.actor_uri)
+        _feature_request(
+            remote_identity.actor_uri, actor_uri=remote_identity2.actor_uri
+        )
     )
 
     assert not FeatureAuthorization.objects.exists()
@@ -258,7 +273,138 @@ def test_inbox_routes_feature_request(
         Identity, "signed_request", lambda self, method, uri, body=None: None
     )
     message = InboxMessage.objects.create(
-        message=_feature_request(remote_identity.actor_uri, identity.actor_uri)
+        message=_feature_request(
+            identity.actor_uri, actor_uri=remote_identity.actor_uri
+        )
     )
     assert InboxMessageStates.handle_received(message) == InboxMessageStates.processed
     assert FeatureAuthorization.objects.filter(identity=identity).exists()
+
+
+### Inbox delivery ###
+
+
+def _sign_and_post(client, identity: Identity, document: dict, keypair, key_id: str):
+    """POST document to identity's inbox, HTTP-signed by key_id."""
+    body = json.dumps(document).encode()
+    path = identity.inbox_uri.replace("https://example.com", "")
+    digest = HttpSignature.calculate_digest(body)
+    date_str = format_datetime(timezone.now(), usegmt=True)
+    headers_to_sign = ["(request-target)", "host", "date", "digest", "content-type"]
+    headers_string = "\n".join(
+        f"{h}: {v}"
+        for h, v in [
+            ("(request-target)", f"post {path}"),
+            ("host", "example.com"),
+            ("date", date_str),
+            ("digest", digest),
+            ("content-type", "application/activity+json"),
+        ]
+    )
+    private_key = serialization.load_pem_private_key(
+        keypair["private_key"].encode(), password=None
+    )
+    signature = base64.b64encode(
+        private_key.sign(headers_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+    ).decode()
+    return client.post(
+        identity.inbox_uri,
+        data=body,
+        content_type="application/activity+json",
+        HTTP_HOST="example.com",
+        HTTP_DATE=date_str,
+        HTTP_DIGEST=digest,
+        HTTP_SIGNATURE=(
+            f'keyId="{key_id}",'
+            f'headers="{" ".join(headers_to_sign)}",'
+            f'signature="{signature}",'
+            f'algorithm="rsa-sha256"'
+        ),
+    )
+
+
+@pytest.mark.django_db
+def test_inbox_takes_requester_from_signature(
+    monkeypatch,
+    client,
+    identity: Identity,
+    remote_identity: Identity,
+    keypair,
+    config_system,
+):
+    """
+    The actual delivery carries no `actor`, so the inbox used to answer 400
+    "Unspecified actor" before storing anything -- and Mastodon treats 400 as
+    permanent, so nothing was ever retried. The requester is the signer.
+    """
+    identity.discoverable = True
+    identity.save()
+    key_id = f"{remote_identity.actor_uri}#main-key"
+    remote_identity.public_key = keypair["public_key"]
+    remote_identity.public_key_id = key_id
+    remote_identity.save()
+
+    sent: dict = {}
+    monkeypatch.setattr(
+        Identity,
+        "signed_request",
+        lambda self, method, uri, body=None: sent.update(uri=uri, body=body),
+    )
+
+    document = _feature_request(identity.actor_uri)
+    assert "actor" not in document
+    resp = _sign_and_post(client, identity, document, keypair, key_id)
+
+    assert resp.status_code == 202
+    message = InboxMessage.objects.get()
+    assert message.metadata is None
+    assert message.message["actor"] == remote_identity.actor_uri
+
+    assert InboxMessageStates.handle_received(message) == InboxMessageStates.processed
+    auth = FeatureAuthorization.objects.get(identity=identity)
+    assert auth.collection_uri == COLLECTION_URI
+    assert auth.request_uri == REQUEST_URI
+    assert sent["uri"] == remote_identity.inbox_uri
+    assert sent["body"]["type"] == "Accept"
+
+
+@pytest.mark.django_db
+def test_inbox_rejects_unsigned_feature_request(identity: Identity, config_system):
+    """Without a signature there is nobody to attribute the request to."""
+    client = Client()
+    resp = client.post(
+        identity.inbox_uri,
+        data=json.dumps(_feature_request(identity.actor_uri)),
+        content_type="application/activity+json",
+        HTTP_HOST="example.com",
+    )
+    assert resp.status_code == 400
+    assert InboxMessage.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_inbox_still_rejects_other_activities_without_actor(
+    client, identity: Identity, remote_identity: Identity, keypair, config_system
+):
+    """
+    Only the types that are defined without an actor may borrow the signer's:
+    everything else keeps failing closed.
+    """
+    key_id = f"{remote_identity.actor_uri}#main-key"
+    remote_identity.public_key = keypair["public_key"]
+    remote_identity.public_key_id = key_id
+    remote_identity.save()
+
+    resp = _sign_and_post(
+        client,
+        identity,
+        {
+            "type": "Follow",
+            "id": f"{remote_identity.actor_uri}activities/follow/1",
+            "object": identity.actor_uri,
+        },
+        keypair,
+        key_id,
+    )
+    assert resp.status_code == 400
+    assert InboxMessage.objects.count() == 0

--- a/takahe/tests/users/models/test_feature_authorization.py
+++ b/takahe/tests/users/models/test_feature_authorization.py
@@ -383,6 +383,23 @@ def test_inbox_rejects_unsigned_feature_request(identity: Identity, config_syste
 
 
 @pytest.mark.django_db
+def test_inbox_rejects_feature_request_signed_by_a_non_uri_key(
+    identity: Identity, keypair, config_system
+):
+    """
+    keyId is attacker-controlled: a parseable but non-URI one must not be
+    adopted as the actor, or actor and domain lookup choke on it before any
+    signature has been checked.
+    """
+    client = Client()
+    resp = _sign_and_post(
+        client, identity, _feature_request(identity.actor_uri), keypair, "not-a-url#key"
+    )
+    assert resp.status_code == 400
+    assert InboxMessage.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_inbox_still_rejects_other_activities_without_actor(
     client, identity: Identity, remote_identity: Identity, keypair, config_system
 ):

--- a/takahe/tests/users/views/test_inbox_auth.py
+++ b/takahe/tests/users/views/test_inbox_auth.py
@@ -840,6 +840,42 @@ def test_relay_unknown_relay_deferred(
 
 
 @pytest.mark.django_db
+def test_relay_actorless_activity_attributed_to_ld_creator(
+    client, identity, remote_identity, relay_identity, relay_keypair, keypair
+):
+    """
+    Activities that carry no actor of their own (FEP-7aa9 FeatureRequest) take
+    the signer's. Relayed, that must be the LD signature creator and not the
+    relay, otherwise the relay's HTTP signature alone would carry the request
+    through and it would be answered as if the relay had asked.
+    """
+    key_id = f"{remote_identity.actor_uri}#main-key"
+    remote_identity.public_key = keypair["public_key"]
+    remote_identity.public_key_id = key_id
+    remote_identity.save()
+
+    document = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": f"{remote_identity.actor_uri}feature_requests/1",
+        "type": "FeatureRequest",
+        "object": identity.actor_uri,
+        "instrument": f"{remote_identity.actor_uri}collections/1",
+    }
+    # Sign as the requester before handing it to the relay: the helper derives
+    # its LD key ID from document["actor"], which is exactly what is missing.
+    document["signature"] = LDSignature.create_signature(
+        document, keypair["private_key"], key_id
+    )
+
+    resp = _relay_sign_and_post(client, identity, document, relay_keypair)
+    assert resp.status_code == 202
+    msg = InboxMessage.objects.last()
+    assert msg is not None
+    assert msg.message["actor"] == remote_identity.actor_uri
+    assert msg.metadata is None
+
+
+@pytest.mark.django_db
 def test_deferred_relay_http_sig_verified(relay_keypair):
     """
     Deferred relay_http_sig verifies once the relay's public key becomes available.

--- a/takahe/users/models/identity.py
+++ b/takahe/users/models/identity.py
@@ -878,6 +878,11 @@ class Identity(StatorModel):
         Handles an incoming FeatureRequest (FEP-7aa9), i.e. someone asking to
         list this identity in their featured collection ("collection" on
         Mastodon). Auto-accepts for discoverable identities, rejects otherwise.
+
+        The requester is `actor`, which the inbox fills in from the signer of
+        the delivery: on the wire a FeatureRequest carries only `object` and
+        `instrument`, its requester being implicitly the owner of that
+        collection (see IMPLICIT_ACTOR_TYPES in users.views.activitypub).
         """
         from users.models import FeatureAuthorization
 
@@ -885,6 +890,10 @@ class Identity(StatorModel):
         object_uri = get_str_or_id(data.get("object"))
         collection_uri = get_str_or_id(data.get("instrument"))
         if not actor_uri or not object_uri or not collection_uri:
+            logger.warning(
+                "Ignoring FeatureRequest %s: needs actor, object and instrument",
+                data.get("id"),
+            )
             return
         try:
             identity = cls.by_actor_uri(object_uri)

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -30,9 +30,35 @@ from users.shortcuts import by_handle_or_404
 
 logger = logging.getLogger(__name__)
 
+# Activities whose requester is implicit rather than carried in `actor`.
+# A FEP-7aa9 FeatureRequest names only `object` (the actor to feature) and
+# `instrument` (the collection); the requester owns that collection and is
+# proven by the signature on the delivery. Mastodon's
+# ActivityPub::FeatureRequestSerializer emits id, type, object and instrument
+# and nothing else, so without this the inbox rejects every real one.
+IMPLICIT_ACTOR_TYPES = {
+    "featurerequest",
+    "https://w3id.org/fep/7aa9#featurerequest",
+}
+
 
 class HttpResponseUnauthorized(HttpResponse):
     status_code = 401
+
+
+def ld_signature_creator(document: dict) -> str | None:
+    """
+    The actor URI credited with the document's LD signature, or None when there
+    is no well-formed signature block. Malformed blocks are reported by the
+    inbox itself, so this only has to be lenient.
+    """
+    signature = document.get("signature")
+    if not isinstance(signature, dict):
+        return None
+    creator = signature.get("creator")
+    if not isinstance(creator, str):
+        return None
+    return urldefrag(creator).url
 
 
 class FederatedView(View):
@@ -183,12 +209,42 @@ class Inbox(FederatedView):
         if isinstance(document.get("object"), dict):
             document_subtype = document["object"].get("type")
 
+        # Parse the signatures before looking at the actor: for the activity
+        # types that carry no `actor`, the signer is the only statement of who
+        # sent this. The signatures themselves are checked further down.
+        http_sig_present = "Signature" in request.headers
+        ld_sig_present = "signature" in document
+        signature_details = None
+        key_id_actor = None
+        if http_sig_present:
+            try:
+                signature_details = HttpSignature.parse_signature(
+                    request.headers["signature"]
+                )
+            except VerificationFormatError as e:
+                logger.warning("Inbox error: Bad HTTP signature format: %s", e.args[0])
+                return HttpResponseBadRequest(e.args[0])
+            key_id_actor = urldefrag(signature_details["keyid"]).url
+
         # Find the Identity by the actor on the incoming item
         # This ensures that the signature used for the headers matches the actor
         # described in the payload.
         if "actor" not in document:
-            logger.warning("Inbox error: unspecified actor")
-            return HttpResponseBadRequest("Unspecified actor")
+            implicit_actor = (
+                document_type.lower() in IMPLICIT_ACTOR_TYPES
+                if isinstance(document_type, str)
+                else False
+            )
+            signer_uri = key_id_actor or ld_signature_creator(document)
+            if not implicit_actor or not signer_uri:
+                logger.warning("Inbox error: unspecified actor")
+                return HttpResponseBadRequest("Unspecified actor")
+            # Adopt the signer as the actor so blocking, signature verification
+            # and the handlers downstream all work off one notion of who sent
+            # the activity. Nothing is trusted yet: the signature is verified
+            # below exactly as it is for any other delivery, and it is that
+            # check which makes this attribution safe.
+            document["actor"] = signer_uri
 
         identity = Identity.by_actor_uri(document["actor"], create=True, transient=True)
         if (
@@ -226,28 +282,18 @@ class Inbox(FederatedView):
         ]:
             return HttpResponse(status=202)
 
-        http_sig_present = "Signature" in request.headers
-        ld_sig_present = "signature" in document
         verified = False
         ld_sig_verified = False  # True when the LD signature itself checked out
         relay_mode = False  # True when HTTP signer != document actor
         relay_http_verified = False  # True when relay HTTP sig verified immediately
         metadata = {}
 
-        # Authenticate HTTP signature if present. Parse keyId first to detect
-        # relay deliveries (where the HTTP signer differs from document["actor"]).
-        # An invalid signature is a hard rejection. For unknown signers without a
-        # cached key, pre-compute data for deferred verification.
+        # Authenticate HTTP signature if present, using the keyId parsed above to
+        # detect relay deliveries (where the HTTP signer differs from
+        # document["actor"]). An invalid signature is a hard rejection. For
+        # unknown signers without a cached key, pre-compute data for deferred
+        # verification.
         if http_sig_present:
-            try:
-                signature_details = HttpSignature.parse_signature(
-                    request.headers["signature"]
-                )
-            except VerificationFormatError as e:
-                logger.warning("Inbox error: Bad HTTP signature format: %s", e.args[0])
-                return HttpResponseBadRequest(e.args[0])
-
-            key_id_actor = urldefrag(signature_details["keyid"]).url
             relay_mode = key_id_actor != document["actor"]
             signer_identity = (
                 Identity.by_actor_uri(key_id_actor, create=True, transient=True)

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -61,6 +61,20 @@ def ld_signature_creator(document: dict) -> str | None:
     return urldefrag(creator).url
 
 
+def signer_actor_uri(candidate: str | None) -> str | None:
+    """
+    A signer is only usable as an actor if it names one: keyId and creator are
+    both sender-controlled, and anything without a hostname would reach actor
+    and domain lookup as garbage before a signature has been checked.
+    """
+    if not candidate:
+        return None
+    parts = urlparse(candidate)
+    if parts.scheme not in ["http", "https"] or not parts.hostname:
+        return None
+    return candidate
+
+
 class FederatedView(View):
     """
     Base class for all views requires federation
@@ -235,7 +249,14 @@ class Inbox(FederatedView):
                 if isinstance(document_type, str)
                 else False
             )
-            signer_uri = key_id_actor or ld_signature_creator(document)
+            # The LD signature creator comes first: it credits the origin,
+            # while a relayed delivery is HTTP-signed by the relay. Where the
+            # two differ this puts the request into relay_mode below, which is
+            # what makes the relay prove itself and the origin prove the
+            # document, rather than the relay's signature carrying it alone.
+            signer_uri = signer_actor_uri(
+                ld_signature_creator(document)
+            ) or signer_actor_uri(key_id_actor)
             if not implicit_actor or not signer_uri:
                 logger.warning("Inbox error: unspecified actor")
                 return HttpResponseBadRequest("Unspecified actor")


### PR DESCRIPTION
Follow-up to #1773. The outbound half of that PR works -- local actors advertise `interactionPolicy.canFeature`, which is why mastodon.social offers "Add to collection" -- but the inbound half never ran.

## What was wrong

A FEP-7aa9 `FeatureRequest` has no `actor`. Mastodon's `ActivityPub::FeatureRequestSerializer` emits only `id`, `type`, `object` and `instrument`; the requester is implicitly the owner of the collection in `instrument`, and is proven by the signature on the delivery. The FEP agrees: the two mandatory properties are `object` and `instrument`.

The inbox rejected the document before storing anything:

```
POST /@user@example.org/inbox/   400 17    ("Unspecified actor")
```

so the routing added in #1773 never fired, and Mastodon treats 400 as permanent and does not retry -- the pending collection entry stayed pending forever. `Identity.handle_feature_request_ap` had the same assumption a layer down, bailing on a missing `actor`. The tests passed over both because the payload helper synthesised an `actor` key that no real sender emits.

## The fix

The inbox parses the signatures before it looks for an actor, and for the activity types that are defined without one it adopts the authenticated signer -- HTTP signature `keyId`, else the LD signature `creator` -- as `actor`. Everything downstream (user and domain blocking, immediate and deferred signature verification, and the handlers) keeps working off a single notion of who sent the activity, and it is that signature check which makes the attribution safe.

The requester could instead be found by dereferencing `instrument` and reading its `attributedTo`, but the signer is already authenticated and needs no fetch.

Failing closed is preserved: an unsigned delivery, or any other activity type that omits `actor`, still gets 400.

## Tests

`takahe/tests/users/models/test_feature_authorization.py`: the payload helper no longer invents an `actor`, and a new test drives a wire-shaped request through the real inbox, over the HTTP signature, to the outgoing `Accept`. It reproduces the exact production failure without the fix (`400 == 202`, `Inbox error: unspecified actor`).

Full takahe suite: 503 passed. `pre-commit run -a` clean.

## Note for verifying against a live Mastodon

Because the earlier 400s were permanent, the existing entry stays pending. After deploying, remove and re-add the account in the collection to trigger a fresh `FeatureRequest`.
