### PR TITLE
refactor(journal): key index docs by piece pk and funnel index writes

### DIFF
--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -174,7 +174,9 @@ def list_posts_for_item(
     query.filter("item_id", item.pk)
     # NB: no `post_id:>0` filter to align `count` with `data`: post_id has no
     # range index and millions of distinct values, so it scans the whole
-    # numeric tree and saturates Typesense (NEODB-SOCIAL-7NF)
+    # numeric tree and saturates Typesense (NEODB-SOCIAL-7NF). So `count` may
+    # exceed len(data): a doc whose post takahe pruned still counts here but
+    # resolves to no post; accepted drift, healed by refetch or idx-rebuild
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     result = {

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -477,9 +477,13 @@ class NdjsonImporter(BaseImporter):
                     existing_comment.created_time = published_dt
                 existing_comment.visibility = visibility
                 existing_comment.metadata = metadata
-                existing_comment.save()
+                # no index during import, like import_article/import_note;
+                # the mark import covers commented marks, idx-sync covers
+                # lone comments (e.g. on episodes), same as before import
+                # hooks existed
+                existing_comment.save(index_when_save=False)
                 return "imported"
-            Comment.objects.create(
+            comment = Comment(
                 owner=owner,
                 item=item,
                 text=content,
@@ -487,6 +491,7 @@ class NdjsonImporter(BaseImporter):
                 metadata=metadata,
                 **({"created_time": published_dt} if published_dt else {}),
             )
+            comment.save(index_when_save=False)
             return "imported"
         except Exception:
             logger.exception("Error importing comment")

--- a/neodb/journal/jobs/migrations.py
+++ b/neodb/journal/jobs/migrations.py
@@ -65,3 +65,60 @@ def backfill_member_progress_from_notes_20260720(batch_size: int = 1000) -> int:
         f"Backfilled current reading progress for up to {candidates} shelf members"
     )
     return candidates
+
+
+def reindex_piece_keyed_docs_20260818(batch_size: int = 1000) -> int:
+    """Rebuild the journal index for the piece-keyed doc id scheme.
+
+    Piece docs were previously keyed by the latest linked post id; they
+    are now keyed "p<pk>", so the new writers cannot address the old
+    docs. Upsert every piece doc first, then delete the docs keyed under
+    the old scheme, then write the piece-less post docs. Search stays
+    populated throughout, and a failed delete leaves duplicates that
+    idx-sync can collect rather than an empty index. Safe to run
+    repeatedly. Holds two in-memory id sets, roughly a few dozen MB per
+    million linked pieces.
+    """
+    from itertools import batched
+
+    from django.core.paginator import Paginator
+
+    from journal.models import Piece
+    from journal.search import JournalIndex
+    from takahe.models import Post
+
+    index = JournalIndex.instance()
+    if not index.initialize_collection(max_wait=30):
+        logger.error("Journal index is not ready, reindex aborted.")
+        return 0
+    total = 0
+    # old-scheme doc ids: one per piece with any linked post
+    old_ids: set[str] = set()
+    # live posts referenced by the docs written, to skip in the post pass
+    covered_post_ids: set[int] = set()
+    pieces = Piece.objects.order_by("id")
+    pg = Paginator(pieces, batch_size)
+    for p in pg.page_range:
+        page = list(pg.get_page(p).object_list)
+        docs = index.pieces_to_docs(page)
+        for piece in page:
+            if piece.latest_post_id:
+                old_ids.add(str(piece.latest_post_id))
+        for doc in docs:
+            covered_post_ids.update(doc.get("post_id", []))
+        total += index.replace_docs(docs)
+    logger.info(f"Reindexed {total} journal piece docs")
+    deleted = 0
+    for chunk in batched(sorted(old_ids), 200):
+        deleted += index.delete_docs("id", chunk)
+    logger.info(f"Deleted {deleted} docs keyed under the old scheme")
+    posts = Post.objects.filter(local=True).exclude(
+        state__in=["deleted", "deleted_fanned_out"]
+    )
+    c = 0
+    pg = Paginator(posts.order_by("id"), batch_size)
+    for p in pg.page_range:
+        docs = index.posts_to_docs(pg.get_page(p).object_list, covered_post_ids)
+        c += index.replace_docs(docs)
+    logger.info(f"Reindexed {c} journal post docs")
+    return total + c

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -175,7 +175,7 @@ class Command(SiteCommand):
             self.stdout.write(self.style.ERROR("--hour parameter is required"))
             return
         cutoff_time = timezone.now() - timedelta(hours=hours)
-        model_classes = [ShelfMember, Review, Comment, Collection, Note]
+        model_classes = _INDEXABLE_PIECE_CLASSES
         for model_cls in model_classes:
             items = model_cls.objects.filter(edited_time__gte=cutoff_time).order_by(
                 "pk"
@@ -202,27 +202,16 @@ class Command(SiteCommand):
     ) -> dict[str, tuple[str, int]]:
         """Doc ids an active identity should have in the index.
 
-        Local identities get a doc per live local post plus one per piece
-        not covered by such a post; for remote identities only pieces are
-        indexed.
+        Every indexable piece gets a "p<pk>" doc. Local identities also
+        get a doc per live local post not covered by a piece doc; remote
+        identities have no post docs.
 
         Returns a map of doc id -> (kind, pk), mirroring how
-        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids: a
-        piece doc is keyed by its latest linked post id even if that post
-        is gone from db. Kind is "post" or "piece".
+        JournalIndex.piece_to_doc() / post_to_doc() assign doc ids. Kind
+        is "post" or "piece".
         """
         expected: dict[str, tuple[str, int]] = {}
-        if not remote:
-            live_posts = (
-                Post.objects.filter(local=True, author_id=identity_id)
-                .exclude(state__in=_DELETED_POST_STATES)
-                .values_list("pk", flat=True)
-            )
-            for post_id in live_posts:
-                expected[str(post_id)] = ("post", post_id)
-        piece_ids: set[int] = set()
-        # piece_id -> (piece_post_pk, post_id) of the latest linked post
-        latest_pps: dict[int, tuple[int, int]] = {}
+        covered_post_ids: set[int] = set()
         for cls in _INDEXABLE_PIECE_CLASSES:
             pieces = cls.objects.filter(owner_id=identity_id, local=not remote)
             if cls is Comment:
@@ -233,24 +222,20 @@ class Command(SiteCommand):
                     .order_by()
                 )
             # left join keeps pieces without any post
-            rows = pieces.values_list(
-                "pk", "post_relations__pk", "post_relations__post_id"
-            )
-            for piece_id, pp_pk, post_id in rows:
-                piece_ids.add(piece_id)
-                if pp_pk is not None and (
-                    piece_id not in latest_pps or pp_pk > latest_pps[piece_id][0]
-                ):
-                    latest_pps[piece_id] = (pp_pk, post_id)
-        for piece_id in piece_ids:
-            post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
-            if post_id is None:
+            rows = pieces.values_list("pk", "post_relations__post_id")
+            for piece_id, post_id in rows:
                 expected["p" + str(piece_id)] = ("piece", piece_id)
-            else:
-                # first writer wins: for local, the live post's own entry
-                # (inserted above) covers the piece; for remote, this
-                # arbitrates pieces sharing one post
-                expected.setdefault(str(post_id), ("piece", piece_id))
+                if post_id is not None:
+                    covered_post_ids.add(post_id)
+        if not remote:
+            live_posts = (
+                Post.objects.filter(local=True, author_id=identity_id)
+                .exclude(state__in=_DELETED_POST_STATES)
+                .values_list("pk", flat=True)
+            )
+            for post_id in live_posts:
+                if post_id not in covered_post_ids:
+                    expected[str(post_id)] = ("post", post_id)
         return expected
 
     def sync_identity_index(
@@ -462,55 +447,45 @@ class Command(SiteCommand):
                         .filter(q)
                         .values_list("identity", flat=True)
                     )
-                if not remote:
-                    # index all posts first
-                    posts = Post.objects.filter(local=True).exclude(
-                        state__in=["deleted", "deleted_fanned_out"]
+                if owners:
+                    self.stdout.write(
+                        self.style.SUCCESS(f"indexing for {len(owners)} users.")
                     )
-                    if owners:
-                        self.stdout.write(
-                            self.style.SUCCESS(
-                                f"indexing for {len(owners)} local users."
-                            )
-                        )
-                        posts = posts.filter(author_id__in=owners)
-                    c = 0
-                    pg = Paginator(posts.order_by("id"), self.batch_size)
-                    for p in tqdm(pg.page_range):
-                        docs = index.posts_to_docs(pg.get_page(p).object_list)
-                        c += len(docs)
-                        index.replace_docs(docs)
-                    self.stdout.write(self.style.SUCCESS(f"indexed {c} local posts."))
-                # index remaining pieces without posts
-                for cls in (
-                    [
-                        ShelfMember,
-                        Review,
-                        Collection,
-                    ]
-                    if fast
-                    else [Piece]
-                ):
+                # piece docs first, collecting the posts they reference so
+                # the posts pass can skip covered posts without a per-post
+                # piece lookup
+                covered_post_ids: set[int] = set()
+                for cls in _INDEXABLE_PIECE_CLASSES:
                     pieces = cls.objects.filter(local=not remote)
                     if owners:
                         pieces = pieces.filter(owner_id__in=owners)
                     c = 0
                     pg = Paginator(pieces.order_by("id"), self.batch_size)
                     for p in tqdm(pg.page_range):
-                        pieces = pg.get_page(p).object_list
-                        if not remote:
-                            pieces = [p for p in pieces if p.latest_post is None]
-                        docs = index.pieces_to_docs(pieces)
+                        docs = index.pieces_to_docs(pg.get_page(p).object_list)
+                        for doc in docs:
+                            covered_post_ids.update(doc.get("post_id", []))
                         c += len(docs)
                         index.replace_docs(docs)
                     self.stdout.write(
                         self.style.SUCCESS(f"indexed {c} {cls.__name__}.")
                     )
-                # posts = posts.exclude(type_data__object__has_key="relatedWith")
-                # docs = index.posts_to_docs(posts)
-                # c = len(docs)
-                # index.insert_docs(docs)
-                # self.stdout.write(self.style.SUCCESS(f"indexed {c} posts."))
+                if not remote:
+                    # piece-less post docs
+                    posts = Post.objects.filter(local=True).exclude(
+                        state__in=["deleted", "deleted_fanned_out"]
+                    )
+                    if owners:
+                        posts = posts.filter(author_id__in=owners)
+                    c = 0
+                    pg = Paginator(posts.order_by("id"), self.batch_size)
+                    for p in tqdm(pg.page_range):
+                        docs = index.posts_to_docs(
+                            pg.get_page(p).object_list, covered_post_ids
+                        )
+                        c += len(docs)
+                        index.replace_docs(docs)
+                    self.stdout.write(self.style.SUCCESS(f"indexed {c} local posts."))
 
             case "search":
                 q = JournalQueryParser("" if query == "-" else query, page_size=100)

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -40,10 +40,10 @@ idx-alt:        update index schema
 idx-delete:     delete docs in index
 idx-rebuild:    rebuild docs in index
 idx-catchup:    update index for journal items edited in last X hours (use --hour)
-idx-sync:       add missing docs, delete stale docs and rewrite docs still
-                referencing dead posts for each local identity, purge docs of
-                deactivated identities (use --dry-run to preview, --remote to
-                sync remote pieces and identities instead)
+idx-sync:       add missing docs and delete stale docs for each local
+                identity, purge docs of deactivated identities (use
+                --dry-run to preview, --remote to sync remote pieces and
+                identities instead)
 """
 
 _DELETED_POST_STATES = ["deleted", "deleted_fanned_out"]
@@ -203,23 +203,22 @@ class Command(SiteCommand):
         """Doc ids an active identity should have in the index.
 
         Local identities get a doc per live local post plus one per piece
-        without a live post; for remote identities only pieces are indexed.
+        not covered by such a post; for remote identities only pieces are
+        indexed.
 
         Returns a map of doc id -> (kind, pk), mirroring how
-        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids. Kind
-        is "post", "piece", or "stale-piece" for a piece doc keyed by a
-        dead post id: its content may still reference that post from
-        before the post died, so it must be rewritten even when present.
+        JournalIndex.post_to_doc() / piece_to_doc() assign doc ids: a
+        piece doc is keyed by its latest linked post id even if that post
+        is gone from db. Kind is "post" or "piece".
         """
         expected: dict[str, tuple[str, int]] = {}
-        live_post_ids: set[int] = set()
         if not remote:
-            live_post_ids = set(
+            live_posts = (
                 Post.objects.filter(local=True, author_id=identity_id)
                 .exclude(state__in=_DELETED_POST_STATES)
                 .values_list("pk", flat=True)
             )
-            for post_id in live_post_ids:
+            for post_id in live_posts:
                 expected[str(post_id)] = ("post", post_id)
         piece_ids: set[int] = set()
         # piece_id -> (piece_post_pk, post_id) of the latest linked post
@@ -243,26 +242,15 @@ class Command(SiteCommand):
                     piece_id not in latest_pps or pp_pk > latest_pps[piece_id][0]
                 ):
                     latest_pps[piece_id] = (pp_pk, post_id)
-        if remote:
-            # for remote identities, live-ness of the linked posts decides
-            # which piece docs may carry a stale post reference
-            live_post_ids = set(
-                Post.objects.filter(pk__in=[v[1] for v in latest_pps.values()])
-                .exclude(state__in=_DELETED_POST_STATES)
-                .values_list("pk", flat=True)
-            )
         for piece_id in piece_ids:
             post_id = latest_pps[piece_id][1] if piece_id in latest_pps else None
             if post_id is None:
                 expected["p" + str(piece_id)] = ("piece", piece_id)
-            elif post_id in live_post_ids:
-                if remote:
-                    expected[str(post_id)] = ("piece", piece_id)
-                # for local, the piece is covered by the doc of its live post
             else:
-                # piece_to_doc() keys the doc by the latest linked post id
-                # even if that post is gone from db
-                expected[str(post_id)] = ("stale-piece", piece_id)
+                # first writer wins: for local, the live post's own entry
+                # (inserted above) covers the piece; for remote, this
+                # arbitrates pieces sharing one post
+                expected.setdefault(str(post_id), ("piece", piece_id))
         return expected
 
     def sync_identity_index(
@@ -270,8 +258,14 @@ class Command(SiteCommand):
     ) -> tuple[int, int] | None:
         """Add missing docs and delete stale docs for one active identity.
 
-        Docs already in the index are left as is (no deep comparison),
-        except "stale-piece" docs which are always rewritten.
+        Docs already in the index are left as is (no deep comparison). In
+        particular, a piece doc may keep claiming a post that was pruned
+        or hard-deleted; only queries filtering on post_id (local
+        timeline search) see the dangling reference, and it is healed by
+        a refetch (relink_post_id, remote pieces only), an edit of the
+        piece, or idx-rebuild. Rewriting those docs here instead would
+        never converge: the classification depends only on db state,
+        which a rewrite does not change.
         Returns (added, deleted), or None on index error.
         """
         expected = self.expected_index_docs(identity_id, remote)
@@ -280,13 +274,8 @@ class Command(SiteCommand):
             return None
         extra = indexed - expected.keys()
         missing = expected.keys() - indexed
-        rewrite = {
-            i
-            for i, (kind, _) in expected.items()
-            if kind == "stale-piece" and i in indexed
-        }
         if self.dry_run:
-            return len(missing) + len(rewrite), len(extra)
+            return len(missing), len(extra)
         deleted = 0
         for chunk in batched(extra, _SYNC_DELETE_CHUNK):
             deleted += index.delete_docs("id", chunk)
@@ -295,9 +284,7 @@ class Command(SiteCommand):
         for chunk in batched(post_ids, self.batch_size):
             posts = Post.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.posts_to_docs(posts))
-        piece_ids = [
-            expected[i][1] for i in missing | rewrite if expected[i][0] != "post"
-        ]
+        piece_ids = [expected[i][1] for i in missing if expected[i][0] != "post"]
         for chunk in batched(piece_ids, self.batch_size):
             pieces = Piece.objects.filter(pk__in=chunk)
             added += index.replace_docs(index.pieces_to_docs(pieces))

--- a/neodb/journal/migrations/0018_reindex_piece_keyed_docs.py
+++ b/neodb/journal/migrations/0018_reindex_piece_keyed_docs.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+from catalog.common.migrations import enqueue_migration_job
+
+
+def queue_reindex(apps: object, schema_editor: object) -> None:
+    enqueue_migration_job("journal.jobs.migrations:reindex_piece_keyed_docs_20260818")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("journal", "0017_article_cover"),
+    ]
+
+    operations = [
+        migrations.RunPython(queue_reindex, migrations.RunPython.noop),
+    ]

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -19,6 +19,7 @@ from .shelf import ShelfManager, ShelfType
 
 class Comment(Content):
     dedupe_content_fields = ("text",)
+    index_when_save = True
     text = models.TextField(blank=False, null=False)
 
     class Meta:
@@ -166,6 +167,24 @@ class Comment(Content):
         from .shelf import ShelfMember
 
         return ShelfMember.objects.filter(owner=self.owner, item=self.item).first()
+
+    def update_index(self):
+        # a comment with a sibling mark indexes within the mark's doc;
+        # drop any own doc left from when the comment was still lone
+        if self.sibling_shelfmember:
+            self.sibling_shelfmember.update_index()
+            super().delete_index()
+        else:
+            super().update_index()
+
+    def delete(self, *args, **kwargs):
+        sm = self.sibling_shelfmember
+        r = super().delete(*args, **kwargs)
+        if sm:
+            # the mark doc embeds this comment's text; rebuild it now
+            # that the row is gone
+            sm.update_index()
+        return r
 
     def to_indexable_doc(self) -> dict[str, Any]:
         if self.sibling_shelfmember:

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -294,8 +294,14 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             self.__dict__.pop(attr, None)
 
     def link_post_id(self, post_id: int):
-        PiecePost.objects.get_or_create(piece=self, post_id=post_id)
+        _, created = PiecePost.objects.get_or_create(piece=self, post_id=post_id)
         self._invalidate_post_caches()
+        if created and self.local:
+            # the post may have been indexed as a piece-less post doc
+            # before this piece claimed it (e.g. a reply later becoming a
+            # Note); this piece's doc covers it now, so drop the
+            # duplicate. Remote posts never get post docs.
+            JournalIndex.instance().delete_post_doc(post_id)
 
     def relink_post_id(self, post_id: int):
         """Link a post that arrived for an existing piece whose latest known
@@ -323,11 +329,8 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         self._invalidate_post_caches()
         if orphaned:
             # The unlinked posts stay on the timeline (e.g. the previous
-            # mark post after a shelf change), but update_index() is about
-            # to delete_by_piece() their docs; rewrite them as piece-less
-            # post docs first so they stay searchable. Ordering matters:
-            # with the link rows gone, the docs carry no piece_id, so the
-            # later delete cannot reach them.
+            # mark post after a shelf change); give each a piece-less
+            # post doc so they stay searchable.
             JournalIndex.instance().replace_posts(
                 Takahe.get_posts(orphaned).filter(local=True)
             )
@@ -1110,6 +1113,10 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
         doc = index.piece_to_doc(self)
         if doc:
             try:
+                # the delete collects docs of this piece keyed under the
+                # pre-p<pk> id scheme; with stable ids the upsert alone
+                # suffices, so this can go once every deployment has run
+                # the 0018 reindex
                 index.delete_by_piece([self.pk])
                 index.replace_docs([doc])
             except Exception as e:

--- a/neodb/journal/models/rating.py
+++ b/neodb/journal/models/rating.py
@@ -48,6 +48,8 @@ def _calculate_distribution(grades: list[int], total: int) -> list[int]:
 
 
 class Rating(Content):
+    # no index_when_save: the only production writer is Mark.update,
+    # which reindexes the sibling mark once at the end of its flow
     class Meta:
         unique_together = [["owner", "item"]]
         indexes = [
@@ -57,6 +59,26 @@ class Rating(Content):
     grade = models.PositiveSmallIntegerField(
         default=0, validators=[MaxValueValidator(10), MinValueValidator(1)], null=True
     )
+
+    @property
+    def sibling_shelfmember(self):
+        from .shelf import ShelfMember
+
+        return ShelfMember.objects.filter(owner=self.owner, item=self.item).first()
+
+    def update_index(self):
+        # a rating never indexes alone; its grade lives in the sibling
+        # mark's doc
+        sm = self.sibling_shelfmember
+        if sm:
+            sm.update_index()
+
+    def delete(self, *args, **kwargs):
+        sm = self.sibling_shelfmember
+        r = super().delete(*args, **kwargs)
+        if sm:
+            sm.update_index()
+        return r
 
     @property
     def ap_object(self):
@@ -86,7 +108,9 @@ class Rating(Content):
             return p
         value = obj.get("value", 0) if obj else 0
         if not value:
-            cls.objects.filter(owner=owner, item=item).delete()
+            # instance deletes so the sibling mark doc is refreshed
+            for r in cls.objects.filter(owner=owner, item=item):
+                r.delete()
             return
         best = obj.get("best", 5)
         worst = obj.get("worst", 1)

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -352,6 +352,12 @@ class ShelfMemberManager(PolymorphicManager):
 
 
 class ShelfMember(ListMember):
+    # NB deliberately not index_when_save: save() runs mid-flow in
+    # Mark.update before siblings and the timeline post exist, and an
+    # early doc build would cache sibling_comment/sibling_rating as None
+    # on the very instance to_post_params renders the post from.
+    # Indexing happens via explicit update_index() calls after the flow
+    # settles, and via the hooks on Comment, Rating and Tag.
     if TYPE_CHECKING:
         parent: models.ForeignKey["ShelfMember", "Shelf"]
         owner_id: int
@@ -536,6 +542,14 @@ class ShelfMember(ListMember):
         except AttributeError:
             pass
         return super().save(*args, **kwargs)
+
+    def update_index(self):
+        # always rebuild from db truth: an instance held across a longer
+        # flow (e.g. Mark.update) may have resolved and cached siblings
+        # before they were saved
+        for attr in ("sibling_comment", "sibling_rating", "mark", "_tags"):
+            self.__dict__.pop(attr, None)
+        super().update_index()
 
     @cached_property
     def sibling_comment(self) -> "Comment | None":

--- a/neodb/journal/models/tag.py
+++ b/neodb/journal/models/tag.py
@@ -100,6 +100,26 @@ class Tag(List):
     def to_indexable_doc(self):
         return {}
 
+    def _refresh_mark_index(self, item: Item):
+        # the mark doc carries the owner's tag list for the item
+        from .shelf import ShelfMember
+
+        sm = ShelfMember.objects.filter(owner=self.owner, item=item).first()
+        if sm:
+            sm.update_index()
+
+    def append_item(self, item, **params):
+        member, created = super().append_item(item, **params)
+        if created:
+            self._refresh_mark_index(item)
+        return member, created
+
+    def remove_item(self, item):
+        member = self.get_member_for_item(item)
+        super().remove_item(item)
+        if member:
+            self._refresh_mark_index(item)
+
 
 class TagManager:
     @staticmethod

--- a/neodb/journal/models/utils.py
+++ b/neodb/journal/models/utils.py
@@ -40,13 +40,11 @@ def cleanup_deleted_post(post_pk: int) -> None:
             piece.delete()
         else:
             logger.debug(f"Matched piece {piece} has newer posts, not deleting")
-    # Docs keyed by this post that nothing above rewrites (piece-less
-    # posts, or posts orphaned by a shelf change that still link a
-    # Comment/Rating indexing within its mark) must go now, or only
-    # idx-sync can collect them. Piece docs rewritten above are safe:
-    # the post is dead by this point, so those docs carry no post_id
-    # field and this filter cannot match them.
-    JournalIndex.instance().delete_by_post([post_pk])
+    # A piece-less post doc (plain post, or a post orphaned by a shelf
+    # change that only links a Comment/Rating indexing within its mark)
+    # is keyed by the post id and must go now, or only idx-sync can
+    # collect it. Piece docs are keyed by piece and were refreshed above.
+    JournalIndex.instance().delete_post_doc(post_pk)
 
 
 def reset_journal_visibility_for_user(owner: APIdentity, visibility: int):

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -412,7 +412,9 @@ class JournalIndex(Index):
             "visibility": piece.visibility,
         }
         if piece.latest_post:
-            # fk is not enforced, so post might be deleted
+            # fk is not enforced, so post might be deleted; a doc without
+            # post_id marks its post as dead, which cleanup_deleted_post's
+            # trailing delete_by_post relies on
             doc["post_id"] = [piece.latest_post_id]
             # enable this in future when we support search other users
             # doc["viewer_id"] = list(

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -384,12 +384,6 @@ class JournalIndex(Index):
                 "type": "int32",
                 "sort": False,
             },
-            {
-                "name": "viewer_id",
-                "type": "int64[]",
-                "sort": False,
-                "optional": True,
-            },
         ]
     }
     search_result_class = JournalSearchResult
