### PR TITLE
fix(sitemap): write sitemap.txt as 0644 and clean up the temp file

### DIFF
--- a/neodb/common/management/commands/sitemap.py
+++ b/neodb/common/management/commands/sitemap.py
@@ -89,7 +89,10 @@ class Command(SiteCommand):
                 f.write(Item.objects.get(pk=r["item_id"]).absolute_url + "\n")
 
         fn = settings.MEDIA_ROOT + "/" + settings.EXPORT_FILE_PATH_ROOT + "sitemap.txt"
-        shutil.copy2(temp, fn)
+        # mkstemp() creates the file as 0600, so set the mode the web server expects
+        shutil.copyfile(temp, fn)
+        os.chmod(fn, 0o644)
+        os.remove(temp)
         url = (
             settings.SITE_INFO["site_url"]
             + settings.MEDIA_URL


### PR DESCRIPTION
`neodb-manage sitemap` published `sitemap.txt` with mode `0600`, so the web server could not read it.

`tempfile.mkstemp()` creates the scratch file as `0600`, and `shutil.copy2()` copies the mode bits along with the content, so the destination inherited the restrictive mode. Every other file under `export/` is written through Django storage, which applies the default `FILE_UPLOAD_PERMISSIONS` of `0644`, so this command was the only outlier.

This copies the content only, then sets `0644` explicitly. The explicit `chmod` matters because `copyfile` truncates an existing destination in place, so a `sitemap.txt` already sitting at `0600` from an earlier run would otherwise stay `0600` forever.

Also removes the temp file, which every run previously left behind in the system temp dir.

Verified by replaying the exact sequence: the destination comes out `0644` both on a fresh run and when overwriting a pre-existing `0600` file, the temp file is gone afterwards, and the content is unchanged. `pre-commit` passes on the changed file.
