### PR TITLE
fix(catalog): throttle and identify OpenLibrary, stop search blocking on rate limits

### DIFF
--- a/neodb/catalog/common/rate_limit.py
+++ b/neodb/catalog/common/rate_limit.py
@@ -6,6 +6,17 @@ request to a host may fire. Every caller atomically advances that cursor by
 process (web, RQ worker, management command) competes for the same slots on
 the shared Redis.
 
+Two acquisition modes:
+
+* :meth:`RedisRateLimiter.acquire` blocks until its slot. Use it on scrape and
+  batch paths, where waiting is cheaper than being throttled upstream.
+* :meth:`RedisRateLimiter.try_acquire` never blocks: it takes a slot if one is
+  free right now and otherwise returns ``False`` so the caller can skip the
+  request entirely. Use it on the interactive external-search fan-out, where
+  a wait would stall the whole result page. Its ``burst`` argument spends
+  credit the host accrued while idle, for the cases where several callers
+  legitimately fire together; the sustained rate is unaffected.
+
 Failure modes are advisory rather than fatal:
 
 * If Redis is unreachable the limiter falls through without sleeping; the
@@ -36,6 +47,8 @@ if TYPE_CHECKING:
 # KEYS[1] = cursor key. ARGV[1] = now (float seconds). ARGV[2] = interval
 # (seconds between consecutive requests). ARGV[3] = max_wait (seconds; refuse
 # to advance the cursor if a caller would end up waiting longer than this).
+# ARGV[4] = credit (seconds the cursor may lag behind `now`, letting an idle
+# host absorb a short burst before the interval starts biting).
 # Returns the wall-clock time at which the caller may proceed, or "-1" to
 # signal "queue is full, fall open".
 _RESERVE_SLOT_LUA = """
@@ -43,9 +56,11 @@ local key = KEYS[1]
 local now = tonumber(ARGV[1])
 local interval = tonumber(ARGV[2])
 local max_wait = tonumber(ARGV[3])
+local credit = tonumber(ARGV[4])
 local current = tonumber(redis.call('GET', key)) or 0
+local floor = now - credit
 local target = current
-if target < now then target = now end
+if target < floor then target = floor end
 if target - now > max_wait then
   return '-1'
 end
@@ -85,12 +100,25 @@ class RedisRateLimiter:
                 return None
             return self._script
 
-    def _reserve(self, timeout: float) -> float | None:
+    def _credit(self, burst: int) -> float:
+        """Seconds of lag the cursor may carry for a ``burst``-sized caller.
+
+        ``burst=1`` is strict serialization (no credit). ``burst=n`` lets an
+        idle host serve n requests back to back, after which the interval
+        applies as usual, so the sustained rate is unchanged.
+        """
+        if burst < 1:
+            raise ValueError("burst must be >= 1")
+        return (burst - 1) * self.interval
+
+    def _reserve(self, timeout: float, credit: float = 0.0) -> float | None:
         """Atomically claim the next slot.
 
         Returns the wall-clock time the caller should fire at, ``None`` when
         Redis is unreachable, or a value <= now-1 when the cursor declined to