@@ -400,11 +394,7 @@ class JournalIndex(Index):
         if not d:
             return {}
         doc = {
-            "id": (
-                str(piece.latest_post_id)
-                if piece.latest_post_id
-                else "p" + str(piece.pk)
-            ),
+            "id": "p" + str(piece.pk),
             "piece_id": [piece.pk],
             "piece_class": [piece.__class__.__name__],
             "created": int(piece.created_time.timestamp()),
@@ -412,54 +402,55 @@ class JournalIndex(Index):
             "visibility": piece.visibility,
         }
         if piece.latest_post:
-            # fk is not enforced, so post might be deleted; a doc without
-            # post_id marks its post as dead, which cleanup_deleted_post's
-            # trailing delete_by_post relies on
+            # fk is not enforced, so post might be deleted; the field is
+            # omitted then, and post searches skip the doc
             doc["post_id"] = [piece.latest_post_id]
-            # enable this in future when we support search other users
-            # doc["viewer_id"] = list(
-            #     piece.latest_post.interactions.values_list("identity_id", flat=True)
-            # )
         doc.update(d)
         return doc
 
     @classmethod
     def pieces_to_docs(cls, pieces: "Iterable[Piece]") -> list[dict]:
+        from journal.models.common import prefetch_latest_posts  # circular
+
+        pieces = list(pieces)
+        prefetch_latest_posts(pieces)
         docs = [cls.piece_to_doc(p) for p in pieces]
         return [d for d in docs if d]
 
     @classmethod
     def post_to_doc(cls, post: Post, item_map: dict[int, Item] | None = None) -> dict:
