### PR TITLE
fix(journal): batch-fetch items when building Collection index doc

### DIFF
--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -806,10 +806,20 @@ class Collection(List):
         item_id = []
         item_title = []
         item_class = set()
-        for m in self.members.all():
-            item_id.append(m.item.pk)
-            item_title += m.item.to_indexable_titles()
-            item_class |= {m.item.__class__.__name__}
+        members = list(self.members.all())
+        # Item is polymorphic; per-member FK access costs two queries each
+        # (base row + subclass join). Batch-fetch through the polymorphic
+        # manager instead (Sentry: EGGPLANT-1HD).
+        items_map = {
+            i.pk: i for i in Item.objects.filter(pk__in=[m.item_id for m in members])
+        }
+        for m in members:
+            item = items_map.get(m.item_id)
+            if item is None:
+                continue
+            item_id.append(item.pk)
+            item_title += item.to_indexable_titles()
+            item_class |= {item.__class__.__name__}
             if m.note:
                 content.append(m.note)
         return {

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -7,7 +7,7 @@ from django.test import Client
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
-from catalog.models import Edition, ExternalResource, IdType, ItemCredit, Movie
+from catalog.models import Edition, ExternalResource, IdType, Item, ItemCredit, Movie
 from journal.apis.collection import _prefetch_collection_member_items
 from journal.models import Mark, ShelfType
 from journal.models.collection import Collection
@@ -301,6 +301,39 @@ class TestCollectionEditItemsNPlusOne:
         assert len(credit_queries) <= 1, (
             f"edit_items fired {len(credit_queries)} catalog_itemcredit queries "
             f"for {len(movies)} members; expected <=1 (batched)."
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCollectionIndexDocNPlusOne:
+    """EGGPLANT-1HD: reordering members re-saves the Collection, whose index
+    doc iterated members and fetched each polymorphic item individually (two
+    queries per member). Items must be batch-fetched instead.
+    """
+
+    def test_no_per_member_item_query(self):
+        user = User.register(email="indexer@test.com", username="indexer")
+        collection = Collection(owner=user.identity, title="C", brief="b")
+        collection.save()
+        items: list[Item] = [
+            Edition.objects.create(title=f"Index Book {i}") for i in range(3)
+        ]
+        items += [Movie.objects.create(title=f"Index Movie {i}") for i in range(3)]
+        for item in items:
+            collection.append_item(item)
+
+        collection.refresh_from_db()
+        with CaptureQueriesContext(connection) as ctx:
+            doc = collection.to_indexable_doc()
+        assert sorted(doc["item_id"]) == sorted(i.pk for i in items)
+        assert set(doc["item_class"]) == {"Edition", "Movie"}
+        point_lookups = [
+            q for q in ctx.captured_queries if '"catalog_item"."id" = ' in q["sql"]
+        ]
+        assert point_lookups == [], (
+            f"to_indexable_doc fired {len(point_lookups)} per-member catalog_item "
+            f"point lookups for {len(items)} members; expected 0 (batched). "
+            f"First: {point_lookups[0]['sql'] if point_lookups else 'n/a'}"
         )
 
 


### PR DESCRIPTION
## Summary

Sentry EGGPLANT-1HD flagged an N+1 on `POST /collection/<uuid>/collection_update_member_order`: reordering members fires `list_add`, whose receiver re-saves the Collection; the save path rebuilds the search index doc, and `Collection.to_indexable_doc` resolved each member's polymorphic item through the FK descriptor -- two queries per member (base `catalog_item` point lookup plus subclass join), 166 queries for an 83-member collection in the sampled event.

This batch-fetches the members' items through the polymorphic manager and re-attaches them, mirroring the existing pattern in `List.ap_items_page` and `collection_edit_items`.

## Testing

- New regression test `TestCollectionIndexDocNPlusOne` asserts `to_indexable_doc` fires no per-member `catalog_item` point lookups (verified it fails against the previous code).
- `tests/journal/` suite passes (759 passed) in the dockerized dev environment; `pre-commit run -a` clean.

Fixes EGGPLANT-1HD