### PR TITLE
fix(journal): funnel index writes through the mark family

### DIFF
--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -477,9 +477,13 @@ class NdjsonImporter(BaseImporter):
                     existing_comment.created_time = published_dt
                 existing_comment.visibility = visibility
                 existing_comment.metadata = metadata
-                existing_comment.save()
+                # no index during import, like import_article/import_note;
+                # the mark import covers commented marks, idx-sync covers
+                # lone comments (e.g. on episodes), same as before import
+                # hooks existed
+                existing_comment.save(index_when_save=False)
                 return "imported"
-            Comment.objects.create(
+            comment = Comment(
                 owner=owner,
                 item=item,
                 text=content,
@@ -487,6 +491,7 @@ class NdjsonImporter(BaseImporter):
                 metadata=metadata,
                 **({"created_time": published_dt} if published_dt else {}),
             )
+            comment.save(index_when_save=False)
             return "imported"
         except Exception:
             logger.exception("Error importing comment")

--- a/neodb/journal/management/commands/journal.py
+++ b/neodb/journal/management/commands/journal.py
@@ -175,7 +175,7 @@ class Command(SiteCommand):
             self.stdout.write(self.style.ERROR("--hour parameter is required"))
             return
         cutoff_time = timezone.now() - timedelta(hours=hours)
-        model_classes = [ShelfMember, Review, Comment, Collection, Note]
+        model_classes = _INDEXABLE_PIECE_CLASSES
         for model_cls in model_classes:
             items = model_cls.objects.filter(edited_time__gte=cutoff_time).order_by(
                 "pk"

--- a/neodb/journal/models/comment.py
+++ b/neodb/journal/models/comment.py
@@ -19,6 +19,7 @@ from .shelf import ShelfManager, ShelfType
 
 class Comment(Content):
     dedupe_content_fields = ("text",)
+    index_when_save = True
     text = models.TextField(blank=False, null=False)
 
     class Meta:
@@ -166,6 +167,24 @@ class Comment(Content):
         from .shelf import ShelfMember
 
         return ShelfMember.objects.filter(owner=self.owner, item=self.item).first()
+
+    def update_index(self):
+        # a comment with a sibling mark indexes within the mark's doc;
+        # drop any own doc left from when the comment was still lone
+        if self.sibling_shelfmember:
+            self.sibling_shelfmember.update_index()
+            super().delete_index()
+        else:
+            super().update_index()
+
+    def delete(self, *args, **kwargs):
+        sm = self.sibling_shelfmember
+        r = super().delete(*args, **kwargs)
+        if sm:
+            # the mark doc embeds this comment's text; rebuild it now
+            # that the row is gone
+            sm.update_index()
+        return r
 
     def to_indexable_doc(self) -> dict[str, Any]:
         if self.sibling_shelfmember:

--- a/neodb/journal/models/rating.py
+++ b/neodb/journal/models/rating.py
@@ -59,6 +59,26 @@ class Rating(Content):
     )
 
     @property
+    def sibling_shelfmember(self):
+        from .shelf import ShelfMember
+
+        return ShelfMember.objects.filter(owner=self.owner, item=self.item).first()
+
+    def update_index(self):
+        # a rating never indexes alone; its grade lives in the sibling
+        # mark's doc
+        sm = self.sibling_shelfmember
+        if sm:
+            sm.update_index()
+
+    def delete(self, *args, **kwargs):
+        sm = self.sibling_shelfmember
+        r = super().delete(*args, **kwargs)
+        if sm:
+            sm.update_index()
+        return r
+
+    @property
     def ap_object(self):
         return {
             "id": self.absolute_url,
@@ -86,7 +106,9 @@ class Rating(Content):
             return p
         value = obj.get("value", 0) if obj else 0
         if not value:
-            cls.objects.filter(owner=owner, item=item).delete()
+            # instance deletes so the sibling mark doc is refreshed
+            for r in cls.objects.filter(owner=owner, item=item):
+                r.delete()
             return
         best = obj.get("best", 5)
         worst = obj.get("worst", 1)
@@ -282,7 +304,9 @@ class Rating(Content):
         if rating_grade and (rating_grade < 1 or rating_grade > 10):
             raise ValueError(f"Invalid rating grade: {rating_grade}")
         if not rating_grade:
-            Rating.objects.filter(owner=owner, item=item).delete()
+            # instance deletes so the sibling mark doc is refreshed
+            for r in Rating.objects.filter(owner=owner, item=item):
+                r.delete()
         else:
             d: dict[str, Any] = {"grade": rating_grade, "visibility": visibility}
             if created_time:

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -352,6 +352,12 @@ class ShelfMemberManager(PolymorphicManager):
 
 
 class ShelfMember(ListMember):
+    # NB deliberately not index_when_save: save() runs mid-flow in
+    # Mark.update before siblings and the timeline post exist, and an
+    # early doc build would cache sibling_comment/sibling_rating as None
+    # on the very instance to_post_params renders the post from.
+    # Indexing happens via explicit update_index() calls after the flow
+    # settles, and via the hooks on Comment, Rating and Tag.
     if TYPE_CHECKING:
         parent: models.ForeignKey["ShelfMember", "Shelf"]
         owner_id: int
@@ -536,6 +542,14 @@ class ShelfMember(ListMember):
         except AttributeError:
             pass
         return super().save(*args, **kwargs)
+
+    def update_index(self):
+        # always rebuild from db truth: an instance held across a longer
+        # flow (e.g. Mark.update) may have resolved and cached siblings
+        # before they were saved
+        for attr in ("sibling_comment", "sibling_rating", "mark", "_tags"):
+            self.__dict__.pop(attr, None)
+        super().update_index()
 
     @cached_property
     def sibling_comment(self) -> "Comment | None":

--- a/neodb/journal/models/tag.py
+++ b/neodb/journal/models/tag.py
@@ -100,6 +100,26 @@ class Tag(List):
     def to_indexable_doc(self):
         return {}
 
+    def _refresh_mark_index(self, item: Item):
+        # the mark doc carries the owner's tag list for the item
+        from .shelf import ShelfMember
+
+        sm = ShelfMember.objects.filter(owner=self.owner, item=item).first()
+        if sm:
+            sm.update_index()
+
+    def append_item(self, item, **params):
+        member, created = super().append_item(item, **params)
+        if created:
+            self._refresh_mark_index(item)
+        return member, created
+
+    def remove_item(self, item):
+        member = self.get_member_for_item(item)
+        super().remove_item(item)
+        if member:
+            self._refresh_mark_index(item)
+
 
 class TagManager:
     @staticmethod

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -384,12 +384,6 @@ class JournalIndex(Index):
                 "type": "int32",
                 "sort": False,
             },
-            {
-                "name": "viewer_id",
-                "type": "int64[]",
-                "sort": False,
-                "optional": True,
-            },
         ]
     }
     search_result_class = JournalSearchResult
