### PR TITLE
fix(federation): reject malformed inbox documents instead of crashing

### DIFF
--- a/takahe/core/ld.py
+++ b/takahe/core/ld.py
@@ -769,12 +769,15 @@ def get_list(container, key) -> list:
 
 def get_str_or_id(value: str | dict | None, key: str = "id") -> str | None:
     """
-    Given a value that could be a str or {"id": str}, return the str
+    Given a value that could be a str or {"id": str}, return the str.
+    Callers feed the result to URI lookups, so a nested value that is not
+    itself a string is no more usable than a missing one.
     """
     if isinstance(value, str):
         return value
     elif isinstance(value, dict):
-        return value.get(key)
+        nested = value.get(key)
+        return nested if isinstance(nested, str) else None
     return None
 
 

--- a/takahe/tests/users/views/test_activitypub.py
+++ b/takahe/tests/users/views/test_activitypub.py
@@ -65,6 +65,60 @@ def test_delete_unknown_actor(client, identity):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "mangle",
+    [
+        {"@context": 42},
+        {"actor": {"id": {"nested": "bad"}}},
+        {"type": {"weird": "object"}},
+        {"type": None},
+        {"type": "Delete", "object": None},
+    ],
+    ids=[
+        "bad-context",
+        "nested-actor-id",
+        "non-string-type",
+        "no-type",
+        "delete-without-object",
+    ],
+)
+def test_malformed_document_rejected(client, identity, mangle):
+    """
+    Documents that crash JSON-LD processing, name no usable type, or delete
+    nothing are rejected with 400 rather than a server error. None values
+    mean the key is dropped (canonicalise discards nulls anyway).
+    """
+    document = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://remote.test/a/activities/1",
+        "type": "Create",
+        "actor": "https://remote.test/a/",
+        "object": {"id": "https://remote.test/a/posts/1", "type": "Note"},
+    }
+    document.update(mangle)
+    document = {k: v for k, v in document.items() if v is not None}
+    resp = client.post(
+        identity.inbox_uri, data=document, content_type="application/activity+json"
+    )
+    assert resp.status_code == 400
+    assert InboxMessage.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_invalid_utf8_body_rejected(client, identity):
+    """
+    A body that does not decode as UTF-8 is a 400; the error logging must
+    not assume it decodes either.
+    """
+    resp = client.post(
+        identity.inbox_uri,
+        data=b'{"actor": "\xff"}',
+        content_type="application/activity+json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
 def test_ignore_lemmy(client, identity):
     """
     Tests that message types we know we cannot handle are ignored immediately

--- a/takahe/tests/users/views/test_inbox_auth.py
+++ b/takahe/tests/users/views/test_inbox_auth.py
@@ -38,8 +38,12 @@ def _post_to_inbox(client, identity, document, extra_headers=None):
     return client.post(identity.inbox_uri, **kwargs)
 
 
-def _sign_and_post(client, identity, document, keypair):
-    """Sign a document with HTTP Signature and post it to the inbox."""
+def _sign_and_post(client, identity, document, keypair, actor_uri=None):
+    """
+    Sign a document with HTTP Signature and post it to the inbox.
+    `actor_uri` names the signer for documents that do not carry the actor as
+    a bare URI (e.g. an embedded actor object).
+    """
     body = json.dumps(document).encode()
     path = identity.inbox_uri.replace("https://example.com", "")
     digest = HttpSignature.calculate_digest(body)
@@ -69,7 +73,7 @@ def _sign_and_post(client, identity, document, keypair):
     # keyId must be derived from the document actor URI so that urldefrag(keyid)
     # matches document["actor"] and direct delivery is not mistaken for a relay.
     # Preserve the trailing slash to keep the URI identical to document["actor"].
-    actor_uri = document.get("actor", "")
+    actor_uri = actor_uri or document.get("actor", "")
     key_id = actor_uri + "#main-key" if actor_uri else keypair["public_key_id"]
     sig_header = (
         f'keyId="{key_id}",'
@@ -111,6 +115,53 @@ def test_valid_http_signature_accepted(client, identity, remote_identity, keypai
     msg = InboxMessage.objects.last()
     assert msg is not None
     assert msg.metadata is None
+
+
+@pytest.mark.django_db
+def test_embedded_actor_object_accepted(client, identity, remote_identity, keypair):
+    """
+    An `actor` delivered as an embedded object rather than a bare URI is
+    reduced to its id, and the queued message carries that URI so the
+    handlers see the same shape as any other delivery.
+    """
+    remote_identity.public_key = keypair["public_key"]
+    remote_identity.public_key_id = keypair["public_key_id"]
+    remote_identity.save()
+
+    document = _make_document(actor_uri=remote_identity.actor_uri)
+    document["actor"] = {"id": remote_identity.actor_uri, "type": "Person"}
+    resp = _sign_and_post(
+        client, identity, document, keypair, actor_uri=remote_identity.actor_uri
+    )
+    assert resp.status_code == 202
+    msg = InboxMessage.objects.last()
+    assert msg is not None
+    assert msg.message["actor"] == remote_identity.actor_uri
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "actor",
+    [
+        None,
+        "acct:someone@remote.test",
+        {"type": "Person"},
+        ["https://remote.test/a/", "https://remote.test/b/"],
+    ],
+    ids=["null", "non-http-scheme", "object-without-id", "several-actors"],
+)
+def test_actor_not_naming_a_uri_rejected(client, identity, keypair, actor):
+    """
+    An `actor` that does not name a fetchable URI is rejected outright, rather
+    than reaching identity or domain lookup as something that is not a string.
+    """
+    document = _make_document()
+    document["actor"] = actor
+    resp = _sign_and_post(
+        client, identity, document, keypair, actor_uri="https://remote.test/test-actor/"
+    )
+    assert resp.status_code == 400
+    assert InboxMessage.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/takahe/tests/users/views/test_inbox_auth.py
+++ b/takahe/tests/users/views/test_inbox_auth.py
@@ -165,6 +165,25 @@ def test_actor_not_naming_a_uri_rejected(client, identity, keypair, actor):
 
 
 @pytest.mark.django_db
+def test_list_type_normalized(client, identity, remote_identity, keypair):
+    """
+    JSON-LD allows `type` to be a list of types; the first concrete one is
+    adopted so dispatch here and in the handlers sees a single string.
+    """
+    remote_identity.public_key = keypair["public_key"]
+    remote_identity.public_key_id = keypair["public_key_id"]
+    remote_identity.save()
+
+    document = _make_document(actor_uri=remote_identity.actor_uri)
+    document["type"] = ["Activity", "Create"]
+    resp = _sign_and_post(client, identity, document, keypair)
+    assert resp.status_code == 202
+    msg = InboxMessage.objects.last()
+    assert msg is not None
+    assert msg.message["type"] == "Create"
+
+
+@pytest.mark.django_db
 def test_http_sig_passes_invalid_ld_sig_ignored(
     client, identity, remote_identity, keypair
 ):

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -61,11 +61,12 @@ def ld_signature_creator(document: dict) -> str | None:
     return urldefrag(creator).url
 
 
-def signer_actor_uri(candidate: str | None) -> str | None:
+def usable_actor_uri(candidate: str | None) -> str | None:
     """
-    A signer is only usable as an actor if it names one: keyId and creator are
-    both sender-controlled, and anything without a hostname would reach actor
-    and domain lookup as garbage before a signature has been checked.
+    A candidate is only usable as an actor if it names one: the payload actor,
+    keyId and creator are all sender-controlled, and anything without a
+    hostname would reach actor and domain lookup as garbage before a signature
+    has been checked.
     """
     if not candidate:
         return None
@@ -243,7 +244,13 @@ class Inbox(FederatedView):
         # Find the Identity by the actor on the incoming item
         # This ensures that the signature used for the headers matches the actor
         # described in the payload.
-        if "actor" not in document:
+        # `actor` may arrive embedded as an object rather than a bare URI, so
+        # reduce it to the URI once here: identity lookup, relay detection,
+        # signature matching and every handler downstream expect that URI, and
+        # anything that does not name one has to be rejected before it reaches
+        # domain lookup as garbage.
+        actor_uri = usable_actor_uri(get_str_or_id(document.get("actor")))
+        if not actor_uri:
             implicit_actor = (
                 document_type.lower() in IMPLICIT_ACTOR_TYPES
                 if isinstance(document_type, str)
@@ -254,18 +261,19 @@ class Inbox(FederatedView):
             # two differ this puts the request into relay_mode below, which is
             # what makes the relay prove itself and the origin prove the
             # document, rather than the relay's signature carrying it alone.
-            signer_uri = signer_actor_uri(
+            signer_uri = usable_actor_uri(
                 ld_signature_creator(document)
-            ) or signer_actor_uri(key_id_actor)
+            ) or usable_actor_uri(key_id_actor)
             if not implicit_actor or not signer_uri:
-                logger.warning("Inbox error: unspecified actor")
+                logger.warning("Inbox error: unspecified or invalid actor")
                 return HttpResponseBadRequest("Unspecified actor")
             # Adopt the signer as the actor so blocking, signature verification
             # and the handlers downstream all work off one notion of who sent
             # the activity. Nothing is trusted yet: the signature is verified
             # below exactly as it is for any other delivery, and it is that
             # check which makes this attribution safe.
-            document["actor"] = signer_uri
+            actor_uri = signer_uri
+        document["actor"] = actor_uri
 
         identity = Identity.by_actor_uri(document["actor"], create=True, transient=True)
         if (

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -7,7 +7,7 @@ from activities.models import Post
 from activities.services import TimelineService
 from core import sentry
 from core.decorators import cache_page
-from core.ld import canonicalise, get_str_or_id
+from core.ld import GENERIC_AS_TYPES, canonicalise, get_str_or_id
 from core.signatures import (
     HttpSignature,
     LDSignature,
@@ -22,6 +22,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from pyld.jsonld import JsonLdError
 from takahe.neodb import __version__ as __neodb_version__
 
 from users.models import FeatureAuthorization, Identity, InboxMessage, SystemActor
@@ -214,12 +215,30 @@ class Inbox(FederatedView):
         try:
             raw_document = json.loads(request.body)
             document = canonicalise(raw_document, include_security=True, outbound=False)
-        except ValueError:
+        except ValueError, JsonLdError:
+            # pyld reports malformed JSON-LD with its own exception, and a
+            # non-UTF-8 body arrives here as UnicodeDecodeError, so the log
+            # line must not assume the body decodes either.
             logger.warning(
-                "Inbox error when parsing JSON to LDDocument: %s", request.body.decode()
+                "Inbox error when parsing JSON to LDDocument: %s",
+                request.body.decode(errors="replace"),
             )
             return HttpResponseBadRequest("Error parsing JSON")
-        document_type = document["type"]
+
+        # JSON-LD allows a list of types; adopt the first concrete one
+        # (preserving case, which the comparisons below expect) so dispatch
+        # here and in the handlers works off a single type string.
+        document_type = document.get("type")
+        if isinstance(document_type, list):
+            named = [t for t in document_type if isinstance(t, str) and t]
+            document_type = next(
+                (t for t in named if t.lower() not in GENERIC_AS_TYPES),
+                named[0] if named else None,
+            )
+        if not isinstance(document_type, str) or not document_type:
+            logger.warning("Inbox error: missing or invalid type")
+            return HttpResponseBadRequest("Missing or invalid type")
+        document["type"] = document_type
         document_subtype = None
         if isinstance(document.get("object"), dict):
             document_subtype = document["object"].get("type")
@@ -276,13 +295,14 @@ class Inbox(FederatedView):
         document["actor"] = actor_uri
 
         identity = Identity.by_actor_uri(document["actor"], create=True, transient=True)
-        if (
-            document_type == "Delete"
-            and document["actor"] == document["object"]
-            and identity._state.adding
-        ):
-            # We don't have an Identity record for the user. No-op
-            return HttpResponse(status=202)
+        if document_type == "Delete":
+            if "object" not in document:
+                # Nothing to delete, and the handlers dispatch on the object
+                logger.warning("Inbox error: Delete without object")
+                return HttpResponseBadRequest("Delete without object")
+            if document["actor"] == document["object"] and identity._state.adding:
+                # We don't have an Identity record for the user. No-op
+                return HttpResponse(status=202)
 
         # See if it's from a blocked user or domain - without calling
         # fetch_actor, which would fetch data from potentially bad actor


### PR DESCRIPTION
## Problem

A remote peer delivering `Create`/`Note` activities with the `actor` embedded as an object (rather than a bare URI) crashed the inbox with `AttributeError: 'dict' object has no attribute 'decode'` at `urlparse()`. Every delivery 500ed, so the sender kept retrying (48 events in under an hour, Sentry NEODB-SOCIAL-7TS). The dict also silently missed the `Identity.by_actor_uri()` lookup, since Django stringifies it into the query.

Probing the endpoint with crafted signed payloads then turned up five more sender-controlled 500s in the same view.

## Changes

Commit 1 — the reported crash:
- Reduce `actor` to its URI once, where the identity is resolved, using the existing `get_str_or_id()` plus the URI validator (renamed `signer_actor_uri` -> `usable_actor_uri` since it now guards the payload actor too). Identity lookup, relay detection, LD-signature creator matching and the queued handlers all see one plain URI.
- An actor object with no `id`, several actors at once, or a non-http(s) scheme such as `acct:` (which previously reached `Domain.get_remote_domain(None)`) are now 400s.
- `get_str_or_id()` is hardened to match its `-> str | None` annotation: a nested non-string `id` returns `None` instead of leaking through to its twelve callers.

Commit 2 — the adjacent crashes, all now 400s:
- `canonicalise()` reports malformed JSON-LD (bad `@context`, non-string `type`, nested `id`) as pyld's `JsonLdError`, which the `except ValueError` missed.
- A non-UTF-8 body was caught as `UnicodeDecodeError`, but the warning log then re-decoded the body and raised again; the log now uses `errors="replace"`.
- A document with no `type` hit `KeyError`.
- A JSON-LD list of types (valid per spec) survived to `document["type"].startswith()` and the handlers' `.lower()`; the first concrete type is now adopted, case preserved.
- A `Delete` with no `object` hit `KeyError` at the self-delete check, and would have crashed the handlers' object dispatch had it got further, so it is rejected at the boundary.

## Testing

- Every case is covered by a regression test that was run against the preceding commit and shown to reproduce its 500 (the reported one with the exact production traceback).
- Full takahe suite: 517 passed. `pre-commit run -a` clean.
- Sentry over the last 90 days shows no other unresolved code-caused unhandled errors on request paths.

Fixes NEODB-SOCIAL-7TS