-        advance because the wait would exceed ``timeout``.
+        advance because the wait would exceed ``timeout``. The returned time
+        may sit slightly in the past when ``credit`` is in play; callers treat
+        anything not in the future as "fire now".
         """
         script = self._load_script()
         if script is None:
@@ -98,7 +126,7 @@ class RedisRateLimiter:
         try:
             result = script(
                 keys=[self.key],
-                args=[time.time(), self.interval, timeout],
+                args=[time.time(), self.interval, timeout, credit],
             )
         except Exception as e:
             logger.warning(f"rate-limit redis error for {self.key}: {e}")
@@ -136,6 +164,52 @@ class RedisRateLimiter:
                 )
             return
         time.sleep(wait)
+
+    def _slot_is_free(self, target: float | None) -> bool:
+        """Interpret a ``_reserve(0.0)`` result as "may I fire right now?".
+
+        With ``max_wait=0`` the Lua script only advances the cursor when the
+        slot it would hand out is not in the future, so a ``False`` here means
+        we consumed nothing and the next caller still sees a full slot.
+
+        Redis being unreachable resolves to ``True``: the module's contract is
+        that a broken limiter degrades to no limiter, not to a closed door.
+        """
+        if target is None:
+            return True
+        return target - time.time() <= 0 and target >= 0
+
+    def try_acquire(self, burst: int = 1) -> bool:
+        """Take a slot if one is free right now; never block.
+
+        Returns ``True`` when the caller may fire immediately and ``False``
+        when it should skip the request. Unlike :meth:`acquire` a refusal is
+        silent -- skipping is the designed outcome here, not an anomaly worth
+        a warning on every interactive search.
+
+        Pass ``burst=n`` when n callers legitimately fire together against one
+        host, as the sibling search sites do (AniList anime plus manga,
+        MusicBrainz release plus artist). Without it the second sibling is
+        refused every time and its half of the results disappears from every
+        ``category=all`` query. Burst spends credit the host accrued while
+        idle, so the sustained rate stays at ``rate``.
+        """
+        if get_mock_mode():
+            return True
+        return self._slot_is_free(self._reserve(0.0, self._credit(burst)))
+
+    async def try_acquire_async(self, burst: int = 1) -> bool:
+        """Async variant of :meth:`try_acquire`.
+
+        The reservation goes to a worker thread for the same reason
+        :meth:`acquire_async` does it: redis-py blocks, and this runs inside
+        an ``asyncio.gather`` fan-out where one blocking call stalls every
+        other site's search.
+        """
+        if get_mock_mode():
+            return True
+        credit = self._credit(burst)
+        return self._slot_is_free(await asyncio.to_thread(self._reserve, 0.0, credit))
 
     async def acquire_async(self, timeout: float = 15.0) -> None:
         """Async variant of :meth:`acquire`.

--- a/neodb/catalog/sites/anilist.py
+++ b/neodb/catalog/sites/anilist.py
@@ -382,10 +382,19 @@ class AniList(AbstractSite):
         if category not in cls.SEARCH_CATEGORIES:
             return []
         results = []
-        # Deliberately not rate-limited: search_task runs inside the interactive
-        # external-search dispatcher (asyncio.gather over every searchable
-        # site), and blocking a user's search to wait for a slot would freeze
-        # the whole result page. Same reasoning as musicbrainz.search_task.
+        # Take a slot when one is free, never wait for one: search_task runs
+        # inside the interactive external-search dispatcher (asyncio.gather over
+        # every searchable site), and blocking a user's search to wait for a
+        # slot would freeze the whole result page. Same policy as
+        # musicbrainz.search_task. Searches share the observed 30/min budget
+        # with the scrape path, so skipping keeps that accounting honest.
+        # burst=2 because AniListAnime and AniListManga are both registered
+        # search sites on this one host and both answer category=all, so they
+        # always reserve together; without the credit one of them would be
+        # refused on every such query.
+        if not await anilist_limiter().try_acquire_async(burst=2):
+            record_search_failure(cls.SITE_NAME.value, "throttled")
+            return results
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(

--- a/neodb/catalog/sites/igdb.py
+++ b/neodb/catalog/sites/igdb.py
@@ -260,14 +260,17 @@ class IGDB(AbstractSite):
         limit = page_size
         offset = (page - 1) * limit
         q = f'fields *, cover.url, genres.name, platforms.name, involved_companies.*, involved_companies.company.name; search "{quote_plus(q)}"; limit {limit}; offset {offset};'
+        # Shares the same 4 req/s IGDB quota as api_query, so take a slot when
+        # one is free. Never wait for one: this runs in the interactive fan-out
+        # and used to wait up to 15s, three times its own HTTP timeout, which
+        # let a bulk Steam import hold every game search on the site hostage.
+        if not await igdb_limiter().try_acquire_async():
+            record_search_failure(SiteName.IGDB.value, "throttled")
+            return []
         _wrapper = IGDBWrapper(SiteConfig.system.igdb_client_id, _igdb_access_token())
         async with httpx.AsyncClient() as client:
             rs = []
             try:
-                # Shares the same 4 req/s IGDB quota as api_query, so a bulk
-                # import running concurrently doesn't push interactive
-                # searches (or itself) over the cap.
-                await igdb_limiter().acquire_async(timeout=15.0)
                 url = IGDBWrapper._build_url("games")
                 params = _wrapper._compose_request(q)
                 response = await client.post(url, **params)

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -556,13 +556,21 @@ class MusicBrainzRelease(AbstractSite):
             "Accept": "application/json",
         }
 
