### PR TITLE
feat(sentry): surface swallowed errors and record catalog activity

### DIFF
--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -14,6 +14,7 @@ from django.views.decorators.http import require_http_methods
 from loguru import logger
 
 from common.models.lang import get_current_locales
+from common.sentry import record_catalog_edit
 from common.utils import discord_send, get_uuid_or_404
 from journal.models import update_journal_for_merged_item_task
 from users.models import User
@@ -91,6 +92,7 @@ def create(request, item_model):
                 form.instance.set_parent_item(parent)
             form.instance.save()
             form.instance.sync_credits_from_metadata()
+            record_catalog_edit("create", form.instance.class_name, "create")
             return redirect(form.instance.url)
         else:
             raise BadRequest(_add_error_map_detail(form.errors))
@@ -161,6 +163,7 @@ def edit(request, item_path, item_uuid):
             form.instance.edited_time = timezone.now()
             form.instance.save()
             form.instance.sync_credits_from_metadata()
+            record_catalog_edit("update", form.instance.class_name, "edit")
             return redirect(form.instance.url)
         else:
             raise BadRequest(_add_error_map_detail(form.errors))
@@ -203,6 +206,7 @@ def pick_cover(request, item_path, item_uuid):
     item.cover = resource.cover
     item.edited_time = timezone.now()
     item.save()
+    record_catalog_edit("update", item.class_name, "pick_cover")
     return redirect(item.url)
 
 
@@ -219,7 +223,9 @@ def delete(request, item_path, item_uuid):
     if request.POST.get("sure", 0) != "1":
         return render(request, "catalog_delete.html", {"item": item})
     else:
+        item_type = item.class_name
         item.delete()