-        pc = post.piece
-        doc = {}
-        if pc:
-            pc.latest_post = post
-            pc.latest_post_id = post.pk
-            doc = cls.piece_to_doc(pc)
-        if not doc:
-            doc = {
-                "id": str(post.pk),
-                "post_id": [post.pk],
-                "piece_class": ["Post"],
-                "content": [post.content],
-                "created": int(post.created.timestamp()),
-                "visibility": Takahe.visibility_t2n(post.visibility),
-                "owner_id": post.author_id,
-                # enable this in future when we support search other users
-                # "viewer_id": list(
-                #     post.interactions.values_list("identity_id", flat=True)
-                # ),
-            }
-            # A post orphaned by a shelf change (or linked only to pieces
-            # that index within another doc) still relates to an item via
-            # its ShelfLogEntry; carry the item fields so item-scoped
-            # search can reach it. piece_class stays ["Post"]: journal
-            # search excludes it to keep old marks out of piece results.
-            item = item_map.get(post.pk) if item_map is not None else post.item
-            if item:
-                doc["item_id"] = [item.pk]
-                doc["item_class"] = [item.__class__.__name__]
-                doc["item_title"] = item.to_indexable_titles()
+        """Doc for a post not covered by a piece doc; {} otherwise.
+
+        A post is covered when any linked piece indexes on its own: that
+        piece's doc (keyed "p<pk>") references the post, so a second doc
+        would duplicate the piece in every search. This is the same rule
+        expected_index_docs states as a query, and they must agree or
+        idx-sync fights the runtime writers.
+        """
+        from journal.models import Piece  # circular; see header
+
+        pcs = Piece.objects.filter(posts=post.pk)
+        if any(pc.to_indexable_doc() for pc in pcs):
+            return {}
+        doc = {
+            "id": str(post.pk),
+            "post_id": [post.pk],
+            "piece_class": ["Post"],
+            "content": [post.content],
+            "created": int(post.created.timestamp()),
+            "visibility": Takahe.visibility_t2n(post.visibility),
+            "owner_id": post.author_id,
+        }
+        # A post orphaned by a shelf change (or linked only to pieces
+        # that index within another doc) still relates to an item via
+        # its ShelfLogEntry; carry the item fields so item-scoped
+        # search can reach it. piece_class stays ["Post"]: journal
+        # search excludes it to keep old marks out of piece results.
+        item = item_map.get(post.pk) if item_map is not None else post.item
+        if item:
+            doc["item_id"] = [item.pk]
+            doc["item_class"] = [item.__class__.__name__]
+            doc["item_title"] = item.to_indexable_titles()
         return doc
 
     @classmethod