+        # Take a slot when one is free, but never wait for one: search_task
+        # runs inside the interactive external-search dispatcher (asyncio.gather
+        # over every searchable site), and blocking a user's search to wait for
+        # a slot would freeze the whole result page. Skipping still keeps these
+        # requests on the books, so the cursor reflects the real load we put on
+        # MB rather than silently overspending the 1 req/s guideline.
+        # burst=2 because MusicBrainzRelease and MusicBrainzArtist are both
+        # registered search sites on this one host and both answer
+        # category=all, so they always reserve together; without the credit
+        # one of them would be refused on every such query.
+        if not await musicbrainz_limiter().try_acquire_async(burst=2):
+            record_search_failure(SiteName.MusicBrainz.value, "throttled")
+            return results
         async with httpx.AsyncClient() as client:
             try:
-                # Deliberately not rate-limited: search_task runs inside the
-                # interactive external-search dispatcher (asyncio.gather over
-                # every searchable site). Blocking a user's search to wait
-                # for a slot would freeze the whole result page; we'd rather
-                # let MB return 503 here and skip MB results for this query.
                 response = await client.get(
                     api_url, params=params, headers=headers, timeout=10
                 )
@@ -888,12 +896,13 @@ class MusicBrainzArtist(AbstractSite):
             "User-Agent": settings.NEODB_USER_AGENT,
             "Accept": "application/json",
         }
+        # Same policy as the release search above, burst included: the two
+        # sibling sites reserve together on every category=all query.
+        if not await musicbrainz_limiter().try_acquire_async(burst=2):
+            record_search_failure(SiteName.MusicBrainz.value, "throttled")
+            return results
         async with httpx.AsyncClient() as client:
             try:
