### PR TITLE
fix(atproto): link long-form documents to their publication

### DIFF
--- a/docs/internals/atproto.md
+++ b/docs/internals/atproto.md
@@ -1,13 +1,15 @@
 # NeoDB ATProto Implementation
 
-NeoDB can publish a user's marks and reviews (with ratings embedded) to their
-ATProto Personal Data Server (PDS) as structured records, in addition to
-crossposting a human-readable skeet to Bluesky. This lets other ATProto
+NeoDB can publish a user's marks, reviews and articles (with ratings embedded)
+to their ATProto Personal Data Server (PDS) as structured records, in addition
+to crossposting a human-readable skeet to Bluesky. This lets other ATProto
 applications read a user's NeoDB activity directly from their repository.
 
-The lexicon is project-owned under the `net.neodb.*` namespace (reverse of
-`neodb.net`), so it is shared by every NeoDB instance. The schema files live in
-[`docs/lexicons/net/neodb/`](../lexicons/net/neodb).
+The activity lexicon is project-owned under the `net.neodb.*` namespace
+(reverse of `neodb.net`), so it is shared by every NeoDB instance. The schema
+files live in [`docs/lexicons/net/neodb/`](../lexicons/net/neodb). Long-form
+pieces are *also* published under the [standard.site](https://standard.site/)
+lexicon; see [Long-form documents](#long-form-documents).
 
 ## How it connects
 
@@ -34,11 +36,13 @@ they re-authorize.
 
 ## Record types
 
-| Collection (NSID)   | Written from         | Purpose                                   |
-| ------------------- | -------------------- | ----------------------------------------- |
-| `net.neodb.mark`    | a shelf entry        | status (+ optional rating/comment/tags)   |
-| `net.neodb.review`  | a review             | long-form review (+ optional rating)      |
-| `net.neodb.profile` | the linked account   | verifiable link to the NeoDB identity     |
+| Collection (NSID)             | Written from         | Purpose                                   |
+| ----------------------------- | -------------------- | ----------------------------------------- |
+| `net.neodb.mark`              | a shelf entry        | status (+ optional rating/comment/tags)   |
+| `net.neodb.review`            | a review             | long-form review (+ optional rating)      |
+| `net.neodb.profile`           | the linked account   | verifiable link to the NeoDB identity     |
+| `site.standard.document`      | a review or article  | the long-form piece, for generic readers  |
+| `site.standard.publication`   | the linked account   | the owner's journal the documents belong to |
 
 ### Subject
 
@@ -104,6 +108,60 @@ rather than on crossposting; disconnecting the account removes it.
 [FEP-c390]: https://codeberg.org/fediverse/fep/src/branch/main/fep/c390/fep-c390.md
 [W3C Data Integrity]: https://www.w3.org/TR/vc-data-integrity/
 
+## Long-form documents
+
+Reviews and articles are additionally published as
+[standard.site](https://standard.site/) records: a `site.standard.document`
+carrying the piece (markdown, plaintext and cover image) and a
+`site.standard.publication` describing the owner's journal (name, summary,
+avatar and a theme matching the instance's colors).
+
+### The document -> publication link
+
+A document's `site` points at the publication record by AT-URI. Without
+that link the pair reads as a stray page rather than a publication:
+bsky.app renders the enhanced article card only when it can resolve a
+document to its publication.
+
+A document's canonical URL is the publication's `url` joined with the
+document's `path`. The publication's `url` is the owner's profile, so
+every piece is served beneath it as well:
+
+```
+publication url   https://neodb.social/users/alice
+document path                              /article/<uuid>
+canonical         https://neodb.social/users/alice/article/<uuid>
+```
+
+These user-scoped URLs render the same page as the canonical
+`/<type>/<uuid>`, which stays the `rel=canonical` target, and are not
+found when the handle does not own the piece. The crossposted skeet's
+external embed points at the user-scoped URL, so the embed, the document
+and the page all name one URL.
+
+An owner who is not publicly discoverable has no publication record; their
+documents stay loose, with `site` set to the instance URL so the same
+`path` joins to `/<type>/<uuid>`.
+
+### Discovery and verification
+
+The records name web pages, and the pages name the records back:
+
+- `/users/<handle>/.well-known/site.standard.publication` returns the
+  publication's AT-URI as plain text, served under the record's own `url`.
+- Piece pages carry `<link rel="site.standard.document">` and
+  `<link rel="site.standard.publication">` holding the matching AT-URIs.
+
+### Crosspost wiring
+
+The skeet's external embed strong-refs both records, publication first.
+The document is written before the skeet so the refs exist, then written
+again afterwards to add `bskyPostRef` pointing back at the skeet, which
+keeps off-platform comments discoverable. That second write changes the
+document's CID, so the CID in the embed goes stale by design: the refs are
+resolved by URI, and bsky.app keeps the original snapshot rather than
+re-rendering edited records.
+
 ## Record keys
 
 Every record is keyed by the mark's or review's own uuid, which is
@@ -117,6 +175,10 @@ at://<did>/net.neodb.review/<review-uuid>
 Keying by the mark/review rather than the subject item keeps the AT-URI stable
 across catalog item merges, and lets distinct items (e.g. multiple reviews of
 one work) map to distinct records.
+
+The `site.standard.*` records use [TID](https://atproto.com/specs/tid) keys instead, as that lexicon
+requires. The key is frozen on first write, so later backdating cannot
+orphan the record.
 
 Records are reconciled idempotently against the PDS: each record that should
 exist is written by key (overwriting in place on edit), and any record that

--- a/neodb/journal/models/atproto.py
+++ b/neodb/journal/models/atproto.py
@@ -50,6 +50,7 @@ RATING_MAX = 10
 # at worst a pathological description is cut inside an emoji cluster
 DOCUMENT_DESCRIPTION_MAX_GRAPHEMES = 3000
 DOCUMENT_TAG_MAX_GRAPHEMES = 128
+DOCUMENT_CONTRIBUTOR_NAME_MAX_GRAPHEMES = 100
 
 _TID_ALPHABET = "234567abcdefghijklmnopqrstuvwxyz"  # base32-sortable
 _TID_CLOCKID_BITS = 10
@@ -189,6 +190,32 @@ def build_document_rkey(piece: "Piece") -> str:
     return build_tid(piece.created_time, piece.pk or 0)
 
 
+def build_document_contributor(piece: "Piece") -> dict[str, str] | None:
+    """``site.standard.document#contributor`` naming the piece's owner as
+    author, or ``None`` when they have no linked ATProto account.
+
+    The DID is the repo the document is written to, so naming it discloses
+    nothing new; it is what lets an appview attribute the document --
+    bsky.app renders it as ``associatedProfiles`` on the card.
+
+    ``displayName`` is identity data rather than a pointer, so it follows
+    the same gate as the other identity-describing records: it is written
+    only while the identity is **publicly discoverable**, since a
+    non-discoverable owner has their ``net.neodb.profile`` and
+    ``site.standard.publication`` (which both carry the name) deleted from
+    the same world-readable repo.
+    """
+    account = piece.owner.user.bluesky if piece.owner.user_id else None
+    did = getattr(account, "uid", None)
+    if not did:
+        return None
+    contributor = {"did": did, "role": "author"}
+    name = (piece.owner.display_name or "").strip()
+    if name and piece.owner.discoverable:
+        contributor["displayName"] = name[:DOCUMENT_CONTRIBUTOR_NAME_MAX_GRAPHEMES]
+    return contributor
+
+
 def build_document(
     piece: "Piece",
     *,
@@ -200,16 +227,25 @@ def build_document(
 ) -> dict[str, Any]:
     """``site.standard.document`` record for a long-form piece.
 
-    Published as a "loose" document: ``site`` is the instance base URL and
-    ``path`` the piece's local path, so ``site + path`` reconstructs the
-    canonical NeoDB URL. The full markdown ``body`` travels in the open
-    ``content`` union (``at.markpub.markdown``) next to the plaintext
-    ``textContent``, and the crossposted skeet (when one exists) is linked
-    via ``bskyPostRef`` so off-platform comments stay discoverable.
+    ``site`` points at the owner's ``site.standard.publication`` record, so
+    consumers can resolve the publication behind the document -- bsky.app
+    needs that edge to hydrate ``embed.external.source`` and render the
+    enhanced card instead of a plain link card. ``path`` joins onto the
+    publication's ``url`` (the owner's profile) to form the piece's
+    user-scoped URL, e.g. ``user_article_retrieve``. Owners with no
+    publication record (not publicly discoverable) fall back to a "loose"
+    document rooted at the instance URL, where the same ``path`` joins to
+    the canonical ``/<type>/<uuid>``.
+
+    The full markdown ``body`` travels in the open ``content`` union
+    (``at.markpub.markdown``) next to the plaintext ``textContent``, and
+    the crossposted skeet (when one exists) is linked via ``bskyPostRef``
+    so off-platform comments stay discoverable.
     """
     record: dict[str, Any] = {
         "$type": DOCUMENT_NSID,
-        "site": settings.SITE_INFO["site_url"].rstrip("/"),
+        "site": piece.atproto_publication_uri
+        or settings.SITE_INFO["site_url"].rstrip("/"),
         "path": piece.url,
         "title": title,
         "publishedAt": format_datetime(piece.created_time),
@@ -226,6 +262,9 @@ def build_document(
         record["description"] = description[:DOCUMENT_DESCRIPTION_MAX_GRAPHEMES]
     if tags:
         record["tags"] = [t for t in tags if len(t) <= DOCUMENT_TAG_MAX_GRAPHEMES]
+    contributor = build_document_contributor(piece)
+    if contributor:
+        record["contributors"] = [contributor]
     metadata = getattr(piece, "metadata", None) or {}
     post_uri = metadata.get("bluesky_id")
     post_cid = metadata.get("bluesky_cid")

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -468,6 +468,27 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             return None
         return account.publication_uri
 
+    @property
+    def atproto_document_url(self) -> str | None:
+        """Absolute user-scoped URL of this piece -- the standard.site
+        canonical URL of its ``site.standard.document`` (the publication's
+        ``url`` joined with the document ``path``).
+
+        ``None`` when the piece publishes no publication-linked document,
+        in which case that join already lands on :attr:`absolute_url` and
+        there is nothing to prefer over it. The crossposted skeet's
+        external embed points here so the embed uri, the document's
+        canonical URL and the page carrying the ``site.standard.*`` link
+        tags are one and the same, which is the shape bsky.app hydrates
+        the enhanced publication card from.
+        """
+        if not self.atproto_publication_uri:
+            return None
+        account = self.owner.user.bluesky if self.owner.user_id else None
+        if not account:
+            return None
+        return account.publication_url + self.url
+
     @classmethod
     def update_by_ap_object(
         cls,

--- a/neodb/journal/urls.py
+++ b/neodb/journal/urls.py
@@ -98,6 +98,28 @@ urlpatterns = [
         collection_retrieve_redirect,
         name="collection_retrieve_redirect",
     ),
+    # Aliases of the three canonical piece pages under the owner's profile
+    # path. standard.site forms a document's canonical URL by joining the
+    # publication ``url`` (the owner's profile) with the document ``path``,
+    # so these are the URLs that join has to resolve to; the pages keep
+    # pointing ``rel=canonical`` at the ``/<type>/<uuid>`` form. The views
+    # 404 when the handle does not own the piece, otherwise a document
+    # could claim another identity's publication.
+    re_path(
+        r"^users/(?P<user_name>[~A-Za-z0-9_\-.@]+)/article/(?P<article_uuid>[A-Za-z0-9]{21,22})$",
+        article_retrieve,
+        name="user_article_retrieve",
+    ),
+    re_path(
+        r"^users/(?P<user_name>[~A-Za-z0-9_\-.@]+)/review/(?P<review_uuid>[A-Za-z0-9]{21,22})$",
+        review_retrieve,
+        name="user_review_retrieve",
+    ),
+    re_path(
+        r"^users/(?P<user_name>[~A-Za-z0-9_\-.@]+)/collection/(?P<collection_uuid>[A-Za-z0-9]{21,22})$",
+        collection_retrieve,
+        name="user_collection_retrieve",
+    ),
     path("collection/create/", collection_edit, name="collection_create"),
     path(
         "collection/edit/<str:collection_uuid>", collection_edit, name="collection_edit"

--- a/neodb/journal/views/article.py
+++ b/neodb/journal/views/article.py
@@ -20,7 +20,12 @@ from ..forms import ArticleForm
 from ..models import Article
 from ..models.common import prefetch_latest_posts, q_owned_piece_visible_to_user
 from ..models.renderers import convert_leading_space_in_md
-from .common import conditional_get_for_anonymous, post_quotes_count
+from .common import (
+    conditional_get_for_anonymous,
+    piece_handle_matches,
+    post_quotes_count,
+    require_piece_handle,
+)
 
 
 def _parse_tags(raw: str) -> list[str]:
@@ -99,7 +104,7 @@ def article_edit(request: AuthedHttpRequest, article_uuid: str | None = None):
     return redirect(reverse("journal:article_retrieve", args=[article.uuid]))
 
 
-def _article_last_modified(request, article_uuid: str):
+def _article_last_modified(request, article_uuid: str, user_name: str | None = None):
     # Owner-level toggles (``anonymous_viewable``, ``restricted``) don't
     # bump piece ``edited_time``, so the visibility check must run here —
     # otherwise a privacy flip would leave anonymous clients with a
@@ -111,13 +116,19 @@ def _article_last_modified(request, article_uuid: str):
     article = Article.objects.filter(uid=uid).select_related("owner").first()
     if not article or not article.is_visible_to(request.user):
         return None
+    # a handle that doesn't own the article renders 404, not a 304
+    if not piece_handle_matches(article, user_name):
+        return None
     return article.edited_time
 
 
 @require_http_methods(["GET", "HEAD"])
 @conditional_get_for_anonymous(_article_last_modified)
-def article_retrieve(request, article_uuid: str):
+def article_retrieve(request, article_uuid: str, user_name: str | None = None):
     article = get_object_or_404(Article, uid=get_uuid_or_404(article_uuid))
+    # checked before visibility so a mismatched handle cannot tell a
+    # private article apart from a missing one
+    require_piece_handle(article, user_name)
     if not article.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "HEAD":

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -26,8 +26,10 @@ from ..models import *
 from ..models.renderers import sanitize_md_images
 from .common import (
     conditional_get_for_anonymous,
+    piece_handle_matches,
     post_quotes_count,
     render_relogin,
+    require_piece_handle,
     target_identity_required,
 )
 
@@ -205,7 +207,7 @@ def collection_ap_items(request, collection_uuid):
     return _list_items_view(request, collection)
 
 
-def _collection_last_modified(request, collection_uuid):
+def _collection_last_modified(request, collection_uuid, user_name: str | None = None):
     try:
         uid = get_uuid_or_404(collection_uuid)
     except Http404:
@@ -223,17 +225,25 @@ def _collection_last_modified(request, collection_uuid):
     # flip doesn't leave anonymous clients with a cached 200.
     if not collection.is_visible_to(request.user):
         return None
+    # a handle that doesn't own the collection renders 404, not a 304
+    if not piece_handle_matches(collection, user_name):
+        return None
     return collection.edited_time
 
 
 @conditional_get_for_anonymous(_collection_last_modified)
-def collection_retrieve(request: AuthedHttpRequest, collection_uuid):
+def collection_retrieve(
+    request: AuthedHttpRequest, collection_uuid, user_name: str | None = None
+):
     # AP clients consume the Shelf envelope inline from the announcement
     # Post's ``relatedWith[0]`` (which carries the items endpoint URL in
     # its ``first``/``last`` fields); the canonical ``/collection/<uuid>/``
     # only needs to render HTML for humans. Mirrors ``article_retrieve``
     # / ``review_retrieve``.
     collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
+    # checked before visibility so a mismatched handle cannot tell a
+    # private collection apart from a missing one
+    require_piece_handle(collection, user_name)
     if not collection.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     page_number = int_(request.GET.get("page"), 1)

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -4,11 +4,11 @@ from functools import wraps
 import filetype
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import BadRequest, PermissionDenied
+from django.core.exceptions import BadRequest, ObjectDoesNotExist, PermissionDenied
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db.models import F, Min, OuterRef, Subquery
-from django.http import HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -26,6 +26,7 @@ from common.utils import (
     get_uuid_or_404,
     target_identity_required,
 )
+from users.models.apidentity import APIdentity
 
 from ..models import (
     Mark,
@@ -89,6 +90,33 @@ def post_quotes_count(post) -> int:
         .exclude(state__in=["deleted", "deleted_fanned_out"])
         .count()
     )
+
+
+def piece_handle_matches(piece, user_name: str | None) -> bool:
+    """True when ``user_name`` addresses ``piece``'s owner, or is absent.
+
+    Articles, reviews and collections are served both at their canonical
+    ``/<type>/<uuid>`` and under the owner's profile path, so a
+    ``site.standard.publication`` ``url`` composes with the document
+    ``path`` into a URL that resolves (see
+    ``journal.models.atproto.build_document``). Serving a piece under
+    another handle would let its document claim someone else's
+    publication, so the handle has to match.
+    """
+    if user_name is None:
+        return True
+    try:
+        target = APIdentity.get_by_handle(user_name)
+    except ObjectDoesNotExist:
+        return False
+    return target.pk == piece.owner_id
+
+
+def require_piece_handle(piece, user_name: str | None) -> None:
+    """404 unless ``user_name`` addresses ``piece``'s owner; see
+    :func:`piece_handle_matches`."""
+    if not piece_handle_matches(piece, user_name):
+        raise Http404(_("Content not found"))
 
 
 def conditional_get_for_anonymous(get_timestamp):

--- a/neodb/journal/views/review.py
+++ b/neodb/journal/views/review.py
@@ -28,10 +28,16 @@ from ..models.renderers import (
     render_md,
     sanitize_md_images,
 )
-from .common import conditional_get_for_anonymous, post_quotes_count, render_list
+from .common import (
+    conditional_get_for_anonymous,
+    piece_handle_matches,
+    post_quotes_count,
+    render_list,
+    require_piece_handle,
+)
 
 
-def _review_last_modified(request, review_uuid):
+def _review_last_modified(request, review_uuid, user_name: str | None = None):
     # Visibility must be checked here: owner-level privacy toggles
     # (``anonymous_viewable``, ``restricted``) don't bump
     # ``Review.edited_time`` and would otherwise leave cached 200s
@@ -39,15 +45,21 @@ def _review_last_modified(request, review_uuid):
     piece = Review.get_by_url(review_uuid)
     if piece is None or not piece.is_visible_to(request.user):
         return None
+    # a handle that doesn't own the review renders 404, not a 304
+    if not piece_handle_matches(piece, user_name):
+        return None
     return piece.edited_time
 
 
 @require_http_methods(["GET", "HEAD"])
 @conditional_get_for_anonymous(_review_last_modified)
-def review_retrieve(request, review_uuid):
+def review_retrieve(request, review_uuid, user_name: str | None = None):
     piece = Review.get_by_url(review_uuid)
     if piece is None:
         raise Http404(_("Content not found"))
+    # checked before visibility so a mismatched handle cannot tell a
+    # private review apart from a missing one
+    require_piece_handle(piece, user_name)
     if not piece.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "HEAD":

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -57,6 +57,73 @@ PUBLICATION_NSID = "site.standard.publication"
 PUBLICATION_NAME_MAX_GRAPHEMES = 500
 PUBLICATION_DESCRIPTION_MAX_GRAPHEMES = 3000
 PUBLICATION_ICON_MAX_SIZE = 1000000
+THEME_BASIC_NSID = "site.standard.theme.basic"
+THEME_COLOR_RGB_NSID = "site.standard.theme.color#rgb"
+
+# ``--pico-primary`` / ``--pico-primary-inverse`` of the PicoCSS 2.1.1
+# stylesheet each ``site_color`` choice loads (see common_libs.html), read
+# from the light theme: standard.site publications carry a single palette,
+# not a light/dark pair. Regenerate by extracting those two custom
+# properties from ``pico.<color>.min.css`` (``pico.min.css`` for azure).
+_PICO_ACCENT = {
+    "amber": ("#876400", "#000"),
+    "azure": ("#0172ad", "#fff"),
+    "blue": ("#2060df", "#fff"),
+    "cyan": ("#047878", "#fff"),
+    "fuchsia": ("#c1208b", "#fff"),
+    "green": ("#33790f", "#fff"),
+    "grey": ("#6a6a6a", "#000"),
+    "indigo": ("#655cd6", "#fff"),
+    "jade": ("#007a50", "#fff"),
+    "lime": ("#577400", "#000"),
+    "orange": ("#bd3c13", "#fff"),
+    "pink": ("#c72259", "#fff"),
+    "pumpkin": ("#9c5900", "#000"),
+    "purple": ("#aa40bf", "#fff"),
+    "red": ("#c52f21", "#fff"),
+    "sand": ("#6e6a60", "#000"),
+    "slate": ("#5d6b89", "#fff"),
+    "violet": ("#8352c5", "#fff"),
+    "yellow": ("#756b00", "#000"),
+    "zinc": ("#646b79", "#fff"),
+}
+# ``--pico-background-color`` / ``--pico-color``; the color themes only
+# vary the primary, so these are the same for every choice above
+_PICO_BACKGROUND = "#fff"
+_PICO_FOREGROUND = "#373c44"
+
+
+def _theme_rgb(color: str) -> dict[str, typing.Any]:
+    """``site.standard.theme.color#rgb`` from a ``#rgb``/``#rrggbb`` literal."""
+    h = color.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return {
+        "$type": THEME_COLOR_RGB_NSID,
+        "r": int(h[0:2], 16),
+        "g": int(h[2:4], 16),
+        "b": int(h[4:6], 16),
+    }
+
+
+def build_basic_theme() -> dict[str, typing.Any]:
+    """``site.standard.theme.basic`` mirroring the instance's PicoCSS theme.
+
+    Publications are per-user but every journal renders in the same
+    instance skin, so the palette is instance-wide. Apps displaying the
+    publication use it to stay visually close to the site the document
+    links back to; bsky.app tints the article card with these colors.
+    """
+    accent, accent_foreground = _PICO_ACCENT.get(
+        settings.SITE_INFO.get("site_color", "azure"), _PICO_ACCENT["azure"]
+    )
+    return {
+        "$type": THEME_BASIC_NSID,
+        "background": _theme_rgb(_PICO_BACKGROUND),
+        "foreground": _theme_rgb(_PICO_FOREGROUND),
+        "accent": _theme_rgb(accent),
+        "accentForeground": _theme_rgb(accent_foreground),
+    }
 
 
 class Bluesky:
@@ -480,6 +547,18 @@ class BlueskyAccount(SocialAccount):
     def publication_uri(self) -> str:
         return f"at://{self.uid}/{PUBLICATION_NSID}/{self.publication_rkey}"
 
+    @property
+    def publication_url(self) -> str:
+        """``url`` of the account's ``site.standard.publication``: the
+        owner's journal, i.e. their profile page, without the trailing
+        slash the spec advises against.
+
+        Document ``path`` values join onto this to form the standard.site
+        canonical URL of a piece, so it has to stay in step with the
+        user-scoped piece routes (see ``Piece.atproto_document_url``).
+        """
+        return (settings.SITE_INFO["site_url"] + self.user.identity.url).rstrip("/")
+
     def _clear_publication_icon_cache(self) -> None:
         """Forget the uploaded icon blob. Called whenever a record stops
         referencing it: the PDS may garbage-collect the blob, so a later
@@ -527,11 +606,11 @@ class BlueskyAccount(SocialAccount):
         identity = self.user.identity
         record: dict[str, typing.Any] = {
             "$type": PUBLICATION_NSID,
-            # the spec wants base urls without a trailing slash
-            "url": (settings.SITE_INFO["site_url"] + identity.url).rstrip("/"),
+            "url": self.publication_url,
             "name": (identity.display_name or identity.full_handle)[
                 :PUBLICATION_NAME_MAX_GRAPHEMES
             ],
+            "basicTheme": build_basic_theme(),
             "preferences": {"showInDiscover": True},
         }
         # summaries are stored as HTML (ProfileForm.clean_summary); html2txt
@@ -753,7 +832,12 @@ class BlueskyAccount(SocialAccount):
                 external=models.AppBskyEmbedExternal.External(
                     title=obj.display_title,
                     description=obj.brief_description,
-                    uri=obj.absolute_url,
+                    # the piece's user-scoped URL when it publishes a
+                    # publication-linked document, so the card, the
+                    # document's canonical URL and the page carrying the
+                    # standard.site link tags all agree; long-form pieces
+                    # without a publication fall back to the canonical URL
+                    uri=getattr(obj, "atproto_document_url", None) or obj.absolute_url,
                     thumb=blob_ref,
                     # standard.site records backing this card, so bsky.app
                     # renders the enhanced publication view
@@ -827,8 +911,12 @@ class BlueskyAccount(SocialAccount):
 
 
 class EmbedObj:
-    def __init__(self, title, description, uri, image=None):
+    def __init__(self, title, description, uri, image=None, document_url=None):
         self.display_title = title
         self.brief_description = description
         self.absolute_url = uri
         self.image = image
+        # the external card links here instead of ``absolute_url`` when set;
+        # named for the ``Piece`` property ``post()`` reads off pieces, so
+        # both kinds of embed object satisfy the same contract
+        self.atproto_document_url: str | None = document_url

--- a/neodb/tests/journal/test_atproto_records.py
+++ b/neodb/tests/journal/test_atproto_records.py
@@ -7,6 +7,7 @@ import pytest
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
+from django.urls import resolve
 from django.utils import timezone
 from PIL import Image
 
@@ -373,6 +374,134 @@ def test_article_atproto_document():
     # no author summary: description falls back to the body excerpt
     assert doc["description"] == article.excerpt
     assert article.atproto_document_collections() == {DOCUMENT_NSID}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_review_document_site_points_at_publication_record():
+    user = User.register(email="pubdoc@example.com", username="pubdocuser")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="pubdoc.example"
+    )
+    book = Edition.objects.create(title="Dune")
+    review = Review.update_item_review(book, user.identity, "Linked", "body")
+    assert review is not None
+
+    doc = review.to_atproto_document()
+
+    assert doc["site"] == account.publication_uri
+    # publication url + document path is the standard.site canonical URL;
+    # it has to resolve back to the piece, which is what the user-scoped
+    # routes exist for
+    site_url = settings.SITE_INFO["site_url"]
+    canonical = account._build_publication_record()["url"] + doc["path"]
+    assert canonical.startswith(site_url)
+    match = resolve(canonical[len(site_url) :])
+    assert match.view_name == "journal:user_review_retrieve"
+    assert match.kwargs == {
+        "user_name": user.identity.handle,
+        "review_uuid": review.uuid,
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_article_document_site_path_resolves_to_user_scoped_url():
+    user = User.register(email="pubart@example.com", username="pubartuser")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="pubart.example"
+    )
+    article = Article.update_local_article(user.identity, "Linked Essay", "body")
+
+    doc = article.to_atproto_document()
+
+    assert doc["site"] == account.publication_uri
+    site_url = settings.SITE_INFO["site_url"]
+    canonical = account._build_publication_record()["url"] + doc["path"]
+    match = resolve(canonical[len(site_url) :])
+    assert match.view_name == "journal:user_article_retrieve"
+    assert match.kwargs == {
+        "user_name": user.identity.handle,
+        "article_uuid": article.uuid,
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_document_falls_back_to_loose_site_when_not_discoverable():
+    user = User.register(email="hiddoc@example.com", username="hiddocuser")
+    takahe_identity = user.identity.takahe_identity
+    takahe_identity.discoverable = False
+    takahe_identity.save()
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="hiddoc.example"
+    )
+    article = Article.update_local_article(user.identity, "Hidden", "body")
+
+    doc = article.to_atproto_document()
+
+    # a non-discoverable identity publishes no publication record, so the
+    # document stays loose and its path joins the instance url instead
+    assert doc["site"] == settings.SITE_INFO["site_url"].rstrip("/")
+    assert doc["site"] + doc["path"] == article.absolute_url
+    # and the display name stays withheld, like net.neodb.profile and
+    # site.standard.publication are for a non-discoverable identity
+    assert doc["contributors"] == [{"did": "did:plc:fake", "role": "author"}]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_atproto_document_url_matches_the_document_canonical_url():
+    user = User.register(email="docurl@example.com", username="docurluser")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="docurl.example"
+    )
+    article = Article.update_local_article(user.identity, "Carded", "body")
+
+    doc = article.to_atproto_document()
+
+    # the url the skeet's external embed points at is exactly the url
+    # the document record resolves to
+    assert article.atproto_document_url == account.publication_url + doc["path"]
+    assert article.atproto_document_url != article.absolute_url
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_atproto_document_url_none_for_loose_document():
+    user = User.register(email="looseurl@example.com", username="looseurluser")
+    article = Article.update_local_article(user.identity, "Plain", "body")
+
+    # no publication to join onto: the canonical url is already the
+    # piece's own, so the embed has nothing to prefer over absolute_url
+    assert article.atproto_document_url is None
+    assert article.to_atproto_document()["site"] == settings.SITE_INFO[
+        "site_url"
+    ].rstrip("/")
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_document_contributors_name_the_owner():
+    user = User.register(email="contrib@example.com", username="contribuser")
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:fake", handle="contrib.example"
+    )
+    article = Article.update_local_article(user.identity, "Credited", "body")
+
+    doc = article.to_atproto_document()
+
+    assert doc["contributors"] == [
+        {
+            "did": "did:plc:fake",
+            "role": "author",
+            "displayName": user.identity.display_name,
+        }
+    ]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_document_omits_contributors_without_account():
+    user = User.register(email="nocontrib@example.com", username="nocontribuser")
+    article = Article.update_local_article(user.identity, "Unattributed", "body")
+
+    doc = article.to_atproto_document()
+
+    assert "contributors" not in doc
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_user_scoped_urls.py
+++ b/neodb/tests/journal/test_user_scoped_urls.py
@@ -1,0 +1,115 @@
+"""Piece pages served under the owner's profile path.
+
+standard.site forms a document's canonical URL by joining the publication
+``url`` (the owner's profile) with the document ``path``, so articles,
+reviews and collections are reachable at ``/users/<handle>/<type>/<uuid>``
+as well as their canonical ``/<type>/<uuid>``. The alias must serve the
+same page, keep pointing ``rel=canonical`` at the canonical form, and 404
+for a handle that does not own the piece -- otherwise a document could
+claim someone else's publication.
+"""
+
+import pytest
+from django.test import Client
+from django.utils.http import http_date
+
+from catalog.models import Edition
+from journal.models import Article, Collection, Review
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestUserScopedPieceUrls:
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="scoped@test.com", username="scoped")
+        self.other = User.register(email="stranger@test.com", username="stranger")
+        self.identity = self.user.identity
+        self.client = Client()
+        self.article = Article.update_local_article(
+            owner=self.identity, title="Scoped Essay", body="**bold**", visibility=0
+        )
+        book = Edition.objects.create(title="Dune")
+        self.review = Review.update_item_review(
+            book, self.identity, "Scoped Review", "review body"
+        )
+        assert self.review is not None
+        self.collection = Collection.objects.create(
+            owner=self.identity, title="Scoped List", brief="", visibility=0
+        )
+
+    def _scoped(self, piece, handle=None):
+        return f"/users/{handle or self.identity.handle}{piece.url}"
+
+    def test_article_served_under_owner_profile_path(self):
+        resp = self.client.get(self._scoped(self.article))
+
+        assert resp.status_code == 200
+        assert b"Scoped Essay" in resp.content
+        assert b"<strong>bold</strong>" in resp.content
+
+    def test_review_served_under_owner_profile_path(self):
+        resp = self.client.get(self._scoped(self.review))
+
+        assert resp.status_code == 200
+        assert b"Scoped Review" in resp.content
+
+    def test_collection_served_under_owner_profile_path(self):
+        resp = self.client.get(self._scoped(self.collection))
+
+        assert resp.status_code == 200
+        assert b"Scoped List" in resp.content
+
+    @pytest.mark.parametrize("piece_name", ["article", "review", "collection"])
+    def test_canonical_link_stays_on_canonical_url(self, piece_name):
+        piece = getattr(self, piece_name)
+
+        resp = self.client.get(self._scoped(piece))
+
+        assert resp.status_code == 200
+        expected = f'<link rel="canonical" href="{piece.absolute_url}">'
+        assert expected.encode() in resp.content
+
+    @pytest.mark.parametrize("piece_name", ["article", "review", "collection"])
+    def test_wrong_handle_is_not_found(self, piece_name):
+        piece = getattr(self, piece_name)
+
+        resp = self.client.get(self._scoped(piece, handle="stranger"))
+
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("piece_name", ["article", "review", "collection"])
+    def test_unknown_handle_is_not_found(self, piece_name):
+        piece = getattr(self, piece_name)
+
+        resp = self.client.get(self._scoped(piece, handle="nobody"))
+
+        assert resp.status_code == 404
+
+    def test_private_piece_under_wrong_handle_is_not_found(self):
+        # 404 before the visibility check, so a mismatched handle cannot
+        # tell a private piece apart from a missing one
+        private = Article.update_local_article(
+            owner=self.identity, title="Secret", body="body", visibility=2
+        )
+
+        assert (
+            self.client.get(self._scoped(private, handle="stranger")).status_code == 404
+        )
+
+    @pytest.mark.parametrize("piece_name", ["article", "review", "collection"])
+    def test_wrong_handle_not_served_from_conditional_cache(self, piece_name):
+        # the Last-Modified callback runs before the view, so it has to
+        # decline the mismatch too or a stale If-Modified-Since would get
+        # a 304 instead of the 404
+        piece = getattr(self, piece_name)
+        resp = self.client.get(
+            self._scoped(piece, handle="stranger"),
+            HTTP_IF_MODIFIED_SINCE=_future_date(piece),
+        )
+
+        assert resp.status_code == 404
+
+
+def _future_date(piece):
+    return http_date(piece.edited_time.timestamp() + 3600)

--- a/neodb/tests/mastodon/test_bluesky.py
+++ b/neodb/tests/mastodon/test_bluesky.py
@@ -8,12 +8,16 @@ import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from django.conf import settings
+from django.test import override_settings
 
 from mastodon.models.bluesky import (
     PROFILE_NSID,
     PUBLICATION_NSID,
+    THEME_BASIC_NSID,
+    THEME_COLOR_RGB_NSID,
     BlueskyAccount,
     EmbedObj,
+    build_basic_theme,
 )
 from users.models import User
 
@@ -248,7 +252,51 @@ def test_publication_record_synced(monkeypatch):
     assert not record["url"].endswith("/")  # spec: base url without trailing slash
     assert record["name"] == identity.display_name
     assert record["preferences"] == {"showInDiscover": True}
+    assert record["basicTheme"]["$type"] == THEME_BASIC_NSID
     assert "icon" not in record  # test identity has no avatar file
+
+
+def test_basic_theme_mirrors_pico_site_color():
+    with override_settings(SITE_INFO={**settings.SITE_INFO, "site_color": "jade"}):
+        theme = build_basic_theme()
+
+    assert theme["$type"] == THEME_BASIC_NSID
+    # jade: --pico-primary #007a50 over --pico-primary-inverse #fff
+    assert theme["accent"] == {"$type": THEME_COLOR_RGB_NSID, "r": 0, "g": 122, "b": 80}
+    assert theme["accentForeground"] == {
+        "$type": THEME_COLOR_RGB_NSID,
+        "r": 255,
+        "g": 255,
+        "b": 255,
+    }
+    # --pico-background-color #fff / --pico-color #373c44, theme-independent
+    assert theme["background"] == {
+        "$type": THEME_COLOR_RGB_NSID,
+        "r": 255,
+        "g": 255,
+        "b": 255,
+    }
+    assert theme["foreground"] == {
+        "$type": THEME_COLOR_RGB_NSID,
+        "r": 55,
+        "g": 60,
+        "b": 68,
+    }
+
+
+def test_basic_theme_falls_back_to_azure_for_unknown_site_color():
+    with override_settings(
+        SITE_INFO={**settings.SITE_INFO, "site_color": "chartreuse"}
+    ):
+        theme = build_basic_theme()
+
+    # azure is the default PicoCSS theme: --pico-primary #0172ad
+    assert theme["accent"] == {
+        "$type": THEME_COLOR_RGB_NSID,
+        "r": 1,
+        "g": 114,
+        "b": 173,
+    }
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -404,6 +452,28 @@ def test_post_attaches_associated_refs():
     account.post("read ##obj##", obj=obj)
     dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
     assert "associatedRefs" not in dumped["embed"]["external"]
+
+
+def test_post_embed_prefers_the_document_canonical_url():
+    account = BlueskyAccount(uid="did:plc:poster")
+    captured: dict = {}
+    account._client = _stub_client(captured)
+    # a piece whose document hangs off a publication exposes the
+    # user-scoped url the document resolves to; the card points there so
+    # bsky.app sees one url across embed, document and page
+    obj = EmbedObj(
+        "T",
+        "desc",
+        "https://nd.test/article/x",
+        document_url="https://nd.test/users/alice/article/x",
+    )
+
+    account.post("read ##obj##", obj=obj)
+
+    dumped = captured["record"].model_dump(by_alias=True, exclude_none=True)
+    assert dumped["embed"]["external"]["uri"] == "https://nd.test/users/alice/article/x"
+    # the in-text link stays on the canonical url
+    assert "https://nd.test/article/x" in json.dumps(dumped["facets"])
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## Problem

Crossposted articles and reviews render on bsky.app as a plain link card, not the enhanced publication card that other standard.site publishers get.

Comparing the hydrated `app.bsky.embed.external` the AppView returns for a NeoDB article against one from `atproto.com`:

| field in the hydrated view | atproto.com | NeoDB |
| --- | --- | --- |
| `uri` / `title` / `description` / `thumb` | yes | yes |
| `createdAt` / `updatedAt` | yes | — |
| `source` (publication name, description, theme) | yes | — |
| `associatedProfiles` (author) | yes | — |

`source` is what makes bsky.app draw the enhanced card. Everything missing comes from the AppView failing to resolve the `site.standard.document` to a `site.standard.publication`.

## Root cause

`build_document` published documents as *loose*: `site` was the instance base URL, so nothing linked a document to its publication.

```
site: "https://example.social"                                   # NeoDB
site: "at://did:plc:…/site.standard.publication/3memeaezix223"   # atproto.com
```

The `https://` fallback could not resolve either, since `document.site` (the instance root) never equalled `publication.url` (the owner's profile page). So there was no path, by AT-URI or by URL, from document to publication.

Ruled out along the way: the `<link rel="site.standard.*">` tags and the `.well-known` endpoint were already correct — `atproto.com` serves no `.well-known` at all and still renders, so verification was not the gate.

## The URL-composition problem

`site` could not simply be flipped to the AT-URI. standard.site forms a document's canonical URL by joining `publication.url` with `document.path`, and the two did not compose:

```
publication url   https://example.social/users/alice
document path                                  /article/<uuid>
canonical         https://example.social/users/alice/article/<uuid>   ← 404
```

Publications are rooted at the owner's profile, but pieces were served only at the instance root.

## Changes

- **`site` points at the publication record**, falling back to the loose instance URL for owners with no publication (i.e. not publicly discoverable).
- **Pieces are also served under the owner's profile path** — `users/<handle>/article/<uuid>`, `users/<handle>/review/<uuid>` and `users/<handle>/collection/<uuid>`. They render the same page, keep `rel=canonical` on the existing `/<type>/<uuid>`, and 404 when the handle does not own the piece, since otherwise a document could claim another identity's publication. That check runs before the visibility check, and the `Last-Modified` callbacks decline the mismatch too, so a stale `If-Modified-Since` cannot turn the 404 into a 304. Collections get the route for symmetry; they publish no document today.
- **The skeet's external embed points at the user-scoped URL**, so the embed, the document's canonical URL and the page carrying the link tags are all one URL — the shape bsky.app hydrates from.
- **`contributors`** names the owner, restoring `associatedProfiles`. `displayName` is gated on `discoverable`, matching `net.neodb.profile` and `site.standard.publication`, which are both withheld and deleted for a non-discoverable identity; the DID is the repo the record already lives in, so it goes out either way.
- **`basicTheme`** on the publication, mapped from the instance's PicoCSS `site_color` (all 20 choices) to the light-theme `--pico-primary` / `--pico-primary-inverse`. Background and foreground are identical across every Pico colour theme, so they are constants. The comment records how to regenerate the table.
- `BlueskyAccount.publication_url` is now the single source for the publication `url`, used by both the record builder and the URL join, so they cannot drift.
- `docs/internals/atproto.md` gains a **Long-form documents** section: the `site.standard.*` records were previously undocumented.

## Testing

`tests/journal` + `tests/mastodon`: **891 passed, 0 failed**.

New coverage:

- `tests/journal/test_user_scoped_urls.py` — the three routes render, `rel=canonical` is unchanged, and a wrong, unknown or private-piece handle 404s, including via the conditional-GET path.
- `tests/journal/test_atproto_records.py` — `site` is the publication AT-URI and the composed canonical URL resolves back to the piece (asserted with `django.urls.resolve`); the loose fallback for a non-discoverable owner; `contributors` with and without a linked account, and the `displayName` gate.
- `tests/mastodon/test_bluesky.py` — the embed prefers the document canonical URL while the in-text link stays canonical; `basicTheme` colour mapping and its fallback for an unknown `site_color`.

## Note

One thing is not yet confirmed against the live AppView: whether pointing all three URLs at the user-scoped form is sufficient for bsky.app to hydrate `source`, or whether it needs something further. The document-to-publication link is required regardless — it is what `source` is built from — and the URL agreement matches the shape of publishers whose cards do render. Happy to iterate if a deployed instance still shows a plain card.