@@ -490,10 +481,21 @@ class JournalIndex(Index):
         }
 
     @classmethod
-    def posts_to_docs(cls, posts: Iterable[Post]) -> list[dict]:
+    def posts_to_docs(
+        cls, posts: Iterable[Post], covered_post_ids: set[int] | None = None
+    ) -> list[dict]:
+        """Docs for posts not covered by piece docs.
+
+        covered_post_ids, when given, skips those posts without the
+        per-post piece lookup; batch callers (idx-rebuild, the reindex
+        job) collect it from the piece docs they just wrote.
+        """
         posts = list(posts)
+        if covered_post_ids is not None:
+            posts = [p for p in posts if p.pk not in covered_post_ids]
         item_map = cls._items_for_posts([p.pk for p in posts])
-        return [cls.post_to_doc(p, item_map) for p in posts]
+        docs = [cls.post_to_doc(p, item_map) for p in posts]
+        return [d for d in docs if d]
 
     def delete_all(self):
         return self.delete_docs("owner_id", ">0")
@@ -524,22 +526,18 @@ class JournalIndex(Index):
     def delete_by_piece(self, piece_ids):
         return self.delete_docs("piece_id", piece_ids)
 
-    def delete_by_post(self, post_ids):
-        return self.delete_docs("post_id", post_ids)
+    def delete_post_doc(self, post_id: int):
+        """Delete the piece-less post doc of one post, if any.
+
+        Piece docs keep their dead post reference in post_id and are
+        refreshed (not deleted) when their post dies, so deletion by
+        post is only ever by doc id.
+        """
+        return self.delete_docs("id", [str(post_id)])
 
     def replace_posts(self, posts: Iterable[Post]):
         docs = self.posts_to_docs(posts)
         self.replace_docs(docs)