-                # Deliberately not rate-limited: search_task is dispatched
-                # from the interactive external-search page; blocking on a
-                # slot would stall the whole result render for every user
-                # who searches. Accept the occasional MB 503 instead.
                 response = await client.get(
                     "https://musicbrainz.org/ws/2/artist",
                     params=params,

--- a/neodb/catalog/sites/openlibrary.py
+++ b/neodb/catalog/sites/openlibrary.py
@@ -1,16 +1,101 @@
 import re
+import threading
 from datetime import datetime
 from urllib.parse import quote_plus
 
 import httpx
+from django.conf import settings
 from loguru import logger
 
 from catalog.common import *
+from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import *
 from catalog.models.utils import detect_isbn_asin, isbn_10_to_13
 from catalog.search import *
-from common.models import detect_language
+from common.models import SiteConfig, detect_language
 from common.models.lang import normalize_language
+
+# OpenLibrary serves 1 req/s to unidentified clients and 3 req/s to callers
+# that send an app name plus a contact address, and warns that a generic or
+# missing User-Agent may be throttled or blocked outright:
+# https://openlibrary.org/developers/api. Pace for the identified tier, which
+# `_openlibrary_user_agent` earns us whenever the operator has configured a
+# from-address.
+_OPENLIBRARY_RATE = 3.0
+
+_openlibrary_limiter: RedisRateLimiter | None = None
+_openlibrary_limiter_lock = threading.Lock()
+
+
+def openlibrary_limiter() -> RedisRateLimiter:
+    """Singleton limiter for openlibrary.org calls.
+
+    covers.openlibrary.org is a separate host and stays off this cursor, the
+    same way coverartarchive.org stays off the MusicBrainz one.
+    """
+    global _openlibrary_limiter
+    if _openlibrary_limiter is None:
+        with _openlibrary_limiter_lock:
+            if _openlibrary_limiter is None:
+                _openlibrary_limiter = RedisRateLimiter(
+                    key="ratelimit:openlibrary.org",
+                    rate=_OPENLIBRARY_RATE,
+                )
+    return _openlibrary_limiter
+
+
+def _openlibrary_user_agent() -> str:
+    """Identify this instance to OpenLibrary.
+
+    Their 3 req/s tier wants the app name and a contact email or phone.
+    NEODB_USER_AGENT already carries the name and site URL, so append the
+    operator's from-address when one is configured; without it we still send
+    an honest UA, just on the slower unidentified tier.
+    """
+    contact = (SiteConfig.system.email_from or "").strip()
+    if contact:
+        return f"{settings.NEODB_USER_AGENT} ({contact})"
+    return settings.NEODB_USER_AGENT
+
+
+def _openlibrary_api_headers() -> dict[str, str]:
+    return {
+        "User-Agent": _openlibrary_user_agent(),
+        "Accept": "application/json",
+    }
+
+
+class OpenLibraryDownloader(BasicDownloader):
+    """BasicDownloader that identifies us to OpenLibrary and throttles every
+    call through the shared Redis cursor.
+
+    Use for any openlibrary.org request. Plain BasicDownloader would send the
+    class-level browser UA, which is exactly the unidentified-client case
+    OpenLibrary reserves the right to block.
+
+    A single work scrape fans out to one work request, one per author, and up
+    to five edition pages, so these bursts are the reason the cursor exists.
+    ``rate_limit_timeout`` is separate from BasicDownloader's HTTP ``timeout``.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict | None = None,
+        timeout: float | None = None,
+        *,
+        rate_limit_timeout: float = 15.0,
+    ):
+        super().__init__(
+            url,
+            headers=_openlibrary_api_headers() if headers is None else headers,
+            timeout=timeout,
+        )
+        self._rate_limit_timeout = rate_limit_timeout
+
+    def download(self):
+        openlibrary_limiter().acquire(timeout=self._rate_limit_timeout)
+        return super().download()
 
 
 def _author_id_from_key(key: str) -> str | None:
@@ -59,7 +144,7 @@ class OpenLibrary(AbstractSite):
     def scrape(self):
         # id_value should always be an OpenLibrary book ID (OL...M format)
         api_url = f"https://openlibrary.org/books/{self.id_value}.json"
-        response = BasicDownloader(api_url).download()
+        response = OpenLibraryDownloader(api_url).download()
         book_data = response.json()
         if not book_data:
             raise ParseError(self, "no data returned")
@@ -74,7 +159,7 @@ class OpenLibrary(AbstractSite):
                 if not author_key:
                     continue
                 author_url = "https://openlibrary.org" + author_key + ".json"
-                author_json = BasicDownloader(author_url).download().json()
+                author_json = OpenLibraryDownloader(author_url).download().json()
                 author_name = author_json.get("name", "")
                 authors.append(author_name)
                 author_id = _author_id_from_key(author_key)
@@ -190,10 +275,20 @@ class OpenLibrary(AbstractSite):
         if category not in ["all", "book"]:
             return []
         results = []
+        # search.json shares the openlibrary.org quota with every scrape, so
+        # take a slot when one is free. Never wait for one: this runs in the
+        # interactive fan-out, where a wait would stall the whole result page.
+        # Dropping OpenLibrary from one page of results beats holding the page
+        # back, and beats spending quota a scrape is queued for.
+        if not await openlibrary_limiter().try_acquire_async():
+            record_search_failure(cls.SITE_NAME.value, "throttled")
+            return results
         search_url = f"https://openlibrary.org/search.json?q={quote_plus(q)}&limit={page_size}&offset={(page - 1) * page_size}&fields=key,title,author_name,first_publish_year,editions,editions.key,editions.title,editions.language"
         async with httpx.AsyncClient() as client:
             try:
-                response = await client.get(search_url, timeout=3)
+                response = await client.get(
+                    search_url, headers=_openlibrary_api_headers(), timeout=3
+                )
                 data = response.json()
                 if "docs" in data:
                     for work in data["docs"]:
@@ -281,7 +376,7 @@ class OpenLibrary_Work(AbstractSite):
                 api_url = f"https://openlibrary.org/works/{self.id_value}/editions.json?offset={offset}"
 
             try:
-                response = BasicDownloader(api_url).download()
+                response = OpenLibraryDownloader(api_url).download()
                 data = response.json()
 
                 if "entries" not in data:
@@ -325,7 +420,7 @@ class OpenLibrary_Work(AbstractSite):
     def scrape(self):
         api_url = f"https://openlibrary.org/works/{self.id_value}.json"
 
-        response = BasicDownloader(api_url).download()
+        response = OpenLibraryDownloader(api_url).download()
         work_data = response.json()
 
         if not work_data:
@@ -342,7 +437,7 @@ class OpenLibrary_Work(AbstractSite):
                 if not author_key:
                     continue
                 author_url = "https://openlibrary.org" + author_key + ".json"
-                author_json = BasicDownloader(author_url).download().json()
+                author_json = OpenLibraryDownloader(author_url).download().json()
                 author_name = author_json.get("name", "")
                 authors.append(author_name)
                 author_id = _author_id_from_key(author_key)
@@ -432,7 +527,7 @@ class OpenLibrary_Author(AbstractSite):
 
     def scrape(self):
         api_url = f"https://openlibrary.org/authors/{self.id_value}.json"
-        response = BasicDownloader(api_url).download()
+        response = OpenLibraryDownloader(api_url).download()
         data = response.json()
         if not data:
             raise ParseError(self, "no author data")

--- a/neodb/tests/catalog/test_rate_limit.py
+++ b/neodb/tests/catalog/test_rate_limit.py
@@ -9,8 +9,10 @@ import uuid
 import pytest
 
 from catalog.common.rate_limit import RedisRateLimiter
+from catalog.sites.anilist import anilist_limiter
 from catalog.sites.igdb import igdb_limiter
 from catalog.sites.musicbrainz import musicbrainz_limiter
+from catalog.sites.openlibrary import _openlibrary_user_agent, openlibrary_limiter
 
 
 def _fresh_limiter(rate: float) -> RedisRateLimiter:
@@ -77,6 +79,107 @@ def test_redis_offline_uses_local_fallback(monkeypatch: pytest.MonkeyPatch) -> N
     assert 0.05 <= elapsed < 0.3, f"local fallback slept {elapsed:.3f}s"
 
 
+def test_try_acquire_takes_a_free_slot() -> None:
+    """An idle cursor hands out a slot; the caller may fire."""
+    rl = _fresh_limiter(rate=2.0)
+    t0 = time.monotonic()
+    assert rl.try_acquire() is True
+    assert time.monotonic() - t0 < 0.05, "try_acquire must never sleep"
+
+
+def test_try_acquire_refuses_when_no_slot_is_free() -> None:
+    """A second caller inside the same interval is told to skip, not to wait."""
+    rl = _fresh_limiter(rate=2.0)  # interval = 0.5s
+    assert rl.try_acquire() is True
+    t0 = time.monotonic()
+    assert rl.try_acquire() is False
+    assert time.monotonic() - t0 < 0.05, "refusal must be instant"
+
+
+def test_try_acquire_refusal_does_not_consume_a_slot() -> None:
+    """A skipped caller must not steal the slot the cursor is holding.
+
+    Without this, N concurrent searches would each push the cursor forward and
+    starve the scrape paths queued behind them.
+    """
+    rl = _fresh_limiter(rate=10.0)  # interval = 0.1s
+    assert rl.try_acquire() is True
+    for _ in range(5):
+        assert rl.try_acquire() is False
+    # The cursor should still be only one interval out, so a blocking caller
+    # waits ~0.1s rather than the ~0.6s six advances would have cost.
+    t0 = time.monotonic()
+    rl.acquire(timeout=5.0)
+    waited = time.monotonic() - t0
+    assert waited < 0.3, f"refusals advanced the cursor; waited {waited:.3f}s"
+
+
+def test_try_acquire_async_matches_sync_semantics() -> None:
+    rl = _fresh_limiter(rate=2.0)
+
+    async def run() -> tuple[bool, bool, float]:
+        first = await rl.try_acquire_async()
+        t0 = time.monotonic()
+        second = await rl.try_acquire_async()
+        return first, second, time.monotonic() - t0
+
+    first, second, elapsed = asyncio.run(run())
+    assert first is True
+    assert second is False
+    assert elapsed < 0.05, "async refusal must not block the gather fan-out"
+
+
+def test_try_acquire_burst_admits_concurrent_siblings() -> None:
+    """burst=n lets n callers through back to back on an idle host.
+
+    This is what keeps both AniList sites (and both MusicBrainz sites) in the
+    results of a single `category=all` query.
+    """
+    rl = _fresh_limiter(rate=1.0)  # interval = 1s
+    assert rl.try_acquire(burst=2) is True
+    assert rl.try_acquire(burst=2) is True, "sibling was refused"
+    # Credit is spent; the third caller in the same interval still skips.
+    assert rl.try_acquire(burst=2) is False
+
+
+def test_try_acquire_burst_does_not_raise_sustained_rate() -> None:
+    """Burst spends accrued credit, it does not widen the interval.
+
+    After the burst the host is exactly one interval further out, not n.
+    """
+    rl = _fresh_limiter(rate=10.0)  # interval = 0.1s
+    assert rl.try_acquire(burst=3) is True
+    assert rl.try_acquire(burst=3) is True
+    assert rl.try_acquire(burst=3) is True
+    t0 = time.monotonic()
+    rl.acquire(timeout=5.0)
+    waited = time.monotonic() - t0
+    # Three slots were handed out, so the cursor sits ~one interval past now,
+    # not three intervals: the credit came out of idle time, not the future.
+    assert waited < 0.3, f"burst pushed the cursor too far; waited {waited:.3f}s"
+
+
+def test_burst_credit_does_not_leak_to_strict_callers() -> None:
+    """A scrape path (burst=1) sees no tolerance even on a host whose
+    searches use burst=2, because the credit is per call, not per cursor."""
+    rl = _fresh_limiter(rate=1.0)
+    assert rl.try_acquire(burst=1) is True
+    assert rl.try_acquire(burst=1) is False
+
+
+def test_try_acquire_rejects_burst_below_one() -> None:
+    rl = _fresh_limiter(rate=1.0)
+    with pytest.raises(ValueError):
+        rl.try_acquire(burst=0)
+
+
+def test_try_acquire_allows_when_redis_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A broken limiter degrades to no limiter, not to a closed door."""
+    rl = _fresh_limiter(rate=1.0)
+    monkeypatch.setattr(rl, "_reserve", lambda timeout, credit=0.0: None)
+    assert rl.try_acquire() is True
+
+
 def test_musicbrainz_limiter_is_singleton() -> None:
     a = musicbrainz_limiter()
     b = musicbrainz_limiter()
@@ -93,3 +196,47 @@ def test_igdb_limiter_is_singleton() -> None:
     assert a.key == "ratelimit:api.igdb.com"
     # IGDB's documented 4 req/s/client-ID ceiling.
     assert 1.0 / a.interval <= 4.0
+
+
+def test_anilist_limiter_is_singleton() -> None:
+    a = anilist_limiter()
+    b = anilist_limiter()
+    assert a is b
+    assert a.key == "ratelimit:graphql.anilist.co"
+    # The live x-ratelimit-limit header has been serving 30/min.
+    assert 1.0 / a.interval <= 0.5
+
+
+def test_openlibrary_limiter_is_singleton() -> None:
+    a = openlibrary_limiter()
+    b = openlibrary_limiter()
+    assert a is b
+    assert a.key == "ratelimit:openlibrary.org"
+    # OpenLibrary's identified-client tier; the default tier is 1 req/s.
+    assert 1.0 / a.interval <= 3.0
+
+
+def test_openlibrary_user_agent_includes_contact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The contact address is what earns the 3 req/s tier."""
+    from common.models import SiteConfig
+
+    monkeypatch.setattr(SiteConfig.system, "email_from", "ops@example.org")
+    ua = _openlibrary_user_agent()
+    assert "ops@example.org" in ua
+    assert ua.startswith("NeoDB/")
+
+
+def test_openlibrary_user_agent_falls_back_without_contact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No contact configured still means an honest UA, never a browser string."""
+    from django.conf import settings
+
+    from common.models import SiteConfig
+
+    monkeypatch.setattr(SiteConfig.system, "email_from", "")
+    ua = _openlibrary_user_agent()
+    assert ua == settings.NEODB_USER_AGENT
+    assert "Mozilla" not in ua


### PR DESCRIPTION
## OpenLibrary was unthrottled and unidentified

`openlibrary.org` had no rate limiter. Every scrape went out through a bare
`BasicDownloader`, which inherits the class-level spoofed iPad Safari
User-Agent, and `search.json` sent no headers at all, so httpx supplied
`python-httpx/x.y.z`.

[Their docs](https://openlibrary.org/developers/api) serve 1 req/s to
unidentified clients and 3 req/s to callers that send an app name plus a
contact email or phone, and warn that a generic or missing User-Agent "may
result in aggressive rate limiting or blocking" because it leaves them no way
to reach a heavy user.

The bursts are not theoretical: one work scrape is 1 work request, plus 1 per
author in a loop, plus up to 5 edition pages, so a 3-author work is about 9
back-to-back requests. This adds a shared 3 req/s cursor for the host and an
`OpenLibraryDownloader` that sends `NEODB_USER_AGENT` with the operator's
configured from-address, wired into all six scrape call sites.
`covers.openlibrary.org` is a separate host and stays off the cursor, matching
how `coverartarchive.org` stays off the MusicBrainz one.

## Search behaved three different ways

In the interactive `asyncio.gather` fan-out over every searchable site:

- **IGDB** waited up to 15 s for a slot, three times its own 5 s HTTP timeout.
  A bulk Steam import could stall every game search on the instance before a
  single byte went out.
- **MusicBrainz** and **AniList** skipped the limiter entirely, so their
  searches spent host quota the cursor could not see. AniList's 0.5 req/s is
  tuned to an observed 30/min header, and search traffic was eating straight
  into the scrape budget.

`RedisRateLimiter` gains a non-blocking `try_acquire` / `try_acquire_async`:
take a slot if one is free, otherwise return `False` so the caller skips that
site for this query. A refusal leaves the cursor untouched, so a skipped search
cannot steal the slot a queued scrape is waiting for. Every search path now
uses it; no search can block on a slot any more.

## Sibling search sites need a burst allowance

`MusicBrainzRelease` and `MusicBrainzArtist` are both registered search sites
on one host, and both answer `category=all`. Same for `AniListAnime` and
`AniListManga`. They always reserve together, so under strict serialization the
second was refused every time and half of each site's results vanished from
every `category=all` query.

The Lua now lets the cursor lag `now` by `(burst - 1) * interval`, so an idle
host serves `burst` requests back to back and is then exactly one interval out,
not `burst` intervals. Sustained rate is unchanged. **Burst is a per-call
argument, not limiter state**, so the two callers can hold different tolerances
against the same Redis key: only the sibling searches spend credit, and the
scrape paths keep strict serialization.

## Where things land

| Host | Rate | Interactive search | Scrape |
|---|---|---|---|
| openlibrary.org | 3 req/s, identified | skip if busy | wait up to 15 s |
| api.igdb.com | 4 req/s | skip if busy | wait up to 60 s |
| musicbrainz.org | 1 req/s | skip if busy, burst 2 | 15 s, 300 s on batch |
| graphql.anilist.co | 0.5 req/s | skip if busy, burst 2 | wait up to 30 s |

Skips are recorded through `record_search_failure` with reason `throttled`, so
they stay separable from real errors while still showing when the limiter
starts costing results.

## One caveat for review

The 3 req/s OpenLibrary rate assumes `SiteConfig.system.email_from` is set.
Without it the User-Agent carries no contact address, OpenLibrary keeps the
instance on the 1 req/s tier, and the limiter paces at 3 regardless, so those
instances would be over-rate. Options if you would rather not ship that: gate
the rate on a contact being present (1 req/s without, 3 with), or add a
dedicated OpenLibrary contact field. Happy to change it either way.

## Test plan

- 13 new tests in `tests/catalog/test_rate_limit.py`, 20 in the file total, all
  passing. They cover: `try_acquire` true on idle and false on busy with no
  sleep either way; a refusal not advancing the cursor; the async variant;
  Redis offline falling open rather than closed; burst admitting concurrent
  siblings and then refusing; burst not raising the sustained rate; burst
  credit not leaking to strict callers; the OpenLibrary limiter singleton; and
  the User-Agent both with and without a configured contact.
- `tests/catalog/` full run: the failing set is byte-identical before and after
  this change (30 failures, all the typesense-index tests that fail in any
  cluster without index sync). Verified by capturing the sorted `FAILED` list
  on a clean tree and diffing with `comm`, in both directions.
