### PR TITLE
fix(catalog): close the gaps in the user fetch throttle

### DIFF
--- a/neodb/catalog/search/__init__.py
+++ b/neodb/catalog/search/__init__.py
@@ -1,7 +1,14 @@
 from .external import ExternalSearchResultItem, ExternalSources
 from .index import CatalogIndex, CatalogQueryParser, CatalogSearchResult
 from .people_index import PeopleIndex, PeopleQueryParser, PeopleSearchResult
-from .utils import enqueue_fetch, get_fetch_lock, query_index, record_search_failure
+from .utils import (
+    enqueue_fetch,
+    get_actor_fetch_lock,
+    get_fetch_lock,
+    mark_fetch_completed,
+    query_index,
+    record_search_failure,
+)
 
 __all__ = [
     "CatalogIndex",
@@ -11,7 +18,9 @@ __all__ = [
     "PeopleQueryParser",
     "PeopleSearchResult",
     "query_index",
+    "get_actor_fetch_lock",
     "get_fetch_lock",
+    "mark_fetch_completed",
     "enqueue_fetch",
     "record_search_failure",
     "ExternalSources",

--- a/neodb/catalog/search/utils.py
+++ b/neodb/catalog/search/utils.py
@@ -113,7 +113,21 @@ def query_index(
     return items, r.pages, r.total, r.facet_by_category, q.q
 
 
-def get_fetch_lock(user, url):
+# Hold a url briefly when its fetch is enqueued, then extend to the long TTL
+# once the fetch actually lands. A fetch that fails is therefore retryable in
+# minutes rather than hours.
+FETCH_URL_LOCK_TTL = 300
+FETCH_URL_LOCK_TTL_DONE = 7200
+
+
+def get_actor_fetch_lock(user):
+    """Claim the per-actor fetch slot.
+
+    An authenticated user gets a key of their own; every anonymous caller
+    shares one key, so unauthenticated traffic cannot outpace signed-in
+    traffic in aggregate. Every path that makes NeoDB issue an outbound
+    request on a user's behalf goes through here.
+    """
     if user and user.is_authenticated:
         _fetch_lock_key = f"_fetch_lock:{user.id}"
         _fetch_lock_ttl = 1 if settings.DEBUG else 3
@@ -123,13 +137,30 @@ def get_fetch_lock(user, url):
     if cache.get(_fetch_lock_key):
         return False
     cache.set(_fetch_lock_key, 1, timeout=_fetch_lock_ttl)
-    # do not fetch the same url twice in 2 hours
+    return True
+
+
+def get_fetch_lock(user, url):
+    if not get_actor_fetch_lock(user):
+        return False
+    # do not fetch the same url twice while one is in flight; a successful
+    # fetch extends this via mark_fetch_completed()
     _fetch_lock_key = f"_fetch_lock:{url}"
-    _fetch_lock_ttl = 1 if settings.DEBUG else 7200
+    _fetch_lock_ttl = 1 if settings.DEBUG else FETCH_URL_LOCK_TTL
     if cache.get(_fetch_lock_key):
         return False
     cache.set(_fetch_lock_key, 1, timeout=_fetch_lock_ttl)
     return True
+
+
+def mark_fetch_completed(url):
+    """Hold the url lock for the long TTL now that the fetch has landed, so
+    the same url is not fetched again for hours."""
+    cache.set(
+        f"_fetch_lock:{url}",
+        1,
+        timeout=1 if settings.DEBUG else FETCH_URL_LOCK_TTL_DONE,
+    )
 
 
 def enqueue_fetch(url, is_refetch, user=None):
@@ -181,6 +212,8 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
                 item_url = search_by_ap_url(url, fetcher)
                 if item_url:
                     logger.info(f"fetched {url} {item_url}")
+                    if not is_refetch:
+                        mark_fetch_completed(url)
                     return item_url
                 logger.warning(f"Site not found for {url}")
                 _record_fetch_failure(url)
@@ -189,6 +222,10 @@ def _fetch_task(url: str, is_refetch: bool, user_pk: int | None):
             item = res.item if res else None
             if item:
                 logger.info(f"fetched {url} {item.url} {item}")
+                # A refetch deliberately does not extend the lock: an editor
+                # correcting bad metadata should not be locked out for hours.
+                if not is_refetch:
+                    mark_fetch_completed(url)
                 return item.url
             else:
                 logger.error(f"fetch {url} failed")

--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -78,14 +78,16 @@ def fetch(request, url, site: AbstractSite | None, is_refetch: bool = False):
     item = site.get_item(allow_rematch=False) if site else None
     if item and not is_refetch:
         return redirect(item.url)
-    if item and is_refetch:
-        item.log_action(
-            {
-                "!refetch": [url, None],
-            }
-        )
     job_id = None
-    if is_refetch or get_fetch_lock(request.user, url):
+    # A refetch goes through the same lock as any other fetch, so it cannot be
+    # used to bypass the throttle; the action is logged only when it is queued.
+    if get_fetch_lock(request.user, url):
+        if item and is_refetch:
+            item.log_action(
+                {
+                    "!refetch": [url, None],
+                }
+            )
         job_id = enqueue_fetch(url, is_refetch, request.user)
     return render(
         request,

--- a/neodb/tests/catalog/test_fetch_lock.py
+++ b/neodb/tests/catalog/test_fetch_lock.py
@@ -1,0 +1,169 @@
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from catalog.models import Movie
+from catalog.search.utils import (
+    FETCH_URL_LOCK_TTL,
+    FETCH_URL_LOCK_TTL_DONE,
+    get_actor_fetch_lock,
+    get_fetch_lock,
+    mark_fetch_completed,
+)
+from users.models import User
+
+
+class FakeCache:
+    """Cache double that records the timeout each key was set with."""
+
+    def __init__(self):
+        self.values = {}
+        self.timeouts = {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.timeouts[key] = timeout
+
+
+class FakeUser:
+    is_authenticated = True
+
+    def __init__(self, id):
+        self.id = id
+
+
+class FakeAnonymous:
+    is_authenticated = False
+
+
+@pytest.fixture(autouse=True)
+def _production_ttls(settings):
+    """The lock collapses every TTL to 1s under DEBUG; pin it off so the
+    real values are asserted."""
+    settings.DEBUG = False
+
+
+@pytest.fixture
+def fake_cache():
+    c = FakeCache()
+    with patch("catalog.search.utils.cache", c):
+        yield c
+
+
+class TestFetchLockTtl:
+    def test_url_lock_starts_short(self, fake_cache):
+        url = "https://example.com/a"
+        assert get_fetch_lock(FakeUser(1), url) is True
+        assert fake_cache.timeouts[f"_fetch_lock:{url}"] == FETCH_URL_LOCK_TTL
+
+    def test_completed_fetch_extends_url_lock(self, fake_cache):
+        url = "https://example.com/a"
+        get_fetch_lock(FakeUser(1), url)
+        mark_fetch_completed(url)
+        assert fake_cache.timeouts[f"_fetch_lock:{url}"] == FETCH_URL_LOCK_TTL_DONE
+
+    def test_url_lock_blocks_a_different_user(self, fake_cache):
+        """The url half of the lock is global, so a second user is refused
+        even though their own actor slot is free."""
+        url = "https://example.com/a"
+        assert get_fetch_lock(FakeUser(1), url) is True
+        assert get_fetch_lock(FakeUser(2), url) is False
+
+    def test_failed_fetch_leaves_the_short_ttl(self, fake_cache):
+        """No mark_fetch_completed call means the url is retryable in
+        minutes rather than hours."""
+        url = "https://example.com/a"
+        get_fetch_lock(FakeUser(1), url)
+        assert fake_cache.timeouts[f"_fetch_lock:{url}"] == FETCH_URL_LOCK_TTL
+
+
+class TestActorFetchLock:
+    def test_second_call_by_same_user_is_refused(self, fake_cache):
+        user = FakeUser(1)
+        assert get_actor_fetch_lock(user) is True
+        assert get_actor_fetch_lock(user) is False
+
+    def test_users_do_not_share_a_slot(self, fake_cache):
+        assert get_actor_fetch_lock(FakeUser(1)) is True
+        assert get_actor_fetch_lock(FakeUser(2)) is True
+
+    def test_anonymous_callers_share_one_slot(self, fake_cache):
+        assert get_actor_fetch_lock(FakeAnonymous()) is True
+        assert get_actor_fetch_lock(FakeAnonymous()) is False
+
+    def test_actor_lock_refuses_before_touching_the_url(self, fake_cache):
+        user = FakeUser(1)
+        assert get_fetch_lock(user, "https://example.com/a") is True
+        assert get_fetch_lock(user, "https://example.com/b") is False
+        assert "_fetch_lock:https://example.com/b" not in fake_cache.values
+
+
+class StubSiteName:
+    label = "Example"
+
+
+class StubSite:
+    SITE_NAME = StubSiteName()
+
+    def __init__(self, item=None):
+        self._item = item
+
+    def get_item(self, allow_rematch=True):
+        return self._item
+
+    def get_resource(self):
+        return None
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRefetchIsThrottled:
+    """Regression: refetch used to skip get_fetch_lock entirely, so a POST
+    loop could queue an unbounded number of fetch jobs."""
+
+    def _client(self, username="editor"):
+        user = User.register(email=f"{username}@example.com", username=username)
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        return client
+
+    def _post(self, client, url, fake_cache, item=None):
+        with (
+            patch(
+                "catalog.views.search.SiteManager.get_site_by_url",
+                return_value=StubSite(item),
+            ),
+            patch("catalog.search.utils.cache", fake_cache),
+            patch("catalog.views.search.enqueue_fetch") as enqueue,
+        ):
+            response = client.post(reverse("catalog:refetch"), {"url": url})
+        return response, enqueue
+
+    def test_second_refetch_of_same_url_is_not_queued(self):
+        fake_cache = FakeCache()
+        client = self._client()
+        url = "https://example.com/refetch-me"
+
+        response, enqueue = self._post(client, url, fake_cache)
+        assert response.status_code == 200
+        assert enqueue.call_count == 1
+
+        response, enqueue = self._post(client, url, fake_cache)
+        assert response.status_code == 200
+        assert enqueue.call_count == 0
+
+    def test_refused_refetch_does_not_log_the_action(self):
+        fake_cache = FakeCache()
+        client = self._client()
+        movie = Movie.objects.create(title="Blocked Refetch")
+        url = "https://example.com/refetch-logged"
+
+        with patch.object(Movie, "log_action") as log_action:
+            self._post(client, url, fake_cache, item=movie)
+            assert log_action.call_count == 1
+            self._post(client, url, fake_cache, item=movie)
+            assert log_action.call_count == 1

--- a/neodb/tests/users/test_query_identity.py
+++ b/neodb/tests/users/test_query_identity.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from users.models import User
+
+
+class FakeCache:
+    """Cache double so the throttle is exercised without touching redis."""
+
+    def __init__(self):
+        self.values = {}
+        self.timeouts = {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set(self, key, value, timeout=None):
+        self.values[key] = value
+        self.timeouts[key] = timeout
+
+
+@pytest.fixture(autouse=True)
+def _production_ttls(settings):
+    """The lock collapses every TTL to 1s under DEBUG."""
+    settings.DEBUG = False
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestQueryIdentityIsThrottled:
+    """Each miss makes Takahe send a signed request to an arbitrary domain,
+    so the search box cannot be used as an unthrottled outbound fan-out."""
+
+    def _search(self, client, handle, fake_cache):
+        with (
+            patch("catalog.search.utils.cache", fake_cache),
+            patch("users.views.actions.Takahe.fetch_remote_identity") as fetch,
+        ):
+            response = client.get(reverse("common:search"), {"q": handle})
+        return response, fetch
+
+    def test_anonymous_callers_share_one_slot(self):
+        fake_cache = FakeCache()
+
+        response, fetch = self._search(Client(), "@alice@example.com", fake_cache)
+        assert response.status_code == 200
+        assert fetch.call_count == 1
+
+        # A different anonymous caller and a different handle: still refused,
+        # because unauthenticated traffic shares a single slot.
+        response, fetch = self._search(Client(), "@bob@example.org", fake_cache)
+        assert response.status_code == 200
+        assert fetch.call_count == 0
+
+    def test_second_query_by_same_user_is_refused(self):
+        fake_cache = FakeCache()
+        user = User.register(email="searcher@example.com", username="searcher")
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+        _, fetch = self._search(client, "@alice@example.com", fake_cache)
+        assert fetch.call_count == 1
+
+        _, fetch = self._search(client, "@bob@example.org", fake_cache)
+        assert fetch.call_count == 0
+
+    def test_authenticated_user_has_their_own_slot(self):
+        fake_cache = FakeCache()
+        user = User.register(email="searcher2@example.com", username="searcher2")
+        client = Client()
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+        # An anonymous caller taking the shared slot must not block a
+        # signed-in user.
+        _, fetch = self._search(Client(), "@alice@example.com", fake_cache)
+        assert fetch.call_count == 1
+        _, fetch = self._search(client, "@bob@example.org", fake_cache)
+        assert fetch.call_count == 1

--- a/neodb/users/views/actions.py
+++ b/neodb/users/views/actions.py
@@ -24,11 +24,19 @@ from .data import *
 
 
 def query_identity(request, handle):
+    from catalog.search import get_actor_fetch_lock
+
     try:
         i = APIdentity.get_by_handle(handle)
         return redirect(i.url)
     except APIdentity.DoesNotExist:
         if len(handle.split("@")) == 3:
+            # Each miss makes Takahe send a signed request to whichever domain
+            # the caller names, so this shares the per-user / anonymous fetch
+            # slot with catalog fetches. Without a slot, show the busy page
+            # instead of queueing the request.
+            if not get_actor_fetch_lock(request.user):
+                return render(request, "users/fetch_identity_pending.html", {})
             Takahe.fetch_remote_identity(handle)
             return render(
                 request, "users/fetch_identity_pending.html", {"handle": handle}


### PR DESCRIPTION
Three user-facing paths could make NeoDB issue outbound requests without passing the fetch throttle, or blocked retries for far longer than intended.

## Split the lock

`get_fetch_lock` becomes two functions: `get_actor_fetch_lock(user)` holds the per-actor slot (per user, or one shared key for all anonymous callers), and `get_fetch_lock(user, url)` calls it and then takes the per-url lock. Callers that need only the actor half can now take it. TTL values are unchanged.

## Refetch skipped the lock entirely

`catalog/views/search.py` read `if is_refetch or get_fetch_lock(...)`, so refetch never took the lock and a POST loop could queue an unbounded number of fetch jobs. It is `@login_required` and permission-checked, but there was no rate limit of any kind behind that.

It now takes the same lock as any other fetch. A successful refetch deliberately does not extend the url lock, so an editor correcting bad metadata waits minutes rather than hours before the next pass.

The `!refetch` audit action was also logged before the enqueue decision, so a refetch that queued nothing still recorded an action. It is now logged only when a job is queued.

## The url lock started at its long TTL

The 7200s url lock was written during the check, before the fetch had run. A site being down, or `enqueue_fetch` rejecting the url, therefore blocked every retry for two hours.

The lock now starts at 300s, and `mark_fetch_completed()` extends it to 7200s from `_fetch_task` once the fetch actually lands. Behavior on the happy path is unchanged; a failure is retryable in 5 minutes.

## query_identity had no limit

`/search?q=@user@domain` reaches `Takahe.fetch_remote_identity` with no login and no throttle. Each miss creates an InboxMessage that makes a signed outbound request to whichever domain the caller names, once per request, with only a domain-block check in front of it.

It now takes the actor slot and renders the busy page when refused. The per-handle lock is deliberately omitted: with one, a user whose poll page times out would be locked out of retrying their own handle for the full window.

## Tests

13 new tests in `tests/catalog/test_fetch_lock.py` and `tests/users/test_query_identity.py` covering the TTL transitions, the actor/url split, and both regressions. With the two view fixes reverted, exactly the 4 behavior tests fail.

`tests/catalog` + `tests/users` (819 tests) produce an identical failure list before and after the change.

## Not addressed

Two related gaps are left alone here to keep the diff scoped:

- All anonymous callers share a single lock key, so one client polling `/api/catalog/fetch` (which is `auth=None`) can hold the slot and 429 everyone else. Keying on client IP would fix the fairness problem.
- `fetch_works_for_person_task` calls `enqueue_fetch` in a loop with no cap on `len(urls)`, so one POST can enqueue hundreds of jobs behind a single 10-minute per-person lock.