### PR TITLE
fix(journal): stop rewriting index docs that claim pruned posts

### DIFF
--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -174,7 +174,9 @@ def list_posts_for_item(
     query.filter("item_id", item.pk)
     # NB: no `post_id:>0` filter to align `count` with `data`: post_id has no
     # range index and millions of distinct values, so it scans the whole
-    # numeric tree and saturates Typesense (NEODB-SOCIAL-7NF)
+    # numeric tree and saturates Typesense (NEODB-SOCIAL-7NF). So `count` may
+    # exceed len(data): a doc whose post takahe pruned still counts here but
+    # resolves to no post; accepted drift, healed by refetch or idx-rebuild
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     result = {

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -40,10 +40,10 @@ idx-alt:        update index schema
 idx-delete:     delete docs in index
 idx-rebuild:    rebuild docs in index
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
-idx-sync:       add missing docs, delete stale docs and rewrite docs still
-                referencing dead posts for each local identity, purge docs of
-                deactivated identities (use --dry-run to preview, --remote to
-                sync remote pieces and identities instead)
+idx-sync:       add missing docs and delete stale docs for each local
+                identity, purge docs of deactivated identities (use
+                --dry-run to preview, --remote to sync remote pieces and
+                identities instead)
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -203,23 +203,22 @@ class Command(SiteCommand):
         """Doc ids an active identity should have in the index.
 
         Local identities get a doc per live local post plus one per piece
-        without a live post; for remote identities only pieces are indexed.
+        not covered by such a post; for remote identities only pieces are
+        indexed.
 
         Returns a map of doc id -> (kind, pk), mirroring how
-        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids. Kind
-        is "post", "piece", or "stale-piece" for a piece doc keyed by a
-        dead post id: its content may still reference that post from
-        before the post died, so it must be rewritten even when present.
+        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids: a
+        piece doc is keyed by its latest linked post id even if that post
+        is gone from db. Kind is "post" or "piece".
         """
         expected: dict[str, tuple[str, int]] = {}
-        live_post_ids: set[int] = set()
         if not remote:
-            live_post_ids = set(
+            live_posts = (
                 Post.objects.filter(local=True, author_id=identity_id)
                 .exclude(state__in=_DELETED_POST_STATES)
                 .values_list("pk", flat=True)
             )
-            for post_id in live_post_ids:
+            for post_id in live_posts:
                 expected[str(post_id)] = ("post", post_id)
         piece_ids: set[int] = set()
         # piece_id -> (piece_post_pk, post_id) of the latest linked post
@@ -243,26 +242,15 @@ class Command(SiteCommand):
                     piece_id not in latest_pps or pp_pk > latest_pps[piece_id][0]
                 ):
                     latest_pps[piece_id] = (pp_pk, post_id)
-        if remote:
-            # for remote identities, live-ness of the linked posts decides
-            # which piece docs may carry a stale post reference
-            live_post_ids = set(
-                Post.objects.filter(pk__in=[v[1] for v in latest_pps.values()])
-                .exclude(state__in=_DELETED_POST_STATES)
-                .values_list("pk", flat=True)
-            )
         for piece_id in piece_ids:
             post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
             if post_id is None:
                 expected["p" + str(piece_id)] = ("piece", piece_id)
-            elif post_id in live_post_ids:
-                if remote:
-                    expected[str(post_id)] = ("piece", piece_id)
-                # for local, the piece is covered by the doc of its live post
             else:
-                # piece_to_doc() keys the doc by the latest linked post id
-                # even if that post is gone from db
-                expected[str(post_id)] = ("stale-piece", piece_id)
+                # first writer wins: for local, the live post's own entry
+                # (inserted above) covers the piece; for remote, this
+                # arbitrates pieces sharing one post
+                expected.setdefault(str(post_id), ("piece", piece_id))
         return expected
 
     def sync_identity_index(
@@ -270,8 +258,14 @@ class Command(SiteCommand):
     ) -> tuple[int, int] | None:
         """Add missing docs and delete stale docs for one active identity.
 
-        Docs already in the index are left as is (no deep comparison),
-        except "stale-piece" docs which are always rewritten.
+        Docs already in the index are left as is (no deep comparison). In
+        particular, a piece doc may keep claiming a post that was pruned
+        or hard-deleted; only queries filtering on post_id (local
+        timeline search) see the dangling reference, and it is healed by
+        a refetch (relink_post_id, remote pieces only), an edit of the
+        piece, or idx-rebuild. Rewriting those docs here instead would
+        never converge: the classification depends only on db state,
+        which a rewrite does not change.
         Returns (added, deleted), or None on index error.
         """
         expected = self.expected_index_docs(identity_id, remote)
@@ -280,13 +274,8 @@ class Command(SiteCommand):
             return None
         extra = indexed - expected.keys()
         missing = expected.keys() - indexed
-        rewrite = {
-            i
-            for i, (kind, _) in expected.items()
-            if kind == "stale-piece" and i in indexed
-        }
         if self.dry_run:
-            return len(missing) + len(rewrite), len(extra)
+            return len(missing), len(extra)
         deleted = 0
         for chunk in batched(extra, _SYNC_DELETE_CHUNK):
             deleted += index.delete_docs("id", chunk)
@@ -295,9 +284,7 @@ class Command(SiteCommand):
         for chunk in batched(post_ids, self.batch_size):
             posts = Post.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.posts_to_docs(posts))
-        piece_ids = [
-            expected[i][1] for i in missing | rewrite if expected[i][0] != "post"
-        ]
+        piece_ids = [expected[i][1] for i in missing if expected[i][0] != "post"]
         for chunk in batched(piece_ids, self.batch_size):
             pieces = Piece.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.pieces_to_docs(pieces))

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -412,7 +412,9 @@ class JournalIndex(Index):
             "visibility": piece.visibility,
         }
         if piece.latest_post:
-            # fk is not enforced, so post might be deleted
+            # fk is not enforced, so post might be deleted; a doc without
+            # post_id marks its post as dead, which cleanup_deleted_post's
+            # trailing delete_by_post relies on
             doc["post_id"] = [piece.latest_post_id]
             # enable this in future when we support search other users
             # doc["viewer_id"] = list(

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -97,6 +97,24 @@ class TestIdxSync:
         self.run_sync()
         assert self.doc_ids(self.identity1.pk) == before
 
+    def test_local_pruned_post_doc_left_alone(self):
+        # the mark post dies without the post_deleted callback; the doc
+        # keeps claiming the dead post_id (accepted drift, see
+        # sync_identity_index docstring). Soft-delete here so the
+        # _DELETED_POST_STATES branch is covered; the remote twin covers
+        # the row-gone branch
+        mark = Mark(self.identity1, self.book1)
+        assert mark.shelfmember is not None
+        post_id = mark.shelfmember.latest_post_id
+        assert post_id
+        before = self.doc_ids(self.identity1.pk)
+        Takahe.delete_posts([post_id])
+        output = self.run_sync()
+        assert "0 docs added, 0 docs deleted" in output
+        assert self.doc_ids(self.identity1.pk) == before
+        doc = self.index.write_collection.documents[str(post_id)].retrieve()
+        assert doc["post_id"] == [post_id]
+
     def test_purge_deactivated_identity(self):
         assert self.doc_ids(self.identity2.pk)
         self.user2.is_active = False
@@ -398,16 +416,29 @@ class TestIdxSyncRemote:
         r = self.index.search(q)
         return r.total, len(list(r.posts))
 
-    def test_remote_sync_rewrites_doc_of_pruned_post(self):
+    def test_remote_pruned_post_doc_left_alone(self):
         post_pk = self.post.pk
         assert self.doc_ids(self.owner.pk) == {str(post_pk)}
