### PR TITLE
fix(journal): keep index docs for posts orphaned by a shelf change

### DIFF
--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -215,6 +215,10 @@ def timeline_link(
     query = JournalQueryParser("", page_size=limit)
     query.filter_by_viewer(request.user.identity)
     query.filter("item_id", item.pk)
+    # posts orphaned by a shelf change carry item fields too; keep them
+    # out to preserve pre-enrichment behavior (surfacing old mark posts
+    # here would arguably be correct, but that is a product decision)
+    query.exclude("piece_class", "Post")
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     return [

--- a/neodb/journal/models/__init__.py
+++ b/neodb/journal/models/__init__.py
@@ -32,6 +32,7 @@ from .shelf import (
 )
 from .tag import Tag, TagManager, TagMember
 from .utils import (
+    cleanup_deleted_post,
     journal_exists_for_item,
     remove_data_by_identity,
     reset_journal_visibility_for_user,
@@ -74,6 +75,7 @@ __all__ = [
     "TagManager",
     "TagMember",
     "UNMARKED",
+    "cleanup_deleted_post",
     "journal_exists_for_item",
     "remove_data_by_identity",
     "reset_journal_visibility_for_user",

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -201,6 +201,11 @@ class Collection(List):
         q = JournalQueryParser(self.query, **kwargs)
         q.filter_by_owner_viewer(self.owner, viewer)
         q.filter("item_id", ">0")
+        # posts orphaned by a shelf change carry item fields too; exclude
+        # them like the journal search page does so only current pieces
+        # match (r.items would dedup anyway, but total and pagination
+        # must not inflate)
+        q.exclude("piece_class", "Post")
         q.facet_by = ["item_class"]
         return q
 

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -318,8 +318,19 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         self.update_index()
 
     def clear_post_ids(self):
+        orphaned = self.all_post_ids
         PiecePost.objects.filter(piece=self).delete()
         self._invalidate_post_caches()
+        if orphaned:
+            # The unlinked posts stay on the timeline (e.g. the previous
+            # mark post after a shelf change), but update_index() is about
+            # to delete_by_piece() their docs; rewrite them as piece-less
+            # post docs first so they stay searchable. Ordering matters:
+            # with the link rows gone, the docs carry no piece_id, so the
+            # later delete cannot reach them.
+            JournalIndex.instance().replace_posts(
+                Takahe.get_posts(orphaned).filter(local=True)
+            )
 
     @cached_property
     def latest_post_id(self):

--- a/neodb/journal/models/utils.py
+++ b/neodb/journal/models/utils.py
@@ -10,13 +10,43 @@ from users.models import APIdentity, User
 from .article import Article
 from .collection import Collection, CollectionMember, FeaturedCollection
 from .comment import Comment
-from .common import Content, Debris
+from .common import Content, Debris, Piece
 from .itemlist import ListMember
 from .note import Note
 from .rating import Rating
 from .review import Review
 from .shelf import ShelfLogEntry, ShelfMember
 from .tag import Tag, TagMember
+
+
+def cleanup_deleted_post(post_pk: int) -> None:
+    """Clean up journal pieces and index docs after a post is deleted.
+
+    Both deletion paths must call this: the web UI post_delete view
+    directly, and takahe's PostService.delete() via the
+    takahe.ap_handlers.post_deleted queue callback.
+    """
+    for piece in Piece.objects.filter(posts__id=post_pk):
+        if piece.local and piece.__class__ not in (Note, Article):
+            # Marks/Reviews/Comments are NeoDB-managed; keep the piece even
+            # if the user nukes the timeline post (legacy behavior), but
+            # refresh its index doc, which may reference the deleted post
+            piece.update_index()
+            continue
+        # delete piece if the deleted post is the most recent one for the piece
+        if piece.latest_post_id == post_pk:
+            logger.debug(f"Deleting piece {piece}")
+            piece.delete_index()
+            piece.delete()
+        else:
+            logger.debug(f"Matched piece {piece} has newer posts, not deleting")
+    # Docs keyed by this post that nothing above rewrites (piece-less
+    # posts, or posts orphaned by a shelf change that still link a
+    # Comment/Rating indexing within its mark) must go now, or only
+    # idx-sync can collect them. Piece docs rewritten above are safe:
+    # the post is dead by this point, so those docs carry no post_id
+    # field and this filter cannot match them.
+    JournalIndex.instance().delete_by_post([post_pk])
 
 
 def reset_journal_visibility_for_user(owner: APIdentity, visibility: int):

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -427,7 +427,7 @@ class JournalIndex(Index):
         return [d for d in docs if d]
 
     @classmethod
-    def post_to_doc(cls, post: Post) -> dict:
+    def post_to_doc(cls, post: Post, item_map: dict[int, Item] | None = None) -> dict:
         pc = post.piece
         doc = {}
         if pc:
@@ -448,11 +448,50 @@ class JournalIndex(Index):
                 #     post.interactions.values_list("identity_id", flat=True)
                 # ),
             }
+            # A post orphaned by a shelf change (or linked only to pieces
+            # that index within another doc) still relates to an item via
+            # its ShelfLogEntry; carry the item fields so item-scoped
+            # search can reach it. piece_class stays ["Post"]: journal
+            # search excludes it to keep old marks out of piece results.
+            item = item_map.get(post.pk) if item_map is not None else post.item
+            if item:
+                doc["item_id"] = [item.pk]
+                doc["item_class"] = [item.__class__.__name__]
+                doc["item_title"] = item.to_indexable_titles()
         return doc
 
     @classmethod
+    def _items_for_posts(cls, post_ids: list[int]) -> dict[int, Item]:
+        """Batched Post.item fallback: map post id -> Item via ShelfLogEntry.
+
+        Only ShelfMember-derived posts have log entries; other posts get
+        no entry. Two queries regardless of batch size, so idx-rebuild's
+        per-batch cost stays flat.
+        """
+        from journal.models.shelf import ShelfLogEntryPost  # circular; see header
+
+        if not post_ids:
+            return {}
+        rows = list(
+            ShelfLogEntryPost.objects.filter(post_id__in=post_ids).values_list(
+                "post_id", "log_entry__item_id"
+            )
+        )
+        items = {
+            i.pk: i
+            for i in Item.objects.filter(
+                pk__in={item_id for _, item_id in rows}, is_deleted=False
+            )
+        }
+        return {
+            post_id: items[item_id] for post_id, item_id in rows if item_id in items
+        }
+
+    @classmethod
     def posts_to_docs(cls, posts: Iterable[Post]) -> list[dict]:
-        return [cls.post_to_doc(p) for p in posts]
+        posts = list(posts)
+        item_map = cls._items_for_posts([p.pk for p in posts])
+        return [cls.post_to_doc(p, item_map) for p in posts]
 
     def delete_all(self):
         return self.delete_docs("owner_id", ">0")

--- a/neodb/journal/views/post.py
+++ b/neodb/journal/views/post.py
@@ -93,12 +93,19 @@ def post_replies(request: AuthedHttpRequest, post_id: int):
 @require_http_methods(["POST"])
 @login_required
 def post_delete(request: AuthedHttpRequest, post_id: int):
+    from takahe.ap_handlers import post_deleted
+
     p = Takahe.get_post(post_id)
     if not p:
         raise Http404(_("Post not found"))
     if p.author_id != request.user.identity.pk:
         raise PermissionDenied(_("Insufficient permission"))
     Takahe.delete_posts([post_id])
+    # Takahe.delete_posts() only flips the post state; run the same
+    # cleanup the Mastodon API path gets via PostService.delete(), so
+    # linked pieces and the post's index doc do not outlive the post
+    # (the delete button even promises the piece cleanup)
+    post_deleted(post_id, True, (p.type_data or {}).get("object", {}))
     return HttpResponse("<!-- DELETED -->")
 
 

--- a/neodb/journal/views/post.py
+++ b/neodb/journal/views/post.py
@@ -93,8 +93,6 @@ def post_replies(request: AuthedHttpRequest, post_id: int):
 @require_http_methods(["POST"])
 @login_required
 def post_delete(request: AuthedHttpRequest, post_id: int):
-    from takahe.ap_handlers import post_deleted
-
     p = Takahe.get_post(post_id)
     if not p:
         raise Http404(_("Post not found"))
@@ -105,7 +103,7 @@ def post_delete(request: AuthedHttpRequest, post_id: int):
     # cleanup the Mastodon API path gets via PostService.delete(), so
     # linked pieces and the post's index doc do not outlive the post
     # (the delete button even promises the piece cleanup)
-    post_deleted(post_id, True, (p.type_data or {}).get("object", {}))
+    cleanup_deleted_post(post_id)
     return HttpResponse("<!-- DELETED -->")
 
 

--- a/neodb/takahe/ap_handlers.py
+++ b/neodb/takahe/ap_handlers.py
@@ -18,6 +18,7 @@ from journal.models import (
     Review,
     Shelf,
     ShelfMember,
+    cleanup_deleted_post,
 )
 from journal.search import JournalIndex
 from users.middlewares import activate_language_for_user
@@ -214,27 +215,7 @@ def _post_fetched(pk, local, post_data, create: bool | None = None):
 
 
 def post_deleted(pk, local, post_data):
-    for piece in Piece.objects.filter(posts__id=pk):
-        if piece.local and piece.__class__ not in (Note, Article):
-            # Marks/Reviews/Comments are NeoDB-managed; keep the piece even
-            # if the user nukes the timeline post (legacy behavior), but
-            # refresh its index doc, which may reference the deleted post
-            piece.update_index()
-            continue
-        # delete piece if the deleted post is the most recent one for the piece
-        if piece.latest_post_id == pk:
-            logger.debug(f"Deleting piece {piece}")
-            piece.delete_index()
-            piece.delete()
-        else:
-            logger.debug(f"Matched piece {piece} has newer posts, not deleting")
-    # Docs keyed by this post that nothing above rewrites (piece-less
-    # posts, or posts orphaned by a shelf change that still link a
-    # Comment/Rating indexing within its mark) must go now, or only
-    # idx-sync can collect them. Piece docs rewritten above are safe:
-    # the post is dead by this point, so those docs carry no post_id
-    # field and this filter cannot match them.
-    JournalIndex.instance().delete_by_post([pk])
+    cleanup_deleted_post(pk)
 
 
 def post_interacted(interaction_pk, interaction, post_pk, identity_pk):

--- a/neodb/takahe/ap_handlers.py
+++ b/neodb/takahe/ap_handlers.py
@@ -228,6 +228,13 @@ def post_deleted(pk, local, post_data):
             piece.delete()
         else:
             logger.debug(f"Matched piece {piece} has newer posts, not deleting")
+    # Docs keyed by this post that nothing above rewrites (piece-less
+    # posts, or posts orphaned by a shelf change that still link a
+    # Comment/Rating indexing within its mark) must go now, or only
+    # idx-sync can collect them. Piece docs rewritten above are safe:
+    # the post is dead by this point, so those docs carry no post_id
+    # field and this filter cannot match them.
+    JournalIndex.instance().delete_by_post([pk])
 
 
 def post_interacted(interaction_pk, interaction, post_pk, identity_pk):

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -2,11 +2,14 @@ from io import StringIO
 
 import pytest
 from django.core.management import call_command
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from catalog.models import Edition
-from journal.models import Comment, Mark, Review, ShelfType
+from journal.models import Collection, Comment, Mark, Review, ShelfType
 from journal.search import JournalIndex, JournalQueryParser
+from takahe.ap_handlers import post_deleted
 from takahe.models import Domain, Post
 from takahe.models import Identity as TakaheIdentity
 from takahe.utils import Takahe
@@ -119,6 +122,154 @@ class TestIdxSync:
         self.run_sync("--owner", "userx")
         assert self.doc_ids(self.identity1.pk)
         assert self.doc_ids(self.identity2.pk) == set()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfChangeOrphanedPost:
+    """A shelf change unlinks the previous mark post but leaves it on the
+    timeline; its doc must survive as a piece-less post doc."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(
+            title="Hyperion",
+            localized_title=[{"lang": "en", "text": "Hyperion"}],
+        )
+        self.user = User.register(email="x@y.com", username="userx")
+        self.identity = self.user.identity
+
+    def run_sync(self, *args) -> str:
+        out = StringIO()
+        call_command("journal", "idx-sync", *args, stdout=out)
+        return out.getvalue()
+
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
+    def get_doc(self, doc_id: str) -> dict:
+        return self.index.write_collection.documents[doc_id].retrieve()
+
+    def transition(self, book=None, comment=None, rating=None) -> tuple[int, int]:
+        """Mark progress then complete; return (old, new) post ids."""
+        book = book or self.book
+        mark = Mark(self.identity, book)
+        mark.update(ShelfType.PROGRESS, comment, rating, [], 0)
+        assert mark.shelfmember is not None
+        old_post_id = mark.shelfmember.latest_post_id
+        mark = Mark(self.identity, book)
+        mark.update(ShelfType.COMPLETE, comment, rating, [], 0)
+        assert mark.shelfmember is not None
+        new_post_id = mark.shelfmember.latest_post_id
+        assert old_post_id and new_post_id and old_post_id != new_post_id
+        return old_post_id, new_post_id
+
+    def assert_orphan_doc(self, post_id: int):
+        doc = self.get_doc(str(post_id))
+        assert doc["piece_class"] == ["Post"]
+        assert "piece_id" not in doc
+        assert doc["item_id"] == [self.book.pk]
+        assert doc["item_class"] == ["Edition"]
+        assert "Hyperion" in doc["item_title"]
+
+    def test_shelf_change_keeps_previous_post_doc(self):
+        old_pid, new_pid = self.transition()
+        # the old post stays live on the timeline, so its doc must stay too
+        assert Takahe.get_posts([old_pid]).exists()
+        ids = self.doc_ids(self.identity.pk)
+        assert str(old_pid) in ids
+        assert str(new_pid) in ids
+        self.assert_orphan_doc(old_pid)
+        assert "ShelfMember" in self.get_doc(str(new_pid))["piece_class"]
+        # reachable from post search ("search my posts")
+        q = JournalQueryParser("Hyperion", 1)
+        q.filter_by_owner(self.identity)
+        r = self.index.search(q)
+        assert old_pid in [p.pk for p in r.posts]
+        # but still hidden from the journal search page
+        q = JournalQueryParser("Hyperion", 1)
+        q.filter_by_owner(self.identity)
+        q.exclude("piece_class", "Post")
+        r = self.index.search(q)
+        pks = [p.pk for p in r.posts]
+        assert old_pid not in pks
+        assert new_pid in pks
+
+    def test_shelf_change_with_comment(self):
+        # the old post keeps a PiecePost row to the Comment, whose
+        # to_indexable_doc() is empty; the doc must fall back to the
+        # piece-less post shape
+        old_pid, _ = self.transition(comment="so far so good")
+        self.assert_orphan_doc(old_pid)
+
+    def test_shelf_change_with_comment_and_rating(self):
+        # two sibling pieces remain linked, so post.piece resolves to None
+        old_pid, _ = self.transition(comment="so far so good", rating=8)
+        self.assert_orphan_doc(old_pid)
+
+    def test_user_path_doc_matches_batch_builder(self):
+        # the doc written on the user path must equal the one idx-sync and
+        # idx-rebuild would write, or they would fight each other
+        old_pid, _ = self.transition(comment="so far so good")
+        indexed = self.get_doc(str(old_pid))
+        built = self.index.posts_to_docs(list(Post.objects.filter(pk=old_pid)))[0]
+        assert set(indexed) == set(built)
+        for k, v in built.items():
+            assert indexed[k] == v, k
+
+    def test_idx_sync_clean_after_shelf_change(self):
+        self.transition(comment="so far so good", rating=8)
+        output = self.run_sync("--dry-run")
+        assert "0 docs would be added, 0 docs would be deleted" in output
+
+    def test_delete_orphaned_post_drops_doc(self):
+        # the linked Comment still matches in post_deleted() but rewrites
+        # nothing, so only the unconditional delete_by_post removes the doc
+        old_pid, new_pid = self.transition(comment="so far so good")
+        assert str(old_pid) in self.doc_ids(self.identity.pk)
+        Takahe.delete_posts([old_pid])
+        post_deleted(old_pid, True, None)
+        ids = self.doc_ids(self.identity.pk)
+        assert str(old_pid) not in ids
+        assert str(new_pid) in ids
+
+    def test_delete_pieceless_orphaned_post_drops_doc(self):
+        old_pid, new_pid = self.transition()
+        Takahe.delete_posts([old_pid])
+        post_deleted(old_pid, True, None)
+        ids = self.doc_ids(self.identity.pk)
+        assert str(old_pid) not in ids
+        assert str(new_pid) in ids
+
+    def test_dynamic_collection_excludes_orphaned_posts(self):
+        self.transition(comment="so far so good")
+        collection = Collection(owner=self.identity, title="dyn", query="Hyperion")
+        q = collection.get_query(self.identity)
+        assert q is not None
+        r = self.index.search(q)
+        assert r.total == 1
+        assert [i.pk for i in r.items] == [self.book.pk]
+
+    def test_posts_to_docs_constant_batch_queries(self):
+        # idx-rebuild walks millions of posts; item resolution must stay
+        # batched so the only per-post query is the post.piece lookup
+        books = [self.book] + [Edition.objects.create(title=f"Book {i}") for i in "23"]
+        orphans = [self.transition(book=book)[0] for book in books]
+
+        def build(pks):
+            return self.index.posts_to_docs(list(Post.objects.filter(pk__in=pks)))
+
+        build(orphans)  # warm up shared caches
+        with CaptureQueriesContext(connections["default"]) as one:
+            docs = build(orphans[:1])
+        assert docs[0]["item_id"]
+        with CaptureQueriesContext(connections["default"]) as three:
+            docs = build(orphans)
+        assert all(d.get("item_id") for d in docs)
+        assert len(three.captured_queries) - len(one.captured_queries) == 2
 
 
 def _make_remote_identity(username: str, domain_name: str = "remote.example"):

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -4,6 +4,7 @@ import pytest
 from django.core.management import call_command
 from django.db import connections
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 from django.utils import timezone
 
 from catalog.models import Edition
@@ -240,6 +241,17 @@ class TestShelfChangeOrphanedPost:
         old_pid, new_pid = self.transition()
         Takahe.delete_posts([old_pid])
         post_deleted(old_pid, True, None)
+        ids = self.doc_ids(self.identity.pk)
+        assert str(old_pid) not in ids
+        assert str(new_pid) in ids
+
+    def test_post_delete_view_drops_doc(self, client):
+        # the web UI delete button must run the same cleanup as the
+        # Mastodon API path, or the doc outlives the post
+        old_pid, new_pid = self.transition(comment="so far so good")
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        response = client.post(reverse("journal:post_delete", args=[old_pid]))
+        assert response.status_code == 200
         ids = self.doc_ids(self.identity.pk)
         assert str(old_pid) not in ids
         assert str(new_pid) in ids

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -26,6 +26,8 @@ class TestSearch:
         # mark two books
         mark = Mark(self.user1.identity, self.book1)
         mark.update(ShelfType.WISHLIST, "a gentle comment", 9, ["Sci-Fi", "fic"], 0)
+        assert mark.shelfmember is not None
+        book1_wishlist_post_id = mark.shelfmember.latest_post_id
         mark = Mark(self.user1.identity, self.book2)
         mark.update(ShelfType.WISHLIST, "a gentle comment", None, ["nonfic"], 1)
 
@@ -41,7 +43,9 @@ class TestSearch:
         r = self.index.search(q)
         assert r.total == 1
 
-        # update mark and search again
+        # update mark and search again: the book2 mark still matches, and
+        # so does the previous book1 wishlist post, which stays on the
+        # timeline and therefore stays searchable as a piece-less post doc
         mark = Mark(self.user1.identity, self.book1)
         mark.update(ShelfType.PROGRESS, "an updated comment", 9, ["Sci-Fi", "fic"], 0)
 
@@ -49,18 +53,19 @@ class TestSearch:
         q = JournalQueryParser("gentle")
         q.filter_by_owner(self.user1.identity)
         r = self.index.search(q)
-        assert r.total == 1
-        assert r.posts[0].state == "new"
+        assert r.total == 2
+        assert all(p.state == "new" for p in r.posts)
 
         # delete the other mark
         mark = Mark(self.user1.identity, self.book2)
         mark.delete()
 
-        # search the marks
+        # search the marks: only the orphaned wishlist post remains
         q = JournalQueryParser("gentle")
         q.filter_by_owner(self.user1.identity)
         r = self.index.search(q)
-        assert r.total == 0
+        assert r.total == 1
+        assert r.posts[0].pk == book1_wishlist_post_id
 
     def test_search_post_visibility_for_viewer(self):
         mark = Mark(self.user1.identity, self.book1)


### PR DESCRIPTION
## Problem

Changing an item's shelf (e.g. progress to complete) permanently deletes the search document of the previous mark post, while the post itself deliberately stays on the user's timeline (`update_mode=2`). The post becomes unfindable in post search forever, on every shelf transition. `journal idx-sync` repairs it after the fact, but nothing repairs it in the request path and no scheduled job runs it.

## Mechanism

1. `Mark._update_shelfmember()` takes the shelf-changed branch and calls `shelfmember.clear_post_ids()`, which deletes the mark's `PiecePost` rows while leaving the old post on the timeline.
2. `_sync_timeline()` then creates the new post and calls `shelfmember.update_index()`, whose `delete_by_piece()` removes the old post's document (it carried the mark's `piece_id`). Nothing writes a replacement.

## Fix

- `Piece.clear_post_ids()` now rewrites the documents of the posts it unlinks as piece-less post docs before `update_index()` runs. With the link rows gone, the docs carry no `piece_id`, so the later `delete_by_piece()` cannot reach them.
- `JournalIndex.post_to_doc()` enriches the piece-less fallback with `item_id` / `item_class` / `item_title`, resolved via the post's `ShelfLogEntry` and batched per `posts_to_docs()` call, so `idx-rebuild` pays two extra queries per batch rather than per post. Every writer (user action, `idx-sync`, `idx-rebuild`) funnels through this builder, so all paths produce identical documents by construction. `piece_class` stays `["Post"]`: the journal search page keeps excluding old mark posts, while post search ("search my posts") now finds them.
- `takahe.ap_handlers.post_deleted()` now drops documents keyed by the dead post via the previously unused `delete_by_post()`. This is unconditional: an orphaned post may still link a Comment/Rating piece that matches the piece loop but rewrites nothing, so a no-piece-matched guard would leak its doc. Piece docs rewritten in the loop are safe, as the post is dead by then and their rewritten docs carry no `post_id` field.
- Dynamic collections and `/api/v1/timelines/link` exclude `piece_class:Post` docs, preserving their pre-enrichment results now that orphaned mark posts carry item fields.
- The web UI `post_delete` view now runs the same `post_deleted()` cleanup as the Mastodon API path (`PostService.delete()`), instead of only flipping the post state via `Takahe.delete_posts()`. Previously this path leaked the post's index doc and skipped the piece cleanup that the delete button's confirm dialog already promises.

## Notes

- Remote posts are unaffected: remote identities index one document per piece, and none of the changed paths can produce post-keyed documents for remote posts (`clear_post_ids()` filters `local=True`, rebuild and sync only walk local posts).
- Deployments with existing orphans need one `neodb-manage journal idx-sync` run to backfill; this fix stops the leak going forward.

## Tests

- 10 new tests in `tests/journal/test_idx_sync.py`: the shelf transition keeps the previous post's doc (plain, with comment, with comment and rating), the user-path document equals the batch-builder document, `idx-sync --dry-run` is clean right after a transition, deleting an orphaned post drops its doc (via handler and via the web UI view), dynamic collections exclude orphaned posts, and a query-count guard that keeps item resolution batched.
- `tests/journal/test_search.py::test_search_post` asserted the old behavior (previous post's doc disappearing after a shelf change) and was updated to the new semantics.

7 of the new tests fail without the fix. Full suite passes locally against postgres/redis/typesense (2122 passed).