-
-    def replace_pieces(self, pieces: "Iterable[Piece] | QuerySet[Piece]"):
-        if isinstance(pieces, QuerySet):
-            pids = list(pieces.values_list("pk", flat=True))
-        else:
-            pids = [p.pk for p in pieces]
-        if not pids:
-            return
-        self.delete_by_piece(pids)
-        self.insert_docs(self.pieces_to_docs(pieces))
 
     def search(
         self,

--- a/neodb/tests/journal/test_crosspost.py
+++ b/neodb/tests/journal/test_crosspost.py
@@ -103,8 +103,10 @@ class TestCrosspostRetryRecording:
 
     def test_boost_failure_recorded_and_cleared(self, user, comment, monkeypatch):
         _link_mastodon(user, repost_mode=0)
+        # patch the instance, not the class: indexing on save already
+        # resolved the cached_property into the instance dict
         monkeypatch.setattr(
-            Comment,
+            comment,
             "latest_post",
             SimpleNamespace(url="https://example.org/p/1"),
         )

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -97,6 +97,24 @@ class TestIdxSync:
         self.run_sync()
         assert self.doc_ids(self.identity1.pk) == before
 
+    def test_local_pruned_post_doc_left_alone(self):
+        # the mark post dies without the post_deleted callback; the doc
+        # keeps claiming the dead post_id (accepted drift, see
+        # sync_identity_index docstring). Soft-delete here so the
+        # _DELETED_POST_STATES branch is covered; the remote twin covers
+        # the row-gone branch
+        mark = Mark(self.identity1, self.book1)
+        assert mark.shelfmember is not None
+        post_id = mark.shelfmember.latest_post_id
+        assert post_id
+        before = self.doc_ids(self.identity1.pk)
+        Takahe.delete_posts([post_id])
+        output = self.run_sync()
+        assert "0 docs added, 0 docs deleted" in output
+        assert self.doc_ids(self.identity1.pk) == before
+        doc = self.index.write_collection.documents[str(post_id)].retrieve()
+        assert doc["post_id"] == [post_id]
+
     def test_purge_deactivated_identity(self):
         assert self.doc_ids(self.identity2.pk)
         self.user2.is_active = False
@@ -398,16 +416,29 @@ class TestIdxSyncRemote:
         r = self.index.search(q)
         return r.total, len(list(r.posts))
 
-    def test_remote_sync_rewrites_doc_of_pruned_post(self):
+    def test_remote_pruned_post_doc_left_alone(self):
         post_pk = self.post.pk
         assert self.doc_ids(self.owner.pk) == {str(post_pk)}
-        # takahe pruned the post; the doc still claims post_id, so it is
-        # counted while its post can never be returned
+        # takahe pruned the post; the doc keeps claiming its post_id
+        # (accepted drift, see sync_identity_index docstring; the count
+        # probe below filters on post_id, which no item query does in
+        # production). A refetch or idx-rebuild heals the doc; sync must
+        # not rewrite it, as that can never converge
         self.post.delete()
         assert self._item_review_posts_count() == (1, 0)
-        self.run_sync("--remote")
-        # same doc id, but content rewritten without the dead post_id
+        output = self.run_sync("--remote")
+        assert "0 docs added, 0 docs deleted" in output
         assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        assert self._item_review_posts_count() == (1, 0)
+
+    def test_missing_doc_of_pruned_post_restored(self):
+        post_pk = self.post.pk
+        self.post.delete()
+        self.index.delete_by_owner([self.owner.pk])
+        output = self.run_sync("--remote")
+        assert "1 docs added, 0 docs deleted" in output
+        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        # rebuilt from db truth, so it no longer claims the dead post
         assert self._item_review_posts_count() == (0, 0)
 
     def test_remote_sync_cleans_docs_of_pieceless_owner(self):

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from catalog.models import Edition
-from journal.models import Collection, Comment, Mark, Review, ShelfType
+from journal.models import Collection, Comment, Mark, Review, ShelfType, Tag
 from journal.search import JournalIndex, JournalQueryParser
 from takahe.ap_handlers import post_deleted
 from takahe.models import Domain, Post
@@ -107,12 +107,14 @@ class TestIdxSync:
         assert mark.shelfmember is not None
         post_id = mark.shelfmember.latest_post_id
         assert post_id
+        doc_id = f"p{mark.shelfmember.pk}"
         before = self.doc_ids(self.identity1.pk)
+        assert doc_id in before
         Takahe.delete_posts([post_id])
         output = self.run_sync()
         assert "0 docs added, 0 docs deleted" in output
         assert self.doc_ids(self.identity1.pk) == before
-        doc = self.index.write_collection.documents[str(post_id)].retrieve()
+        doc = self.index.write_collection.documents[doc_id].retrieve()
         assert doc["post_id"] == [post_id]
 
     def test_purge_deactivated_identity(self):
@@ -172,6 +174,11 @@ class TestShelfChangeOrphanedPost:
     def get_doc(self, doc_id: str) -> dict:
         return self.index.write_collection.documents[doc_id].retrieve()
 
+    def mark_doc_id(self) -> str:
+        sm = Mark(self.identity, self.book).shelfmember
+        assert sm is not None
+        return f"p{sm.pk}"
+
     def transition(self, book=None, comment=None, rating=None) -> tuple[int, int]:
         """Mark progress then complete; return (old, new) post ids."""
         book = book or self.book
@@ -198,11 +205,14 @@ class TestShelfChangeOrphanedPost:
         old_pid, new_pid = self.transition()
         # the old post stays live on the timeline, so its doc must stay too
         assert Takahe.get_posts([old_pid]).exists()
+        doc_id = self.mark_doc_id()
         ids = self.doc_ids(self.identity.pk)
         assert str(old_pid) in ids
-        assert str(new_pid) in ids
+        # the live mark post is covered by its piece doc, not a post doc
+        assert str(new_pid) not in ids
+        assert doc_id in ids
         self.assert_orphan_doc(old_pid)
-        assert "ShelfMember" in self.get_doc(str(new_pid))["piece_class"]
+        assert "ShelfMember" in self.get_doc(doc_id)["piece_class"]
         # reachable from post search ("search my posts")
         q = JournalQueryParser("Hyperion", 1)
         q.filter_by_owner(self.identity)
@@ -229,10 +239,13 @@ class TestShelfChangeOrphanedPost:
         old_pid, _ = self.transition(comment="so far so good", rating=8)
         self.assert_orphan_doc(old_pid)
 
-    def test_user_path_doc_matches_batch_builder(self):
-        # the doc written on the user path must equal the one idx-sync and
-        # idx-rebuild would write, or they would fight each other
-        old_pid, _ = self.transition(comment="so far so good")
+    def test_covered_post_produces_no_doc(self):
+        # a live post whose piece indexes on its own must not get a post
+        # doc, or every search would return the mark twice
+        old_pid, new_pid = self.transition(comment="so far so good")
+        assert self.index.posts_to_docs(list(Post.objects.filter(pk=new_pid))) == []
+        # the orphan doc written on the user path must equal the one
+        # idx-sync and idx-rebuild would write, or they would fight
         indexed = self.get_doc(str(old_pid))
         built = self.index.posts_to_docs(list(Post.objects.filter(pk=old_pid)))[0]
         assert set(indexed) == set(built)
@@ -245,34 +258,34 @@ class TestShelfChangeOrphanedPost:
         assert "0 docs would be added, 0 docs would be deleted" in output
 
     def test_delete_orphaned_post_drops_doc(self):
-        # the linked Comment still matches in post_deleted() but rewrites
-        # nothing, so only the unconditional delete_by_post removes the doc
-        old_pid, new_pid = self.transition(comment="so far so good")
+        # the orphan's doc is removed by the trailing delete_post_doc in
+        # cleanup_deleted_post; the mark doc is keyed by piece and stays
+        old_pid, _ = self.transition(comment="so far so good")
         assert str(old_pid) in self.doc_ids(self.identity.pk)
         Takahe.delete_posts([old_pid])
         post_deleted(old_pid, True, None)
         ids = self.doc_ids(self.identity.pk)
         assert str(old_pid) not in ids
-        assert str(new_pid) in ids
+        assert self.mark_doc_id() in ids
 
     def test_delete_pieceless_orphaned_post_drops_doc(self):
-        old_pid, new_pid = self.transition()
+        old_pid, _ = self.transition()
         Takahe.delete_posts([old_pid])
         post_deleted(old_pid, True, None)
         ids = self.doc_ids(self.identity.pk)
         assert str(old_pid) not in ids
-        assert str(new_pid) in ids
+        assert self.mark_doc_id() in ids
 
     def test_post_delete_view_drops_doc(self, client):
         # the web UI delete button must run the same cleanup as the
         # Mastodon API path, or the doc outlives the post
-        old_pid, new_pid = self.transition(comment="so far so good")
+        old_pid, _ = self.transition(comment="so far so good")
         client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
         response = client.post(reverse("journal:post_delete", args=[old_pid]))
         assert response.status_code == 200
         ids = self.doc_ids(self.identity.pk)
         assert str(old_pid) not in ids
-        assert str(new_pid) in ids
+        assert self.mark_doc_id() in ids
 
     def test_dynamic_collection_excludes_orphaned_posts(self):
         self.transition(comment="so far so good")
@@ -300,6 +313,165 @@ class TestShelfChangeOrphanedPost:
             docs = build(orphans)
         assert all(d.get("item_id") for d in docs)
         assert len(three.captured_queries) - len(one.captured_queries) == 2
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMarkFamilyIndex:
+    """Comment, rating and tags index within the mark's doc; mutating
+    them outside Mark.update must refresh it."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.user = User.register(email="x@y.com", username="userx")
+        self.identity = self.user.identity
+        mark = Mark(self.identity, self.book)
+        mark.update(ShelfType.PROGRESS, "old text", 9, ["scifi"], 0)
+        self.sm = mark.shelfmember
+        assert self.sm is not None
+        self.doc_id = f"p{self.sm.pk}"
+
+    def get_doc(self, doc_id: str) -> dict:
+        return self.index.write_collection.documents[doc_id].retrieve()
+
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
+    def test_comment_edit_refreshes_mark_doc(self):
+        Comment.comment_item(self.book, self.identity, "new text", 0)
+        assert self.get_doc(self.doc_id)["content"] == ["new text"]
+
+    def test_comment_delete_refreshes_mark_doc(self):
+        Comment.objects.get(owner=self.identity, item=self.book).delete()
+        doc = self.get_doc(self.doc_id)
+        assert doc["content"] == []
+        assert "Comment" not in doc["piece_class"]
+
+    def test_rating_delete_refreshes_mark_doc(self):
+        from journal.models import Rating
+
+        Rating.objects.get(owner=self.identity, item=self.book).delete()
+        assert self.get_doc(self.doc_id)["rating"] == 0
+
+    def test_tag_change_refreshes_mark_doc(self):
+        tag, _ = Tag.objects.get_or_create(owner=self.identity, title="epic")
+        tag.append_item(self.book)
+        assert "epic" in self.get_doc(self.doc_id)["tag"]
+        tag.remove_item(self.book)
+        assert "epic" not in self.get_doc(self.doc_id)["tag"]
+
+    def test_lone_comment_covers_its_post(self):
+        book2 = Edition.objects.create(title="Endymion")
+        c = Comment.comment_item(book2, self.identity, "a lone comment", 0)
+        assert c is not None
+        c.sync_to_timeline()
+        c = Comment.objects.get(pk=c.pk)
+        pid = c.latest_post_id
+        assert pid
+        # covered by the lone comment's own doc, so no post doc
+        assert self.index.posts_to_docs(list(Post.objects.filter(pk=pid))) == []
+        output = StringIO()
+        call_command("journal", "idx-sync", "--dry-run", stdout=output)
+        assert "0 docs would be added, 0 docs would be deleted" in output.getvalue()
+
+    def test_link_post_id_drops_piece_less_post_doc(self):
+        post = Post.objects.create(
+            author_id=self.identity.pk,
+            local=True,
+            object_uri="https://example.org/p/reply1",
+            content="a reply",
+            visibility=Post.Visibilities.public,
+            state="fanned_out",
+        )
+        assert (
+            self.index.insert_docs(
+                [
+                    {
+                        "id": str(post.pk),
+                        "post_id": [post.pk],
+                        "piece_class": ["Post"],
+                        "content": ["a reply"],
+                        "created": 1700000000,
+                        "owner_id": self.identity.pk,
+                        "visibility": 0,
+                    }
+                ]
+            )
+            == 1
+        )
+        book2 = Edition.objects.create(title="Endymion")
+        note = Comment(owner=self.identity, item=book2, text="from reply")
+        note.save(post_when_save=False)
+        note.link_post_id(post.pk)
+        # the piece doc covers the post now; the post doc is dropped
+        assert str(post.pk) not in self.doc_ids(self.identity.pk)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReindexMigrationJob:
+    """The 0018 deploy migration reindexes for the p<pk> id scheme:
+    upsert new docs, delete old-scheme docs, rebuild post docs."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.user = User.register(email="x@y.com", username="userx")
+        self.identity = self.user.identity
+
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
+    def test_reindex_piece_keyed_docs(self):
+        from journal.jobs.migrations import reindex_piece_keyed_docs_20260818
+
+        mark = Mark(self.identity, self.book)
+        mark.update(ShelfType.PROGRESS, "so far", None, [], 0)
+        assert mark.shelfmember is not None
+        old_pid = mark.shelfmember.latest_post_id
+        mark = Mark(self.identity, self.book)
+        mark.update(ShelfType.COMPLETE, "so far", None, [], 0)
+        sm = mark.shelfmember
+        assert sm is not None
+        new_pid = sm.latest_post_id
+        assert old_pid and new_pid
+        # replicate the pre-migration state: only an old-scheme piece doc
+        # keyed by the live mark post
+        self.index.delete_all()
+        assert (
+            self.index.insert_docs(
+                [
+                    {
+                        "id": str(new_pid),
+                        "post_id": [new_pid],
+                        "piece_id": [sm.pk],
+                        "piece_class": ["ShelfMember"],
+                        "content": ["stale"],
+                        "created": 1700000000,
+                        "owner_id": self.identity.pk,
+                        "visibility": 0,
+                    }
+                ]
+            )
+            == 1
+        )
+        assert reindex_piece_keyed_docs_20260818(batch_size=2) > 0
+        ids = self.doc_ids(self.identity.pk)
+        # piece doc under the new id; old-scheme doc gone and the covered
+        # post gets no doc of its own; the orphan post doc is rebuilt
+        assert f"p{sm.pk}" in ids
+        assert str(new_pid) not in ids
+        assert str(old_pid) in ids
+        doc = self.index.write_collection.documents[f"p{sm.pk}"].retrieve()
+        assert doc["post_id"] == [new_pid]
+        assert doc["content"] == ["so far"]
 
 
 def _make_remote_identity(username: str, domain_name: str = "remote.example"):
@@ -355,33 +527,10 @@ class TestIdxSyncRemote:
         return ids
 
     def test_add_missing_remote_docs(self):
-        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        assert self.doc_ids(self.owner.pk) == {f"p{self.review.pk}"}
         self.index.delete_by_owner([self.owner.pk])
         self.run_sync("--remote")
-        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
-
-    def test_repair_dangling_doc(self):
-        # replicate the doc shape indexed before the #1761 fix: keyed by
-        # piece with no post_id, counted by item post search but never
-        # returned
-        self.index.delete_by_owner([self.owner.pk])
-        self.index.insert_docs(
-            [
-                {
-                    "id": f"p{self.review.pk}",
-                    "piece_id": [self.review.pk],
-                    "piece_class": ["Review"],
-                    "item_id": [self.book.pk],
-                    "item_class": ["Edition"],
-                    "content": ["review body"],
-                    "created": 1700000000,
-                    "owner_id": self.owner.pk,
-                    "visibility": 0,
-                }
-            ]
-        )
-        self.run_sync("--remote")
-        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        assert self.doc_ids(self.owner.pk) == {f"p{self.review.pk}"}
         q = JournalQueryParser("type:review", 1)
         q.filter_by_viewer(None)
         q.filter("item_id", self.book.pk)
@@ -400,7 +549,7 @@ class TestIdxSyncRemote:
 
     def test_local_sync_leaves_remote_docs(self):
         self.run_sync()
-        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        assert self.doc_ids(self.owner.pk) == {f"p{self.review.pk}"}
 
     def test_remote_dry_run(self):
         self.index.delete_by_owner([self.owner.pk])
@@ -417,8 +566,8 @@ class TestIdxSyncRemote:
         return r.total, len(list(r.posts))
 
     def test_remote_pruned_post_doc_left_alone(self):
-        post_pk = self.post.pk
-        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        doc_id = f"p{self.review.pk}"
+        assert self.doc_ids(self.owner.pk) == {doc_id}
         # takahe pruned the post; the doc keeps claiming its post_id
         # (accepted drift, see sync_identity_index docstring; the count
         # probe below filters on post_id, which no item query does in
@@ -428,21 +577,20 @@ class TestIdxSyncRemote:
         assert self._item_review_posts_count() == (1, 0)
         output = self.run_sync("--remote")
         assert "0 docs added, 0 docs deleted" in output
-        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        assert self.doc_ids(self.owner.pk) == {doc_id}
         assert self._item_review_posts_count() == (1, 0)
 
     def test_missing_doc_of_pruned_post_restored(self):
-        post_pk = self.post.pk
         self.post.delete()
         self.index.delete_by_owner([self.owner.pk])
         output = self.run_sync("--remote")
         assert "1 docs added, 0 docs deleted" in output
-        assert self.doc_ids(self.owner.pk) == {str(post_pk)}
+        assert self.doc_ids(self.owner.pk) == {f"p{self.review.pk}"}
         # rebuilt from db truth, so it no longer claims the dead post
         assert self._item_review_posts_count() == (0, 0)
 
     def test_remote_sync_cleans_docs_of_pieceless_owner(self):
-        assert self.doc_ids(self.owner.pk) == {str(self.post.pk)}
+        assert self.doc_ids(self.owner.pk) == {f"p{self.review.pk}"}
         # queryset delete bypasses Piece.delete()'s index cleanup, leaving
         # a stale doc while the owner no longer has any piece
         Review.objects.filter(pk=self.review.pk).delete()
@@ -451,8 +599,8 @@ class TestIdxSyncRemote:
 
     def test_remote_lone_comment_refetch_updates_doc(self):
         # a comment without a sibling mark gets its own doc; a pruned then
-        # refetched post must be relinked and the doc refreshed even though
-        # Comment does not index itself on save
+        # refetched post must be relinked and the doc's post_id refreshed
+        # under the same doc id
         obj = {
             "id": "https://remote.example/comment/1",
             "type": "Comment",
@@ -471,8 +619,13 @@ class TestIdxSyncRemote:
         )
         comment = Comment.update_by_ap_object(self.owner, self.book, obj, post1)
         assert comment is not None
+        doc_id = f"p{comment.pk}"
+        # a lone remote comment indexes itself at save, before any sync
+        assert doc_id in self.doc_ids(self.owner.pk)
         self.run_sync("--remote")
-        assert str(post1.pk) in self.doc_ids(self.owner.pk)
+        assert doc_id in self.doc_ids(self.owner.pk)
+        doc = self.index.write_collection.documents[doc_id].retrieve()
+        assert doc["post_id"] == [post1.pk]
         post1.delete()
         post2 = Post.objects.create(
             author_id=self.owner.pk,
@@ -485,6 +638,6 @@ class TestIdxSyncRemote:
             state="fanned_out",
         )
         Comment.update_by_ap_object(self.owner, self.book, obj, post2)
-        ids = self.doc_ids(self.owner.pk)
-        assert str(post2.pk) in ids
-        assert str(post1.pk) not in ids
+        assert doc_id in self.doc_ids(self.owner.pk)
+        doc = self.index.write_collection.documents[doc_id].retrieve()
+        assert doc["post_id"] == [post2.pk]

--- a/neodb/tests/journal/test_search.py
+++ b/neodb/tests/journal/test_search.py
@@ -120,9 +120,11 @@ def _make_remote_post(owner_pk: int, uri: str, obj: dict) -> Post:
 
 @pytest.mark.django_db(databases="__all__")
 class TestRemotePieceIndex:
-    """Regression tests for #1761: docs indexed for remote pieces must
-    reference the linked post, so that item post search returns as many
-    posts as it counts."""
+    """Regression tests for #1761: when a pruned remote post is refetched
+    under a new pk, the piece doc must be relinked to it so item post
+    search returns the post again. A doc whose post is pruned and never
+    refetched keeps claiming the dead post; that drift is accepted (see
+    sync_identity_index docstring)."""
 
     @pytest.fixture(autouse=True)
     def setup_data(self):


### PR DESCRIPTION
Depends on #1793; the first commit here is that branch. Draft until it lands, then this will be rebased.

## Why

A design review of the piece-to-typesense sync found that most of its defensive machinery exists to protect one design choice: the doc id doubles as the latest linked post id, which is mutable and can point at a dead post. That forced rekeying on shelf change, an ordering-sensitive orphan-resurrection dance in clear_post_ids, delete-before-insert in update_index, ordering constraints in cleanup_deleted_post, a doc id space reconstruction in idx-sync, and a two-writers-must-agree invariant between the piece path and the post path. Separately, index writes were scattered across ~30 call sites, and several mutation paths (comment-only edits, rating deletion, tag changes) left the mark doc stale because their update_index calls were silent no-ops.

## P1: stable doc identity

- Piece docs are always keyed `p<pk>`. Post docs are keyed `str(post.pk)` and exist only for live local posts not covered by a piece doc (plain posts, replies, posts orphaned by a shelf change).
- No search behavior changes: nothing on the read side consumes doc ids; all resolution runs on the post_id / piece_id / item_id fields, which are unchanged.
- `update_index` is a pure upsert (the id never changes, so the delete-before-insert is gone).
- `delete_by_post` (field-filter delete) is retired for `delete_post_doc` (delete by doc id). Piece docs are refreshed, never deleted, when their post dies; the ordering constraint in `cleanup_deleted_post` is gone.
- `clear_post_ids` still writes orphan post docs, but without any ordering dependency.
- `link_post_id` drops the piece-less post doc of a post that a piece now covers, so the two doc kinds cannot duplicate.
- idx-sync's expected set is now a pure function: one `p<pk>` per indexable piece, one `str(pk)` per uncovered live local post. The latest-post computation is gone.
- idx-rebuild no longer needs the `latest_post is None` piece filter; local and remote pieces rebuild identically.
- Removed dead weight: `replace_pieces` (no callers), the `viewer_id` schema field (no writer, no reader).
- idx-catchup now uses `_INDEXABLE_PIECE_CLASSES`, fixing the omission of Article.

## P2: single write funnel

- Comment indexes on save; Comment and Rating refresh the sibling ShelfMember doc on save and delete; Tag refreshes it on membership add and remove. The mark's flat doc carries their text, grade, and tags. This fixes real staleness gaps: a comment-only edit, a comment or rating deleted alone (including the AP zero-value rating path), and tag changes through the tag API previously left the mark doc stale until the next Mark.update or rebuild.
- Hooks live only where they are load-bearing, so the hot paths stay lean: a mark update stays at roughly the same number of index writes as before, and remote-mark ingest keeps its single explicit reindex. The ndjson importer keeps its no-index-during-import convention.
- ShelfMember deliberately does not index on save: its save() runs mid-flow in Mark.update before siblings and the timeline post exist, and an early doc build would cache sibling_comment/sibling_rating as None on the very instance to_post_params renders the post from. It indexes via the explicit update_index call after the flow settles, and its update_index now always invalidates cached siblings first, so a doc rebuild can never use stale instance state.
- The MQ post handlers stop co-writing piece docs: post_to_doc returns {} for covered posts, so the async arm only writes plain-post docs. The piece doc has exactly one builder.

## Behavior notes

- A covered post is represented by its piece doc, which references the latest linked post. A non-latest live linked post no longer gets its own doc; normal flows never produce that shape.
- The coverage rule is one sentence stated twice with the same meaning: a post is covered when any linked piece indexes on its own (post_to_doc checks it structurally, expected_index_docs as a query). Keeping them equal is what makes idx-sync converge.
- Tag renames (Tag.update) and whole-tag deletion still do not reindex member marks; that stays eventual (idx-catchup or rebuild), as before.
- idx-rebuild now runs the pieces pass first in both modes over all indexable classes (fast mode previously skipped Note/Article/lone-Comment coverage) and skips covered posts via the collected set, so nothing is built twice.

## Migration

Automatic: journal migration 0018 enqueues a background reindex job. The job upserts every piece doc under the new ids, then deletes the docs keyed under the old scheme, then rebuilds the piece-less post docs, so journal search stays populated throughout and a partial failure leaves duplicates for idx-sync to collect rather than an empty index. No manual step; `journal idx-rebuild` remains available. `Piece.update_index` keeps a transitional delete-by-piece before its upsert so pieces edited before the job finishes self-heal; that line can be removed once every deployment has run 0018, making update_index a pure upsert. The `viewer_id` schema removal only affects freshly created collections. Note when rebasing: 0018 may need renumbering if another journal migration lands first.

## Tests

- Full neodb suite passes locally (2130 tests).
- Updated idx-sync and shelf-change tests to the new id scheme; new tests pin: covered posts produce no post doc (including the lone-comment variant), comment edit and delete refresh the mark doc, rating delete refreshes it, tag add and remove refresh it, link_post_id drops a duplicated post doc, a lone remote comment indexes at save, the relink flow refreshes post_id under a stable doc id, the orphan doc equals what rebuild would write, and the 0018 reindex job migrates an old-scheme index in place.