-        # takahe pruned the post; the doc still claims post_id, so it is
-        # counted while its post can never be returned
+        # takahe pruned the post; the doc keeps claiming its post_id
+        # (accepted drift, see sync_identity_index docstring; the count
+        # probe below filters on post_id, which no item query does in
+        # production). A refetch or idx-rebuild heals the doc; sync must
+        # not rewrite it, as that can never converge
         self.post.delete()
         assert self._item_review_posts_count() == (1, 0)
-        self.run_sync("--remote")
-        # same doc id, but content rewritten without the dead post_id
+        output = self.run_sync("--remote")
+        assert "0 docs added, 0 docs deleted" in output
         assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        assert self._item_review_posts_count() == (1, 0)
+
+    def test_missing_doc_of_pruned_post_restored(self):
+        post_pk = self.post.pk
+        self.post.delete()
+        self.index.delete_by_owner([self.owner.pk])
+        output = self.run_sync("--remote")
+        assert "1 docs added, 0 docs deleted" in output
+        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        # rebuilt from db truth, so it no longer claims the dead post
         assert self._item_review_posts_count() == (0, 0)
 
     def test_remote_sync_cleans_docs_of_pieceless_owner(self):

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -120,9 +120,11 @@ def _make_remote_post(owner_pk: int, uri: str, obj: dict) -> Post:
 
 @pytest.mark.django_db(databases="__all__")
 class TestRemotePieceIndex:
-    """Regression tests for #1761: docs indexed for remote pieces must
-    reference the linked post, so that item post search returns as many
-    posts as it counts."""
+    """Regression tests for #1761: when a pruned remote post is refetched
+    under a new pk, the piece doc must be relinked to it so item post
+    search returns the post again. A doc whose post is pruned and never
+    refetched keeps claiming the dead post; that drift is accepted (see
+    sync_identity_index docstring)."""
 
     @pytest.fixture(autouse=True)
     def setup_data(self):


### PR DESCRIPTION
## Problem

Running `journal idx-sync --remote` twice back to back reported "5247 docs added" both times. All of them were rewrites of the same "stale-piece" docs: piece docs keyed by a post that takahe has pruned. The classification depends only on db state, which a rewrite does not change, so sync re-upserted the same docs on every run, forever, and counted them as added.

## Approach change

The first draft of this PR gated the rewrite so it ran once per doc. A design review of the whole piece-to-typesense sync chose a simpler answer: stop rewriting these docs at all, and accept the drift.

Why the drift is acceptable:

- The only production query that filters `post_id:>0` is "search my posts", which is always scoped to the local viewer's own docs (`social/views.py`). Remote docs never reach it.
- Local docs stay exact regardless: `cleanup_deleted_post` rewrites them synchronously on both real deletion paths (web view and the `post_deleted` queue callback), without involving idx-sync.
- The item posts API already documents its `count` as approximate for exactly this drift class (`apis/post.py`, NEODB-SOCIAL-7NF).
- When the pruned post is refetched, `relink_post_id` links the new post and refreshes the doc. That path (#1761) is untouched and stays tested.

## Changes

- `expected_index_docs` drops the "stale-piece" kind and the remote post-liveness query; a piece doc is expected under its latest linked post id whether or not that post still exists.
- `sync_identity_index` no longer rewrites any existing doc; it only adds missing docs and deletes extra ones, so repeated runs converge to zero by construction.
- Tests now pin the compromise: after a prune, sync reports zeros and the doc still carries the dangling `post_id`; a doc rebuilt from scratch no longer claims the dead post.

## Ops note

Existing docs that already claim pruned posts (about 5.2k on the instance measured) stay as they are. They are harmless to search results (dead posts are dropped at hydration) and can be cleaned up with a one-time `journal idx-rebuild --remote` if desired.

## Acceptance

- idx-sync twice with no db changes: second run reports 0 added, 0 deleted, and writes nothing.
- Full tests/journal suite passes (794 tests).