+        record_catalog_edit("delete", item_type, "delete")
         discord_send(
             "audit",
             f"{item.absolute_url}?skipcheck=1\nby [@{request.user.username}]({request.user.absolute_url})",
@@ -241,6 +247,7 @@ def undelete(request, item_path, item_uuid):
         raise PermissionDenied(_("Insufficient permission"))
     item.is_deleted = False
     item.save()
+    record_catalog_edit("update", item.class_name, "undelete")
     return redirect(item.url)
 
 
@@ -279,6 +286,7 @@ def recast(request, item_path, item_uuid):
             season.show = None
             season.save(update_fields=["show"])
     new_item = item.recast_to(model)
+    record_catalog_edit("update", new_item.class_name, "recast")
     if douban_movie_to_tvseason:
         for res in item.external_resources.filter(
             id_type__in=[IdType.IMDB, IdType.TMDB_TV]
@@ -299,7 +307,9 @@ def unlink(request):
     resource = get_object_or_404(ExternalResource, id=res_id)
     if not resource.item:
         raise BadRequest(_("Invalid parameter"))
+    item_type = resource.item.class_name
     resource.unlink_from_item()
+    record_catalog_edit("update", item_type, "unlink_resource")
     referer = request.META.get("HTTP_REFERER") or ""
     if not url_has_allowed_host_and_scheme(
         referer,
@@ -329,6 +339,7 @@ def assign_parent(request, item_path, item_uuid):
     logger.warning(f"{request.user} assign {item} to {parent_item}")
     item.set_parent_item(parent_item)
     item.save()
+    record_catalog_edit("update", item.class_name, "assign_parent")
     return redirect(item.url)
 
 
@@ -342,6 +353,7 @@ def remove_unused_seasons(request, item_path, item_uuid):
     for s in sl:
         if not s.journal_exists():
             s.delete()
+    record_catalog_edit("delete", "tvseason", "remove_unused_seasons")
     ol = [s.pk for s in sl]
     nl = [s.pk for s in item.seasons.all()]
     discord_send(
@@ -361,6 +373,7 @@ def fetch_tvepisodes(request, item_path, item_uuid):
     if item.class_name != "tvseason" or not item.imdb or item.season_number is None:
         raise BadRequest(_("TV Season with IMDB id and season number required."))
     item.log_action({"!fetch_tvepisodes": ["", ""]})
+    record_catalog_edit("fetch", item.class_name, "fetch_tvepisodes")
     django_rq.get_queue("crawl").enqueue(
         fetch_episodes_for_season_task, item.uuid, request.user.pk
     )
@@ -390,6 +403,7 @@ def fetch_people_works(request, item_path, item_uuid):
     )
     if not resource:
         raise BadRequest(_("This person has no supported source to fetch works from."))
+    record_catalog_edit("fetch", item.class_name, "fetch_people_works")
     lock_key = f"_fetch_works_lock:{item.pk}"
     if not cache.add(lock_key, 1, timeout=people_works.FETCH_PEOPLE_WORKS_LOCK_TTL):
         messages.add_message(
@@ -433,6 +447,7 @@ def merge(request, item_path, item_uuid):
             raise BadRequest(_("Cannot merge an item to itself"))
         logger.warning(f"{request.user} merges {item} to {new_item}")
         item.merge_to(new_item)
+        record_catalog_edit("delete", item.class_name, "merge")
         django_rq.get_queue("crawl").enqueue(
             update_journal_for_merged_item_task, request.user.pk, item.uuid
         )
@@ -447,6 +462,7 @@ def merge(request, item_path, item_uuid):
         if item.merged_to_item:
             logger.warning(f"{request.user} cancels merge for {item}")
             item.merge_to(None)
+            record_catalog_edit("update", item.class_name, "merge_cancel")
         discord_send(
             "audit",
             f"{item.absolute_url}\n⬇\n(none)\nby [@{request.user.username}]({request.user.absolute_url})",
@@ -483,6 +499,7 @@ def link_edition(request, item_path, item_uuid):
         )
     logger.warning(f"{request.user} merges {item} to {new_item}")
     item.link_to_related_book(new_item)
+    record_catalog_edit("update", item.class_name, "link_edition")
     discord_send(
         "audit",
         f"{item.absolute_url}?skipcheck=1\n⬇\n{new_item.absolute_url}\nby [@{request.user.username}]({request.user.absolute_url})",
@@ -501,6 +518,7 @@ def unlink_works(request, item_path, item_uuid):
     if not request.user.is_staff and item.journal_exists():
         raise PermissionDenied(_("Insufficient permission"))
     item.set_parent_item(None)
+    record_catalog_edit("update", item.class_name, "unlink_works")
     discord_send(
         "audit",
         f"{item.absolute_url}?skipcheck=1\nby [@{request.user.username}]({request.user.absolute_url})",
@@ -534,6 +552,7 @@ def protect(request, item_path, item_uuid):
         raise PermissionDenied(_("Insufficient permission"))
     item.is_protected = bool(request.POST.get("protected"))
     item.save()
+    record_catalog_edit("update", item.class_name, "protect")
     return redirect(item.url)
 
 
@@ -596,6 +615,7 @@ def add_credit(request, item_path, item_uuid):
         name=name,
         defaults={"person": person, "order": order},
     )
+    record_catalog_edit("create", item.class_name, "add_credit")
     credits = item.credits.select_related("person").all()
     return render(
         request,
@@ -617,6 +637,7 @@ def remove_credit(request, item_path, item_uuid, credit_id):
         raise PermissionDenied(_("Editing this item is restricted."))
     credit = get_object_or_404(ItemCredit, pk=credit_id, item=item)
     credit.delete()
+    record_catalog_edit("delete", item.class_name, "remove_credit")
     credits = item.credits.select_related("person").all()
     return render(
         request,
@@ -640,6 +661,7 @@ def update_credit(request, item_path, item_uuid, credit_id):
     character_name = request.POST.get("character_name", "").strip()
     credit.character_name = character_name
     credit.save()
+    record_catalog_edit("update", item.class_name, "update_credit")
     credits = item.credits.select_related("person").all()
     return render(
         request,

--- a/neodb/catalog/views/verify.py
+++ b/neodb/catalog/views/verify.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from common.sentry import record_catalog_edit
 from common.utils import (
     discord_send,
     get_uuid_or_404,
@@ -103,6 +104,7 @@ def verify_creator_status(request, item_path, item_uuid):
 @user_identity_required
 def verify_creator_start(request, item_path, item_uuid):
     item = _get_verifiable_item(item_uuid)
+    record_catalog_edit("verify", item.class_name, "verify_creator_start")
     if not getattr(item, "feed_url", None):
         messages.add_message(
             request, messages.ERROR, _("No feed url available for this item.")
@@ -173,6 +175,7 @@ def verify_creator_manual(request, item_path, item_uuid):
     item.log_action(
         {"!creator_verified": ["", f"{identity} (manual by @{request.user.username})"]}
     )
+    record_catalog_edit("update", item.class_name, "verify_creator")
     discord_send(
         "audit",
         f"{item.absolute_url}\nverified creator: @{identity.full_handle} (manual)\n"
@@ -203,6 +206,7 @@ def unverify_creator(request, item_path, item_uuid):
         raise PermissionDenied(_("Insufficient permission"))
     item.log_action({"!creator_unverified": ["", str(claim.owner)]})
     claim.delete()
+    record_catalog_edit("update", item.class_name, "unverify_creator")
     discord_send(
         "audit",
         f"{item.absolute_url}\nremoved creator: @{claim.owner.full_handle}\n"

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -20,6 +20,7 @@ from typesense.types.document import MultiSearchCommonParameters, SearchResponse
 from typesense.types.multi_search import MultiSearchRequestSchema
 
 from common.models.site_config import SiteConfig
+from common.sentry import count as sentry_count
 
 # Exceptions that any Typesense network operation may raise.
 # typesense 2.x uses httpx for transport and, after exhausting node retries,
@@ -290,6 +291,13 @@ class Index:
         schema.update(cls.schema)
         return schema  # type: ignore
 
+    def _record_error(self, op: str, reason: str = "error", value: int = 1) -> None:
+        sentry_count(
+            "search.error",
+            value,
+            attributes={"index": self.name, "op": op, "reason": reason},
+        )
+
     def check(self) -> CollectionSchema:
         if not self._read_client.operations.is_healthy():
             raise ValueError("Typesense: server not healthy")
@@ -313,6 +321,7 @@ class Index:
                 wait -= 1
             if not wait:
                 logger.error("Typesense: timeout waiting for server")
+                self._record_error("init", "timeout")
                 return False
             cname = SiteConfig.system.index_aliases.get(
                 self.name + "_write"
@@ -329,6 +338,7 @@ class Index:
             logger.error("Typesense: server unknown error")
         except Exception as e:
             logger.error(f"Typesense: initialization error {e}")
+        self._record_error("init")
         return False
 
     def replace_docs(self, docs: List[dict]):
@@ -339,6 +349,7 @@ class Index:
             rs = self.write_collection.documents.import_(docs, {"action": "upsert"})
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("replace")
             return 0
         c = 0
         for r in rs:
@@ -350,6 +361,10 @@ class Index:
                     logger.error(f"Typesense: {r}")
             else:
                 c += 1
+        if c < len(docs):
+            # Partial failure: the call returned 2xx but some docs were rejected,
+            # so it is invisible unless counted separately.
+            self._record_error("replace", "rejected", len(docs) - c)
         return c
 
     def insert_docs(self, docs: List[dict]) -> int:
@@ -359,6 +374,7 @@ class Index:
             rs = self.write_collection.documents.import_(docs)
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("insert")
             return 0
         c = 0
         for r in rs:
@@ -369,6 +385,8 @@ class Index:
                     logger.error(f"Typesense: {r}")
             else:
                 c += 1
+        if c < len(docs):
+            self._record_error("insert", "rejected", len(docs) - c)
         return c
 
     def delete_docs(self, field: str, values: Iterable[int | str] | int | str) -> int:
@@ -381,6 +399,7 @@ class Index:
             r = self.write_collection.documents.delete({"filter_by": f"{field}:{v}"})
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("delete")
             return 0
         return (r or {}).get("num_deleted", 0)
 
@@ -394,6 +413,7 @@ class Index:
             )
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("patch")
 
     def get_doc(self, doc_id: int | str) -> dict | None:
         try:
@@ -403,6 +423,7 @@ class Index:
             raise
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("get")
             return None
 
     def _error_result(self, error: str) -> SearchResult:
@@ -426,6 +447,7 @@ class Index:
             )
         except TYPESENSE_ERRORS as e:
             logger.error(f"Typesense: error {e}")
+            self._record_error("search")
             return self._error_result(str(e))
         results = r.get("results") if isinstance(r, dict) else None
         if (
@@ -434,10 +456,12 @@ class Index:
             or not isinstance(results[0], dict)
         ):
             logger.error(f"Typesense: search {self.name} invalid response {r}")
+            self._record_error("search", "invalid_response")
             return self._error_result("invalid response")
         sr = self.search_result_class(self, results[0])
         if sr.error:
             logger.error(f"Typesense: search error {sr.error}")
+            self._record_error("search", "result_error")
         elif settings.DEBUG:
             logger.debug(f"Typesense: search result {sr}")
         return sr

--- a/neodb/common/sentry.py
+++ b/neodb/common/sentry.py
@@ -52,3 +52,20 @@ def record_activity(action: str, source: str) -> None:
     export *start* is recorded by the triggering view instead).
     """
     count("user.activity", attributes={"action": action, "source": source})
+
+
+def record_catalog_edit(action: str, item_type: str, op: str = "") -> None:
+    """Emit a `catalog.edit` counter for a user-initiated catalog change.
+
+    ``action`` is the coarse bucket (``create``/``update``/``delete``, plus
+    ``fetch``/``verify`` for the crawl and verification triggers); ``op`` names
+    the specific view so a single bucket stays breakable down. ``item_type`` is
+    ``Item.class_name``.
+
+    Call this at the view layer only. Background refresh writes items through
+    the same models, so a model-level hook could not tell the two apart.
+    """
+    count(
+        "catalog.edit",
+        attributes={"action": action, "type": item_type, "op": op or action},
+    )

--- a/neodb/journal/views/wrapped.py
+++ b/neodb/journal/views/wrapped.py
@@ -13,6 +13,7 @@ from django.http.response import HttpResponse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
+from loguru import logger
 
 from catalog.models import (
     AvailableItemCategory,
@@ -20,6 +21,7 @@ from catalog.models import (
     PodcastEpisode,
     item_content_types,
 )
+from common.sentry import count as sentry_count
 from common.utils import int_
 from journal.models import Comment, ShelfType
 from journal.models.common import VisibilityType
@@ -133,21 +135,28 @@ class WrappedShareView(LoginRequiredMixin, TemplateView):
         )
         classic_crosspost = user.preference.mastodon_repost_mode == 1
         if classic_crosspost and user.mastodon:
+            attrs = {"platform": "mastodon", "mode": "wrapped"}
             try:
                 user.mastodon.post(
                     comment, visibility, attachments=[("year.png", img, "image/png")]
                 )
-            except Exception:
-                pass
+                sentry_count("crosspost.success", attributes=attrs)
+            except Exception as e:
+                # Warnings aren't Sentry issues; metric keeps them trackable.
+                logger.warning(f"wrapped post to {user.mastodon} failed: {e}")
+                sentry_count("crosspost.failure", attributes=attrs)
         elif post and user.mastodon:
             user.mastodon.boost_later(post.url)
         if visibility == VisibilityType.Public and user.bluesky:
             o = EmbedObj("🧩", "", user.absolute_url)
             txt = comment.rstrip() + "\n\n##obj##"
+            attrs = {"platform": "bluesky", "mode": "wrapped"}
             try:
                 user.bluesky.post(txt, obj=o, images=[img])
-            except Exception:
-                pass
+                sentry_count("crosspost.success", attributes=attrs)
+            except Exception as e:
+                logger.warning(f"wrapped post to {user.bluesky} failed: {e}")
+                sentry_count("crosspost.failure", attributes=attrs)
         messages.add_message(request, messages.INFO, _("Summary posted to timeline."))
         referer = request.META.get("HTTP_REFERER") or ""
         if not url_has_allowed_host_and_scheme(

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -563,8 +563,8 @@ class Takahe:
             actor_uri, _ = Identity.fetch_webfinger(handle)
             if actor_uri:
                 return Identity.objects.filter(actor_uri=actor_uri).first()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"webfinger lookup for {handle} failed: {e}")
         return None
 
     @staticmethod
@@ -593,8 +593,13 @@ class Takahe:
                 data = response.json()
                 identity.aliases = data.get("alsoKnownAs")
                 identity.save(update_fields=["aliases"])
-        except Exception:
-            pass
+            else:
+                # A non-200 leaves aliases stale, same as an exception would.
+                logger.error(
+                    f"refresh {identity.actor_uri} failed: HTTP {response.status_code}"
+                )
+        except Exception as e:
+            logger.error(f"refresh {identity.actor_uri} failed: {e}")
 
     @staticmethod
     def identity_get_aliases(identity_pk: int) -> list[Identity]:

--- a/takahe/users/models/inbox_message.py
+++ b/takahe/users/models/inbox_message.py
@@ -18,6 +18,14 @@ from stator.models import State, StateField, StateGraph, StatorModel
 logger = logging.getLogger(__name__)
 
 
+def _internal_subject(message, key: str) -> str:
+    try:
+        obj = message["object"]
+        return str(obj[key] if isinstance(obj, dict) else obj)
+    except Exception:
+        return "unknown"
+
+
 class InboxMessageStates(StateGraph):
     received = State(try_interval=300, delete_after=86400 * 3)
     processed = State(externally_progressed=True, delete_after=86400)
@@ -41,8 +49,8 @@ class InboxMessageStates(StateGraph):
             return True
         try:
             identity.fetch_actor()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error("Key fetch failed for %s: %s", identity.actor_uri, e)
         return bool(identity.public_key)
 
     @classmethod
@@ -305,14 +313,22 @@ class InboxMessageStates(StateGraph):
                                 elif not i.deleted:
                                     i.mark_deleted()
                             except Exception as e:
-                                print(e)
+                                logger.error(
+                                    "deleteidentity failed for %s: %s",
+                                    _internal_subject(instance.message, "actor"),
+                                    e,
+                                )
                         case "fetchidentity":
                             try:
                                 Identity.by_handle(
                                     instance.message["object"]["handle"], fetch=True
                                 )
                             except Exception as e:
-                                print(e)
+                                logger.error(
+                                    "fetchidentity failed for %s: %s",
+                                    _internal_subject(instance.message, "handle"),
+                                    e,
+                                )
                         case "fetchpost":
                             Post.handle_fetch_internal(instance.message["object"])
                         case "fetchreplies":


### PR DESCRIPTION
Six failure paths reported nothing to Sentry, as neither an issue nor a metric, and catalog edits had no activity metric at all.

## Errors that were fully swallowed

| Where | Was | Now |
|---|---|---|
| `journal/views/wrapped.py` | `except Exception: pass` on both Mastodon and Bluesky | log + `crosspost.success`/`crosspost.failure` with `mode=wrapped` |
| `takahe/utils.py` webfinger lookup | `except Exception: pass` | `logger.error` |
| `takahe/utils.py` identity refresh | `except Exception: pass`, and a non-200 silently left aliases stale | `logger.error` on both |
| `inbox_message.py` actor key fetch | `except Exception: pass` | `logger.error` |
| `inbox_message.py` deleteidentity / fetchidentity | `print(e)` | `logger.error` |

Error level is what makes these Sentry issues, under `LoguruIntegration` in neodb and `LoggingIntegration` in takahe. Warning level would not: takahe does not enable log forwarding, so a warning there is a breadcrumb and nothing more.

The swallowed key fetch is the one worth calling out. It later surfaces as a permanent signature verification failure, with no trace of the original cause.

The subject of an `__internal__` message is read through a helper that cannot raise, since a malformed payload is one of the things that lands in those handlers, and the old `print(e)` could not fail there.

## Typesense

Failures already logged at error level, but issues are grouped and sampled, so failure volume per index was not readable. Adds `search.error {index, op, reason}`.

Failures only. `search` runs on the request path, so counting successes would emit a metric per search. Partial imports count rejected documents under `reason=rejected`: that is the one failure mode that raises nothing and logs no error of its own, because the call returns 2xx while Typesense refuses individual documents.

## Catalog activity

Adds `record_catalog_edit()` next to the existing `record_activity()`, emitting `catalog.edit {action, type, op}` from 21 views.

`action` buckets into `create`/`update`/`delete`, plus `fetch`/`verify` for the crawl and verification triggers. `op` names the specific view, so a bucket stays breakable down. `type` is `Item.class_name`.

Two things worth reviewing:

- Calls sit at the view layer. That is what separates user edits from background refresh, which writes through the same models.
- The `fetch` and `verify` triggers record on trigger, ahead of the dedupe lock and the already-verified early returns, so a blocked retry still counts as a user asking for it.

## Testing

| Suite | Result |
|---|---|
| neodb (`tests/`) | 2113 passed |
| takahe | 517 passed |
| pre-commit (`ruff`, `ruff-format`, `ty`) | passed |

Also removes the 5 pre-existing `S110` try-except-pass lint findings in these files.

Unrelated flake seen once and not reproduced: `tests/catalog/test_rate_limit.py` failed 5 tests in one `-n auto` run, then passed in a full re-run and in isolation. Those tests are clock-based and share one Redis, so they contend under parallel load. Nothing in this PR touches rate limiting.