@@ -416,15 +410,15 @@ class JournalIndex(Index):
             # post_id marks its post as dead, which cleanup_deleted_post's
             # trailing delete_by_post relies on
             doc["post_id"] = [piece.latest_post_id]
-            # enable this in future when we support search other users
-            # doc["viewer_id"] = list(
-            #     piece.latest_post.interactions.values_list("identity_id", flat=True)
-            # )
         doc.update(d)
         return doc
 
     @classmethod
     def pieces_to_docs(cls, pieces: "Iterable[Piece]") -> list[dict]:
+        from journal.models.common import prefetch_latest_posts  # circular
+
+        pieces = list(pieces)
+        prefetch_latest_posts(pieces)
         docs = [cls.piece_to_doc(p) for p in pieces]
         return [d for d in docs if d]
 
@@ -445,10 +439,6 @@ class JournalIndex(Index):
                 "created": int(post.created.timestamp()),
                 "visibility": Takahe.visibility_t2n(post.visibility),
                 "owner_id": post.author_id,
-                # enable this in future when we support search other users
-                # "viewer_id": list(
-                #     post.interactions.values_list("identity_id", flat=True)
-                # ),
             }
             # A post orphaned by a shelf change (or linked only to pieces
             # that index within another doc) still relates to an item via
@@ -530,16 +520,6 @@ class JournalIndex(Index):
     def replace_posts(self, posts: Iterable[Post]):
         docs = self.posts_to_docs(posts)
         self.replace_docs(docs)
