### PR TITLE
fix(journal): center shelf covers in a clamped box

### DIFF
--- a/neodb/common/static/scss/_gallery.scss
+++ b/neodb/common/static/scss/_gallery.scss
@@ -57,6 +57,8 @@
     transition: all 0.2s;
     text-align: center;
     vertical-align: middle;
+    // container unit source for the square cover box below
+    container-type: inline-size;
 
     a {
       margin-top: auto;
@@ -66,7 +68,12 @@
       background: var(--pico-background-color);
       // border-radius: 5px;
       width: 100%;
-      min-height: 3rem;
+      // Keep the cover box between 1:1 and 1:2, and center the cover in it.
+      // Covers wider than tall no longer hug the bottom of the card, and
+      // very tall covers no longer stretch the whole row.
+      min-height: 100cqw;
+      max-height: 200cqw;
+      object-fit: contain;
       vertical-align: middle;
       margin: auto;
       font-size: 80%;


### PR DESCRIPTION
## Problem

Shelf cards (`.shelf .card`, used on the profile page, discover, similar items, other editions, the sidebar and mark groups) stretch to the height of the tallest cover in the row, and card content is bottom aligned. So:

- a cover wider than tall hugs the bottom edge of the card, with a large gap above it;
- a very tall cover sets the height of the whole row;
- a cover flatter than the old `min-height: 3rem` fallback is stretched vertically, because the default `object-fit: fill` applies once the min-height kicks in.

## Change

One rule in `_gallery.scss`: make the card a size container, then clamp the cover box between 1:1 and 1:2 of the card width and center the cover in it.

```scss
.card { container-type: inline-size; }
.card img { min-height: 100cqw; max-height: 200cqw; object-fit: contain; }
```

## Rendered results

Measured at a 147px card width, before and after:

| cover | before | after |
| --- | --- | --- |
| 200x294, typical | 147x215 | unchanged |
| 285x200, thin | 147x105, on the card bottom edge | 147x147 box, cover centered |
| 400x80, very flat | 147x38, stretched | 147x147 box, drawn 147x29, centered, no distortion |
| 200x420 (1:2.1) | 147x305 | 147x295, capped |
| 200x600 (1:3) | 147x434 | 147x295, capped |
| 10x10, 1x1, 10x4, tiny | square or natural | identical, no breakage |

Checked on the profile page at desktop and at 375px width, in light and dark mode.

## Notes

- A cover taller than 1:2 is scaled down to fit the box, so the whole cover stays visible with a gap at each side. `object-fit` takes one value, so cropping the tall ones would also crop the thin ones.
- A cover that fails to load now reserves a full square instead of one line of alt text.
- On progress cards the progress bar is anchored to the cover box, so on a thin cover it sits below the cover edge rather than on it. That needs a markup change and is left out of this PR.