-
-    def replace_pieces(self, pieces: "Iterable[Piece] | QuerySet[Piece]"):
-        if isinstance(pieces, QuerySet):
-            pids = list(pieces.values_list("pk", flat=True))
-        else:
-            pids = [p.pk for p in pieces]
-        if not pids:
-            return
-        self.delete_by_piece(pids)
-        self.insert_docs(self.pieces_to_docs(pieces))
 
     def search(
         self,

--- a/neodb/tests/journal/test_crosspost.py
+++ b/neodb/tests/journal/test_crosspost.py
@@ -103,8 +103,10 @@ class TestCrosspostRetryRecording:
 
     def test_boost_failure_recorded_and_cleared(self, user, comment, monkeypatch):
         _link_mastodon(user, repost_mode=0)
+        # patch the instance, not the class: indexing on save already
+        # resolved the cached_property into the instance dict
         monkeypatch.setattr(
-            Comment,
+            comment,
             "latest_post",
             SimpleNamespace(url="https://example.org/p/1"),
         )

--- a/neodb/tests/journal/test_idx_sync.py
+++ b/neodb/tests/journal/test_idx_sync.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from catalog.models import Edition
-from journal.models import Collection, Comment, Mark, Review, ShelfType
+from journal.models import Collection, Comment, Mark, Rating, Review, ShelfType, Tag
 from journal.search import JournalIndex, JournalQueryParser
 from takahe.ap_handlers import post_deleted
 from takahe.models import Domain, Post
@@ -245,8 +245,9 @@ class TestShelfChangeOrphanedPost:
         assert "0 docs would be added, 0 docs would be deleted" in output
 
     def test_delete_orphaned_post_drops_doc(self):
-        # the linked Comment still matches in post_deleted() but rewrites
-        # nothing, so only the unconditional delete_by_post removes the doc
+        # the linked Comment matched in post_deleted() refreshes the mark
+        # doc (a different doc id); only the unconditional delete_by_post
+        # removes the orphan's own doc
         old_pid, new_pid = self.transition(comment="so far so good")
         assert str(old_pid) in self.doc_ids(self.identity.pk)
         Takahe.delete_posts([old_pid])
@@ -300,6 +301,73 @@ class TestShelfChangeOrphanedPost:
             docs = build(orphans)
         assert all(d.get("item_id") for d in docs)
         assert len(three.captured_queries) - len(one.captured_queries) == 2
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMarkFamilyIndex:
+    """Comment, rating and tags index within the mark's doc; mutating
+    them outside Mark.update must refresh it."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.index = JournalIndex.instance()
+        self.index.delete_all()
+        self.book = Edition.objects.create(title="Hyperion")
+        self.user = User.register(email="x@y.com", username="userx")
+        self.identity = self.user.identity
+        mark = Mark(self.identity, self.book)
+        mark.update(ShelfType.PROGRESS, "old text", 9, ["scifi"], 0)
+        self.sm = mark.shelfmember
+        assert self.sm is not None
+        assert self.sm.latest_post_id
+        self.doc_id = str(self.sm.latest_post_id)
+
+    def get_doc(self, doc_id: str) -> dict:
+        return self.index.write_collection.documents[doc_id].retrieve()
+
+    def doc_ids(self, owner_id: int) -> set[str]:
+        ids = self.index.get_doc_ids_by_owner(owner_id)
+        assert ids is not None
+        return ids
+
+    def test_comment_edit_refreshes_mark_doc(self):
+        Comment.comment_item(self.book, self.identity, "new text", 0)
+        assert self.get_doc(self.doc_id)["content"] == ["new text"]
+
+    def test_comment_delete_refreshes_mark_doc(self):
+        Comment.objects.get(owner=self.identity, item=self.book).delete()
+        doc = self.get_doc(self.doc_id)
+        assert doc["content"] == []
+        assert "Comment" not in doc["piece_class"]
+
+    def test_rating_delete_refreshes_mark_doc(self):
+        Rating.objects.get(owner=self.identity, item=self.book).delete()
+        doc = self.get_doc(self.doc_id)
+        assert doc["rating"] == 0
+        assert "Rating" not in doc["piece_class"]
+
+    def test_tag_change_refreshes_mark_doc(self):
+        tag, _ = Tag.objects.get_or_create(owner=self.identity, title="epic")
+        tag.append_item(self.book)
+        assert "epic" in self.get_doc(self.doc_id)["tag"]
+        tag.remove_item(self.book)
+        assert "epic" not in self.get_doc(self.doc_id)["tag"]
+
+    def test_marking_then_editing_comment_drops_lone_doc(self):
+        book2 = Edition.objects.create(title="Endymion")
+        c = Comment.comment_item(book2, self.identity, "was lone", 0)
+        assert c is not None
+        # a lone comment owns its doc
+        assert f"p{c.pk}" in self.doc_ids(self.identity.pk)
+        Mark(self.identity, book2).update(ShelfType.WISHLIST, None, None, [], 0)
+        # editing the now-embedded comment refreshes the mark doc and
+        # drops the leftover lone doc
+        Comment.comment_item(book2, self.identity, "now embedded", 0)
+        ids = self.doc_ids(self.identity.pk)
+        assert f"p{c.pk}" not in ids
+        sm = Mark(self.identity, book2).shelfmember
+        assert sm is not None and sm.latest_post_id
+        assert self.get_doc(str(sm.latest_post_id))["content"] == ["now embedded"]
 
 
 def _make_remote_identity(username: str, domain_name: str = "remote.example"):


### PR DESCRIPTION
Smaller alternative to #1796: same staleness fixes and write funnel, no doc id change, no reindex, no migration. Deployable like any other fix.

## Problem

The mark's index doc is flat: it carries the sibling comment's text, the rating grade, and the tag list. But only Mark.update refreshed it. Several real mutation paths updated the database and left the doc stale until the next mark edit or a full rebuild:

- editing or deleting a comment through the comment form (`comment.update_index()` was a silent no-op when a sibling mark exists, because the comment's own doc is empty)
- deleting a rating alone, including the ActivityPub zero-value path (queryset delete, no index write)
- adding or removing tags through the tag API (nothing journal-side reindexed)
- a comment that got a sibling mark later kept its old lone doc, so the same text matched twice

## Fix: index writes funnel through the pieces

- Comment indexes on save; with a sibling mark it refreshes the mark's doc and drops its own leftover lone doc; on delete it refreshes the mark's doc.
- Rating refreshes the sibling mark doc on update_index and delete; the AP zero-value branch uses instance deletes so the hook runs.
- Tag.append_item / remove_item refresh the sibling mark doc once per actual membership change.
- ShelfMember.update_index invalidates its cached siblings before building, so a doc rebuild always reflects db truth. ShelfMember deliberately does not index on save: its save() runs mid-flow in Mark.update before siblings and the timeline post exist, and an early doc build would cache sibling state that post rendering then reuses (this bug was caught in review of #1796; a mark post would have been rendered without its comment text).
- The ndjson importer keeps its no-index-during-import convention for comments; the mark import covers commented marks, idx-sync covers lone comments, same as before.

Mid-flow refreshes are self-healing under the existing id scheme: update_index's delete-by-piece before upsert collects any transient doc, and the final update_index in Mark.update remains the flush point.

## Also

- idx-catchup now covers all indexable classes (it omitted Article).
- pieces_to_docs batch-prefetches latest posts (removes a 2-queries-per-piece N+1 in idx-sync and idx-rebuild).
- Removed dead code: `JournalIndex.replace_pieces` (no callers) and the `viewer_id` schema field (no writer, no reader; existing collections keep the unused field harmlessly).

## Not in this PR

The doc id scheme is unchanged, so no reindex or migration is needed. #1796 (piece-keyed doc ids) remains open as the larger option; this PR delivers the user-visible fixes without it.

## Tests

Full suite passes (2130). New tests pin: comment edit and delete refresh the mark doc, rating delete refreshes it, tag add and remove refresh it, and marking a previously lone-commented item then editing the comment drops the leftover lone doc.
