### PR TITLE
feat(users): optional drag-to-sort registration captcha

### DIFF
--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -12,6 +12,10 @@ from loguru import logger
 from common.config import resolve_email_settings
 from common.models.genre import DEFAULT_GENRE_CATEGORIES
 
+# Bounds for SystemOptions.registration_captcha_items; 0 disables the captcha.
+CAPTCHA_MIN_ITEMS = 4
+CAPTCHA_MAX_ITEMS = 8
+
 
 class SiteConfig(models.Model):
     """
@@ -45,6 +49,10 @@ class SiteConfig(models.Model):
         invite_only: bool = False
         enable_local_only: bool = False
         mastodon_login_whitelist: list[str] = []
+        # Number of covers shown in the registration captcha; 0 disables it.
+        registration_captcha_items: int = 0
+        # Marks an item needs before the captcha considers it recognizable.
+        min_marks_for_captcha: int = 10
 
         # Auth Options
         enable_login_mastodon: bool = True
@@ -151,6 +159,28 @@ class SiteConfig(models.Model):
         disable_cron_jobs: list[str] = []
         index_aliases: dict = {"catalog": "catalog2"}
         skip_migrations: list[str] = []
+
+        @pydantic.field_validator("registration_captcha_items")
+        @classmethod
+        def validate_registration_captcha_items(cls, value: int) -> int:
+            # One correct assignment out of 2**n - 2 plausible ones: with the
+            # three attempts the flow allows, 2 tiles pass by guessing ~87% of
+            # the time and 3 tiles ~42%, so anything below 4 is decorative.
+            if value and value < CAPTCHA_MIN_ITEMS:
+                raise ValueError(
+                    f"{value} is too few to sort: use 0 to disable the captcha,"
+                    f" or at least {CAPTCHA_MIN_ITEMS} items"
+                )
+            if value > CAPTCHA_MAX_ITEMS:
+                raise ValueError(f"at most {CAPTCHA_MAX_ITEMS} items are supported")
+            return value
+
+        @pydantic.field_validator("min_marks_for_captcha")
+        @classmethod
+        def validate_min_marks_for_captcha(cls, value: int) -> int:
+            if value < 1:
+                raise ValueError("at least 1 mark is required")
+            return value
 
         @pydantic.field_validator("language_code")
         @classmethod

--- a/neodb/common/sentry.py
+++ b/neodb/common/sentry.py
@@ -54,6 +54,24 @@ def record_activity(action: str, source: str) -> None:
     count("user.activity", attributes={"action": action, "source": source})
 
 
+def record_registration_captcha(outcome: str, reason: str = "") -> None:
+    """Emit a `registration.captcha` counter for one captcha outcome.
+
+    ``outcome`` is the coarse bucket (``issued``, ``passed``, ``wrong_answer``,
+    ``bad_trace``, ``expired``, ``exhausted``, ``rate_limited``, ``fail_open``).
+    For ``bad_trace``, ``reason`` names the check that rejected it, so a
+    false-positive spike is diagnosable rather than merely visible.
+
+    Attributes stay low-cardinality on purpose: never pass an IP address, item
+    id, tile token or handle. Per-address state belongs in the cache, where the
+    failure cap keeps it.
+    """
+    count(
+        "registration.captcha",
+        attributes={"outcome": outcome, "reason": reason or outcome},
+    )
+
+
 def record_catalog_edit(action: str, item_type: str, op: str = "") -> None:
     """Emit a `catalog.edit` counter for a user-initiated catalog change.
 

--- a/neodb/common/static/scss/_captcha.scss
+++ b/neodb/common/static/scss/_captcha.scss
@@ -1,0 +1,89 @@
+.captcha-page {
+  article {
+    header {
+      text-align: center;
+    }
+  }
+
+  .captcha-pool,
+  .captcha-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 5.5rem;
+    padding: 0.5rem;
+    border: 1px dashed var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    margin-bottom: 0.5rem;
+  }
+
+  .captcha-row {
+    border-style: solid;
+  }
+
+  .captcha-row__label {
+    flex: 0 0 auto;
+    min-width: 6rem;
+    font-weight: bold;
+    color: var(--pico-muted-color);
+  }
+
+  .captcha-row__drop {
+    flex: 0 0 auto;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    margin: 0;
+    border-radius: 50%;
+    line-height: 1;
+  }
+
+  .captcha-row__drop::before {
+    content: "+";
+  }
+
+  .captcha-tile {
+    width: 120px;
+    height: 120px;
+    padding: 0;
+    margin: 0;
+    border: 2px solid transparent;
+    border-radius: var(--pico-border-radius);
+    background: none;
+    overflow: hidden;
+    // the cover is the whole puzzle: no text selection, no long-press menu,
+    // and no native drag ghost competing with the pointer handler
+    touch-action: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    cursor: grab;
+  }
+
+  .captcha-tile img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .captcha-tile[aria-pressed="true"] {
+    border-color: var(--pico-primary);
+  }
+
+  .captcha-tile:focus-visible {
+    outline: 2px solid var(--pico-primary-focus);
+    outline-offset: 2px;
+  }
+
+  .captcha-tile--dragging {
+    cursor: grabbing;
+    opacity: 0.85;
+    z-index: 2;
+    position: relative;
+  }
+
+  .captcha-status {
+    color: var(--pico-muted-color);
+  }
+}

--- a/neodb/common/static/scss/_captcha.scss
+++ b/neodb/common/static/scss/_captcha.scss
@@ -86,4 +86,109 @@
   .captcha-status {
     color: var(--pico-muted-color);
   }
+
+  // a tile that has landed gets a short settle, and the row it landed in
+  // acknowledges it. Small, but it is the difference between the sort feeling
+  // mechanical and feeling like the pieces click into place.
+  .captcha-tile--landed {
+    animation: captcha-settle 260ms cubic-bezier(0.22, 1.4, 0.4, 1);
+  }
+
+  .captcha-row--took {
+    animation: captcha-took 420ms ease-out;
+  }
+
+  // every cover placed: nudge attention to the button that finishes the job
+  .captcha-ready #captcha-submit {
+    animation: captcha-ready 520ms ease-out;
+  }
+
+  .captcha-solved {
+    text-align: center;
+    padding: 1rem 0 0.5rem;
+  }
+
+  .captcha-solved__mark {
+    width: 5.5rem;
+    height: 5.5rem;
+    display: block;
+    margin: 0 auto 0.5rem;
+  }
+
+  .captcha-solved__circle,
+  .captcha-solved__tick {
+    fill: none;
+    stroke: var(--pico-primary);
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .captcha-solved__circle {
+    stroke-dasharray: 145;
+    stroke-dashoffset: 145;
+    animation: captcha-draw 420ms ease-out forwards;
+    opacity: 0.5;
+  }
+
+  .captcha-solved__tick {
+    stroke-width: 4;
+    stroke-dasharray: 44;
+    stroke-dashoffset: 44;
+    animation: captcha-draw 320ms 300ms ease-out forwards;
+  }
+
+  @keyframes captcha-settle {
+    0% {
+      transform: scale(0.86);
+    }
+    60% {
+      transform: scale(1.06);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  @keyframes captcha-took {
+    0% {
+      border-color: var(--pico-primary);
+    }
+    100% {
+      border-color: var(--pico-muted-border-color);
+    }
+  }
+
+  @keyframes captcha-ready {
+    0% {
+      transform: translateY(0.25rem);
+      opacity: 0.75;
+    }
+    100% {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  @keyframes captcha-draw {
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+
+  // Motion here is decoration, never information: every state it marks is
+  // also stated in text or by position.
+  @media (prefers-reduced-motion: reduce) {
+    .captcha-tile--landed,
+    .captcha-row--took,
+    .captcha-ready #captcha-submit {
+      animation: none;
+    }
+
+    .captcha-solved__circle,
+    .captcha-solved__tick {
+      animation: none;
+      stroke-dashoffset: 0;
+    }
+  }
 }

--- a/neodb/common/static/scss/neodb.scss
+++ b/neodb/common/static/scss/neodb.scss
@@ -16,6 +16,7 @@
 @import '_sidebar.scss';
 @import '_common.scss';
 @import '_login.scss';
+@import '_captcha.scss';
 @import '_form.scss';
 @import '_post.scss';
 @import '_l10n.scss';

--- a/neodb/common/utils.py
+++ b/neodb/common/utils.py
@@ -23,6 +23,19 @@ if TYPE_CHECKING:
     from users.models import APIdentity, User
 
 
+def client_ip(request: HttpRequest) -> str:
+    """Best-effort peer address, for rate-limit keys.
+
+    The bundled nginx appends the peer address to any client-supplied
+    X-Forwarded-For, so only the last entry is trustworthy; a forged first
+    entry could otherwise be used to rotate rate-limit keys.
+    """
+    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if xff:
+        return xff.split(",")[-1].strip()
+    return request.META.get("REMOTE_ADDR", "")
+
+
 # Characters that could let JSON serialized into an HTML <script> block break
 # out of the element (`<`, `>`, `&`) or terminate a JS string (U+2028/U+2029).
 # Mirrors the escaping Django applies in django.utils.html.json_script.

--- a/neodb/common/views_manage.py
+++ b/neodb/common/views_manage.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommendations
 from common.models import SiteConfig
+from common.models.site_config import CAPTCHA_MAX_ITEMS
 
 
 def superuser_required(view_func):
@@ -485,7 +486,9 @@ class RecommendationSettings(SiteConfigSettingsPage):
 
 class AccessSettings(SiteConfigSettingsPage):
     section = "access"
-    options = {
+    # annotated so the mix of str/int/list option values does not narrow the
+    # inferred type; test_views_manage indexes into this dict
+    options: ClassVar[dict] = {
         "invite_only": {
             "title": _("Invite Only"),
             "help_text": _(
@@ -500,6 +503,27 @@ class AccessSettings(SiteConfigSettingsPage):
         "mastodon_login_whitelist": {
             "title": _("Mastodon Login Whitelist"),
             "help_text": _("One domain per line. Leave empty to allow any instance."),
+        },
+        "registration_captcha_items": {
+            "title": _("Registration Captcha Items"),
+            "min_value": 0,
+            "max_value": CAPTCHA_MAX_ITEMS,
+            "help_text": _(
+                "Number of item covers a new user must sort into two category "
+                "rows before choosing a username. 0 disables the captcha; "
+                "5-6 is recommended. The covers carry no title text, so this "
+                "cannot be solved with a screen reader: if you enable it, keep "
+                "another way in, such as an invite link."
+            ),
+        },
+        "min_marks_for_captcha": {
+            "title": _("Registration Captcha Minimum Marks"),
+            "min_value": 1,
+            "help_text": _(
+                "Marks an item needs before the captcha treats it as well known "
+                "enough to be recognizable. Categories with too few such items "
+                "fall back to any item."
+            ),
         },
         "enable_login_mastodon": {
             "title": _("Enable Mastodon Login"),
@@ -541,6 +565,8 @@ class AccessSettings(SiteConfigSettingsPage):
             "invite_only",
             "enable_local_only",
             "mastodon_login_whitelist",
+            "registration_captcha_items",
+            "min_marks_for_captcha",
         ],
         _("Login Methods"): [
             "enable_login_mastodon",

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 23:58-0400\n"
+"POT-Creation-Date: 2026-08-23 11:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:274
+#: catalog/templates/_verify_status.html:31 users/views/account.py:303
 msgid "Verification failed"
 msgstr ""
 
@@ -3915,7 +3915,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:491
+#: common/templates/common/about.html:35 common/views_manage.py:493
 msgid "Invite Only"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:554
+#: common/templates/common/about.html:40 common/views_manage.py:556
 msgid "Preferred Languages"
 msgstr ""
 
@@ -3979,7 +3979,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:626
+#: common/templates/common/scan.html:60 common/views_manage.py:628
 msgid "Search"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:148 common/views_manage.py:621
+#: common/views_manage.py:148 common/views_manage.py:623
 msgid "Federation"
 msgstr ""
 
@@ -4330,450 +4330,450 @@ msgstr ""
 msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:493
+#: common/views_manage.py:495
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:498
+#: common/views_manage.py:500
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:499
+#: common/views_manage.py:501
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:502
+#: common/views_manage.py:504
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:503
+#: common/views_manage.py:505
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:506
+#: common/views_manage.py:508
 msgid "Registration Captcha Items"
 msgstr ""
 
-#: common/views_manage.py:510
+#: common/views_manage.py:512
 msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:518
+#: common/views_manage.py:520
 msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
-#: common/views_manage.py:521
+#: common/views_manage.py:523
 msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
-#: common/views_manage.py:527
+#: common/views_manage.py:529
 msgid "Enable Mastodon Login"
 msgstr ""
 
-#: common/views_manage.py:530
+#: common/views_manage.py:532
 msgid "Enable Bluesky Login"
 msgstr ""
 
-#: common/views_manage.py:533
+#: common/views_manage.py:535
 msgid "Enable Threads Login"
 msgstr ""
 
-#: common/views_manage.py:536
+#: common/views_manage.py:538
 msgid "Email URL"
 msgstr ""
 
-#: common/views_manage.py:538
+#: common/views_manage.py:540
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr ""
 
-#: common/views_manage.py:542
+#: common/views_manage.py:544
 msgid "Email From"
 msgstr ""
 
-#: common/views_manage.py:543
+#: common/views_manage.py:545
 msgid "Sender name and address for outgoing email."
 msgstr ""
 
-#: common/views_manage.py:546
+#: common/views_manage.py:548
 msgid "Default Language"
 msgstr ""
 
-#: common/views_manage.py:549
+#: common/views_manage.py:551
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:556
+#: common/views_manage.py:558
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:562
+#: common/views_manage.py:564
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:569
+#: common/views_manage.py:571
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:574 mastodon/models/common.py:28
+#: common/views_manage.py:576 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:578
+#: common/views_manage.py:580
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:589
+#: common/views_manage.py:591
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:591
+#: common/views_manage.py:593
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:596
+#: common/views_manage.py:598
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:597
+#: common/views_manage.py:599
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:601
+#: common/views_manage.py:603
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:603
+#: common/views_manage.py:605
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:608
+#: common/views_manage.py:610
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:609
+#: common/views_manage.py:611
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:612
+#: common/views_manage.py:614
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:613
+#: common/views_manage.py:615
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:616
+#: common/views_manage.py:618
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:617
+#: common/views_manage.py:619
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:638
+#: common/views_manage.py:640
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:639
+#: common/views_manage.py:641
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:642
+#: common/views_manage.py:644
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:643
+#: common/views_manage.py:645
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:646
+#: common/views_manage.py:648
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:647
+#: common/views_manage.py:649
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:650
+#: common/views_manage.py:652
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:652
+#: common/views_manage.py:654
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:656
+#: common/views_manage.py:658
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:657
+#: common/views_manage.py:659
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:660
+#: common/views_manage.py:662
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:663
+#: common/views_manage.py:665
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:665
+#: common/views_manage.py:667
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:670 users/templates/users/steam_import.html:26
+#: common/views_manage.py:672 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:674
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:677
+#: common/views_manage.py:679
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:678
+#: common/views_manage.py:680
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:681
+#: common/views_manage.py:683
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:684
+#: common/views_manage.py:686
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:687
+#: common/views_manage.py:689
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:688
+#: common/views_manage.py:690
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:691
+#: common/views_manage.py:693
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:694
+#: common/views_manage.py:696
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:696
+#: common/views_manage.py:698
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:713
+#: common/views_manage.py:715
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:725
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:728
+#: common/views_manage.py:730
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:732 social/templates/feed.html:27
+#: common/views_manage.py:734 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:742
+#: common/views_manage.py:744
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:743
+#: common/views_manage.py:745
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:746
+#: common/views_manage.py:748
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:747
+#: common/views_manage.py:749
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:750
+#: common/views_manage.py:752
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:753
+#: common/views_manage.py:755
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:756
+#: common/views_manage.py:758
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:759
+#: common/views_manage.py:761
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:762
+#: common/views_manage.py:764
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:765
+#: common/views_manage.py:767
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:766
+#: common/views_manage.py:768
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:769
+#: common/views_manage.py:771
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:773
+#: common/views_manage.py:775
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:777
+#: common/views_manage.py:779
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:782
+#: common/views_manage.py:784
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:787
+#: common/views_manage.py:789
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:794
+#: common/views_manage.py:796
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:806
+#: common/views_manage.py:808
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:807
+#: common/views_manage.py:809
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:810
+#: common/views_manage.py:812
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:811
+#: common/views_manage.py:813
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:814
+#: common/views_manage.py:816
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:816
+#: common/views_manage.py:818
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:822
+#: common/views_manage.py:824
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:823
+#: common/views_manage.py:825
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:826
+#: common/views_manage.py:828
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:827
+#: common/views_manage.py:829
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:837
+#: common/views_manage.py:839
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:839
+#: common/views_manage.py:841
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:845
+#: common/views_manage.py:847
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:847
+#: common/views_manage.py:849
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:853
+#: common/views_manage.py:855
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:855
+#: common/views_manage.py:857
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:862
+#: common/views_manage.py:864
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:865
+#: common/views_manage.py:867
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:881
+#: common/views_manage.py:883
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:883
+#: common/views_manage.py:885
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:888
+#: common/views_manage.py:890
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:890
+#: common/views_manage.py:892
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:895
+#: common/views_manage.py:897
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:897
+#: common/views_manage.py:899
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:902
+#: common/views_manage.py:904
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:904
+#: common/views_manage.py:906
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:909
+#: common/views_manage.py:911
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:911
+#: common/views_manage.py:913
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:916
+#: common/views_manage.py:918
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:918
+#: common/views_manage.py:920
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:924
+#: common/views_manage.py:926
 msgid "Genres by Category"
 msgstr ""
 
@@ -6417,7 +6417,7 @@ msgstr ""
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:336
+#: users/views/account.py:248 users/views/account.py:367
 msgid "Authentication failed"
 msgstr ""
 
@@ -6445,7 +6445,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:377
+#: mastodon/views/common.py:52 users/views/account.py:408
 msgid "Registration failed"
 msgstr ""
 
@@ -7462,28 +7462,28 @@ msgstr ""
 msgid "Time is up. Reload to try again."
 msgstr ""
 
-#: users/templates/users/captcha.html:23
+#: users/templates/users/captcha.html:26
 msgid "One quick check"
 msgstr ""
 
-#: users/templates/users/captcha.html:25
+#: users/templates/users/captcha.html:28
 msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr ""
 
-#: users/templates/users/captcha.html:34 users/templates/users/captcha.html:36
+#: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
 msgid "Item cover"
 msgstr ""
 
-#: users/templates/users/captcha.html:52
+#: users/templates/users/captcha.html:59
 #, python-format
 msgid "Move selected cover to %(label)s"
 msgstr ""
 
-#: users/templates/users/captcha.html:64
+#: users/templates/users/captcha.html:77
 msgid "Confirm"
 msgstr ""
 
-#: users/templates/users/captcha.html:72
+#: users/templates/users/captcha.html:84
 #, python-format
 msgid "Show me another set (%(counter)s left)"
 msgid_plural "Show me another set (%(counter)s left)"
@@ -8362,44 +8362,44 @@ msgstr ""
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:242 users/views/account.py:301
-msgid "Time is up"
-msgstr ""
-
-#: users/views/account.py:243 users/views/account.py:275
-#: users/views/account.py:302
-msgid "Please log in again to continue registration."
-msgstr ""
-
-#: users/views/account.py:277
-msgid "That is not quite right. Here is a new set."
-msgstr ""
-
-#: users/views/account.py:286
-msgid "Too many attempts"
-msgstr ""
-
-#: users/views/account.py:287
-msgid "Please try again later."
-msgstr ""
-
-#: users/views/account.py:337
+#: users/views/account.py:249 users/views/account.py:368
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:378
+#: users/views/account.py:260 users/views/account.py:332
+msgid "Time is up"
+msgstr ""
+
+#: users/views/account.py:261 users/views/account.py:304
+#: users/views/account.py:333
+msgid "Please log in again to continue registration."
+msgstr ""
+
+#: users/views/account.py:307
+msgid "That is not quite right. Here is a new set."
+msgstr ""
+
+#: users/views/account.py:319
+msgid "Too many attempts"
+msgstr ""
+
+#: users/views/account.py:320
+msgid "Please try again later."
+msgstr ""
+
+#: users/views/account.py:409
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:408
+#: users/views/account.py:439
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:489
+#: users/views/account.py:520
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:492
+#: users/views/account.py:523
 msgid "Account mismatch."
 msgstr ""
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 22:51-0400\n"
+"POT-Creation-Date: 2026-08-22 23:58-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31
+#: catalog/templates/_verify_status.html:31 users/views/account.py:274
 msgid "Verification failed"
 msgstr ""
 
@@ -1689,12 +1689,12 @@ msgid "Item has been marked by users."
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
 msgid "Yes"
 msgstr ""
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
 msgid "No"
 msgstr ""
 
@@ -1800,8 +1800,8 @@ msgstr ""
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr ""
 
-#: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:352 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:145
+#: common/views_manage.py:353 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Please wait a moment before trying again."
 msgstr ""
 
-#: catalog/views/verify.py:164 common/utils.py:109 common/utils.py:150
+#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:45 users/views/actions.py:131
 msgid "User not found"
@@ -3915,7 +3915,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: common/templates/common/about.html:35 common/views_manage.py:490
+#: common/templates/common/about.html:35 common/views_manage.py:491
 msgid "Invite Only"
 msgstr ""
 
@@ -3923,7 +3923,7 @@ msgstr ""
 msgid "Open Registration"
 msgstr ""
 
-#: common/templates/common/about.html:40 common/views_manage.py:532
+#: common/templates/common/about.html:40 common/views_manage.py:554
 msgid "Preferred Languages"
 msgstr ""
 
@@ -3979,7 +3979,7 @@ msgstr ""
 msgid "Or type barcode / ISBN manually"
 msgstr ""
 
-#: common/templates/common/scan.html:60 common/views_manage.py:602
+#: common/templates/common/scan.html:60 common/views_manage.py:626
 msgid "Search"
 msgstr ""
 
@@ -4047,717 +4047,733 @@ msgstr ""
 msgid "unavailable"
 msgstr ""
 
-#: common/utils.py:113 common/utils.py:154 users/views/actions.py:134
+#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
 msgid "User no longer exists"
 msgstr ""
 
-#: common/utils.py:120 common/utils.py:122 common/utils.py:125
-#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:499
+#: common/utils.py:133 common/utils.py:135 common/utils.py:138
+#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
 msgid "Access denied"
 msgstr ""
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:204
+#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr ""
 
-#: common/views_manage.py:143 common/views_manage.py:294
+#: common/views_manage.py:144 common/views_manage.py:295
 msgid "Branding"
 msgstr ""
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Recommendations"
 msgstr ""
 
-#: common/views_manage.py:146
+#: common/views_manage.py:147
 msgid "Access"
 msgstr ""
 
-#: common/views_manage.py:147 common/views_manage.py:597
+#: common/views_manage.py:148 common/views_manage.py:621
 msgid "Federation"
 msgstr ""
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "Catalog"
 msgstr ""
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "API Keys"
 msgstr ""
 
-#: common/views_manage.py:150
+#: common/views_manage.py:151
 msgid "Downloader"
 msgstr ""
 
-#: common/views_manage.py:151 common/views_manage.py:302
+#: common/views_manage.py:152 common/views_manage.py:303
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr ""
 
-#: common/views_manage.py:201
+#: common/views_manage.py:202
 msgid "Invalid value."
 msgstr ""
 
-#: common/views_manage.py:205
+#: common/views_manage.py:206
 msgid "Invalid configuration. Please check your input."
 msgstr ""
 
-#: common/views_manage.py:210
+#: common/views_manage.py:211
 msgid "Settings have been saved."
 msgstr ""
 
-#: common/views_manage.py:230
+#: common/views_manage.py:231
 msgid "Site Name"
 msgstr ""
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Site Description"
 msgstr ""
 
-#: common/views_manage.py:234
+#: common/views_manage.py:235
 msgid "Short description shown in metadata and about page."
 msgstr ""
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "Site Logo URL"
 msgstr ""
 
-#: common/views_manage.py:238
+#: common/views_manage.py:239
 msgid "URL path to the site logo image."
 msgstr ""
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "Site Icon URL"
 msgstr ""
 
-#: common/views_manage.py:242
+#: common/views_manage.py:243
 msgid "URL path to the site icon/favicon."
 msgstr ""
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "Default User Avatar URL"
 msgstr ""
 
-#: common/views_manage.py:246
+#: common/views_manage.py:247
 msgid "URL path to the default user avatar."
 msgstr ""
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "Site Color Theme"
 msgstr ""
 
-#: common/views_manage.py:250
+#: common/views_manage.py:251
 msgid "PicoCSS color theme."
 msgstr ""
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "Site Introduction"
 msgstr ""
 
-#: common/views_manage.py:276
+#: common/views_manage.py:277
 msgid "URL path for the intro/welcome sidebar page."
 msgstr ""
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Custom HTML Head"
 msgstr ""
 
-#: common/views_manage.py:280
+#: common/views_manage.py:281
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr ""
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Footer Links"
 msgstr ""
 
-#: common/views_manage.py:285
+#: common/views_manage.py:286
 msgid "Link title mapped to URL."
 msgstr ""
 
-#: common/views_manage.py:314
+#: common/views_manage.py:315
 msgid "Minimum Marks for Discover"
 msgstr ""
 
-#: common/views_manage.py:316
+#: common/views_manage.py:317
 msgid "Number of marks required for an item to appear in discover."
 msgstr ""
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "Update Interval (minutes)"
 msgstr ""
 
-#: common/views_manage.py:322
+#: common/views_manage.py:323
 msgid "How often to refresh the popular items list."
 msgstr ""
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Filter by Preferred Languages"
 msgstr ""
 
-#: common/views_manage.py:327
+#: common/views_manage.py:328
 msgid "Only show items with titles in the preferred languages."
 msgstr ""
 
-#: common/views_manage.py:330
+#: common/views_manage.py:331
 msgid "Show Local Only"
 msgstr ""
 
-#: common/views_manage.py:332
+#: common/views_manage.py:333
 msgid "Only show items marked by local users, not the entire network."
 msgstr ""
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show Popular Posts"
 msgstr ""
 
-#: common/views_manage.py:337
+#: common/views_manage.py:338
 msgid "Show popular public posts instead of recent ones."
 msgstr ""
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show Popular Tags"
 msgstr ""
 
-#: common/views_manage.py:341
+#: common/views_manage.py:342
 msgid "Show popular public tags on the discover page."
 msgstr ""
 
-#: common/views_manage.py:344
+#: common/views_manage.py:345
 msgid "Show Verified Podcasts"
 msgstr ""
 
-#: common/views_manage.py:346
+#: common/views_manage.py:347
 msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr ""
 
-#: common/views_manage.py:385
+#: common/views_manage.py:386
 msgid "Enable Recommendations"
 msgstr ""
 
-#: common/views_manage.py:387
+#: common/views_manage.py:388
 msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr ""
 
-#: common/views_manage.py:392
+#: common/views_manage.py:393
 msgid "Source Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:394
+#: common/views_manage.py:395
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr ""
 
-#: common/views_manage.py:400
+#: common/views_manage.py:401
 msgid "Target Item Mark Threshold"
 msgstr ""
 
-#: common/views_manage.py:402
+#: common/views_manage.py:403
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr ""
 
-#: common/views_manage.py:408
+#: common/views_manage.py:409
 msgid "Top-K Similar Items per Source"
 msgstr ""
 
-#: common/views_manage.py:409
+#: common/views_manage.py:410
 msgid "Number of similar items stored per source item."
 msgstr ""
 
-#: common/views_manage.py:413
+#: common/views_manage.py:414
 msgid "Top-N Recommendations per User"
 msgstr ""
 
-#: common/views_manage.py:414
+#: common/views_manage.py:415
 msgid "Number of personalised rows stored per user."
 msgstr ""
 
-#: common/views_manage.py:418
+#: common/views_manage.py:419
 msgid "Dampen Heavy Shelvers"
 msgstr ""
 
-#: common/views_manage.py:420
+#: common/views_manage.py:421
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr ""
 
-#: common/views_manage.py:425
+#: common/views_manage.py:426
 msgid "Per-User Mark Cap (training)"
 msgstr ""
 
-#: common/views_manage.py:427
+#: common/views_manage.py:428
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr ""
 
-#: common/views_manage.py:433
+#: common/views_manage.py:434
 msgid "Active-User Window (days)"
 msgstr ""
 
-#: common/views_manage.py:435
+#: common/views_manage.py:436
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr ""
 
-#: common/views_manage.py:441
+#: common/views_manage.py:442
 msgid "Per-User Seed Cap (serving)"
 msgstr ""
 
-#: common/views_manage.py:443
+#: common/views_manage.py:444
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr ""
 
-#: common/views_manage.py:449
+#: common/views_manage.py:450
 msgid "Lazy Refresh TTL (days)"
 msgstr ""
 
-#: common/views_manage.py:451
+#: common/views_manage.py:452
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr ""
 
-#: common/views_manage.py:457
+#: common/views_manage.py:458
 msgid "Circles Window (days)"
 msgstr ""
 
-#: common/views_manage.py:459
+#: common/views_manage.py:460
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr ""
 
-#: common/views_manage.py:466
+#: common/views_manage.py:467
 msgid "Master Switch"
 msgstr ""
 
-#: common/views_manage.py:469
+#: common/views_manage.py:470
 msgid "Similarity Builder"
 msgstr ""
 
-#: common/views_manage.py:476
+#: common/views_manage.py:477
 msgid "Personalisation"
 msgstr ""
 
-#: common/views_manage.py:492
+#: common/views_manage.py:493
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr ""
 
-#: common/views_manage.py:497
+#: common/views_manage.py:498
 msgid "Enable Local-Only Posting"
 msgstr ""
 
-#: common/views_manage.py:498
+#: common/views_manage.py:499
 msgid "Allow users to create posts visible only to local users."
 msgstr ""
 
-#: common/views_manage.py:501
+#: common/views_manage.py:502
 msgid "Mastodon Login Whitelist"
 msgstr ""
 
-#: common/views_manage.py:502
+#: common/views_manage.py:503
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr ""
 
-#: common/views_manage.py:505
-msgid "Enable Mastodon Login"
+#: common/views_manage.py:506
+msgid "Registration Captcha Items"
 msgstr ""
 
-#: common/views_manage.py:508
-msgid "Enable Bluesky Login"
+#: common/views_manage.py:510
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr ""
 
-#: common/views_manage.py:511
-msgid "Enable Threads Login"
-msgstr ""
-
-#: common/views_manage.py:514
-msgid "Email URL"
-msgstr ""
-
-#: common/views_manage.py:516
-msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
-msgstr ""
-
-#: common/views_manage.py:520
-msgid "Email From"
+#: common/views_manage.py:518
+msgid "Registration Captcha Minimum Marks"
 msgstr ""
 
 #: common/views_manage.py:521
-msgid "Sender name and address for outgoing email."
-msgstr ""
-
-#: common/views_manage.py:524
-msgid "Default Language"
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr ""
 
 #: common/views_manage.py:527
+msgid "Enable Mastodon Login"
+msgstr ""
+
+#: common/views_manage.py:530
+msgid "Enable Bluesky Login"
+msgstr ""
+
+#: common/views_manage.py:533
+msgid "Enable Threads Login"
+msgstr ""
+
+#: common/views_manage.py:536
+msgid "Email URL"
+msgstr ""
+
+#: common/views_manage.py:538
+msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
+msgstr ""
+
+#: common/views_manage.py:542
+msgid "Email From"
+msgstr ""
+
+#: common/views_manage.py:543
+msgid "Sender name and address for outgoing email."
+msgstr ""
+
+#: common/views_manage.py:546
+msgid "Default Language"
+msgstr ""
+
+#: common/views_manage.py:549
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr ""
 
-#: common/views_manage.py:534
+#: common/views_manage.py:556
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr ""
 
-#: common/views_manage.py:540
+#: common/views_manage.py:562
 msgid "Access Control"
 msgstr ""
 
-#: common/views_manage.py:545
+#: common/views_manage.py:569
 msgid "Login Methods"
 msgstr ""
 
-#: common/views_manage.py:550 mastodon/models/common.py:28
+#: common/views_manage.py:574 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr ""
 
-#: common/views_manage.py:554
+#: common/views_manage.py:578
 msgid "Localization"
 msgstr ""
 
-#: common/views_manage.py:565
+#: common/views_manage.py:589
 msgid "Disable Default Relay"
 msgstr ""
 
-#: common/views_manage.py:567
+#: common/views_manage.py:591
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr ""
 
-#: common/views_manage.py:572
+#: common/views_manage.py:596
 msgid "Fanout Limit (days)"
 msgstr ""
 
-#: common/views_manage.py:573
+#: common/views_manage.py:597
 msgid "Posts older than this many days will not be fanned out."
 msgstr ""
 
-#: common/views_manage.py:577
+#: common/views_manage.py:601
 msgid "Remote Prune Horizon (days)"
 msgstr ""
 
-#: common/views_manage.py:579
+#: common/views_manage.py:603
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr ""
 
-#: common/views_manage.py:584
+#: common/views_manage.py:608
 msgid "Search Sites"
 msgstr ""
 
-#: common/views_manage.py:585
+#: common/views_manage.py:609
 msgid "External search sites to include, one per line."
 msgstr ""
 
-#: common/views_manage.py:588
+#: common/views_manage.py:612
 msgid "Federated Search Peers"
 msgstr ""
 
-#: common/views_manage.py:589
+#: common/views_manage.py:613
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr ""
 
-#: common/views_manage.py:592
+#: common/views_manage.py:616
 msgid "Hidden Categories"
 msgstr ""
 
-#: common/views_manage.py:593
+#: common/views_manage.py:617
 msgid "Category values to hide from the catalog, one per line."
 msgstr ""
 
-#: common/views_manage.py:614
+#: common/views_manage.py:638
 msgid "Spotify API Key"
 msgstr ""
 
-#: common/views_manage.py:615
+#: common/views_manage.py:639
 msgid "https://developer.spotify.com/"
 msgstr ""
 
-#: common/views_manage.py:618
+#: common/views_manage.py:642
 msgid "TMDB API Key"
 msgstr ""
 
-#: common/views_manage.py:619
+#: common/views_manage.py:643
 msgid "https://developer.themoviedb.org/"
 msgstr ""
 
-#: common/views_manage.py:622
+#: common/views_manage.py:646
 msgid "Google Books API Key"
 msgstr ""
 
-#: common/views_manage.py:623
+#: common/views_manage.py:647
 msgid "https://developers.google.com/books/"
 msgstr ""
 
-#: common/views_manage.py:626
+#: common/views_manage.py:650
 msgid "Discogs API Key"
 msgstr ""
 
-#: common/views_manage.py:628
+#: common/views_manage.py:652
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr ""
 
-#: common/views_manage.py:632
+#: common/views_manage.py:656
 msgid "IGDB Client ID"
 msgstr ""
 
-#: common/views_manage.py:633
+#: common/views_manage.py:657
 msgid "https://api-docs.igdb.com/"
 msgstr ""
 
-#: common/views_manage.py:636
+#: common/views_manage.py:660
 msgid "IGDB Client Secret"
 msgstr ""
 
-#: common/views_manage.py:639
+#: common/views_manage.py:663
 msgid "BoardGameGeek API Token"
 msgstr ""
 
-#: common/views_manage.py:641
+#: common/views_manage.py:665
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr ""
 
-#: common/views_manage.py:646 users/templates/users/steam_import.html:26
+#: common/views_manage.py:670 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr ""
 
-#: common/views_manage.py:648
+#: common/views_manage.py:672
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr ""
 
-#: common/views_manage.py:653
+#: common/views_manage.py:677
 msgid "DeepL API Key"
 msgstr ""
 
-#: common/views_manage.py:654
+#: common/views_manage.py:678
 msgid "For translation features."
 msgstr ""
 
-#: common/views_manage.py:657
+#: common/views_manage.py:681
 msgid "LibreTranslate API URL"
 msgstr ""
 
-#: common/views_manage.py:660
+#: common/views_manage.py:684
 msgid "LibreTranslate API Key"
 msgstr ""
 
-#: common/views_manage.py:663
+#: common/views_manage.py:687
 msgid "Threads App ID"
 msgstr ""
 
-#: common/views_manage.py:664
+#: common/views_manage.py:688
 msgid "OAuth app ID for Threads login."
 msgstr ""
 
-#: common/views_manage.py:667
+#: common/views_manage.py:691
 msgid "Threads App Secret"
 msgstr ""
 
-#: common/views_manage.py:670
+#: common/views_manage.py:694
 msgid "Discord Webhooks"
 msgstr ""
 
-#: common/views_manage.py:672
+#: common/views_manage.py:696
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr ""
 
-#: common/views_manage.py:689
+#: common/views_manage.py:713
 msgid "Catalog APIs"
 msgstr ""
 
-#: common/views_manage.py:699
+#: common/views_manage.py:723
 msgid "Translation"
 msgstr ""
 
-#: common/views_manage.py:704
+#: common/views_manage.py:728
 msgid "Third-Party Login"
 msgstr ""
 
-#: common/views_manage.py:708 social/templates/feed.html:27
+#: common/views_manage.py:732 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr ""
 
-#: common/views_manage.py:718
+#: common/views_manage.py:742
 msgid "Scraping Providers"
 msgstr ""
 
-#: common/views_manage.py:719
+#: common/views_manage.py:743
 msgid "Comma-separated list of providers to try in order."
 msgstr ""
 
-#: common/views_manage.py:722
+#: common/views_manage.py:746
 msgid "Proxy List"
 msgstr ""
 
-#: common/views_manage.py:723
+#: common/views_manage.py:747
 msgid "One per line, format: http://server?url=__URL__"
 msgstr ""
 
-#: common/views_manage.py:726
+#: common/views_manage.py:750
 msgid "Backup Proxy"
 msgstr ""
 
-#: common/views_manage.py:729
+#: common/views_manage.py:753
 msgid "Scrapfly API Key"
 msgstr ""
 
-#: common/views_manage.py:732
+#: common/views_manage.py:756
 msgid "Decodo Base64 Auth Token"
 msgstr ""
 
-#: common/views_manage.py:735
+#: common/views_manage.py:759
 msgid "ScraperAPI Key"
 msgstr ""
 
-#: common/views_manage.py:738
+#: common/views_manage.py:762
 msgid "ScrapingBee API Key"
 msgstr ""
 
-#: common/views_manage.py:741
+#: common/views_manage.py:765
 msgid "Custom Scraper URL"
 msgstr ""
 
-#: common/views_manage.py:742
+#: common/views_manage.py:766
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr ""
 
-#: common/views_manage.py:745
+#: common/views_manage.py:769
 msgid "Request Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:749
+#: common/views_manage.py:773
 msgid "Cache Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:753
+#: common/views_manage.py:777
 msgid "Retries"
 msgstr ""
 
-#: common/views_manage.py:758
+#: common/views_manage.py:782
 msgid "Providers"
 msgstr ""
 
-#: common/views_manage.py:763
+#: common/views_manage.py:787
 msgid "Provider Keys"
 msgstr ""
 
-#: common/views_manage.py:770
+#: common/views_manage.py:794
 msgid "Timeouts"
 msgstr ""
 
-#: common/views_manage.py:782
+#: common/views_manage.py:806
 msgid "Alternative Domains"
 msgstr ""
 
-#: common/views_manage.py:783
+#: common/views_manage.py:807
 msgid "One domain per line."
 msgstr ""
 
-#: common/views_manage.py:786
+#: common/views_manage.py:810
 msgid "Mastodon Client Scope"
 msgstr ""
 
-#: common/views_manage.py:787
+#: common/views_manage.py:811
 msgid "OAuth scope when creating Mastodon apps."
 msgstr ""
 
-#: common/views_manage.py:790
+#: common/views_manage.py:814
 msgid "Mastodon API Timeout (seconds)"
 msgstr ""
 
-#: common/views_manage.py:792
+#: common/views_manage.py:816
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr ""
 
-#: common/views_manage.py:798
+#: common/views_manage.py:822
 msgid "Disable Cron Jobs"
 msgstr ""
 
-#: common/views_manage.py:799
+#: common/views_manage.py:823
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr ""
 
-#: common/views_manage.py:802
+#: common/views_manage.py:826
 msgid "Index Aliases"
 msgstr ""
 
-#: common/views_manage.py:803
+#: common/views_manage.py:827
 msgid "Map index names to their aliases."
 msgstr ""
 
-#: common/views_manage.py:813
+#: common/views_manage.py:837
 msgid "Task Cleanup (days)"
 msgstr ""
 
-#: common/views_manage.py:815
+#: common/views_manage.py:839
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr ""
 
-#: common/views_manage.py:821
+#: common/views_manage.py:845
 msgid "Skip Migration Jobs"
 msgstr ""
 
-#: common/views_manage.py:823
+#: common/views_manage.py:847
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr ""
 
-#: common/views_manage.py:829
+#: common/views_manage.py:853
 msgid "ATProto OAuth Client Key"
 msgstr ""
 
-#: common/views_manage.py:831
+#: common/views_manage.py:855
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr ""
 
-#: common/views_manage.py:838
+#: common/views_manage.py:862
 msgid "Domains"
 msgstr ""
 
-#: common/views_manage.py:841
+#: common/views_manage.py:865
 msgid "Operational"
 msgstr ""
 
-#: common/views_manage.py:857
+#: common/views_manage.py:881
 msgid "Movie Genres"
 msgstr ""
 
-#: common/views_manage.py:859
+#: common/views_manage.py:883
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:864
+#: common/views_manage.py:888
 msgid "TV Genres"
 msgstr ""
 
-#: common/views_manage.py:866
+#: common/views_manage.py:890
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:871
+#: common/views_manage.py:895
 msgid "Music Genres"
 msgstr ""
 
-#: common/views_manage.py:873
+#: common/views_manage.py:897
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:878
+#: common/views_manage.py:902
 msgid "Game Genres"
 msgstr ""
 
-#: common/views_manage.py:880
+#: common/views_manage.py:904
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:885
+#: common/views_manage.py:909
 msgid "Podcast Genres"
 msgstr ""
 
-#: common/views_manage.py:887
+#: common/views_manage.py:911
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:892
+#: common/views_manage.py:916
 msgid "Performance Genres"
 msgstr ""
 
-#: common/views_manage.py:894
+#: common/views_manage.py:918
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr ""
 
-#: common/views_manage.py:900
+#: common/views_manage.py:924
 msgid "Genres by Category"
 msgstr ""
 
@@ -5549,7 +5565,7 @@ msgstr ""
 msgid "started following {item}"
 msgstr ""
 
-#: journal/models/shelf.py:907
+#: journal/models/shelf.py:921
 msgid "removed mark"
 msgstr ""
 
@@ -6328,8 +6344,9 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/login.html:20
-#: users/templates/users/register.html:9 users/templates/users/welcome.html:10
+#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: users/templates/users/login.html:20 users/templates/users/register.html:9
+#: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
@@ -6395,12 +6412,12 @@ msgstr ""
 
 #: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
 #: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:40
+#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
 #: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:192
+#: users/views/account.py:336
 msgid "Authentication failed"
 msgstr ""
 
@@ -6424,51 +6441,51 @@ msgstr ""
 msgid "Invalid account data from Bluesky."
 msgstr ""
 
-#: mastodon/views/common.py:40 mastodon/views/common.py:105
+#: mastodon/views/common.py:36 mastodon/views/common.py:107
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:56 users/views/account.py:228
+#: mastodon/views/common.py:52 users/views/account.py:377
 msgid "Registration failed"
 msgstr ""
 
-#: mastodon/views/common.py:56
+#: mastodon/views/common.py:52
 msgid "User already logged in."
 msgstr ""
 
-#: mastodon/views/common.py:68
+#: mastodon/views/common.py:70
 #, python-brace-format
 msgid "Continue login as {handle}."
 msgstr ""
 
-#: mastodon/views/common.py:74
+#: mastodon/views/common.py:76
 msgid "Unable to update login information"
 msgstr ""
 
-#: mastodon/views/common.py:75
+#: mastodon/views/common.py:77
 #, python-brace-format
 msgid "Identity {handle} in use by a different user."
 msgstr ""
 
-#: mastodon/views/common.py:91
+#: mastodon/views/common.py:93
 #, python-brace-format
 msgid "Login information updated as {handle}."
 msgstr ""
 
-#: mastodon/views/common.py:101 mastodon/views/common.py:105
-#: mastodon/views/common.py:114
+#: mastodon/views/common.py:103 mastodon/views/common.py:107
+#: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
 msgstr ""
 
-#: mastodon/views/common.py:101
+#: mastodon/views/common.py:103
 msgid "Identity not found."
 msgstr ""
 
-#: mastodon/views/common.py:115
+#: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr ""
 
-#: mastodon/views/common.py:124
+#: mastodon/views/common.py:126
 #, python-brace-format
 msgid "Login information about {handle} has been removed."
 msgstr ""
@@ -6814,6 +6831,34 @@ msgstr ""
 
 #: social/templates/single_post.html:29
 msgid "Poll"
+msgstr ""
+
+#: takahe/models.py:453
+msgid "Display Name"
+msgstr ""
+
+#: takahe/models.py:455
+msgid "Bio"
+msgstr ""
+
+#: takahe/models.py:457
+msgid "Manually approve new followers"
+msgstr ""
+
+#: takahe/models.py:461
+msgid "Include profile, marks and posts in discovery"
+msgstr ""
+
+#: takahe/models.py:464
+msgid "Include posts in search results"
+msgstr ""
+
+#: takahe/models.py:482
+msgid "Profile picture"
+msgstr ""
+
+#: takahe/models.py:489
+msgid "Header picture"
 msgstr ""
 
 #: users/models/task.py:22
@@ -7400,6 +7445,50 @@ msgstr ""
 #: users/templates/users/authorized_app_created.html:25
 msgid "Token"
 msgstr ""
+
+#: users/templates/users/captcha.html:4
+msgid "Sort every cover to continue."
+msgstr ""
+
+#: users/templates/users/captcha.html:5
+msgid "All sorted. Select Confirm."
+msgstr ""
+
+#: users/templates/users/captcha.html:6
+msgid "Cover selected. Now choose a row."
+msgstr ""
+
+#: users/templates/users/captcha.html:7
+msgid "Time is up. Reload to try again."
+msgstr ""
+
+#: users/templates/users/captcha.html:23
+msgid "One quick check"
+msgstr ""
+
+#: users/templates/users/captcha.html:25
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
+msgstr ""
+
+#: users/templates/users/captcha.html:34 users/templates/users/captcha.html:36
+msgid "Item cover"
+msgstr ""
+
+#: users/templates/users/captcha.html:52
+#, python-format
+msgid "Move selected cover to %(label)s"
+msgstr ""
+
+#: users/templates/users/captcha.html:64
+msgid "Confirm"
+msgstr ""
+
+#: users/templates/users/captcha.html:72
+#, python-format
+msgid "Show me another set (%(counter)s left)"
+msgid_plural "Show me another set (%(counter)s left)"
+msgstr[0] ""
+msgstr[1] ""
 
 #: users/templates/users/crossposts.html:19
 msgid "Secure your account with a passkey for quick sign-in."
@@ -8265,31 +8354,52 @@ msgstr ""
 msgid "Passkey created"
 msgstr ""
 
-#: users/views/account.py:122
+#: users/views/account.py:124
 msgid "This username is already in use."
 msgstr ""
 
-#: users/views/account.py:133
+#: users/views/account.py:135
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:193
-msgid "Registration is for invitation only"
+#: users/views/account.py:242 users/views/account.py:301
+msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:229
-msgid "Username already taken. Please try again."
+#: users/views/account.py:243 users/views/account.py:275
+#: users/views/account.py:302
+msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:259
-msgid "Valid username required"
+#: users/views/account.py:277
+msgid "That is not quite right. Here is a new set."
+msgstr ""
+
+#: users/views/account.py:286
+msgid "Too many attempts"
+msgstr ""
+
+#: users/views/account.py:287
+msgid "Please try again later."
 msgstr ""
 
 #: users/views/account.py:337
+msgid "Registration is for invitation only"
+msgstr ""
+
+#: users/views/account.py:378
+msgid "Username already taken. Please try again."
+msgstr ""
+
+#: users/views/account.py:408
+msgid "Valid username required"
+msgstr ""
+
+#: users/views/account.py:489
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:340
+#: users/views/account.py:492
 msgid "Account mismatch."
 msgstr ""
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 11:41-0400\n"
+"POT-Creation-Date: 2026-08-23 15:40-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Remove my verification"
 msgstr ""
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:303
+#: catalog/templates/_verify_status.html:31 users/views/account.py:309
 msgid "Verification failed"
 msgstr ""
 
@@ -6345,6 +6345,7 @@ msgid ""
 msgstr ""
 
 #: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
@@ -6417,7 +6418,7 @@ msgstr ""
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:248 users/views/account.py:367
+#: users/views/account.py:254 users/views/account.py:373
 msgid "Authentication failed"
 msgstr ""
 
@@ -6445,7 +6446,7 @@ msgstr ""
 msgid "Invalid user."
 msgstr ""
 
-#: mastodon/views/common.py:52 users/views/account.py:408
+#: mastodon/views/common.py:52 users/views/account.py:414
 msgid "Registration failed"
 msgstr ""
 
@@ -7490,6 +7491,21 @@ msgid_plural "Show me another set (%(counter)s left)"
 msgstr[0] ""
 msgstr[1] ""
 
+#: users/templates/users/captcha_solved.html:30
+msgid "Nicely sorted"
+msgstr ""
+
+#: users/templates/users/captcha_solved.html:31
+msgid "That is all we needed. Let's get you a username."
+msgstr ""
+
+#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/login.html:63
+#: users/templates/users/verify_email.html:25
+#: users/templates/users/welcome.html:51
+msgid "Continue"
+msgstr ""
+
 #: users/templates/users/crossposts.html:19
 msgid "Secure your account with a passkey for quick sign-in."
 msgstr ""
@@ -7734,12 +7750,6 @@ msgstr ""
 
 #: users/templates/users/login.html:58
 msgid "logo"
-msgstr ""
-
-#: users/templates/users/login.html:63
-#: users/templates/users/verify_email.html:25
-#: users/templates/users/welcome.html:51
-msgid "Continue"
 msgstr ""
 
 #: users/templates/users/login.html:127
@@ -8362,44 +8372,44 @@ msgstr ""
 msgid "This email address is already in use."
 msgstr ""
 
-#: users/views/account.py:249 users/views/account.py:368
+#: users/views/account.py:255 users/views/account.py:374
 msgid "Registration is for invitation only"
 msgstr ""
 
-#: users/views/account.py:260 users/views/account.py:332
+#: users/views/account.py:266 users/views/account.py:338
 msgid "Time is up"
 msgstr ""
 
-#: users/views/account.py:261 users/views/account.py:304
-#: users/views/account.py:333
+#: users/views/account.py:267 users/views/account.py:310
+#: users/views/account.py:339
 msgid "Please log in again to continue registration."
 msgstr ""
 
-#: users/views/account.py:307
+#: users/views/account.py:313
 msgid "That is not quite right. Here is a new set."
 msgstr ""
 
-#: users/views/account.py:319
+#: users/views/account.py:325
 msgid "Too many attempts"
 msgstr ""
 
-#: users/views/account.py:320
+#: users/views/account.py:326
 msgid "Please try again later."
 msgstr ""
 
-#: users/views/account.py:409
+#: users/views/account.py:415
 msgid "Username already taken. Please try again."
 msgstr ""
 
-#: users/views/account.py:439
+#: users/views/account.py:445
 msgid "Valid username required"
 msgstr ""
 
-#: users/views/account.py:520
+#: users/views/account.py:526
 msgid "Account is being deleted."
 msgstr ""
 
-#: users/views/account.py:523
+#: users/views/account.py:529
 msgid "Account mismatch."
 msgstr ""
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 11:41-0400\n"
+"POT-Creation-Date: 2026-08-23 15:40-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1620,7 +1620,7 @@ msgstr "确定移除你的创作者验证吗？移除后任何人都可以再次
 msgid "Remove my verification"
 msgstr "移除我的验证"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:303
+#: catalog/templates/_verify_status.html:31 users/views/account.py:309
 msgid "Verification failed"
 msgstr "验证失败"
 
@@ -6413,6 +6413,7 @@ msgstr ""
 "{code}"
 
 #: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
@@ -6491,7 +6492,7 @@ msgstr "安全检查失败，请重试。"
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:248 users/views/account.py:367
+#: users/views/account.py:254 users/views/account.py:373
 msgid "Authentication failed"
 msgstr "认证失败"
 
@@ -6519,7 +6520,7 @@ msgstr "Bluesky返回了无效的账号数据。"
 msgid "Invalid user."
 msgstr "无效用户。"
 
-#: mastodon/views/common.py:52 users/views/account.py:408
+#: mastodon/views/common.py:52 users/views/account.py:414
 msgid "Registration failed"
 msgstr "注册失败"
 
@@ -7603,6 +7604,21 @@ msgid "Show me another set (%(counter)s left)"
 msgid_plural "Show me another set (%(counter)s left)"
 msgstr[0] "换一组（还剩 %(counter)s 次）"
 
+#: users/templates/users/captcha_solved.html:30
+msgid "Nicely sorted"
+msgstr "归类得很好"
+
+#: users/templates/users/captcha_solved.html:31
+msgid "That is all we needed. Let's get you a username."
+msgstr "这就够了，接下来选个用户名吧。"
+
+#: users/templates/users/captcha_solved.html:34
+#: users/templates/users/login.html:63
+#: users/templates/users/verify_email.html:25
+#: users/templates/users/welcome.html:51
+msgid "Continue"
+msgstr "继续"
+
 #: users/templates/users/crossposts.html:19
 msgid "Secure your account with a passkey for quick sign-in."
 msgstr "设置通行密钥，快速安全地登录。"
@@ -7848,12 +7864,6 @@ msgstr "登录"
 #: users/templates/users/login.html:58
 msgid "logo"
 msgstr "图标"
-
-#: users/templates/users/login.html:63
-#: users/templates/users/verify_email.html:25
-#: users/templates/users/welcome.html:51
-msgid "Continue"
-msgstr "继续"
 
 #: users/templates/users/login.html:127
 msgid "Sign in with a passkey saved on this device or in your password manager."
@@ -8481,44 +8491,44 @@ msgstr "用户名已被使用"
 msgid "This email address is already in use."
 msgstr "此电子邮件地址已被使用"
 
-#: users/views/account.py:249 users/views/account.py:368
+#: users/views/account.py:255 users/views/account.py:374
 msgid "Registration is for invitation only"
 msgstr "本站仅限邀请注册"
 
-#: users/views/account.py:260 users/views/account.py:332
+#: users/views/account.py:266 users/views/account.py:338
 msgid "Time is up"
 msgstr "时间已到"
 
-#: users/views/account.py:261 users/views/account.py:304
-#: users/views/account.py:333
+#: users/views/account.py:267 users/views/account.py:310
+#: users/views/account.py:339
 msgid "Please log in again to continue registration."
 msgstr "请重新登录以继续注册。"
 
-#: users/views/account.py:307
+#: users/views/account.py:313
 msgid "That is not quite right. Here is a new set."
 msgstr "不太对，换一组新的。"
 
-#: users/views/account.py:319
+#: users/views/account.py:325
 msgid "Too many attempts"
 msgstr "尝试次数过多"
 
-#: users/views/account.py:320
+#: users/views/account.py:326
 msgid "Please try again later."
 msgstr "请稍后再试。"
 
-#: users/views/account.py:409
+#: users/views/account.py:415
 msgid "Username already taken. Please try again."
 msgstr "用户名已被使用，请重试。"
 
-#: users/views/account.py:439
+#: users/views/account.py:445
 msgid "Valid username required"
 msgstr "请输入有效的用户名"
 
-#: users/views/account.py:520
+#: users/views/account.py:526
 msgid "Account is being deleted."
 msgstr "账户删除进行中。"
 
-#: users/views/account.py:523
+#: users/views/account.py:529
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 23:58-0400\n"
+"POT-Creation-Date: 2026-08-23 11:41-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1620,7 +1620,7 @@ msgstr "确定移除你的创作者验证吗？移除后任何人都可以再次
 msgid "Remove my verification"
 msgstr "移除我的验证"
 
-#: catalog/templates/_verify_status.html:31 users/views/account.py:274
+#: catalog/templates/_verify_status.html:31 users/views/account.py:303
 msgid "Verification failed"
 msgstr "验证失败"
 
@@ -3935,7 +3935,7 @@ msgstr "源代码"
 msgid "Registration"
 msgstr "注册"
 
-#: common/templates/common/about.html:35 common/views_manage.py:491
+#: common/templates/common/about.html:35 common/views_manage.py:493
 msgid "Invite Only"
 msgstr "仅限邀请"
 
@@ -3943,7 +3943,7 @@ msgstr "仅限邀请"
 msgid "Open Registration"
 msgstr "开放注册"
 
-#: common/templates/common/about.html:40 common/views_manage.py:554
+#: common/templates/common/about.html:40 common/views_manage.py:556
 msgid "Preferred Languages"
 msgstr "主要语言"
 
@@ -3999,7 +3999,7 @@ msgstr "正在请求摄像头权限…"
 msgid "Or type barcode / ISBN manually"
 msgstr "或手动输入条形码 / ISBN"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:626
+#: common/templates/common/scan.html:60 common/views_manage.py:628
 msgid "Search"
 msgstr "搜索"
 
@@ -4093,7 +4093,7 @@ msgstr "推荐"
 msgid "Access"
 msgstr "访问"
 
-#: common/views_manage.py:148 common/views_manage.py:621
+#: common/views_manage.py:148 common/views_manage.py:623
 msgid "Federation"
 msgstr "联邦"
 
@@ -4350,450 +4350,450 @@ msgstr "相似度构建器"
 msgid "Personalisation"
 msgstr "个性化"
 
-#: common/views_manage.py:493
+#: common/views_manage.py:495
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr "注册需要邀请令牌。可使用 neodb-manage invite --create 生成邀请令牌。"
 
-#: common/views_manage.py:498
+#: common/views_manage.py:500
 msgid "Enable Local-Only Posting"
 msgstr "启用仅本站可见帖文"
 
-#: common/views_manage.py:499
+#: common/views_manage.py:501
 msgid "Allow users to create posts visible only to local users."
 msgstr "允许用户创建仅本站用户可见的帖文。"
 
-#: common/views_manage.py:502
+#: common/views_manage.py:504
 msgid "Mastodon Login Whitelist"
 msgstr "Mastodon 登录白名单"
 
-#: common/views_manage.py:503
+#: common/views_manage.py:505
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr "每行一个域名。留空则允许任意实例。"
 
-#: common/views_manage.py:506
+#: common/views_manage.py:508
 msgid "Registration Captcha Items"
 msgstr "注册验证封面数量"
 
-#: common/views_manage.py:510
+#: common/views_manage.py:512
 msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
 msgstr "新用户在选择用户名之前，需要归类到两个分类行中的条目封面数量。设为 0 则关闭此验证；建议 5 到 6 个。封面不显示标题文字，因此无法通过屏幕阅读器完成：如果启用，请同时保留其他注册途径，例如邀请链接。"
 
-#: common/views_manage.py:518
+#: common/views_manage.py:520
 msgid "Registration Captcha Minimum Marks"
 msgstr "注册验证最少标记数"
 
-#: common/views_manage.py:521
+#: common/views_manage.py:523
 msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
 msgstr "一个条目需要多少标记，验证才认为它足够知名、可被辨认。此类条目过少的分类会改为从全部条目中选取。"
 
-#: common/views_manage.py:527
+#: common/views_manage.py:529
 msgid "Enable Mastodon Login"
 msgstr "启用 Mastodon 登录"
 
-#: common/views_manage.py:530
+#: common/views_manage.py:532
 msgid "Enable Bluesky Login"
 msgstr "启用 Bluesky 登录"
 
-#: common/views_manage.py:533
+#: common/views_manage.py:535
 msgid "Enable Threads Login"
 msgstr "启用 Threads 登录"
 
-#: common/views_manage.py:536
+#: common/views_manage.py:538
 msgid "Email URL"
 msgstr "邮件服务 URL"
 
-#: common/views_manage.py:538
+#: common/views_manage.py:540
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr "用于发送登录验证码的邮件后端 URL，例如 SMTP 或 Anymail URL。"
 
-#: common/views_manage.py:542
+#: common/views_manage.py:544
 msgid "Email From"
 msgstr "邮件发件人"
 
-#: common/views_manage.py:543
+#: common/views_manage.py:545
 msgid "Sender name and address for outgoing email."
 msgstr "外发邮件所使用的发件人名称和地址。"
 
-#: common/views_manage.py:546
+#: common/views_manage.py:548
 msgid "Default Language"
 msgstr "默认语言"
 
-#: common/views_manage.py:549
+#: common/views_manage.py:551
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr "访客以及未自行选择语言的用户所使用的界面语言。"
 
-#: common/views_manage.py:556
+#: common/views_manage.py:558
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr "语言代码，每行一个（如 en、zh、ja）。第一个为默认语言。"
 
-#: common/views_manage.py:562
+#: common/views_manage.py:564
 msgid "Access Control"
 msgstr "访问控制"
 
-#: common/views_manage.py:569
+#: common/views_manage.py:571
 msgid "Login Methods"
 msgstr "登录方式"
 
-#: common/views_manage.py:574 mastodon/models/common.py:28
+#: common/views_manage.py:576 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "电子邮件"
 
-#: common/views_manage.py:578
+#: common/views_manage.py:580
 msgid "Localization"
 msgstr "本地化"
 
-#: common/views_manage.py:589
+#: common/views_manage.py:591
 msgid "Disable Default Relay"
 msgstr "禁用默认中继"
 
-#: common/views_manage.py:591
+#: common/views_manage.py:593
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr "禁用 relay.neodb.net 联邦中继（用于跨实例共享公开评分）。"
 
-#: common/views_manage.py:596
+#: common/views_manage.py:598
 msgid "Fanout Limit (days)"
 msgstr "扩散范围（天）"
 
-#: common/views_manage.py:597
+#: common/views_manage.py:599
 msgid "Posts older than this many days will not be fanned out."
 msgstr "超过此天数的帖文将不再扩散投递。"
 
-#: common/views_manage.py:601
+#: common/views_manage.py:603
 msgid "Remote Prune Horizon (days)"
 msgstr "远端清理期限（天）"
 
-#: common/views_manage.py:603
+#: common/views_manage.py:605
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr "不活跃超过此天数的远端用户资料将被清理。"
 
-#: common/views_manage.py:608
+#: common/views_manage.py:610
 msgid "Search Sites"
 msgstr "搜索站点"
 
-#: common/views_manage.py:609
+#: common/views_manage.py:611
 msgid "External search sites to include, one per line."
 msgstr "要包含的外部搜索站点，每行一个。"
 
-#: common/views_manage.py:612
+#: common/views_manage.py:614
 msgid "Federated Search Peers"
 msgstr "联邦搜索节点"
 
-#: common/views_manage.py:613
+#: common/views_manage.py:615
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr "用于联邦搜索的 NeoDB 节点实例，每行一个。"
 
-#: common/views_manage.py:616
+#: common/views_manage.py:618
 msgid "Hidden Categories"
 msgstr "隐藏的分类"
 
-#: common/views_manage.py:617
+#: common/views_manage.py:619
 msgid "Category values to hide from the catalog, one per line."
 msgstr "在目录中隐藏的分类值，每行一个。"
 
-#: common/views_manage.py:638
+#: common/views_manage.py:640
 msgid "Spotify API Key"
 msgstr "Spotify API 密钥"
 
-#: common/views_manage.py:639
+#: common/views_manage.py:641
 msgid "https://developer.spotify.com/"
 msgstr "https://developer.spotify.com/"
 
-#: common/views_manage.py:642
+#: common/views_manage.py:644
 msgid "TMDB API Key"
 msgstr "TMDB API 密钥"
 
-#: common/views_manage.py:643
+#: common/views_manage.py:645
 msgid "https://developer.themoviedb.org/"
 msgstr "https://developer.themoviedb.org/"
 
-#: common/views_manage.py:646
+#: common/views_manage.py:648
 msgid "Google Books API Key"
 msgstr "Google Books API 密钥"
 
-#: common/views_manage.py:647
+#: common/views_manage.py:649
 msgid "https://developers.google.com/books/"
 msgstr "https://developers.google.com/books/"
 
-#: common/views_manage.py:650
+#: common/views_manage.py:652
 msgid "Discogs API Key"
 msgstr "Discogs API 密钥"
 
-#: common/views_manage.py:652
+#: common/views_manage.py:654
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr "来自 https://www.discogs.com/settings/developers 的个人访问令牌"
 
-#: common/views_manage.py:656
+#: common/views_manage.py:658
 msgid "IGDB Client ID"
 msgstr "IGDB 客户端 ID"
 
-#: common/views_manage.py:657
+#: common/views_manage.py:659
 msgid "https://api-docs.igdb.com/"
 msgstr "https://api-docs.igdb.com/"
 
-#: common/views_manage.py:660
+#: common/views_manage.py:662
 msgid "IGDB Client Secret"
 msgstr "IGDB 客户端密钥"
 
-#: common/views_manage.py:663
+#: common/views_manage.py:665
 msgid "BoardGameGeek API Token"
 msgstr "BoardGameGeek API 令牌"
 
-#: common/views_manage.py:665
+#: common/views_manage.py:667
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr "来自 https://boardgamegeek.com/applications 的 Bearer 令牌（参见 https://boardgamegeek.com/using_the_xml_api#toc9）。"
 
-#: common/views_manage.py:670 users/templates/users/steam_import.html:26
+#: common/views_manage.py:672 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr "Steam API 密钥"
 
-#: common/views_manage.py:672
+#: common/views_manage.py:674
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr "https://steamcommunity.com/dev - Steam 导入器的备用密钥。用户可在导入时提供自己的密钥。"
 
-#: common/views_manage.py:677
+#: common/views_manage.py:679
 msgid "DeepL API Key"
 msgstr "DeepL API 密钥"
 
-#: common/views_manage.py:678
+#: common/views_manage.py:680
 msgid "For translation features."
 msgstr "用于翻译功能。"
 
-#: common/views_manage.py:681
+#: common/views_manage.py:683
 msgid "LibreTranslate API URL"
 msgstr "LibreTranslate API URL"
 
-#: common/views_manage.py:684
+#: common/views_manage.py:686
 msgid "LibreTranslate API Key"
 msgstr "LibreTranslate API 密钥"
 
-#: common/views_manage.py:687
+#: common/views_manage.py:689
 msgid "Threads App ID"
 msgstr "Threads 应用 ID"
 
-#: common/views_manage.py:688
+#: common/views_manage.py:690
 msgid "OAuth app ID for Threads login."
 msgstr "用于 Threads 登录的 OAuth 应用 ID。"
 
-#: common/views_manage.py:691
+#: common/views_manage.py:693
 msgid "Threads App Secret"
 msgstr "Threads 应用密钥"
 
-#: common/views_manage.py:694
+#: common/views_manage.py:696
 msgid "Discord Webhooks"
 msgstr "Discord Webhook"
 
-#: common/views_manage.py:696
+#: common/views_manage.py:698
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr "按频道（default、report、audit、suggest、system）映射的 Webhook URL。所有频道必须是 Discord 论坛或媒体频道（线程模式），因为通知以线程形式发布。"
 
-#: common/views_manage.py:713
+#: common/views_manage.py:715
 msgid "Catalog APIs"
 msgstr "目录 API"
 
-#: common/views_manage.py:723
+#: common/views_manage.py:725
 msgid "Translation"
 msgstr "翻译"
 
-#: common/views_manage.py:728
+#: common/views_manage.py:730
 msgid "Third-Party Login"
 msgstr "第三方登录"
 
-#: common/views_manage.py:732 social/templates/feed.html:27
+#: common/views_manage.py:734 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "通知"
 
-#: common/views_manage.py:742
+#: common/views_manage.py:744
 msgid "Scraping Providers"
 msgstr "抓取服务"
 
-#: common/views_manage.py:743
+#: common/views_manage.py:745
 msgid "Comma-separated list of providers to try in order."
 msgstr "按顺序尝试的服务列表，以逗号分隔。"
 
-#: common/views_manage.py:746
+#: common/views_manage.py:748
 msgid "Proxy List"
 msgstr "代理列表"
 
-#: common/views_manage.py:747
+#: common/views_manage.py:749
 msgid "One per line, format: http://server?url=__URL__"
 msgstr "每行一个，格式：http://server?url=__URL__"
 
-#: common/views_manage.py:750
+#: common/views_manage.py:752
 msgid "Backup Proxy"
 msgstr "备用代理"
 
-#: common/views_manage.py:753
+#: common/views_manage.py:755
 msgid "Scrapfly API Key"
 msgstr "Scrapfly API 密钥"
 
-#: common/views_manage.py:756
+#: common/views_manage.py:758
 msgid "Decodo Base64 Auth Token"
 msgstr "Decodo Base64 鉴权令牌"
 
-#: common/views_manage.py:759
+#: common/views_manage.py:761
 msgid "ScraperAPI Key"
 msgstr "ScraperAPI 密钥"
 
-#: common/views_manage.py:762
+#: common/views_manage.py:764
 msgid "ScrapingBee API Key"
 msgstr "ScrapingBee API 密钥"
 
-#: common/views_manage.py:765
+#: common/views_manage.py:767
 msgid "Custom Scraper URL"
 msgstr "自定义抓取器 URL"
 
-#: common/views_manage.py:766
+#: common/views_manage.py:768
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr "包含 __URL__ 和 __SELECTOR__ 占位符的 URL。"
 
-#: common/views_manage.py:769
+#: common/views_manage.py:771
 msgid "Request Timeout (seconds)"
 msgstr "请求超时（秒）"
 
-#: common/views_manage.py:773
+#: common/views_manage.py:775
 msgid "Cache Timeout (seconds)"
 msgstr "缓存超时（秒）"
 
-#: common/views_manage.py:777
+#: common/views_manage.py:779
 msgid "Retries"
 msgstr "重试次数"
 
-#: common/views_manage.py:782
+#: common/views_manage.py:784
 msgid "Providers"
 msgstr "服务"
 
-#: common/views_manage.py:787
+#: common/views_manage.py:789
 msgid "Provider Keys"
 msgstr "服务密钥"
 
-#: common/views_manage.py:794
+#: common/views_manage.py:796
 msgid "Timeouts"
 msgstr "超时设置"
 
-#: common/views_manage.py:806
+#: common/views_manage.py:808
 msgid "Alternative Domains"
 msgstr "备用域名"
 
-#: common/views_manage.py:807
+#: common/views_manage.py:809
 msgid "One domain per line."
 msgstr "每行一个域名。"
 
-#: common/views_manage.py:810
+#: common/views_manage.py:812
 msgid "Mastodon Client Scope"
 msgstr "Mastodon 客户端授权范围"
 
-#: common/views_manage.py:811
+#: common/views_manage.py:813
 msgid "OAuth scope when creating Mastodon apps."
 msgstr "创建 Mastodon 应用时使用的 OAuth 授权范围。"
 
-#: common/views_manage.py:814
+#: common/views_manage.py:816
 msgid "Mastodon API Timeout (seconds)"
 msgstr "Mastodon API 超时（秒）"
 
-#: common/views_manage.py:816
+#: common/views_manage.py:818
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr "请求 Mastodon 实例及远程联邦宇宙服务器的超时时间。"
 
-#: common/views_manage.py:822
+#: common/views_manage.py:824
 msgid "Disable Cron Jobs"
 msgstr "禁用定时任务"
 
-#: common/views_manage.py:823
+#: common/views_manage.py:825
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr "要禁用的任务名，每行一个。使用 * 禁用所有任务。"
 
-#: common/views_manage.py:826
+#: common/views_manage.py:828
 msgid "Index Aliases"
 msgstr "索引别名"
 
-#: common/views_manage.py:827
+#: common/views_manage.py:829
 msgid "Map index names to their aliases."
 msgstr "索引名称到别名的映射。"
 
-#: common/views_manage.py:837
+#: common/views_manage.py:839
 msgid "Task Cleanup (days)"
 msgstr "任务清理（天）"
 
-#: common/views_manage.py:839
+#: common/views_manage.py:841
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr "在此天数后删除导入/导出任务及其文件。设为 0 则禁用清理。"
 
-#: common/views_manage.py:845
+#: common/views_manage.py:847
 msgid "Skip Migration Jobs"
 msgstr "跳过迁移任务"
 
-#: common/views_manage.py:847
+#: common/views_manage.py:849
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr "要跳过的迁移后任务键，每行一个（如 normalize_genre）。worker 在出队时检查；被跳过的任务会记录警告并通知 Discord system 频道。"
 
-#: common/views_manage.py:853
+#: common/views_manage.py:855
 msgid "ATProto OAuth Client Key"
 msgstr "ATProto OAuth 客户端密钥"
 
-#: common/views_manage.py:855
+#: common/views_manage.py:857
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr "用于向 ATProto 授权服务器标识本站点的私钥（JWK 格式）。首次 Bluesky 登录时自动生成；清空后将重新生成。"
 
-#: common/views_manage.py:862
+#: common/views_manage.py:864
 msgid "Domains"
 msgstr "域名"
 
-#: common/views_manage.py:865
+#: common/views_manage.py:867
 msgid "Operational"
 msgstr "运维"
 
-#: common/views_manage.py:881
+#: common/views_manage.py:883
 msgid "Movie Genres"
 msgstr "电影类型"
 
-#: common/views_manage.py:883
+#: common/views_manage.py:885
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "电影编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:888
+#: common/views_manage.py:890
 msgid "TV Genres"
 msgstr "剧集类型"
 
-#: common/views_manage.py:890
+#: common/views_manage.py:892
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "剧集编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:895
+#: common/views_manage.py:897
 msgid "Music Genres"
 msgstr "音乐类型"
 
-#: common/views_manage.py:897
+#: common/views_manage.py:899
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "音乐编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:902
+#: common/views_manage.py:904
 msgid "Game Genres"
 msgstr "游戏类型"
 
-#: common/views_manage.py:904
+#: common/views_manage.py:906
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "游戏编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:909
+#: common/views_manage.py:911
 msgid "Podcast Genres"
 msgstr "播客类型"
 
-#: common/views_manage.py:911
+#: common/views_manage.py:913
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "播客编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:916
+#: common/views_manage.py:918
 msgid "Performance Genres"
 msgstr "演出类型"
 
-#: common/views_manage.py:918
+#: common/views_manage.py:920
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:924
+#: common/views_manage.py:926
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
@@ -6491,7 +6491,7 @@ msgstr "安全检查失败，请重试。"
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:336
+#: users/views/account.py:248 users/views/account.py:367
 msgid "Authentication failed"
 msgstr "认证失败"
 
@@ -6519,7 +6519,7 @@ msgstr "Bluesky返回了无效的账号数据。"
 msgid "Invalid user."
 msgstr "无效用户。"
 
-#: mastodon/views/common.py:52 users/views/account.py:377
+#: mastodon/views/common.py:52 users/views/account.py:408
 msgid "Registration failed"
 msgstr "注册失败"
 
@@ -7576,28 +7576,28 @@ msgstr "已选中封面，请选择分类行。"
 msgid "Time is up. Reload to try again."
 msgstr "时间已到，请重新载入后再试。"
 
-#: users/templates/users/captcha.html:23
+#: users/templates/users/captcha.html:26
 msgid "One quick check"
 msgstr "简单验证一下"
 
-#: users/templates/users/captcha.html:25
+#: users/templates/users/captcha.html:28
 msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
 msgstr "请把每个封面放进它所属的分类行。可以直接拖动，也可以先选中封面再选择分类行。"
 
-#: users/templates/users/captcha.html:34 users/templates/users/captcha.html:36
+#: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
 msgid "Item cover"
 msgstr "条目封面"
 
-#: users/templates/users/captcha.html:52
+#: users/templates/users/captcha.html:59
 #, python-format
 msgid "Move selected cover to %(label)s"
 msgstr "把选中的封面移到%(label)s"
 
-#: users/templates/users/captcha.html:64
+#: users/templates/users/captcha.html:77
 msgid "Confirm"
 msgstr "确认"
 
-#: users/templates/users/captcha.html:72
+#: users/templates/users/captcha.html:84
 #, python-format
 msgid "Show me another set (%(counter)s left)"
 msgid_plural "Show me another set (%(counter)s left)"
@@ -8481,44 +8481,44 @@ msgstr "用户名已被使用"
 msgid "This email address is already in use."
 msgstr "此电子邮件地址已被使用"
 
-#: users/views/account.py:242 users/views/account.py:301
-msgid "Time is up"
-msgstr "时间已到"
-
-#: users/views/account.py:243 users/views/account.py:275
-#: users/views/account.py:302
-msgid "Please log in again to continue registration."
-msgstr "请重新登录以继续注册。"
-
-#: users/views/account.py:277
-msgid "That is not quite right. Here is a new set."
-msgstr "不太对，换一组新的。"
-
-#: users/views/account.py:286
-msgid "Too many attempts"
-msgstr "尝试次数过多"
-
-#: users/views/account.py:287
-msgid "Please try again later."
-msgstr "请稍后再试。"
-
-#: users/views/account.py:337
+#: users/views/account.py:249 users/views/account.py:368
 msgid "Registration is for invitation only"
 msgstr "本站仅限邀请注册"
 
-#: users/views/account.py:378
+#: users/views/account.py:260 users/views/account.py:332
+msgid "Time is up"
+msgstr "时间已到"
+
+#: users/views/account.py:261 users/views/account.py:304
+#: users/views/account.py:333
+msgid "Please log in again to continue registration."
+msgstr "请重新登录以继续注册。"
+
+#: users/views/account.py:307
+msgid "That is not quite right. Here is a new set."
+msgstr "不太对，换一组新的。"
+
+#: users/views/account.py:319
+msgid "Too many attempts"
+msgstr "尝试次数过多"
+
+#: users/views/account.py:320
+msgid "Please try again later."
+msgstr "请稍后再试。"
+
+#: users/views/account.py:409
 msgid "Username already taken. Please try again."
 msgstr "用户名已被使用，请重试。"
 
-#: users/views/account.py:408
+#: users/views/account.py:439
 msgid "Valid username required"
 msgstr "请输入有效的用户名"
 
-#: users/views/account.py:489
+#: users/views/account.py:520
 msgid "Account is being deleted."
 msgstr "账户删除进行中。"
 
-#: users/views/account.py:492
+#: users/views/account.py:523
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 22:51-0400\n"
+"POT-Creation-Date: 2026-08-22 23:58-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -1620,7 +1620,7 @@ msgstr "确定移除你的创作者验证吗？移除后任何人都可以再次
 msgid "Remove my verification"
 msgstr "移除我的验证"
 
-#: catalog/templates/_verify_status.html:31
+#: catalog/templates/_verify_status.html:31 users/views/account.py:274
 msgid "Verification failed"
 msgstr "验证失败"
 
@@ -1688,12 +1688,12 @@ msgid "Item has been marked by users."
 msgstr "条目已被用户标记过。"
 
 #: catalog/templates/catalog_delete.html:48
-#: catalog/templates/catalog_merge.html:92 common/views_manage.py:50
+#: catalog/templates/catalog_merge.html:92 common/views_manage.py:51
 msgid "Yes"
 msgstr "是"
 
 #: catalog/templates/catalog_delete.html:49
-#: catalog/templates/catalog_merge.html:93 common/views_manage.py:50
+#: catalog/templates/catalog_merge.html:93 common/views_manage.py:51
 msgid "No"
 msgstr "否"
 
@@ -1799,8 +1799,8 @@ msgstr "发送反馈"
 msgid "Questions or issues with creator verification? Let the site moderators know."
 msgstr "对创作者验证有疑问或遇到问题？请告知站点管理员。"
 
-#: catalog/templates/discover.html:28 common/views_manage.py:144
-#: common/views_manage.py:352 users/templates/users/preferences.html:34
+#: catalog/templates/discover.html:28 common/views_manage.py:145
+#: common/views_manage.py:353 users/templates/users/preferences.html:34
 msgid "Discover"
 msgstr "发现"
 
@@ -2283,7 +2283,7 @@ msgstr "验证已在进行中。"
 msgid "Please wait a moment before trying again."
 msgstr "重试前请稍等。"
 
-#: catalog/views/verify.py:164 common/utils.py:109 common/utils.py:150
+#: catalog/views/verify.py:164 common/utils.py:122 common/utils.py:163
 #: journal/views/article.py:186 journal/views/review.py:182
 #: users/views/actions.py:45 users/views/actions.py:131
 msgid "User not found"
@@ -3935,7 +3935,7 @@ msgstr "源代码"
 msgid "Registration"
 msgstr "注册"
 
-#: common/templates/common/about.html:35 common/views_manage.py:490
+#: common/templates/common/about.html:35 common/views_manage.py:491
 msgid "Invite Only"
 msgstr "仅限邀请"
 
@@ -3943,7 +3943,7 @@ msgstr "仅限邀请"
 msgid "Open Registration"
 msgstr "开放注册"
 
-#: common/templates/common/about.html:40 common/views_manage.py:532
+#: common/templates/common/about.html:40 common/views_manage.py:554
 msgid "Preferred Languages"
 msgstr "主要语言"
 
@@ -3999,7 +3999,7 @@ msgstr "正在请求摄像头权限…"
 msgid "Or type barcode / ISBN manually"
 msgstr "或手动输入条形码 / ISBN"
 
-#: common/templates/common/scan.html:60 common/views_manage.py:602
+#: common/templates/common/scan.html:60 common/views_manage.py:626
 msgid "Search"
 msgstr "搜索"
 
@@ -4067,717 +4067,733 @@ msgstr "你"
 msgid "unavailable"
 msgstr "不可用"
 
-#: common/utils.py:113 common/utils.py:154 users/views/actions.py:134
+#: common/utils.py:126 common/utils.py:167 users/views/actions.py:134
 msgid "User no longer exists"
 msgstr "用户不存在了"
 
-#: common/utils.py:120 common/utils.py:122 common/utils.py:125
-#: common/utils.py:161 common/utils.py:165 journal/views/profile.py:499
+#: common/utils.py:133 common/utils.py:135 common/utils.py:138
+#: common/utils.py:174 common/utils.py:178 journal/views/profile.py:499
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: common/utils.py:128 common/utils.py:130 journal/views/article.py:204
+#: common/utils.py:141 common/utils.py:143 journal/views/article.py:204
 #: journal/views/profile.py:540 journal/views/review.py:200
 msgid "Login required"
 msgstr "登录后访问"
 
-#: common/views_manage.py:143 common/views_manage.py:294
+#: common/views_manage.py:144 common/views_manage.py:295
 msgid "Branding"
 msgstr "品牌"
 
-#: common/views_manage.py:145
+#: common/views_manage.py:146
 msgid "Recommendations"
 msgstr "推荐"
 
-#: common/views_manage.py:146
+#: common/views_manage.py:147
 msgid "Access"
 msgstr "访问"
 
-#: common/views_manage.py:147 common/views_manage.py:597
+#: common/views_manage.py:148 common/views_manage.py:621
 msgid "Federation"
 msgstr "联邦"
 
-#: common/views_manage.py:148
+#: common/views_manage.py:149
 msgid "Catalog"
 msgstr "目录"
 
-#: common/views_manage.py:149
+#: common/views_manage.py:150
 msgid "API Keys"
 msgstr "API 密钥"
 
-#: common/views_manage.py:150
+#: common/views_manage.py:151
 msgid "Downloader"
 msgstr "下载器"
 
-#: common/views_manage.py:151 common/views_manage.py:302
+#: common/views_manage.py:152 common/views_manage.py:303
 #: users/templates/users/steam_import.html:113
 msgid "Advanced"
 msgstr "高级"
 
-#: common/views_manage.py:201
+#: common/views_manage.py:202
 msgid "Invalid value."
 msgstr "无效值。"
 
-#: common/views_manage.py:205
+#: common/views_manage.py:206
 msgid "Invalid configuration. Please check your input."
 msgstr "配置无效"
 
-#: common/views_manage.py:210
+#: common/views_manage.py:211
 msgid "Settings have been saved."
 msgstr "设置已保存"
 
-#: common/views_manage.py:230
+#: common/views_manage.py:231
 msgid "Site Name"
 msgstr "站点名称"
 
-#: common/views_manage.py:233
+#: common/views_manage.py:234
 msgid "Site Description"
 msgstr "站点描述"
 
-#: common/views_manage.py:234
+#: common/views_manage.py:235
 msgid "Short description shown in metadata and about page."
 msgstr "在元数据和关于页面中显示的简短描述。"
 
-#: common/views_manage.py:237
+#: common/views_manage.py:238
 msgid "Site Logo URL"
 msgstr "站点 Logo URL"
 
-#: common/views_manage.py:238
+#: common/views_manage.py:239
 msgid "URL path to the site logo image."
 msgstr "站点 Logo 图片的 URL 路径。"
 
-#: common/views_manage.py:241
+#: common/views_manage.py:242
 msgid "Site Icon URL"
 msgstr "站点图标 URL"
 
-#: common/views_manage.py:242
+#: common/views_manage.py:243
 msgid "URL path to the site icon/favicon."
 msgstr "站点图标/favicon 的 URL 路径。"
 
-#: common/views_manage.py:245
+#: common/views_manage.py:246
 msgid "Default User Avatar URL"
 msgstr "默认用户头像 URL"
 
-#: common/views_manage.py:246
+#: common/views_manage.py:247
 msgid "URL path to the default user avatar."
 msgstr "默认用户头像的 URL 路径。"
 
-#: common/views_manage.py:249
+#: common/views_manage.py:250
 msgid "Site Color Theme"
 msgstr "站点配色主题"
 
-#: common/views_manage.py:250
+#: common/views_manage.py:251
 msgid "PicoCSS color theme."
 msgstr "PicoCSS 配色主题。"
 
-#: common/views_manage.py:275
+#: common/views_manage.py:276
 msgid "Site Introduction"
 msgstr "站点介绍"
 
-#: common/views_manage.py:276
+#: common/views_manage.py:277
 msgid "URL path for the intro/welcome sidebar page."
 msgstr "介绍/欢迎侧边栏页面的 URL 路径。"
 
-#: common/views_manage.py:279
+#: common/views_manage.py:280
 msgid "Custom HTML Head"
 msgstr "自定义 HTML Head"
 
-#: common/views_manage.py:280
+#: common/views_manage.py:281
 msgid "Extra HTML injected into the <head> of all pages."
 msgstr "注入所有页面 <head> 的额外 HTML。"
 
-#: common/views_manage.py:284
+#: common/views_manage.py:285
 msgid "Footer Links"
 msgstr "页脚链接"
 
-#: common/views_manage.py:285
+#: common/views_manage.py:286
 msgid "Link title mapped to URL."
 msgstr "链接标题到 URL 的映射。"
 
-#: common/views_manage.py:314
+#: common/views_manage.py:315
 msgid "Minimum Marks for Discover"
 msgstr "进入发现页的最少标记数"
 
-#: common/views_manage.py:316
+#: common/views_manage.py:317
 msgid "Number of marks required for an item to appear in discover."
 msgstr "条目出现在发现页所需的最少标记数。"
 
-#: common/views_manage.py:321
+#: common/views_manage.py:322
 msgid "Update Interval (minutes)"
 msgstr "更新间隔（分钟）"
 
-#: common/views_manage.py:322
+#: common/views_manage.py:323
 msgid "How often to refresh the popular items list."
 msgstr "刷新热门条目列表的频率。"
 
-#: common/views_manage.py:326
+#: common/views_manage.py:327
 msgid "Filter by Preferred Languages"
 msgstr "按偏好语言过滤"
 
-#: common/views_manage.py:327
+#: common/views_manage.py:328
 msgid "Only show items with titles in the preferred languages."
 msgstr "仅显示标题为偏好语言的条目。"
 
-#: common/views_manage.py:330
+#: common/views_manage.py:331
 msgid "Show Local Only"
 msgstr "仅显示本站内容"
 
-#: common/views_manage.py:332
+#: common/views_manage.py:333
 msgid "Only show items marked by local users, not the entire network."
 msgstr "仅显示本站用户标记的条目，而非整个联邦网络。"
 
-#: common/views_manage.py:336
+#: common/views_manage.py:337
 msgid "Show Popular Posts"
 msgstr "显示热门帖文"
 
-#: common/views_manage.py:337
+#: common/views_manage.py:338
 msgid "Show popular public posts instead of recent ones."
 msgstr "显示热门公开帖文，而非最近的帖文。"
 
-#: common/views_manage.py:340
+#: common/views_manage.py:341
 msgid "Show Popular Tags"
 msgstr "显示热门标签"
 
-#: common/views_manage.py:341
+#: common/views_manage.py:342
 msgid "Show popular public tags on the discover page."
 msgstr "在发现页显示热门公开标签。"
 
-#: common/views_manage.py:344
+#: common/views_manage.py:345
 msgid "Show Verified Podcasts"
 msgstr "显示已验证播客"
 
-#: common/views_manage.py:346
+#: common/views_manage.py:347
 msgid "Show a shelf of recent episodes from podcasts with a verified creator on the discover page."
 msgstr "在发现页显示一个货架，展示拥有已验证创作者的播客的最新单集。"
 
-#: common/views_manage.py:385
+#: common/views_manage.py:386
 msgid "Enable Recommendations"
 msgstr "启用推荐"
 
-#: common/views_manage.py:387
+#: common/views_manage.py:388
 msgid "Master switch. When off, all recommendation surfaces are hidden and the cron jobs are not scheduled."
 msgstr "推荐功能总开关。关闭时，所有推荐界面都会被隐藏，相关定时任务也不会被调度。"
 
-#: common/views_manage.py:392
+#: common/views_manage.py:393
 msgid "Source Item Mark Threshold"
 msgstr "源条目标记阈值"
 
-#: common/views_manage.py:394
+#: common/views_manage.py:395
 msgid "Minimum public marks an item needs before similarity rows are built for it."
 msgstr "为某条目构建相似条目所需的最少公开标记数。"
 
-#: common/views_manage.py:400
+#: common/views_manage.py:401
 msgid "Target Item Mark Threshold"
 msgstr "目标条目标记阈值"
 
-#: common/views_manage.py:402
+#: common/views_manage.py:403
 msgid "Minimum public marks an item needs to be eligible as a recommendation target."
 msgstr "条目作为推荐目标所需的最少公开标记数。"
 
-#: common/views_manage.py:408
+#: common/views_manage.py:409
 msgid "Top-K Similar Items per Source"
 msgstr "每个源条目的最相似条目数 (Top-K)"
 
-#: common/views_manage.py:409
+#: common/views_manage.py:410
 msgid "Number of similar items stored per source item."
 msgstr "每个源条目保存的相似条目数量。"
 
-#: common/views_manage.py:413
+#: common/views_manage.py:414
 msgid "Top-N Recommendations per User"
 msgstr "每位用户的推荐条目数 (Top-N)"
 
-#: common/views_manage.py:414
+#: common/views_manage.py:415
 msgid "Number of personalised rows stored per user."
 msgstr "每位用户保存的个性化推荐数量。"
 
-#: common/views_manage.py:418
+#: common/views_manage.py:419
 msgid "Dampen Heavy Shelvers"
 msgstr "抑制高频标记用户"
 
-#: common/views_manage.py:420
+#: common/views_manage.py:421
 msgid "Weight each user's contribution by 1/sqrt(n_marks) to neutralise mega-shelvers in similarity scoring."
 msgstr "对每位用户的贡献按 1/sqrt(n_marks) 加权，以削弱超大量标记用户对相似度评分的影响。"
 
-#: common/views_manage.py:425
+#: common/views_manage.py:426
 msgid "Per-User Mark Cap (training)"
 msgstr "每用户标记上限（训练）"
 
-#: common/views_manage.py:427
+#: common/views_manage.py:428
 msgid "Truncate each user's contribution to their N most recent marks when building the similarity matrix."
 msgstr "构建相似度矩阵时，仅截取每位用户最近的 N 条标记。"
 
-#: common/views_manage.py:433
+#: common/views_manage.py:434
 msgid "Active-User Window (days)"
 msgstr "活跃用户窗口（天）"
 
-#: common/views_manage.py:435
+#: common/views_manage.py:436
 msgid "Refresh personalised recommendations for users with at least one public mark in the last N days."
 msgstr "为最近 N 天内至少有一条公开标记的用户刷新个性化推荐。"
 
-#: common/views_manage.py:441
+#: common/views_manage.py:442
 msgid "Per-User Seed Cap (serving)"
 msgstr "每用户种子标记上限（投递）"
 
-#: common/views_manage.py:443
+#: common/views_manage.py:444
 msgid "Number of recent marks used as seeds when scoring personalised recommendations for one user."
 msgstr "为单个用户计算个性化推荐时，用作种子的最近标记数量。"
 
-#: common/views_manage.py:449
+#: common/views_manage.py:450
 msgid "Lazy Refresh TTL (days)"
 msgstr "懒刷新 TTL（天）"
 
-#: common/views_manage.py:451
+#: common/views_manage.py:452
 msgid "How long cached on-demand recommendations are valid before the next request triggers a refresh."
 msgstr "按需推荐缓存的有效期，过期后下一次请求会触发刷新。"
 
-#: common/views_manage.py:457
+#: common/views_manage.py:458
 msgid "Circles Window (days)"
 msgstr "好友圈窗口（天）"
 
-#: common/views_manage.py:459
+#: common/views_manage.py:460
 msgid "Look back N days when finding items recently marked by people the viewer follows."
 msgstr "回溯 N 天，查找浏览者关注的用户最近标记过的条目。"
 
-#: common/views_manage.py:466
+#: common/views_manage.py:467
 msgid "Master Switch"
 msgstr "总开关"
 
-#: common/views_manage.py:469
+#: common/views_manage.py:470
 msgid "Similarity Builder"
 msgstr "相似度构建器"
 
-#: common/views_manage.py:476
+#: common/views_manage.py:477
 msgid "Personalisation"
 msgstr "个性化"
 
-#: common/views_manage.py:492
+#: common/views_manage.py:493
 msgid "Require an invite token to register. Invite tokens can be generated with neodb-manage invite --create."
 msgstr "注册需要邀请令牌。可使用 neodb-manage invite --create 生成邀请令牌。"
 
-#: common/views_manage.py:497
+#: common/views_manage.py:498
 msgid "Enable Local-Only Posting"
 msgstr "启用仅本站可见帖文"
 
-#: common/views_manage.py:498
+#: common/views_manage.py:499
 msgid "Allow users to create posts visible only to local users."
 msgstr "允许用户创建仅本站用户可见的帖文。"
 
-#: common/views_manage.py:501
+#: common/views_manage.py:502
 msgid "Mastodon Login Whitelist"
 msgstr "Mastodon 登录白名单"
 
-#: common/views_manage.py:502
+#: common/views_manage.py:503
 msgid "One domain per line. Leave empty to allow any instance."
 msgstr "每行一个域名。留空则允许任意实例。"
 
-#: common/views_manage.py:505
+#: common/views_manage.py:506
+msgid "Registration Captcha Items"
+msgstr "注册验证封面数量"
+
+#: common/views_manage.py:510
+msgid "Number of item covers a new user must sort into two category rows before choosing a username. 0 disables the captcha; 5-6 is recommended. The covers carry no title text, so this cannot be solved with a screen reader: if you enable it, keep another way in, such as an invite link."
+msgstr "新用户在选择用户名之前，需要归类到两个分类行中的条目封面数量。设为 0 则关闭此验证；建议 5 到 6 个。封面不显示标题文字，因此无法通过屏幕阅读器完成：如果启用，请同时保留其他注册途径，例如邀请链接。"
+
+#: common/views_manage.py:518
+msgid "Registration Captcha Minimum Marks"
+msgstr "注册验证最少标记数"
+
+#: common/views_manage.py:521
+msgid "Marks an item needs before the captcha treats it as well known enough to be recognizable. Categories with too few such items fall back to any item."
+msgstr "一个条目需要多少标记，验证才认为它足够知名、可被辨认。此类条目过少的分类会改为从全部条目中选取。"
+
+#: common/views_manage.py:527
 msgid "Enable Mastodon Login"
 msgstr "启用 Mastodon 登录"
 
-#: common/views_manage.py:508
+#: common/views_manage.py:530
 msgid "Enable Bluesky Login"
 msgstr "启用 Bluesky 登录"
 
-#: common/views_manage.py:511
+#: common/views_manage.py:533
 msgid "Enable Threads Login"
 msgstr "启用 Threads 登录"
 
-#: common/views_manage.py:514
+#: common/views_manage.py:536
 msgid "Email URL"
 msgstr "邮件服务 URL"
 
-#: common/views_manage.py:516
+#: common/views_manage.py:538
 msgid "Email backend URL for login codes, such as an SMTP or Anymail URL."
 msgstr "用于发送登录验证码的邮件后端 URL，例如 SMTP 或 Anymail URL。"
 
-#: common/views_manage.py:520
+#: common/views_manage.py:542
 msgid "Email From"
 msgstr "邮件发件人"
 
-#: common/views_manage.py:521
+#: common/views_manage.py:543
 msgid "Sender name and address for outgoing email."
 msgstr "外发邮件所使用的发件人名称和地址。"
 
-#: common/views_manage.py:524
+#: common/views_manage.py:546
 msgid "Default Language"
 msgstr "默认语言"
 
-#: common/views_manage.py:527
+#: common/views_manage.py:549
 msgid "Interface language for visitors and for users who have not chosen one themselves."
 msgstr "访客以及未自行选择语言的用户所使用的界面语言。"
 
-#: common/views_manage.py:534
+#: common/views_manage.py:556
 msgid "Language codes, one per line (e.g. en, zh, ja). First language is the default."
 msgstr "语言代码，每行一个（如 en、zh、ja）。第一个为默认语言。"
 
-#: common/views_manage.py:540
+#: common/views_manage.py:562
 msgid "Access Control"
 msgstr "访问控制"
 
-#: common/views_manage.py:545
+#: common/views_manage.py:569
 msgid "Login Methods"
 msgstr "登录方式"
 
-#: common/views_manage.py:550 mastodon/models/common.py:28
+#: common/views_manage.py:574 mastodon/models/common.py:28
 #: users/templates/users/account.html:45 users/templates/users/account.html:55
 #: users/templates/users/login.html:76
 msgid "Email"
 msgstr "电子邮件"
 
-#: common/views_manage.py:554
+#: common/views_manage.py:578
 msgid "Localization"
 msgstr "本地化"
 
-#: common/views_manage.py:565
+#: common/views_manage.py:589
 msgid "Disable Default Relay"
 msgstr "禁用默认中继"
 
-#: common/views_manage.py:567
+#: common/views_manage.py:591
 msgid "Disable relay.neodb.net federation for sharing public ratings across instances."
 msgstr "禁用 relay.neodb.net 联邦中继（用于跨实例共享公开评分）。"
 
-#: common/views_manage.py:572
+#: common/views_manage.py:596
 msgid "Fanout Limit (days)"
 msgstr "扩散范围（天）"
 
-#: common/views_manage.py:573
+#: common/views_manage.py:597
 msgid "Posts older than this many days will not be fanned out."
 msgstr "超过此天数的帖文将不再扩散投递。"
 
-#: common/views_manage.py:577
+#: common/views_manage.py:601
 msgid "Remote Prune Horizon (days)"
 msgstr "远端清理期限（天）"
 
-#: common/views_manage.py:579
+#: common/views_manage.py:603
 msgid "Remote profiles inactive for this many days will be pruned."
 msgstr "不活跃超过此天数的远端用户资料将被清理。"
 
-#: common/views_manage.py:584
+#: common/views_manage.py:608
 msgid "Search Sites"
 msgstr "搜索站点"
 
-#: common/views_manage.py:585
+#: common/views_manage.py:609
 msgid "External search sites to include, one per line."
 msgstr "要包含的外部搜索站点，每行一个。"
 
-#: common/views_manage.py:588
+#: common/views_manage.py:612
 msgid "Federated Search Peers"
 msgstr "联邦搜索节点"
 
-#: common/views_manage.py:589
+#: common/views_manage.py:613
 msgid "NeoDB peer instances for federated search, one per line."
 msgstr "用于联邦搜索的 NeoDB 节点实例，每行一个。"
 
-#: common/views_manage.py:592
+#: common/views_manage.py:616
 msgid "Hidden Categories"
 msgstr "隐藏的分类"
 
-#: common/views_manage.py:593
+#: common/views_manage.py:617
 msgid "Category values to hide from the catalog, one per line."
 msgstr "在目录中隐藏的分类值，每行一个。"
 
-#: common/views_manage.py:614
+#: common/views_manage.py:638
 msgid "Spotify API Key"
 msgstr "Spotify API 密钥"
 
-#: common/views_manage.py:615
+#: common/views_manage.py:639
 msgid "https://developer.spotify.com/"
 msgstr "https://developer.spotify.com/"
 
-#: common/views_manage.py:618
+#: common/views_manage.py:642
 msgid "TMDB API Key"
 msgstr "TMDB API 密钥"
 
-#: common/views_manage.py:619
+#: common/views_manage.py:643
 msgid "https://developer.themoviedb.org/"
 msgstr "https://developer.themoviedb.org/"
 
-#: common/views_manage.py:622
+#: common/views_manage.py:646
 msgid "Google Books API Key"
 msgstr "Google Books API 密钥"
 
-#: common/views_manage.py:623
+#: common/views_manage.py:647
 msgid "https://developers.google.com/books/"
 msgstr "https://developers.google.com/books/"
 
-#: common/views_manage.py:626
+#: common/views_manage.py:650
 msgid "Discogs API Key"
 msgstr "Discogs API 密钥"
 
-#: common/views_manage.py:628
+#: common/views_manage.py:652
 msgid "Personal access token from https://www.discogs.com/settings/developers"
 msgstr "来自 https://www.discogs.com/settings/developers 的个人访问令牌"
 
-#: common/views_manage.py:632
+#: common/views_manage.py:656
 msgid "IGDB Client ID"
 msgstr "IGDB 客户端 ID"
 
-#: common/views_manage.py:633
+#: common/views_manage.py:657
 msgid "https://api-docs.igdb.com/"
 msgstr "https://api-docs.igdb.com/"
 
-#: common/views_manage.py:636
+#: common/views_manage.py:660
 msgid "IGDB Client Secret"
 msgstr "IGDB 客户端密钥"
 
-#: common/views_manage.py:639
+#: common/views_manage.py:663
 msgid "BoardGameGeek API Token"
 msgstr "BoardGameGeek API 令牌"
 
-#: common/views_manage.py:641
+#: common/views_manage.py:665
 msgid "Bearer token from https://boardgamegeek.com/applications (see https://boardgamegeek.com/using_the_xml_api#toc9)."
 msgstr "来自 https://boardgamegeek.com/applications 的 Bearer 令牌（参见 https://boardgamegeek.com/using_the_xml_api#toc9）。"
 
-#: common/views_manage.py:646 users/templates/users/steam_import.html:26
+#: common/views_manage.py:670 users/templates/users/steam_import.html:26
 msgid "Steam API Key"
 msgstr "Steam API 密钥"
 
-#: common/views_manage.py:648
+#: common/views_manage.py:672
 msgid "https://steamcommunity.com/dev - fallback key for Steam importer. Users can provide their own key when importing."
 msgstr "https://steamcommunity.com/dev - Steam 导入器的备用密钥。用户可在导入时提供自己的密钥。"
 
-#: common/views_manage.py:653
+#: common/views_manage.py:677
 msgid "DeepL API Key"
 msgstr "DeepL API 密钥"
 
-#: common/views_manage.py:654
+#: common/views_manage.py:678
 msgid "For translation features."
 msgstr "用于翻译功能。"
 
-#: common/views_manage.py:657
+#: common/views_manage.py:681
 msgid "LibreTranslate API URL"
 msgstr "LibreTranslate API URL"
 
-#: common/views_manage.py:660
+#: common/views_manage.py:684
 msgid "LibreTranslate API Key"
 msgstr "LibreTranslate API 密钥"
 
-#: common/views_manage.py:663
+#: common/views_manage.py:687
 msgid "Threads App ID"
 msgstr "Threads 应用 ID"
 
-#: common/views_manage.py:664
+#: common/views_manage.py:688
 msgid "OAuth app ID for Threads login."
 msgstr "用于 Threads 登录的 OAuth 应用 ID。"
 
-#: common/views_manage.py:667
+#: common/views_manage.py:691
 msgid "Threads App Secret"
 msgstr "Threads 应用密钥"
 
-#: common/views_manage.py:670
+#: common/views_manage.py:694
 msgid "Discord Webhooks"
 msgstr "Discord Webhook"
 
-#: common/views_manage.py:672
+#: common/views_manage.py:696
 msgid "Webhook URLs keyed by channel (default, report, audit, suggest, system). All channels must be Discord forum or media channels (thread mode) because notifications are posted as threads."
 msgstr "按频道（default、report、audit、suggest、system）映射的 Webhook URL。所有频道必须是 Discord 论坛或媒体频道（线程模式），因为通知以线程形式发布。"
 
-#: common/views_manage.py:689
+#: common/views_manage.py:713
 msgid "Catalog APIs"
 msgstr "目录 API"
 
-#: common/views_manage.py:699
+#: common/views_manage.py:723
 msgid "Translation"
 msgstr "翻译"
 
-#: common/views_manage.py:704
+#: common/views_manage.py:728
 msgid "Third-Party Login"
 msgstr "第三方登录"
 
-#: common/views_manage.py:708 social/templates/feed.html:27
+#: common/views_manage.py:732 social/templates/feed.html:27
 #: social/templates/notification.html:35
 msgid "Notifications"
 msgstr "通知"
 
-#: common/views_manage.py:718
+#: common/views_manage.py:742
 msgid "Scraping Providers"
 msgstr "抓取服务"
 
-#: common/views_manage.py:719
+#: common/views_manage.py:743
 msgid "Comma-separated list of providers to try in order."
 msgstr "按顺序尝试的服务列表，以逗号分隔。"
 
-#: common/views_manage.py:722
+#: common/views_manage.py:746
 msgid "Proxy List"
 msgstr "代理列表"
 
-#: common/views_manage.py:723
+#: common/views_manage.py:747
 msgid "One per line, format: http://server?url=__URL__"
 msgstr "每行一个，格式：http://server?url=__URL__"
 
-#: common/views_manage.py:726
+#: common/views_manage.py:750
 msgid "Backup Proxy"
 msgstr "备用代理"
 
-#: common/views_manage.py:729
+#: common/views_manage.py:753
 msgid "Scrapfly API Key"
 msgstr "Scrapfly API 密钥"
 
-#: common/views_manage.py:732
+#: common/views_manage.py:756
 msgid "Decodo Base64 Auth Token"
 msgstr "Decodo Base64 鉴权令牌"
 
-#: common/views_manage.py:735
+#: common/views_manage.py:759
 msgid "ScraperAPI Key"
 msgstr "ScraperAPI 密钥"
 
-#: common/views_manage.py:738
+#: common/views_manage.py:762
 msgid "ScrapingBee API Key"
 msgstr "ScrapingBee API 密钥"
 
-#: common/views_manage.py:741
+#: common/views_manage.py:765
 msgid "Custom Scraper URL"
 msgstr "自定义抓取器 URL"
 
-#: common/views_manage.py:742
+#: common/views_manage.py:766
 msgid "URL with __URL__ and __SELECTOR__ placeholders."
 msgstr "包含 __URL__ 和 __SELECTOR__ 占位符的 URL。"
 
-#: common/views_manage.py:745
+#: common/views_manage.py:769
 msgid "Request Timeout (seconds)"
 msgstr "请求超时（秒）"
 
-#: common/views_manage.py:749
+#: common/views_manage.py:773
 msgid "Cache Timeout (seconds)"
 msgstr "缓存超时（秒）"
 
-#: common/views_manage.py:753
+#: common/views_manage.py:777
 msgid "Retries"
 msgstr "重试次数"
 
-#: common/views_manage.py:758
+#: common/views_manage.py:782
 msgid "Providers"
 msgstr "服务"
 
-#: common/views_manage.py:763
+#: common/views_manage.py:787
 msgid "Provider Keys"
 msgstr "服务密钥"
 
-#: common/views_manage.py:770
+#: common/views_manage.py:794
 msgid "Timeouts"
 msgstr "超时设置"
 
-#: common/views_manage.py:782
+#: common/views_manage.py:806
 msgid "Alternative Domains"
 msgstr "备用域名"
 
-#: common/views_manage.py:783
+#: common/views_manage.py:807
 msgid "One domain per line."
 msgstr "每行一个域名。"
 
-#: common/views_manage.py:786
+#: common/views_manage.py:810
 msgid "Mastodon Client Scope"
 msgstr "Mastodon 客户端授权范围"
 
-#: common/views_manage.py:787
+#: common/views_manage.py:811
 msgid "OAuth scope when creating Mastodon apps."
 msgstr "创建 Mastodon 应用时使用的 OAuth 授权范围。"
 
-#: common/views_manage.py:790
+#: common/views_manage.py:814
 msgid "Mastodon API Timeout (seconds)"
 msgstr "Mastodon API 超时（秒）"
 
-#: common/views_manage.py:792
+#: common/views_manage.py:816
 msgid "Timeout for requests to Mastodon instances and remote fediverse servers."
 msgstr "请求 Mastodon 实例及远程联邦宇宙服务器的超时时间。"
 
-#: common/views_manage.py:798
+#: common/views_manage.py:822
 msgid "Disable Cron Jobs"
 msgstr "禁用定时任务"
 
-#: common/views_manage.py:799
+#: common/views_manage.py:823
 msgid "Job names to disable, one per line. Use * to disable all."
 msgstr "要禁用的任务名，每行一个。使用 * 禁用所有任务。"
 
-#: common/views_manage.py:802
+#: common/views_manage.py:826
 msgid "Index Aliases"
 msgstr "索引别名"
 
-#: common/views_manage.py:803
+#: common/views_manage.py:827
 msgid "Map index names to their aliases."
 msgstr "索引名称到别名的映射。"
 
-#: common/views_manage.py:813
+#: common/views_manage.py:837
 msgid "Task Cleanup (days)"
 msgstr "任务清理（天）"
 
-#: common/views_manage.py:815
+#: common/views_manage.py:839
 msgid "Delete import/export tasks and their files after this many days. Set to 0 to disable cleanup."
 msgstr "在此天数后删除导入/导出任务及其文件。设为 0 则禁用清理。"
 
-#: common/views_manage.py:821
+#: common/views_manage.py:845
 msgid "Skip Migration Jobs"
 msgstr "跳过迁移任务"
 
-#: common/views_manage.py:823
+#: common/views_manage.py:847
 msgid "Post-migration job keys to skip, one per line (e.g. normalize_genre). Checked by the worker at dequeue time; skipped jobs log a warning and notify the Discord system channel."
 msgstr "要跳过的迁移后任务键，每行一个（如 normalize_genre）。worker 在出队时检查；被跳过的任务会记录警告并通知 Discord system 频道。"
 
-#: common/views_manage.py:829
+#: common/views_manage.py:853
 msgid "ATProto OAuth Client Key"
 msgstr "ATProto OAuth 客户端密钥"
 
-#: common/views_manage.py:831
+#: common/views_manage.py:855
 msgid "Private key (JWK) identifying this site to ATProto authorization servers. Auto-generated on first Bluesky login; clear to regenerate."
 msgstr "用于向 ATProto 授权服务器标识本站点的私钥（JWK 格式）。首次 Bluesky 登录时自动生成；清空后将重新生成。"
 
-#: common/views_manage.py:838
+#: common/views_manage.py:862
 msgid "Domains"
 msgstr "域名"
 
-#: common/views_manage.py:841
+#: common/views_manage.py:865
 msgid "Operational"
 msgstr "运维"
 
-#: common/views_manage.py:857
+#: common/views_manage.py:881
 msgid "Movie Genres"
 msgstr "电影类型"
 
-#: common/views_manage.py:859
+#: common/views_manage.py:883
 msgid "Genre codes offered in the Movie edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "电影编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:864
+#: common/views_manage.py:888
 msgid "TV Genres"
 msgstr "剧集类型"
 
-#: common/views_manage.py:866
+#: common/views_manage.py:890
 msgid "Genre codes offered in the TV edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "剧集编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:871
+#: common/views_manage.py:895
 msgid "Music Genres"
 msgstr "音乐类型"
 
-#: common/views_manage.py:873
+#: common/views_manage.py:897
 msgid "Genre codes offered in the Music edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "音乐编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:878
+#: common/views_manage.py:902
 msgid "Game Genres"
 msgstr "游戏类型"
 
-#: common/views_manage.py:880
+#: common/views_manage.py:904
 msgid "Genre codes offered in the Game edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "游戏编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:885
+#: common/views_manage.py:909
 msgid "Podcast Genres"
 msgstr "播客类型"
 
-#: common/views_manage.py:887
+#: common/views_manage.py:911
 msgid "Genre codes offered in the Podcast edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "播客编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:892
+#: common/views_manage.py:916
 msgid "Performance Genres"
 msgstr "演出类型"
 
-#: common/views_manage.py:894
+#: common/views_manage.py:918
 msgid "Genre codes offered in the Performance edit dropdown, one per line. Leave empty to use the built-in default."
 msgstr "演出编辑下拉框中可选的类型代码，每行一个。留空则使用内置默认值。"
 
-#: common/views_manage.py:900
+#: common/views_manage.py:924
 msgid "Genres by Category"
 msgstr "按分类设置类型"
 
@@ -5561,7 +5577,7 @@ msgstr "关注的人"
 msgid "started following {item}"
 msgstr "关注了{item}"
 
-#: journal/models/shelf.py:907
+#: journal/models/shelf.py:921
 msgid "removed mark"
 msgstr "移除标记"
 
@@ -6396,8 +6412,9 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/login.html:20
-#: users/templates/users/register.html:9 users/templates/users/welcome.html:10
+#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: users/templates/users/login.html:20 users/templates/users/register.html:9
+#: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "注册"
 
@@ -6469,12 +6486,12 @@ msgstr "安全检查失败，请重试。"
 
 #: mastodon/views/bluesky.py:34 mastodon/views/bluesky.py:40
 #: mastodon/views/bluesky.py:64 mastodon/views/bluesky.py:72
-#: mastodon/views/bluesky.py:78 mastodon/views/common.py:40
+#: mastodon/views/bluesky.py:78 mastodon/views/common.py:36
 #: mastodon/views/mastodon.py:62 mastodon/views/mastodon.py:70
 #: mastodon/views/mastodon.py:77 mastodon/views/mastodon.py:87
 #: mastodon/views/mastodon.py:94 mastodon/views/threads.py:55
 #: mastodon/views/threads.py:63 mastodon/views/threads.py:69
-#: users/views/account.py:192
+#: users/views/account.py:336
 msgid "Authentication failed"
 msgstr "认证失败"
 
@@ -6498,51 +6515,51 @@ msgstr "ATProto 授权服务器返回信息无效"
 msgid "Invalid account data from Bluesky."
 msgstr "Bluesky返回了无效的账号数据。"
 
-#: mastodon/views/common.py:40 mastodon/views/common.py:105
+#: mastodon/views/common.py:36 mastodon/views/common.py:107
 msgid "Invalid user."
 msgstr "无效用户。"
 
-#: mastodon/views/common.py:56 users/views/account.py:228
+#: mastodon/views/common.py:52 users/views/account.py:377
 msgid "Registration failed"
 msgstr "注册失败"
 
-#: mastodon/views/common.py:56
+#: mastodon/views/common.py:52
 msgid "User already logged in."
 msgstr "用户已经登录了。"
 
-#: mastodon/views/common.py:68
+#: mastodon/views/common.py:70
 #, python-brace-format
 msgid "Continue login as {handle}."
 msgstr "继续以 {handle} 登录。"
 
-#: mastodon/views/common.py:74
+#: mastodon/views/common.py:76
 msgid "Unable to update login information"
 msgstr "无法更新登录信息"
 
-#: mastodon/views/common.py:75
+#: mastodon/views/common.py:77
 #, python-brace-format
 msgid "Identity {handle} in use by a different user."
 msgstr "别的用户在使用 {handle} 身份。"
 
-#: mastodon/views/common.py:91
+#: mastodon/views/common.py:93
 #, python-brace-format
 msgid "Login information updated as {handle}."
 msgstr "登录信息已更新为{handle}。"
 
-#: mastodon/views/common.py:101 mastodon/views/common.py:105
-#: mastodon/views/common.py:114
+#: mastodon/views/common.py:103 mastodon/views/common.py:107
+#: mastodon/views/common.py:116
 msgid "Disconnect identity failed"
 msgstr "未能取消身份关联"
 
-#: mastodon/views/common.py:101
+#: mastodon/views/common.py:103
 msgid "Identity not found."
 msgstr "身份未找到"
 
-#: mastodon/views/common.py:115
+#: mastodon/views/common.py:117
 msgid "You cannot disconnect last login identity."
 msgstr "无法取消唯一的登录用身份。"
 
-#: mastodon/views/common.py:124
+#: mastodon/views/common.py:126
 #, python-brace-format
 msgid "Login information about {handle} has been removed."
 msgstr "{handle} 的登录信息已移除。"
@@ -6929,6 +6946,34 @@ msgstr "文章"
 #: social/templates/single_post.html:29
 msgid "Poll"
 msgstr "投票"
+
+#: takahe/models.py:453
+msgid "Display Name"
+msgstr ""
+
+#: takahe/models.py:455
+msgid "Bio"
+msgstr "简介"
+
+#: takahe/models.py:457
+msgid "Manually approve new followers"
+msgstr ""
+
+#: takahe/models.py:461
+msgid "Include profile, marks and posts in discovery"
+msgstr ""
+
+#: takahe/models.py:464
+msgid "Include posts in search results"
+msgstr "在搜索结果中包含帖文"
+
+#: takahe/models.py:482
+msgid "Profile picture"
+msgstr ""
+
+#: takahe/models.py:489
+msgid "Header picture"
+msgstr ""
 
 #: users/models/task.py:22
 msgid "Started"
@@ -7514,6 +7559,49 @@ msgstr "你的个人访问令牌已创建。请立即复制，之后将无法再
 #: users/templates/users/authorized_app_created.html:25
 msgid "Token"
 msgstr "令牌"
+
+#: users/templates/users/captcha.html:4
+msgid "Sort every cover to continue."
+msgstr "请归类所有封面后继续。"
+
+#: users/templates/users/captcha.html:5
+msgid "All sorted. Select Confirm."
+msgstr "已全部归类，请点击确认。"
+
+#: users/templates/users/captcha.html:6
+msgid "Cover selected. Now choose a row."
+msgstr "已选中封面，请选择分类行。"
+
+#: users/templates/users/captcha.html:7
+msgid "Time is up. Reload to try again."
+msgstr "时间已到，请重新载入后再试。"
+
+#: users/templates/users/captcha.html:23
+msgid "One quick check"
+msgstr "简单验证一下"
+
+#: users/templates/users/captcha.html:25
+msgid "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row."
+msgstr "请把每个封面放进它所属的分类行。可以直接拖动，也可以先选中封面再选择分类行。"
+
+#: users/templates/users/captcha.html:34 users/templates/users/captcha.html:36
+msgid "Item cover"
+msgstr "条目封面"
+
+#: users/templates/users/captcha.html:52
+#, python-format
+msgid "Move selected cover to %(label)s"
+msgstr "把选中的封面移到%(label)s"
+
+#: users/templates/users/captcha.html:64
+msgid "Confirm"
+msgstr "确认"
+
+#: users/templates/users/captcha.html:72
+#, python-format
+msgid "Show me another set (%(counter)s left)"
+msgid_plural "Show me another set (%(counter)s left)"
+msgstr[0] "换一组（还剩 %(counter)s 次）"
 
 #: users/templates/users/crossposts.html:19
 msgid "Secure your account with a passkey for quick sign-in."
@@ -8385,31 +8473,52 @@ msgstr "以后再说"
 msgid "Passkey created"
 msgstr "通行密钥已创建"
 
-#: users/views/account.py:122
+#: users/views/account.py:124
 msgid "This username is already in use."
 msgstr "用户名已被使用"
 
-#: users/views/account.py:133
+#: users/views/account.py:135
 msgid "This email address is already in use."
 msgstr "此电子邮件地址已被使用"
 
-#: users/views/account.py:193
+#: users/views/account.py:242 users/views/account.py:301
+msgid "Time is up"
+msgstr "时间已到"
+
+#: users/views/account.py:243 users/views/account.py:275
+#: users/views/account.py:302
+msgid "Please log in again to continue registration."
+msgstr "请重新登录以继续注册。"
+
+#: users/views/account.py:277
+msgid "That is not quite right. Here is a new set."
+msgstr "不太对，换一组新的。"
+
+#: users/views/account.py:286
+msgid "Too many attempts"
+msgstr "尝试次数过多"
+
+#: users/views/account.py:287
+msgid "Please try again later."
+msgstr "请稍后再试。"
+
+#: users/views/account.py:337
 msgid "Registration is for invitation only"
 msgstr "本站仅限邀请注册"
 
-#: users/views/account.py:229
+#: users/views/account.py:378
 msgid "Username already taken. Please try again."
 msgstr "用户名已被使用，请重试。"
 
-#: users/views/account.py:259
+#: users/views/account.py:408
 msgid "Valid username required"
 msgstr "请输入有效的用户名"
 
-#: users/views/account.py:337
+#: users/views/account.py:489
 msgid "Account is being deleted."
 msgstr "账户删除进行中。"
 
-#: users/views/account.py:340
+#: users/views/account.py:492
 msgid "Account mismatch."
 msgstr "账号信息不匹配。"
 

--- a/neodb/mastodon/views/common.py
+++ b/neodb/mastodon/views/common.py
@@ -6,20 +6,16 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
+from common.utils import client_ip
 from common.views import render_error
 from mastodon.models.common import SocialAccount
+from users import registration_captcha as captcha
 from users.models import User
 from users.views.account import auth_login, logout_takahe
 
-
-def client_ip(request: HttpRequest) -> str:
-    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
-    if xff:
-        # the bundled nginx appends the peer address to any client-supplied
-        # X-Forwarded-For, so only the last entry is trustworthy; the first
-        # entry could be forged to rotate rate-limit keys
-        return xff.split(",")[-1].strip()
-    return request.META.get("REMOTE_ADDR", "")
+# client_ip moved to common.utils so users.views.account can use it too
+# (importing it back from here would be circular); re-exported for callers.
+__all__ = ["client_ip"]
 
 
 def process_verified_account(request: HttpRequest, account: SocialAccount):
@@ -56,6 +52,12 @@ def register_new_user(request: HttpRequest, account: SocialAccount):
             request, _("Registration failed"), _("User already logged in.")
         )
     request.session["verified_account"] = account.to_dict()
+    # Reset any captcha state left over from an abandoned attempt: otherwise a
+    # stale start time would expire this visitor the moment they arrive. It also
+    # means a pass cannot be carried from one verified identity to another.
+    captcha.clear(request)
+    if captcha.is_enabled():
+        return redirect(reverse("users:captcha"))
     return redirect(reverse("users:register"))
 
 

--- a/neodb/tests/users/test_registration_captcha.py
+++ b/neodb/tests/users/test_registration_captcha.py
@@ -37,6 +37,30 @@ def _with_cover(item, name: str):
     return item
 
 
+def _detailed_cover_bytes() -> bytes:
+    """A cover with real detail, for tests about the pixels themselves.
+
+    A flat colour survives cropping and rescaling unchanged, which hides any
+    transform that works by shifting the frame.
+    """
+    image = Image.new("RGB", (60, 90))
+    image.putdata(
+        [
+            ((x * 37 + y * 11) % 256, (x * 5 + y * 61) % 256, (x * 97 + y * 3) % 256)
+            for y in range(90)
+            for x in range(60)
+        ]
+    )
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG", quality=95)
+    return buffer.getvalue()
+
+
+def _with_detailed_cover(item, name: str):
+    item.cover.save(name, ContentFile(_detailed_cover_bytes()), save=True)
+    return item
+
+
 def _make_items(count: int = 4) -> None:
     for i in range(count):
         _with_cover(Movie.objects.create(title=f"Movie {i}"), f"movie{i}.jpg")
@@ -847,23 +871,30 @@ class TestReviewRegressions:
         assert response.status_code == 302
         assert response.url == CAPTCHA_URL
 
-    def test_tile_bytes_differ_between_challenges(self, client, enabled, media_root):
-        """The transform must not be reproducible from the public cover.
+    def test_tile_bytes_vary_by_challenge(self, client, enabled, media_root):
+        """One cover must not render to a single predictable byte string.
 
         The anonymous catalog search hands out an item's cover URL next to its
         category, so a fixed pipeline could be replayed over the catalog and
-        byte-matched against each tile.
+        matched against each tile by checksum.
+
+        Asserted over several challenges rather than as "these two differ":
+        the jitter draws from a bounded set of crop/quality combinations, so
+        any given pair can legitimately collide. What matters is that the
+        output is not one fixed value.
         """
-        # create the item here rather than picking an arbitrary existing one:
-        # each test gets its own MEDIA_ROOT, so another test's row would have
-        # no readable cover file
-        movie = _with_cover(Movie.objects.create(title="Jitter Subject"), "jit.jpg")
-        first = captcha.render_tile(movie, "nonce-one")
-        second = captcha.render_tile(movie, "nonce-two")
-        assert first and second
-        assert first != second
+        # a detailed cover, because cropping a few pixels off a flat colour
+        # changes nothing -- which is exactly how the two-nonce version of this
+        # test passed locally and failed on CI
+        movie = _with_detailed_cover(
+            Movie.objects.create(title="Jitter Subject"), "jit.jpg"
+        )
+        renders = {captcha.render_tile(movie, f"nonce-{i}") for i in range(8)}
+        assert None not in renders
+        assert len(renders) > 1
         # ...but stable within one challenge, so reloads stay cacheable
-        assert captcha.render_tile(movie, "nonce-one") == first
+        first = captcha.render_tile(movie, "nonce-0")
+        assert captcha.render_tile(movie, "nonce-0") == first
 
     def test_expired_challenge_serves_no_tiles(self, client, enabled):
         _verify_email(client)

--- a/neodb/tests/users/test_registration_captcha.py
+++ b/neodb/tests/users/test_registration_captcha.py
@@ -109,7 +109,12 @@ def _drop_captcha_keys() -> None:
     it makes unrelated tests fail depending on the order they run in.
     """
     delete_pattern = getattr(cache, "delete_pattern", None)
-    patterns = ("captcha_pool_*", "captcha_tile_*", "captcha_fail_open*")
+    patterns = (
+        "captcha_pool_*",
+        "captcha_tile_*",
+        "captcha_fail_open*",
+        "captcha_nonce_used*",
+    )
     if delete_pattern:
         for pattern in patterns:
             delete_pattern(pattern)
@@ -209,7 +214,7 @@ class TestSolving:
         response = _submit(client, _challenge(client))
         assert response.status_code == 302
         assert response.url == REGISTER_URL
-        assert client.session[captcha.PASSED_KEY] is True
+        assert captcha.PASSED_KEY in client.session
 
         response = client.post(REGISTER_URL, {"username": "newbie", "email": ""})
         assert response.status_code == 200
@@ -376,8 +381,15 @@ class TestTrajectory:
             token: {
                 "mode": "drag",
                 "duration": 500.0 + i,
-                # perfectly interpolated: what naive automation produces
-                "points": [[0.0, 0.0, 0.0], [10.0, 10.0, 40.0], [20.0, 20.0, 90.0]],
+                # perfectly interpolated along y=x: what naive automation
+                # produces. Long enough that the shape checks apply.
+                "points": [
+                    [0.0, 0.0, 0.0],
+                    [20.0, 20.0, 30.0],
+                    [40.0, 40.0, 71.0],
+                    [60.0, 60.0, 115.0],
+                    [100.0, 100.0, 500.0 + i],
+                ],
             }
             for i, token in enumerate(challenge["tiles"])
         }
@@ -654,23 +666,31 @@ class TestPool:
         response = client.get(CAPTCHA_URL)
         assert response.status_code == 302
         assert response.url == REGISTER_URL
-        assert client.session[captcha.PASSED_KEY] is True
+        assert captcha.PASSED_KEY in client.session
         assert client.post(REGISTER_URL, {"username": "thin", "email": ""})
         assert User.objects.filter(username="thin").exists()
 
 
 @pytest.mark.django_db(databases="__all__")
 class TestRateLimit:
-    def test_cap_blocks_new_challenges(self, client, enabled, monkeypatch):
+    def test_cap_ends_a_live_challenge(self, client, enabled, monkeypatch):
+        """The cap must bite mid-challenge, not only when issuing one.
+
+        Checking it only before issuing let a challenge that started just under
+        the limit keep serving attempts indefinitely.
+        """
         monkeypatch.setattr(captcha, "CAPTCHA_MAX_FAILS", 1)
         _verify_email(client)
         client.get(CAPTCHA_URL)
         challenge = _challenge(client)
-        _submit(client, challenge, answer=_wrong_answer(challenge))
-        # drop the live challenge so the next GET has to issue one
-        session = client.session
-        del session[captcha.SESSION_KEY]
-        session.save()
+        response = _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert response.status_code == 200
+        assert "verified_account" not in client.session
+
+    def test_cap_blocks_issuing_a_new_challenge(self, client, enabled, monkeypatch):
+        monkeypatch.setattr(captcha, "CAPTCHA_MAX_FAILS", 1)
+        captcha.record_fail("127.0.0.1")
+        _verify_email(client)
         response = client.get(CAPTCHA_URL)
         assert response.status_code == 200
         assert captcha.SESSION_KEY not in client.session
@@ -691,7 +711,7 @@ class TestVerificationResetsState:
         _verify_email(client)
         client.get(CAPTCHA_URL)
         _submit(client, _challenge(client))
-        assert client.session[captcha.PASSED_KEY] is True
+        assert captcha.PASSED_KEY in client.session
 
         # a second verification must start the step over
         request = client.request().wsgi_request
@@ -745,3 +765,175 @@ class TestPoolJob:
             assert cache.get(f"captcha_pool_all_{category.value}") is not None
             assert cache.get(f"captcha_pool_popular_{category.value}") is not None
         assert len(cache.get("captcha_pool_all_movie")) == 4
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestReviewRegressions:
+    """One test per hole found in review; each fails against the old code."""
+
+    def test_nonce_claim_is_atomic(self):
+        """Only one caller may consume a given nonce.
+
+        Sequential replay is already caught by the match check, since each
+        state change rotates the nonce. The hole this guards is concurrent
+        posts: session writes are last-write-wins, so without an atomic claim
+        every racing request passes the comparison and they collapse into a
+        single spent regeneration -- unlimited parallel guesses.
+        """
+        nonce = "test-nonce-claim"
+        assert captcha.claim_nonce(nonce) is True
+        assert captcha.claim_nonce(nonce) is False
+        assert captcha.claim_nonce("") is False
+
+    def test_replayed_nonce_costs_nothing(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert _challenge(client)["regens"] == 1
+        replay = _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert replay.status_code == 302
+        assert _challenge(client)["regens"] == 1
+
+    def test_failed_rebuild_does_not_leave_a_reusable_challenge(
+        self, client, enabled, monkeypatch
+    ):
+        """A regeneration that cannot build must not keep the spent quiz.
+
+        Leaving it in the session meant its nonce could be submitted against
+        forever without ever advancing the regeneration count.
+        """
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        monkeypatch.setattr(captcha, "_build_challenge", lambda **kw: None)
+        response = _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL  # fell open rather than looping
+        assert captcha.SESSION_KEY not in client.session
+
+    def test_a_solved_pass_goes_stale(self, client, enabled, monkeypatch):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        _submit(client, _challenge(client))
+        assert client.get(REGISTER_URL).status_code == 200
+        monkeypatch.setattr(captcha, "CAPTCHA_PASS_TTL", -1)
+        response = client.get(REGISTER_URL)
+        assert response.status_code == 302
+        assert response.url == CAPTCHA_URL
+
+    def test_tile_bytes_differ_between_challenges(self, client, enabled, media_root):
+        """The transform must not be reproducible from the public cover.
+
+        The anonymous catalog search hands out an item's cover URL next to its
+        category, so a fixed pipeline could be replayed over the catalog and
+        byte-matched against each tile.
+        """
+        # create the item here rather than picking an arbitrary existing one:
+        # each test gets its own MEDIA_ROOT, so another test's row would have
+        # no readable cover file
+        movie = _with_cover(Movie.objects.create(title="Jitter Subject"), "jit.jpg")
+        first = captcha.render_tile(movie, "nonce-one")
+        second = captcha.render_tile(movie, "nonce-two")
+        assert first and second
+        assert first != second
+        # ...but stable within one challenge, so reloads stay cacheable
+        assert captcha.render_tile(movie, "nonce-one") == first
+
+    def test_expired_challenge_serves_no_tiles(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        token = next(iter(_challenge(client)["tiles"]))
+        assert (
+            client.get(reverse("users:captcha_tile", args=[token])).status_code == 200
+        )
+        session = client.session
+        challenge = session[captcha.SESSION_KEY]
+        challenge["started"] -= captcha.CAPTCHA_TTL + 1
+        session[captcha.SESSION_KEY] = challenge
+        session.save()
+        assert (
+            client.get(reverse("users:captcha_tile", args=[token])).status_code == 404
+        )
+
+    def test_split_is_chosen_from_what_the_pool_can_serve(
+        self, client, monkeypatch, media_root
+    ):
+        """Two categories with two items each must still serve four tiles.
+
+        Drawing for one randomly chosen split first would fail open on a pair
+        that had enough items all along, since only 2/2 works here.
+        """
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        for i in range(2):
+            _with_cover(Movie.objects.create(title=f"Only Movie {i}"), f"m{i}.jpg")
+            _with_cover(Album.objects.create(title=f"Only Album {i}"), f"a{i}.jpg")
+        for _ in range(8):
+            challenge = captcha._build_challenge(started=0, regens=0)
+            assert challenge is not None
+            counts = [0, 0]
+            for tile in challenge["tiles"].values():
+                counts[tile["row"]] += 1
+            assert counts == [2, 2]
+
+    def test_popular_pool_ranks_only_eligible_classes(self, monkeypatch, media_root):
+        """Excluded sub-items must not consume the pool limit.
+
+        Ranking first and filtering afterwards let episodes crowd out the
+        podcasts a person could actually recognize.
+        """
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        monkeypatch.setattr(captcha, "CAPTCHA_POOL_LIMIT", 2)
+        podcast = _with_cover(Podcast.objects.create(title="Show"), "show.jpg")
+        user = User.register(email="marks@example.org", username="marks")
+        for i in range(3):
+            episode = _with_cover(
+                PodcastEpisode.objects.create(
+                    title=f"Ep {i}", program=podcast, pub_date=timezone.now()
+                ),
+                f"ep{i}.jpg",
+            )
+            Mark(user.identity, episode).update(ShelfType.WISHLIST)
+        Mark(user.identity, podcast).update(ShelfType.WISHLIST)
+        # the three marked episodes would otherwise fill a limit of 2
+        assert captcha.build_pool(ItemCategory.Podcast, popular=True) == [podcast.pk]
+
+    def test_invite_only_gate_applies_to_the_captcha(
+        self, client, enabled, monkeypatch
+    ):
+        _configure(
+            monkeypatch,
+            registration_captcha_items=4,
+            min_marks_for_captcha=1,
+            invite_only=True,
+        )
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 200
+        assert captcha.SESSION_KEY not in client.session
+
+    def test_a_short_human_drag_is_not_called_a_bot(self, client, enabled):
+        """Three samples over a short distance must not trip the shape checks.
+
+        One intermediate point near the start-to-end line is ordinary on a
+        short drag, and two equal intervals are ordinary on a browser that
+        coarsens timer resolution.
+        """
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {
+                "mode": "drag",
+                "duration": 180.0 + i * 11,
+                "points": [
+                    [0.0, 0.0, 0.0],
+                    [6.0, 6.0, 60.0],
+                    [12.0, 12.0, 180.0 + i * 11],
+                ],
+            }
+            for i, token in enumerate(challenge["tiles"])
+        }
+        response = _submit(client, challenge, trace=trace)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL

--- a/neodb/tests/users/test_registration_captcha.py
+++ b/neodb/tests/users/test_registration_captcha.py
@@ -23,7 +23,10 @@ REGISTER_URL = reverse("users:register")
 LOGIN_URL = reverse("users:login")
 
 
-def _cover_bytes(color: tuple[int, int, int] = (10, 120, 200)) -> bytes:
+COVER_FILL = (120, 140, 160)  # mid-tone: unmistakable against any pad colour
+
+
+def _cover_bytes(color: tuple[int, int, int] = COVER_FILL) -> bytes:
     buffer = io.BytesIO()
     Image.new("RGB", (60, 90), color).save(buffer, format="JPEG")
     return buffer.getvalue()
@@ -526,9 +529,31 @@ class TestTileProxy:
             assert "Cookie" in response["Vary"]
             image = Image.open(io.BytesIO(response.content))
             sizes.add(image.size)
-        # a 60x90 source must come back padded, not cropped or letterboxed
-        # to a different shape per category
         assert sizes == {(captcha.CAPTCHA_TILE_PX, captcha.CAPTCHA_TILE_PX)}
+
+    def test_tile_is_full_bleed_so_shape_cannot_be_measured(self, client, enabled):
+        """A non-square cover must not come back with padding bars.
+
+        Fitting-and-padding would keep every tile the same pixel size while
+        leaving the original aspect ratio trivially recoverable from the
+        bounding box of the flat bars -- and aspect ratio is close to a
+        giveaway for the category (square album art, 2:3 posters, tall book
+        covers). The cover has to reach all four edges.
+        """
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        for token in _challenge(client)["tiles"]:
+            response = client.get(reverse("users:captcha_tile", args=[token]))
+            image = Image.open(io.BytesIO(response.content)).convert("RGB")
+            w, h = image.size
+            corners = [(1, 1), (w - 2, 1), (1, h - 2), (w - 2, h - 2)]
+            for xy in corners:
+                pixel = image.getpixel(xy)
+                assert isinstance(pixel, tuple)
+                # the source is a solid COVER_FILL rectangle, so every corner
+                # is cover -- a padding bar would read as black or white
+                drift = max(abs(a - b) for a, b in zip(pixel, COVER_FILL))
+                assert drift < 24, f"corner {xy} is not cover: {pixel}"
 
     def test_unknown_token_404s(self, client, enabled):
         _verify_email(client)

--- a/neodb/tests/users/test_registration_captcha.py
+++ b/neodb/tests/users/test_registration_captcha.py
@@ -93,6 +93,18 @@ def _submit(client: Client, challenge: captcha.Challenge, answer=None, trace=Non
     )
 
 
+def _solve(client: Client, challenge: captcha.Challenge, trace=None):
+    """Submit a correct answer and walk through the success page.
+
+    Passing lands on the captcha route, which shows the solved state once and
+    then hands over to the username form.
+    """
+    response = _submit(client, challenge, trace=trace)
+    assert response.status_code == 302
+    assert response.url == CAPTCHA_URL
+    return client.get(CAPTCHA_URL)
+
+
 def _wrong_answer(challenge: captcha.Challenge) -> dict:
     # flip one tile into the other row
     answer = _correct_answer(challenge)
@@ -211,19 +223,38 @@ class TestSolving:
     def test_happy_path(self, client, enabled):
         _verify_email(client)
         assert client.get(CAPTCHA_URL).status_code == 200
-        response = _submit(client, _challenge(client))
-        assert response.status_code == 302
-        assert response.url == REGISTER_URL
+        solved = _solve(client, _challenge(client))
+        assert solved.status_code == 200
+        assert b"captcha-solved" in solved.content
         assert captcha.PASSED_KEY in client.session
 
         response = client.post(REGISTER_URL, {"username": "newbie", "email": ""})
         assert response.status_code == 200
         assert User.objects.filter(username="newbie").exists()
 
+    def test_success_page_is_shown_once(self, client, enabled):
+        """The moment is one-shot: a reload must not replay it."""
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        _solve(client, _challenge(client))
+        again = client.get(CAPTCHA_URL)
+        assert again.status_code == 302
+        assert again.url == REGISTER_URL
+
+    def test_fail_open_is_not_congratulated(self, client, monkeypatch, media_root):
+        """A pass nobody earned skips the celebration."""
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        _with_cover(Movie.objects.create(title="Lonely One"), "lonely1.jpg")
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+        assert captcha.CELEBRATE_KEY not in client.session
+
     def test_passing_clears_captcha_keys_on_login(self, client, enabled):
         _verify_email(client)
         client.get(CAPTCHA_URL)
-        _submit(client, _challenge(client))
+        _solve(client, _challenge(client))
         client.post(REGISTER_URL, {"username": "cleared", "email": ""})
         assert captcha.PASSED_KEY not in client.session
         assert captcha.SESSION_KEY not in client.session
@@ -297,9 +328,7 @@ class TestFailureBudget:
             _submit(client, challenge, answer=_wrong_answer(challenge))
         challenge = _challenge(client)
         assert captcha.regenerations_left(challenge) == 0
-        response = _submit(client, challenge)
-        assert response.status_code == 302
-        assert response.url == REGISTER_URL
+        assert _solve(client, challenge).status_code == 200
 
     def test_regenerate_with_none_left_is_a_no_op(self, client, enabled):
         _verify_email(client)
@@ -456,9 +485,7 @@ class TestTrajectory:
             token: {"mode": "drag", "duration": 0.0, "points": [[0.0, 0.0, 0.0]]}
             for token in challenge["tiles"]
         }
-        response = _submit(client, challenge, trace=trace)
-        assert response.status_code == 302
-        assert response.url == REGISTER_URL
+        assert _solve(client, challenge, trace=trace).status_code == 200
 
     def test_click_mode_passes_above_the_dwell_floor(self, client, enabled):
         _verify_email(client)
@@ -468,9 +495,7 @@ class TestTrajectory:
             token: {"mode": "click", "duration": 500.0 + i * 20, "points": []}
             for i, token in enumerate(challenge["tiles"])
         }
-        response = _submit(client, challenge, trace=trace)
-        assert response.status_code == 302
-        assert response.url == REGISTER_URL
+        assert _solve(client, challenge, trace=trace).status_code == 200
 
     def test_click_mode_fails_below_the_dwell_floor(self, client, enabled):
         _verify_email(client)
@@ -815,7 +840,7 @@ class TestReviewRegressions:
     def test_a_solved_pass_goes_stale(self, client, enabled, monkeypatch):
         _verify_email(client)
         client.get(CAPTCHA_URL)
-        _submit(client, _challenge(client))
+        _solve(client, _challenge(client))
         assert client.get(REGISTER_URL).status_code == 200
         monkeypatch.setattr(captcha, "CAPTCHA_PASS_TTL", -1)
         response = client.get(REGISTER_URL)
@@ -934,6 +959,4 @@ class TestReviewRegressions:
             }
             for i, token in enumerate(challenge["tiles"])
         }
-        response = _submit(client, challenge, trace=trace)
-        assert response.status_code == 302
-        assert response.url == REGISTER_URL
+        assert _solve(client, challenge, trace=trace).status_code == 200

--- a/neodb/tests/users/test_registration_captcha.py
+++ b/neodb/tests/users/test_registration_captcha.py
@@ -1,0 +1,722 @@
+import io
+import json
+from typing import cast
+
+import pytest
+from django.core.cache import cache
+from django.core.files.base import ContentFile
+from django.test import Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from PIL import Image
+
+from catalog.models import Album, Game, ItemCategory, Movie, Podcast, PodcastEpisode
+from common.models import SiteConfig
+from journal.models import Mark, ShelfType
+from mastodon.models import Email
+from users import registration_captcha as captcha
+from users.jobs.captcha_pool import RegistrationCaptchaPool
+from users.models import User
+
+CAPTCHA_URL = reverse("users:captcha")
+REGISTER_URL = reverse("users:register")
+LOGIN_URL = reverse("users:login")
+
+
+def _cover_bytes(color: tuple[int, int, int] = (10, 120, 200)) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (60, 90), color).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _with_cover(item, name: str):
+    item.cover.save(name, ContentFile(_cover_bytes()), save=True)
+    return item
+
+
+def _make_items(count: int = 4) -> None:
+    for i in range(count):
+        _with_cover(Movie.objects.create(title=f"Movie {i}"), f"movie{i}.jpg")
+        _with_cover(Album.objects.create(title=f"Album {i}"), f"album{i}.jpg")
+
+
+def _human_trace(tokens) -> dict:
+    """A trace that passes every check: off-line path, uneven sampling,
+    distinct per-tile durations, and enough total interaction time."""
+    trace = {}
+    for i, token in enumerate(tokens):
+        end = 400.0 + i * 37.0
+        trace[token] = {
+            "mode": "drag",
+            "duration": end,
+            "points": [
+                [0.0, 0.0, 0.0],
+                [10.5, 6.25, 30.0],
+                [22.0, 9.0, 71.0],
+                [40.0, 12.0, end],
+            ],
+        }
+    return trace
+
+
+def _verify_email(client: Client, email: str = "captcha@example.org") -> None:
+    account = Email.new_account(email)
+    assert account is not None
+    session = client.session
+    session["verified_account"] = account.to_dict()
+    session.save()
+
+
+def _challenge(client: Client) -> captcha.Challenge:
+    return cast(captcha.Challenge, client.session[captcha.SESSION_KEY])
+
+
+def _correct_answer(challenge: captcha.Challenge) -> dict:
+    return {token: tile["row"] for token, tile in challenge["tiles"].items()}
+
+
+def _submit(client: Client, challenge: captcha.Challenge, answer=None, trace=None):
+    tokens = list(challenge["tiles"].keys())
+    return client.post(
+        CAPTCHA_URL,
+        {
+            "action": "submit",
+            "nonce": challenge["nonce"],
+            "answer": json.dumps(
+                _correct_answer(challenge) if answer is None else answer
+            ),
+            "trace": json.dumps(_human_trace(tokens) if trace is None else trace),
+        },
+    )
+
+
+def _wrong_answer(challenge: captcha.Challenge) -> dict:
+    # flip one tile into the other row
+    answer = _correct_answer(challenge)
+    token = next(iter(answer))
+    answer[token] = 1 - answer[token]
+    return answer
+
+
+def _drop_captcha_keys() -> None:
+    """Drop only this feature's cache entries.
+
+    Never cache.clear() here: the default cache is a Redis database shared with
+    the rest of the suite (index aliases, site config, rate limits), so flushing
+    it makes unrelated tests fail depending on the order they run in.
+    """
+    delete_pattern = getattr(cache, "delete_pattern", None)
+    patterns = ("captcha_pool_*", "captcha_tile_*", "captcha_fail_open*")
+    if delete_pattern:
+        for pattern in patterns:
+            delete_pattern(pattern)
+        delete_pattern("reg_captcha_fails_*")
+        return
+    for category in ItemCategory:
+        cache.delete(f"captcha_pool_popular_{category.value}")
+        cache.delete(f"captcha_pool_all_{category.value}")
+    cache.delete("captcha_fail_open")
+    cache.delete("captcha_fail_open_warned")
+
+
+@pytest.fixture(autouse=True)
+def _clear_captcha_cache():
+    _drop_captcha_keys()
+    yield
+    _drop_captcha_keys()
+
+
+@pytest.fixture
+def media_root(tmp_path):
+    with override_settings(MEDIA_ROOT=str(tmp_path)):
+        yield tmp_path
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch, **updates) -> None:
+    configured = SiteConfig.system.model_copy(update=updates)
+    monkeypatch.setattr(SiteConfig, "system", configured)
+    monkeypatch.setattr(SiteConfig, "__forced__", True, raising=False)
+
+
+@pytest.fixture
+def enabled(monkeypatch: pytest.MonkeyPatch, media_root):
+    _configure(
+        monkeypatch,
+        registration_captcha_items=4,
+        min_marks_for_captcha=1,
+        invite_only=False,
+        mastodon_login_whitelist=[],
+    )
+    _make_items()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestDisabled:
+    def test_default_is_off(self, client):
+        assert SiteConfig.SystemOptions().registration_captcha_items == 0
+        assert not captcha.is_enabled()
+
+    def test_registration_untouched_when_disabled(self, client, monkeypatch):
+        _configure(monkeypatch, registration_captcha_items=0)
+        _verify_email(client)
+        response = client.get(REGISTER_URL)
+        assert response.status_code == 200
+
+    def test_captcha_page_redirects_when_disabled(self, client, monkeypatch):
+        _configure(monkeypatch, registration_captcha_items=0)
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestGate:
+    def test_get_register_redirects_to_captcha(self, client, enabled):
+        _verify_email(client)
+        response = client.get(REGISTER_URL)
+        assert response.status_code == 302
+        assert response.url == CAPTCHA_URL
+
+    def test_direct_post_to_register_is_blocked(self, client, enabled):
+        _verify_email(client)
+        response = client.post(REGISTER_URL, {"username": "sneaky", "email": ""})
+        assert response.status_code == 302
+        assert response.url == CAPTCHA_URL
+        assert not User.objects.filter(username="sneaky").exists()
+
+    def test_captcha_requires_a_verified_identity(self, client, enabled):
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 302
+        assert response.url == LOGIN_URL
+
+    def test_authenticated_user_is_not_gated(self, client, enabled):
+        # register() doubles as the email-change form for logged-in users
+        user = User.register(email="already@example.org", username="already")
+        client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get(REGISTER_URL)
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSolving:
+    def test_happy_path(self, client, enabled):
+        _verify_email(client)
+        assert client.get(CAPTCHA_URL).status_code == 200
+        response = _submit(client, _challenge(client))
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+        assert client.session[captcha.PASSED_KEY] is True
+
+        response = client.post(REGISTER_URL, {"username": "newbie", "email": ""})
+        assert response.status_code == 200
+        assert User.objects.filter(username="newbie").exists()
+
+    def test_passing_clears_captcha_keys_on_login(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        _submit(client, _challenge(client))
+        client.post(REGISTER_URL, {"username": "cleared", "email": ""})
+        assert captcha.PASSED_KEY not in client.session
+        assert captcha.SESSION_KEY not in client.session
+
+    def test_tiles_are_the_configured_total(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        assert len(challenge["tiles"]) == 4
+        assert len(challenge["rows"]) == 2
+        assert challenge["rows"][0] != challenge["rows"][1]
+
+    def test_both_rows_are_used(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        rows = {tile["row"] for tile in _challenge(client)["tiles"].values()}
+        assert rows == {0, 1}
+
+    def test_get_is_idempotent(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        first = _challenge(client)
+        client.get(CAPTCHA_URL)
+        second = _challenge(client)
+        assert first["tiles"] == second["tiles"]
+        assert first["nonce"] == second["nonce"]
+        assert first["started"] == second["started"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestFailureBudget:
+    def test_wrong_answer_consumes_a_regeneration(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        response = _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert response.status_code == 302
+        assert response.url == CAPTCHA_URL
+        after = _challenge(client)
+        assert after["regens"] == 1
+        assert after["nonce"] != challenge["nonce"]
+        assert captcha.PASSED_KEY not in client.session
+
+    def test_manual_regenerate_consumes_one(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        client.post(CAPTCHA_URL, {"action": "regenerate", "nonce": challenge["nonce"]})
+        assert _challenge(client)["regens"] == 1
+
+    def test_third_failure_ends_the_session(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        for _ in range(2):
+            challenge = _challenge(client)
+            _submit(client, challenge, answer=_wrong_answer(challenge))
+        challenge = _challenge(client)
+        assert challenge["regens"] == 2
+        response = _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert response.status_code == 200
+        assert "verified_account" not in client.session
+        assert captcha.SESSION_KEY not in client.session
+
+    def test_correct_answer_still_passes_with_no_regenerations_left(
+        self, client, enabled
+    ):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        for _ in range(2):
+            challenge = _challenge(client)
+            _submit(client, challenge, answer=_wrong_answer(challenge))
+        challenge = _challenge(client)
+        assert captcha.regenerations_left(challenge) == 0
+        response = _submit(client, challenge)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+
+    def test_regenerate_with_none_left_is_a_no_op(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        for _ in range(2):
+            challenge = _challenge(client)
+            _submit(client, challenge, answer=_wrong_answer(challenge))
+        challenge = _challenge(client)
+        response = client.post(
+            CAPTCHA_URL, {"action": "regenerate", "nonce": challenge["nonce"]}
+        )
+        assert response.status_code == 302
+        assert response.url == CAPTCHA_URL
+        assert _challenge(client)["nonce"] == challenge["nonce"]
+        assert "verified_account" in client.session
+
+    def test_nonce_mismatch_consumes_nothing(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        response = client.post(
+            CAPTCHA_URL,
+            {
+                "action": "submit",
+                "nonce": "stale",
+                "answer": json.dumps(_wrong_answer(challenge)),
+                "trace": json.dumps(_human_trace(list(challenge["tiles"]))),
+            },
+        )
+        assert response.status_code == 302
+        after = _challenge(client)
+        assert after["regens"] == 0
+        assert after["nonce"] == challenge["nonce"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTimeBudget:
+    def _age_challenge(self, client: Client, seconds: int) -> None:
+        session = client.session
+        challenge = session[captcha.SESSION_KEY]
+        challenge["started"] -= seconds
+        session[captcha.SESSION_KEY] = challenge
+        session.save()
+
+    def test_expiry_ends_the_session_even_when_correct(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        self._age_challenge(client, captcha.CAPTCHA_TTL + 1)
+        response = _submit(client, challenge)
+        assert response.status_code == 200
+        assert "verified_account" not in client.session
+
+    def test_expiry_on_get_ends_the_session(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        self._age_challenge(client, captcha.CAPTCHA_TTL + 1)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 200
+        assert "verified_account" not in client.session
+
+    def test_regenerating_does_not_extend_the_budget(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        started = _challenge(client)["started"]
+        self._age_challenge(client, 120)
+        challenge = _challenge(client)
+        client.post(CAPTCHA_URL, {"action": "regenerate", "nonce": challenge["nonce"]})
+        assert _challenge(client)["started"] == started - 120
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTrajectory:
+    def test_collinear_path_is_rejected(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {
+                "mode": "drag",
+                "duration": 500.0 + i,
+                # perfectly interpolated: what naive automation produces
+                "points": [[0.0, 0.0, 0.0], [10.0, 10.0, 40.0], [20.0, 20.0, 90.0]],
+            }
+            for i, token in enumerate(challenge["tiles"])
+        }
+        _submit(client, challenge, trace=trace)
+        assert _challenge(client)["regens"] == 1
+
+    def test_instant_submission_is_rejected(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {
+                "mode": "drag",
+                "duration": 1.0 + i,
+                "points": [[0.0, 0.0, 0.0], [5.0, 9.0, 1.0], [20.0, 20.0, 2.0]],
+            }
+            for i, token in enumerate(challenge["tiles"])
+        }
+        _submit(client, challenge, trace=trace)
+        assert _challenge(client)["regens"] == 1
+
+    def test_single_sample_drag_is_rejected(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {"mode": "drag", "duration": 900.0 + i, "points": [[1.0, 1.0, 0.0]]}
+            for i, token in enumerate(challenge["tiles"])
+        }
+        _submit(client, challenge, trace=trace)
+        assert _challenge(client)["regens"] == 1
+
+    def test_missing_trace_entry_is_rejected(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = _human_trace(list(challenge["tiles"]))
+        trace.pop(next(iter(trace)))
+        _submit(client, challenge, trace=trace)
+        assert _challenge(client)["regens"] == 1
+
+    def test_oversized_payload_is_rejected(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        response = client.post(
+            CAPTCHA_URL,
+            {
+                "action": "submit",
+                "nonce": challenge["nonce"],
+                "answer": json.dumps(_correct_answer(challenge)),
+                "trace": "x" * (captcha.CAPTCHA_PAYLOAD_MAX_LENGTH + 1),
+            },
+        )
+        assert response.status_code == 302
+        assert _challenge(client)["regens"] == 1
+
+    def test_kill_switch_lets_a_flat_trace_through(self, client, enabled, monkeypatch):
+        monkeypatch.setattr(captcha, "REQUIRE_HUMAN_TRAJECTORY", False)
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {"mode": "drag", "duration": 0.0, "points": [[0.0, 0.0, 0.0]]}
+            for token in challenge["tiles"]
+        }
+        response = _submit(client, challenge, trace=trace)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+
+    def test_click_mode_passes_above_the_dwell_floor(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {"mode": "click", "duration": 500.0 + i * 20, "points": []}
+            for i, token in enumerate(challenge["tiles"])
+        }
+        response = _submit(client, challenge, trace=trace)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+
+    def test_click_mode_fails_below_the_dwell_floor(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        trace = {
+            token: {"mode": "click", "duration": 1.0 + i, "points": []}
+            for i, token in enumerate(challenge["tiles"])
+        }
+        _submit(client, challenge, trace=trace)
+        assert _challenge(client)["regens"] == 1
+
+    def test_wrong_answer_beats_a_perfect_trace(self, client, enabled):
+        # correctness is checked first: good telemetry never rescues a bad sort
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        _submit(client, challenge, answer=_wrong_answer(challenge))
+        assert captcha.PASSED_KEY not in client.session
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestLeakage:
+    def test_page_reveals_no_titles_ids_or_categories(self, client, enabled):
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 200
+        body = response.content.decode()
+        challenge = _challenge(client)
+
+        from catalog.models import Item
+
+        for tile in challenge["tiles"].values():
+            item = Item.objects.get(pk=tile["pk"])
+            assert item.display_title not in body
+            assert str(item.uuid) not in body
+            assert item.url not in body
+        # the only category words on the page are the two row labels
+        labels = {str(ItemCategory(v).label) for v in challenge["rows"]}
+        for category in ItemCategory:
+            if str(category.label) in labels:
+                continue
+            assert f">{category.label}<" not in body
+
+    def test_every_image_goes_through_the_proxy(self, client, enabled):
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        body = response.content.decode()
+        challenge = _challenge(client)
+        for token in challenge["tiles"]:
+            assert reverse("users:captcha_tile", args=[token]) in body
+        # a raw media cover URL would carry item/<category>/ in the path
+        assert "/m/item/" not in body
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTileProxy:
+    def test_serves_a_uniform_square(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        sizes = set()
+        for token in challenge["tiles"]:
+            response = client.get(reverse("users:captcha_tile", args=[token]))
+            assert response.status_code == 200
+            assert response["Content-Type"] == captcha.CAPTCHA_TILE_CONTENT_TYPE
+            assert response["Cache-Control"] == "no-store, private"
+            assert "Cookie" in response["Vary"]
+            image = Image.open(io.BytesIO(response.content))
+            sizes.add(image.size)
+        # a 60x90 source must come back padded, not cropped or letterboxed
+        # to a different shape per category
+        assert sizes == {(captcha.CAPTCHA_TILE_PX, captcha.CAPTCHA_TILE_PX)}
+
+    def test_unknown_token_404s(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        response = client.get(reverse("users:captcha_tile", args=["nope"]))
+        assert response.status_code == 404
+
+    def test_stale_token_404s(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        stale = next(iter(challenge["tiles"]))
+        client.post(CAPTCHA_URL, {"action": "regenerate", "nonce": challenge["nonce"]})
+        assert (
+            client.get(reverse("users:captcha_tile", args=[stale])).status_code == 404
+        )
+
+    def test_another_sessions_token_404s(self, client, enabled):
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        token = next(iter(_challenge(client)["tiles"]))
+        other = Client()
+        assert other.get(reverse("users:captcha_tile", args=[token])).status_code == 404
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPool:
+    def test_covers_are_required(self, client, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        _make_items()
+        naked = Movie.objects.create(title="No Cover At All")
+        assert naked.pk not in captcha.build_pool(ItemCategory.Movie, popular=False)
+
+    def test_default_cover_is_not_a_cover(self, client, monkeypatch, media_root):
+        from django.conf import settings
+
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        placeholder = Movie.objects.create(
+            title="Placeholder", cover=settings.DEFAULT_ITEM_COVER
+        )
+        assert placeholder.pk not in captcha.build_pool(
+            ItemCategory.Movie, popular=False
+        )
+
+    def test_performance_is_excluded(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4)
+        assert ItemCategory.Performance not in captcha.eligible_categories()
+
+    def test_hidden_categories_are_excluded(self, monkeypatch, media_root):
+        _configure(
+            monkeypatch, registration_captcha_items=4, hidden_categories=["game"]
+        )
+        assert ItemCategory.Game not in captcha.eligible_categories()
+
+    def test_only_available_categories_are_eligible(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4)
+        eligible = captcha.eligible_categories()
+        assert ItemCategory.People not in eligible
+        assert ItemCategory.Collection not in eligible
+
+    def test_episode_classes_are_excluded(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        podcast = _with_cover(Podcast.objects.create(title="Show"), "show.jpg")
+        episode = _with_cover(
+            PodcastEpisode.objects.create(
+                title="Ep 1", program=podcast, pub_date=timezone.now()
+            ),
+            "ep.jpg",
+        )
+        pool = captcha.build_pool(ItemCategory.Podcast, popular=False)
+        assert podcast.pk in pool
+        assert episode.pk not in pool
+
+    def test_marks_threshold_filters_the_popular_pool(
+        self, client, monkeypatch, media_root
+    ):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        movie = _with_cover(Movie.objects.create(title="Marked"), "marked.jpg")
+        user = User.register(email="marker@example.org", username="marker")
+        Mark(user.identity, movie).update(ShelfType.WISHLIST)
+        assert movie.pk in captcha.build_pool(ItemCategory.Movie, popular=True)
+
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=5)
+        assert movie.pk not in captcha.build_pool(ItemCategory.Movie, popular=True)
+
+    def test_pool_is_capped(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        monkeypatch.setattr(captcha, "CAPTCHA_POOL_LIMIT", 3)
+        for i in range(5):
+            _with_cover(Game.objects.create(title=f"Game {i}"), f"game{i}.jpg")
+        assert len(captcha.build_pool(ItemCategory.Game, popular=False)) == 3
+
+    def test_fail_open_on_a_thin_catalog(self, client, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        # only one category has anything to show
+        _with_cover(Movie.objects.create(title="Lonely"), "lonely.jpg")
+        _verify_email(client)
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 302
+        assert response.url == REGISTER_URL
+        assert client.session[captcha.PASSED_KEY] is True
+        assert client.post(REGISTER_URL, {"username": "thin", "email": ""})
+        assert User.objects.filter(username="thin").exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRateLimit:
+    def test_cap_blocks_new_challenges(self, client, enabled, monkeypatch):
+        monkeypatch.setattr(captcha, "CAPTCHA_MAX_FAILS", 1)
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        challenge = _challenge(client)
+        _submit(client, challenge, answer=_wrong_answer(challenge))
+        # drop the live challenge so the next GET has to issue one
+        session = client.session
+        del session[captcha.SESSION_KEY]
+        session.save()
+        response = client.get(CAPTCHA_URL)
+        assert response.status_code == 200
+        assert captcha.SESSION_KEY not in client.session
+
+    def test_counter_survives_repeated_failures(self):
+        captcha.record_fail("203.0.113.7")
+        captcha.record_fail("203.0.113.7")
+        assert cache.get("reg_captcha_fails_203.0.113.7") == 2
+        assert not captcha.fails_exceeded("203.0.113.7")
+        assert not captcha.fails_exceeded("")
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestVerificationResetsState:
+    def test_new_verified_identity_clears_a_solved_captcha(self, client, enabled):
+        from mastodon.views.common import register_new_user
+
+        _verify_email(client)
+        client.get(CAPTCHA_URL)
+        _submit(client, _challenge(client))
+        assert client.session[captcha.PASSED_KEY] is True
+
+        # a second verification must start the step over
+        request = client.request().wsgi_request
+        request.session = client.session
+        account = Email.new_account("second@example.org")
+        assert account is not None
+        register_new_user(request, account)
+        assert captcha.PASSED_KEY not in request.session
+        assert captcha.SESSION_KEY not in request.session
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSettings:
+    def test_too_few_items_is_rejected(self):
+        for value in (1, 2, 3):
+            with pytest.raises(ValueError):
+                SiteConfig.SystemOptions(registration_captcha_items=value)
+
+    def test_zero_and_sane_values_are_accepted(self):
+        assert SiteConfig.SystemOptions(registration_captcha_items=0)
+        for value in (4, 5, 6, 8):
+            assert (
+                SiteConfig.SystemOptions(
+                    registration_captcha_items=value
+                ).registration_captcha_items
+                == value
+            )
+
+    def test_too_many_items_is_rejected(self):
+        with pytest.raises(ValueError):
+            SiteConfig.SystemOptions(registration_captcha_items=99)
+
+    def test_min_marks_must_be_positive(self):
+        with pytest.raises(ValueError):
+            SiteConfig.SystemOptions(min_marks_for_captcha=0)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPoolJob:
+    def test_no_op_when_disabled(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=0)
+        _make_items()
+        RegistrationCaptchaPool().run()
+        assert cache.get("captcha_pool_all_movie") is None
+
+    def test_populates_every_eligible_category(self, monkeypatch, media_root):
+        _configure(monkeypatch, registration_captcha_items=4, min_marks_for_captcha=1)
+        _make_items()
+        RegistrationCaptchaPool().run()
+        for category in captcha.eligible_categories():
+            assert cache.get(f"captcha_pool_all_{category.value}") is not None
+            assert cache.get(f"captcha_pool_popular_{category.value}") is not None
+        assert len(cache.get("captcha_pool_all_movie")) == 4

--- a/neodb/users/apps.py
+++ b/neodb/users/apps.py
@@ -8,4 +8,4 @@ class UsersConfig(AppConfig):
         from . import apis  # noqa
 
         # register cron jobs
-        from users.jobs import MastodonUserSync  # noqa
+        from users.jobs import MastodonUserSync, RegistrationCaptchaPool  # noqa

--- a/neodb/users/jobs/__init__.py
+++ b/neodb/users/jobs/__init__.py
@@ -1,4 +1,5 @@
+from .captcha_pool import RegistrationCaptchaPool
 from .cleanup import TaskCleanup
 from .sync import MastodonUserSync
 
-__all__ = ["MastodonUserSync", "TaskCleanup"]
+__all__ = ["MastodonUserSync", "RegistrationCaptchaPool", "TaskCleanup"]

--- a/neodb/users/jobs/captcha_pool.py
+++ b/neodb/users/jobs/captcha_pool.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+from loguru import logger
+
+from common.models import BaseJob, JobManager
+from users.registration_captcha import is_enabled, refresh_pools
+
+
+@JobManager.register
+class RegistrationCaptchaPool(BaseJob):
+    """Rebuild the registration captcha's candidate item lists daily.
+
+    The interval stays a flat day even when the captcha is off, rather than
+    returning timedelta(0): BaseJob.schedule() reads a zero interval as "never
+    schedule", so a conditional interval would leave the job unscheduled and
+    enabling the captcha later would not bring it back. The run itself is what
+    no-ops. Operators can still turn it off by name via disable_cron_jobs.
+    """
+
+    @classmethod
+    def get_interval(cls) -> timedelta:
+        return timedelta(days=1)
+
+    def run(self) -> None:
+        if not is_enabled():
+            logger.debug("Registration captcha pool skipped (captcha disabled).")
+            return
+        sizes = refresh_pools()
+        logger.info(f"Registration captcha pools rebuilt: {sizes}")

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -21,6 +21,7 @@ tests can relax them, and state lives in the session rather than in a signed
 client payload.
 """
 
+import hashlib
 import io
 import json
 import random
@@ -62,6 +63,12 @@ CAPTCHA_DRAW_OVERSAMPLE = 3
 CAPTCHA_TILE_PX = 240
 CAPTCHA_TILE_TTL = 600
 CAPTCHA_TILE_CONTENT_TYPE = "image/jpeg"
+# how long a solved pass stays good; the session cookie itself lives for months
+CAPTCHA_PASS_TTL = 30 * 60
+# per-challenge jitter, so a tile is not a checksum of a public cover
+CAPTCHA_TILE_JITTER_PX = 3
+CAPTCHA_TILE_QUALITY_MIN = 80
+CAPTCHA_TILE_QUALITY_MAX = 90
 
 SESSION_KEY = "registration_captcha"
 PASSED_KEY = "registration_captcha_passed"
@@ -69,6 +76,7 @@ PASSED_KEY = "registration_captcha_passed"
 _POPULAR_CACHE_PREFIX = "captcha_pool_popular"
 _ALL_CACHE_PREFIX = "captcha_pool_all"
 _TILE_CACHE_PREFIX = "captcha_tile"
+_NONCE_CACHE_PREFIX = "captcha_nonce_used"
 _FAIL_OPEN_CACHE_KEY = "captcha_fail_open"
 _WARN_CACHE_KEY = "captcha_fail_open_warned"
 
@@ -152,6 +160,11 @@ def build_pool(category: ItemCategory, popular: bool) -> list[int]:
     if popular:
         marked = (
             ShelfMember.objects.filter(q_item_in_category(category))
+            # narrow to eligible classes *inside* the aggregate: ranking first
+            # and filtering after lets excluded sub-items (seasons, episodes)
+            # consume the whole limit, which would drop genuinely popular
+            # items and push the draw onto obscure fallback ones
+            .filter(item__polymorphic_ctype_id__in=ctype_ids)
             .values("item_id")
             .annotate(num=Count("item_id"))
             .filter(num__gte=SiteConfig.system.min_marks_for_captcha)
@@ -199,7 +212,7 @@ def refresh_pools() -> dict[str, int]:
     return sizes
 
 
-def _draw_items(category: ItemCategory, count: int) -> list[Item]:
+def _draw_items(category: ItemCategory, count: int, nonce: str) -> list[Item]:
     """Draw `count` distinct live, covered items of a category.
 
     Samples the popular pool first and tops up from the all-items pool. Pool
@@ -224,12 +237,12 @@ def _draw_items(category: ItemCategory, count: int) -> list[Item]:
         # render eagerly: a tile that 404s later would leave the visitor an
         # unanswerable quiz and cost them a regeneration. The bytes are cached,
         # so the request that serves this tile does no extra work.
-        if item.has_cover() and render_tile(item) is not None:
+        if item.has_cover() and render_tile(item, nonce) is not None:
             chosen.append(item)
     return chosen
 
 
-def render_tile(item: Item) -> bytes | None:
+def render_tile(item: Item, nonce: str) -> bytes | None:
     """Render one cover to the uniform tile image, or None if it cannot be.
 
     Normalization is a security requirement, not cosmetics: cover paths are
@@ -250,8 +263,15 @@ def render_tile(item: Item) -> bytes | None:
     Stretching distorts a little and leaves no geometry to measure: every tile
     is the same full-bleed square with all of the cover still visible. A person
     reads a squashed poster as a poster; a bot has to classify the image.
+
+    The transform is also jittered per challenge. A fixed transform would be
+    reproducible: the anonymous catalog search hands out an item's cover URL
+    alongside its category, so a crawler could run this exact pipeline over the
+    catalog and byte-match each tile, recovering everything the tokens hide.
+    Jitter does not stop perceptual hashing -- nothing here does -- but it does
+    stop a plain checksum join, which is the cheap version of the attack.
     """
-    key = f"{_TILE_CACHE_PREFIX}_{item.pk}"
+    key = f"{_TILE_CACHE_PREFIX}_{nonce}_{item.pk}"
     data = cache.get(key)
     if data is not None:
         return data or None
@@ -260,11 +280,23 @@ def render_tile(item: Item) -> bytes | None:
             raw = f.read()
         source = Image.open(io.BytesIO(raw))
         source.load()
-        canvas = source.convert("RGB").resize(
+        source = source.convert("RGB")
+        # derive the jitter from the challenge so a reload of the same quiz is
+        # stable (and cacheable) while a different quiz renders differently
+        seed = hashlib.sha256(f"{nonce}:{item.pk}".encode()).digest()
+        inset = seed[0] % (CAPTCHA_TILE_JITTER_PX + 1)
+        quality = CAPTCHA_TILE_QUALITY_MIN + (
+            seed[1] % (CAPTCHA_TILE_QUALITY_MAX - CAPTCHA_TILE_QUALITY_MIN + 1)
+        )
+        if inset and source.width > 2 * inset and source.height > 2 * inset:
+            source = source.crop(
+                (inset, inset, source.width - inset, source.height - inset)
+            )
+        canvas = source.resize(
             (CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), Image.Resampling.LANCZOS
         )
         buffer = io.BytesIO()
-        canvas.save(buffer, format="JPEG", quality=85)
+        canvas.save(buffer, format="JPEG", quality=quality)
         data = buffer.getvalue()
     except Exception as e:
         # vector covers and unreadable files are simply not usable as tiles;
@@ -291,15 +323,30 @@ def _build_challenge(started: int, regens: int) -> Challenge | None:
         return None
     categories = eligible_categories()
     random.shuffle(categories)
+    # minted up front so the eager tile render below warms the same cache key
+    # the tile requests will use
+    nonce = secrets.token_urlsafe(16)
 
     for i, first in enumerate(categories):
         for second in categories[i + 1 :]:
-            # split the total between the two rows, at least one each
-            a = random.randint(1, total - 1)
-            counts = {first: a, second: total - a}
-            drawn = {c: _draw_items(c, n) for c, n in counts.items()}
-            if any(len(drawn[c]) < n for c, n in counts.items()):
+            # Draw as many as either row could possibly need, then pick from
+            # the splits the draw can actually support. Drawing for one random
+            # split instead would fail open on a pair that had enough items all
+            # along: two categories with two items each can only serve a 2/2
+            # split, so a 1/3 draw would spuriously give up.
+            available = {c: _draw_items(c, total - 1, nonce) for c in (first, second)}
+            feasible = [
+                a
+                for a in range(1, total)
+                if a <= len(available[first]) and total - a <= len(available[second])
+            ]
+            if not feasible:
                 continue
+            a = random.choice(feasible)
+            drawn = {
+                first: available[first][:a],
+                second: available[second][: total - a],
+            }
             rows = [first.value, second.value]
             # shuffle before assigning tokens: drawing per category would
             # otherwise leave the tiles grouped by row in insertion order,
@@ -315,7 +362,7 @@ def _build_challenge(started: int, regens: int) -> Challenge | None:
             }
             return {
                 "started": started,
-                "nonce": secrets.token_urlsafe(16),
+                "nonce": nonce,
                 "regens": regens,
                 "rows": rows,
                 "tiles": tiles,
@@ -356,26 +403,57 @@ def ensure_challenge(request: HttpRequest) -> Challenge | None:
     return challenge
 
 
-def regenerate(request: HttpRequest, msg: str | None = None) -> Challenge | None:
+class Regenerated(TypedDict):
+    """Outcome of a regeneration attempt.
+
+    ``challenge`` is None when the catalog could not build a fresh quiz, which
+    the caller must treat as fail-open rather than as "try again": leaving the
+    spent challenge in the session would let its nonce be submitted against
+    indefinitely without ever consuming a regeneration.
+    """
+
+    challenge: Challenge | None
+    exhausted: bool
+
+
+def regenerate(request: HttpRequest, msg: str | None = None) -> Regenerated:
     """Spend one regeneration and issue a fresh quiz.
 
-    Returns None when none are left; the caller ends the session. The time
-    budget is deliberately carried over: it covers the whole step.
+    The time budget is deliberately carried over: it covers the whole step.
     """
     current = get_challenge(request)
     if not current:
-        return ensure_challenge(request)
+        return {"challenge": ensure_challenge(request), "exhausted": False}
     if current["regens"] >= CAPTCHA_MAX_REGENERATIONS:
-        return None
+        return {"challenge": None, "exhausted": True}
     challenge = _build_challenge(
         started=current["started"], regens=current["regens"] + 1
     )
     if not challenge:
+        # drop the spent challenge: a stale nonce left in the session is an
+        # unlimited-guess oracle, since submissions against it never advance
+        # the regeneration count
+        request.session.pop(SESSION_KEY, None)
+        request.session.modified = True
         _fail_open("not enough covered items in two categories")
-        return None
+        return {"challenge": None, "exhausted": False}
     challenge["msg"] = msg
     _store(request, challenge)
-    return challenge
+    return {"challenge": challenge, "exhausted": False}
+
+
+def claim_nonce(nonce: str) -> bool:
+    """Atomically consume a challenge nonce; False if already used.
+
+    Session writes are last-write-wins, so comparing the nonce and then
+    rotating it in a later write lets concurrent posts each pass the check and
+    collapse into a single spent regeneration -- effectively unlimited parallel
+    guesses. cache.add is atomic, which is the same guard login_proof uses for
+    solution replay.
+    """
+    if not nonce:
+        return False
+    return cache.add(f"{_NONCE_CACHE_PREFIX}:{nonce}", True, timeout=CAPTCHA_TTL)
 
 
 def regenerations_left(challenge: Challenge) -> int:
@@ -401,15 +479,22 @@ def pop_message(request: HttpRequest) -> str | None:
     return msg
 
 
-def tile_item(request: HttpRequest, token: str) -> Item | None:
-    """Resolve a tile token against the *current* challenge only."""
+def tile_item(request: HttpRequest, token: str) -> tuple[Item, str] | None:
+    """Resolve a tile token against the *current, live* challenge only.
+
+    Returns the item and the challenge nonce, which keys the rendered bytes.
+    An expired challenge serves nothing: its state lingers in the session
+    until some captcha-page request replaces it, and there is no reason to
+    keep answering for it.
+    """
     challenge = get_challenge(request)
-    if not challenge:
+    if not challenge or expired(challenge):
         return None
     tile = challenge["tiles"].get(token)
     if not tile:
         return None
-    return Item.objects.filter(pk=tile["pk"]).first()
+    item = Item.objects.filter(pk=tile["pk"]).first()
+    return (item, challenge["nonce"]) if item else None
 
 
 def check_answer(challenge: Challenge, answer: Any) -> bool:
@@ -432,11 +517,24 @@ def clear(request: HttpRequest) -> None:
 
 def mark_passed(request: HttpRequest) -> None:
     request.session.pop(SESSION_KEY, None)
-    request.session[PASSED_KEY] = True
+    request.session[PASSED_KEY] = _now()
 
 
 def has_passed(request: HttpRequest) -> bool:
-    return bool(request.session.get(PASSED_KEY))
+    """True while a solved pass is still fresh.
+
+    The pass is stamped rather than a bare flag: the session cookie lives for
+    months, and a solve parked for that long has nothing to do with the
+    five-minute budget it was earned under. It still buys exactly one account
+    either way, since auth_login consumes it.
+    """
+    at = request.session.get(PASSED_KEY)
+    if at is True:
+        # a pass stored by an older build, before this was stamped
+        return True
+    if not isinstance(at, int):
+        return False
+    return _now() - at <= CAPTCHA_PASS_TTL
 
 
 # --- interaction telemetry -------------------------------------------------
@@ -453,7 +551,12 @@ CAPTCHA_MAX_TRACE_POINTS = 200
 CAPTCHA_MIN_DRAG_POINTS = 3
 CAPTCHA_MIN_DRAG_MS = 100.0
 CAPTCHA_MIN_CLICK_MS = 80.0
-CAPTCHA_MIN_TOTAL_MS = 1500.0
+# A brisk but genuine sort of four tiles can finish inside a second and a half,
+# so this floor only rules out submissions with essentially no interaction.
+CAPTCHA_MIN_TOTAL_MS = 700.0
+# shape checks need enough of a path to mean anything; see _check_entry
+CAPTCHA_SHAPE_MIN_POINTS = 5
+CAPTCHA_SHAPE_MIN_SPAN_PX = 30.0
 CAPTCHA_MIN_DEVIATION_PX = 0.5
 
 TRACE_MODES = frozenset({"drag", "click"})
@@ -519,11 +622,24 @@ def _check_entry(entry: Any) -> tuple[bool, str, float]:
         return False, "too_few_samples", duration
     if duration < CAPTCHA_MIN_DRAG_MS:
         return False, "dwell", duration
-    intervals = [b - a for a, b in pairwise(times)]
-    if len(intervals) > 1 and len(set(intervals)) <= 1:
-        return False, "uniform_intervals", duration
-    if _max_perpendicular_deviation(points) <= CAPTCHA_MIN_DEVIATION_PX:
-        return False, "collinear", duration
+
+    # Both shape checks below need enough samples to say anything. On a short
+    # drag with three points, one intermediate sample sitting near the
+    # start-to-end line is ordinary, and two intervals coming out equal is
+    # ordinary too on a browser that coarsens timer resolution. Judging those
+    # would reject people, so only apply them once the path is long enough to
+    # carry a real signal.
+    if len(points) >= CAPTCHA_SHAPE_MIN_POINTS:
+        intervals = [b - a for a, b in pairwise(times)]
+        if len(set(intervals)) <= 1:
+            return False, "uniform_intervals", duration
+        (x0, y0, _), (x1, y1, _) = points[0], points[-1]
+        span = ((x1 - x0) ** 2 + (y1 - y0) ** 2) ** 0.5
+        if (
+            span >= CAPTCHA_SHAPE_MIN_SPAN_PX
+            and _max_perpendicular_deviation(points) <= CAPTCHA_MIN_DEVIATION_PX
+        ):
+            return False, "collinear", duration
     return True, "", duration
 
 

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -60,7 +60,6 @@ CAPTCHA_FAIL_OPEN_TTL = 60
 CAPTCHA_DRAW_OVERSAMPLE = 3
 # every tile is the same square and the same mime type; see render_tile
 CAPTCHA_TILE_PX = 240
-CAPTCHA_TILE_BG = (255, 255, 255)
 CAPTCHA_TILE_TTL = 600
 CAPTCHA_TILE_CONTENT_TYPE = "image/jpeg"
 
@@ -234,13 +233,23 @@ def render_tile(item: Item) -> bytes | None:
     """Render one cover to the uniform tile image, or None if it cannot be.
 
     Normalization is a security requirement, not cosmetics: cover paths are
-    ``item/<category>/...`` and the shapes differ by category (book spines,
-    square album art, 2:3 posters), so an un-normalized tile leaks the answer
-    through its dimensions and mime type just as plainly as through its URL.
+    ``item/<category>/...`` and shapes differ by category (square album art,
+    2:3 posters, tall book covers, landscape box art), so an un-normalized tile
+    leaks the answer through its dimensions and mime type just as plainly as
+    through its URL.
 
-    The cover is scaled to fit and padded rather than cropped. With no title
-    beneath it, a crop that takes the top off a book cover can leave the tile
-    unanswerable.
+    The cover is stretched to fill the square, and the alternatives were both
+    worse:
+
+    - fitting and padding keeps the shape perfectly readable. Flat bars have a
+      measurable bounding box, so a bot recovers the aspect ratio, and with it
+      the category, without looking at the picture at all.
+    - cropping to a square hides the shape too, but with no title beneath it a
+      crop that takes the top off a book cover can leave the tile unanswerable.
+
+    Stretching distorts a little and leaves no geometry to measure: every tile
+    is the same full-bleed square with all of the cover still visible. A person
+    reads a squashed poster as a poster; a bot has to classify the image.
     """
     key = f"{_TILE_CACHE_PREFIX}_{item.pk}"
     data = cache.get(key)
@@ -251,15 +260,8 @@ def render_tile(item: Item) -> bytes | None:
             raw = f.read()
         source = Image.open(io.BytesIO(raw))
         source.load()
-        source = source.convert("RGB")
-        source.thumbnail((CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), Image.Resampling.LANCZOS)
-        canvas = Image.new("RGB", (CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), CAPTCHA_TILE_BG)
-        canvas.paste(
-            source,
-            (
-                (CAPTCHA_TILE_PX - source.width) // 2,
-                (CAPTCHA_TILE_PX - source.height) // 2,
-            ),
+        canvas = source.convert("RGB").resize(
+            (CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), Image.Resampling.LANCZOS
         )
         buffer = io.BytesIO()
         canvas.save(buffer, format="JPEG", quality=85)

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -72,6 +72,8 @@ CAPTCHA_TILE_QUALITY_MAX = 90
 
 SESSION_KEY = "registration_captcha"
 PASSED_KEY = "registration_captcha_passed"
+# one-shot: set when a quiz is solved, consumed by the page that celebrates it
+CELEBRATE_KEY = "registration_captcha_solved"
 
 _POPULAR_CACHE_PREFIX = "captcha_pool_popular"
 _ALL_CACHE_PREFIX = "captcha_pool_all"
@@ -513,11 +515,27 @@ def check_answer(challenge: Challenge, answer: Any) -> bool:
 def clear(request: HttpRequest) -> None:
     request.session.pop(SESSION_KEY, None)
     request.session.pop(PASSED_KEY, None)
+    request.session.pop(CELEBRATE_KEY, None)
 
 
-def mark_passed(request: HttpRequest) -> None:
+def mark_passed(request: HttpRequest, celebrate: bool = False) -> None:
     request.session.pop(SESSION_KEY, None)
     request.session[PASSED_KEY] = _now()
+    if celebrate:
+        request.session[CELEBRATE_KEY] = True
+
+
+def pop_celebration(request: HttpRequest) -> bool:
+    """Consume the one-shot 'you just solved it' marker.
+
+    One-shot so a reload or a back-button visit does not replay the moment,
+    and so a fail-open pass -- which the visitor never earned -- does not get
+    congratulated.
+    """
+    if not request.session.pop(CELEBRATE_KEY, False):
+        return False
+    request.session.modified = True
+    return True
 
 
 def has_passed(request: HttpRequest) -> bool:

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -1,0 +1,600 @@
+"""Drag-to-sort registration captcha.
+
+A visitor who has verified an identity but not yet picked a username is shown
+a set of item covers and two category rows, and must drag each cover into the
+row it belongs to. Passing needs both a correct sort and interaction telemetry
+consistent with a person moving a pointer.
+
+Deliberate constraints, each load-bearing:
+
+- Only opaque per-challenge tokens reach the client. Item pks, uuids, titles
+  and category names stay server side, so a tile cannot be resolved back to a
+  catalog entry from the page.
+- Covers carry no title text. A title is a search key: the public catalog
+  search returns an item's category for any title, so showing one would hand
+  the answer over.
+- The whole step shares one time budget and a fixed number of regenerations;
+  see ``CAPTCHA_TTL`` and ``CAPTCHA_MAX_REGENERATIONS``.
+
+The module mirrors ``users.login_proof``: tunables live at module level so
+tests can relax them, and state lives in the session rather than in a signed
+client payload.
+"""
+
+import io
+import json
+import random
+import secrets
+from itertools import pairwise
+from typing import Any, TypedDict, cast
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db.models import Count
+from django.http import HttpRequest
+from django.utils import timezone
+from loguru import logger
+from PIL import Image
+
+from catalog.models import (
+    AvailableItemCategory,
+    Item,
+    ItemCategory,
+    PerformanceProduction,
+    PodcastEpisode,
+    TVEpisode,
+    TVSeason,
+    item_categories,
+    item_content_types,
+)
+from common.models import SiteConfig
+from journal.models import ShelfMember, q_item_in_category
+
+CAPTCHA_TTL = 5 * 60
+CAPTCHA_MAX_REGENERATIONS = 2
+CAPTCHA_POOL_LIMIT = 1000
+CAPTCHA_POOL_TTL = 48 * 3600
+CAPTCHA_FAIL_OPEN_TTL = 60
+# how many candidates to load per tile needed, so stale pool entries can be
+# replaced without another round trip
+CAPTCHA_DRAW_OVERSAMPLE = 3
+# every tile is the same square and the same mime type; see render_tile
+CAPTCHA_TILE_PX = 240
+CAPTCHA_TILE_BG = (255, 255, 255)
+CAPTCHA_TILE_TTL = 600
+CAPTCHA_TILE_CONTENT_TYPE = "image/jpeg"
+
+SESSION_KEY = "registration_captcha"
+PASSED_KEY = "registration_captcha_passed"
+
+_POPULAR_CACHE_PREFIX = "captcha_pool_popular"
+_ALL_CACHE_PREFIX = "captcha_pool_all"
+_TILE_CACHE_PREFIX = "captcha_tile"
+_FAIL_OPEN_CACHE_KEY = "captcha_fail_open"
+_WARN_CACHE_KEY = "captcha_fail_open_warned"
+
+# Sub-item classes: covers are generic and titles are unrecognizable out of
+# context, so sorting them by cover alone would be unfair. PerformanceProduction
+# is moot while Performance is excluded wholesale, and kept for clarity.
+EXCLUDED_CAPTCHA_CLASSES: tuple[type[Item], ...] = (
+    TVSeason,
+    TVEpisode,
+    PerformanceProduction,
+    PodcastEpisode,
+)
+
+# Performances are excluded: too few instances carry cover art distinct enough
+# to sort against another category.
+EXCLUDED_CAPTCHA_CATEGORIES = frozenset({ItemCategory.Performance})
+
+
+class Tile(TypedDict):
+    pk: int
+    row: int
+
+
+class Challenge(TypedDict):
+    started: int
+    nonce: str
+    regens: int
+    rows: list[str]
+    tiles: dict[str, Tile]
+    msg: str | None
+
+
+def is_enabled() -> bool:
+    return SiteConfig.system.registration_captcha_items > 0
+
+
+def _now() -> int:
+    return int(timezone.now().timestamp())
+
+
+def eligible_categories() -> list[ItemCategory]:
+    """Visible catalog categories the captcha may quiz on."""
+    available = set(AvailableItemCategory.values)
+    hidden = set(SiteConfig.system.hidden_categories)
+    return [
+        c
+        for c in item_categories()
+        if c.value in available
+        and c.value not in hidden
+        and c not in EXCLUDED_CAPTCHA_CATEGORIES
+    ]
+
+
+def _category_ctype_ids(category: ItemCategory) -> list[int]:
+    ctypes = item_content_types()
+    excluded = {ctypes[cls] for cls in EXCLUDED_CAPTCHA_CLASSES if cls in ctypes}
+    return [
+        ctypes[cls]
+        for cls in item_categories()[category]
+        if cls in ctypes and ctypes[cls] not in excluded
+    ]
+
+
+def _covered_live_items(pks: list[int] | None = None):
+    """Items with a real cover that are neither deleted nor merged away."""
+    qs = Item.objects.filter(is_deleted=False, merged_to_item__isnull=True)
+    if pks is not None:
+        qs = qs.filter(pk__in=pks)
+    return qs.exclude(cover="").exclude(cover=settings.DEFAULT_ITEM_COVER)
+
+
+def build_pool(category: ItemCategory, popular: bool) -> list[int]:
+    """Build and cache one candidate pk list for a category.
+
+    ``popular`` selects the marks-based pool; otherwise every eligible item in
+    the category is a candidate, which is the fallback for a thin catalog.
+    """
+    ctype_ids = _category_ctype_ids(category)
+    if not ctype_ids:
+        return []
+    if popular:
+        marked = (
+            ShelfMember.objects.filter(q_item_in_category(category))
+            .values("item_id")
+            .annotate(num=Count("item_id"))
+            .filter(num__gte=SiteConfig.system.min_marks_for_captcha)
+            .order_by("-num")[:CAPTCHA_POOL_LIMIT]
+        )
+        item_ids = [m["item_id"] for m in marked]
+        if not item_ids:
+            return []
+        pks = list(
+            _covered_live_items(item_ids)
+            .filter(polymorphic_ctype_id__in=ctype_ids)
+            .values_list("pk", flat=True)
+        )
+    else:
+        pks = list(
+            _covered_live_items()
+            .filter(polymorphic_ctype_id__in=ctype_ids)
+            .order_by("-id")[:CAPTCHA_POOL_LIMIT]
+            .values_list("pk", flat=True)
+        )
+    return pks
+
+
+def _pool(category: ItemCategory, popular: bool) -> list[int]:
+    """Read a cached pool, building it inline when the cache is cold."""
+    prefix = _POPULAR_CACHE_PREFIX if popular else _ALL_CACHE_PREFIX
+    key = f"{prefix}_{category.value}"
+    pks = cache.get(key)
+    if pks is None:
+        pks = build_pool(category, popular)
+        cache.set(key, pks, timeout=CAPTCHA_POOL_TTL)
+    return pks
+
+
+def refresh_pools() -> dict[str, int]:
+    """Rebuild every pool. Called by the daily job."""
+    sizes = {}
+    for category in eligible_categories():
+        for popular in (True, False):
+            prefix = _POPULAR_CACHE_PREFIX if popular else _ALL_CACHE_PREFIX
+            key = f"{prefix}_{category.value}"
+            pks = build_pool(category, popular)
+            cache.set(key, pks, timeout=CAPTCHA_POOL_TTL)
+            sizes[key] = len(pks)
+    return sizes
+
+
+def _draw_items(category: ItemCategory, count: int) -> list[Item]:
+    """Draw `count` distinct live, covered items of a category.
+
+    Samples the popular pool first and tops up from the all-items pool. Pool
+    entries can go stale within the day they are cached, so the loaded objects
+    are re-checked and any that no longer qualify are dropped; oversampling
+    keeps that from costing another query.
+    """
+    popular = list(_pool(category, popular=True))
+    random.shuffle(popular)
+    known = set(popular)
+    topup = [pk for pk in _pool(category, popular=False) if pk not in known]
+    random.shuffle(topup)
+    candidates = (popular + topup)[: count * CAPTCHA_DRAW_OVERSAMPLE]
+    if not candidates:
+        return []
+    items = list(_covered_live_items(candidates))
+    random.shuffle(items)
+    chosen: list[Item] = []
+    for item in items:
+        if len(chosen) >= count:
+            break
+        # render eagerly: a tile that 404s later would leave the visitor an
+        # unanswerable quiz and cost them a regeneration. The bytes are cached,
+        # so the request that serves this tile does no extra work.
+        if item.has_cover() and render_tile(item) is not None:
+            chosen.append(item)
+    return chosen
+
+
+def render_tile(item: Item) -> bytes | None:
+    """Render one cover to the uniform tile image, or None if it cannot be.
+
+    Normalization is a security requirement, not cosmetics: cover paths are
+    ``item/<category>/...`` and the shapes differ by category (book spines,
+    square album art, 2:3 posters), so an un-normalized tile leaks the answer
+    through its dimensions and mime type just as plainly as through its URL.
+
+    The cover is scaled to fit and padded rather than cropped. With no title
+    beneath it, a crop that takes the top off a book cover can leave the tile
+    unanswerable.
+    """
+    key = f"{_TILE_CACHE_PREFIX}_{item.pk}"
+    data = cache.get(key)
+    if data is not None:
+        return data or None
+    try:
+        with item.cover.open("rb") as f:
+            raw = f.read()
+        source = Image.open(io.BytesIO(raw))
+        source.load()
+        source = source.convert("RGB")
+        source.thumbnail((CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), Image.Resampling.LANCZOS)
+        canvas = Image.new("RGB", (CAPTCHA_TILE_PX, CAPTCHA_TILE_PX), CAPTCHA_TILE_BG)
+        canvas.paste(
+            source,
+            (
+                (CAPTCHA_TILE_PX - source.width) // 2,
+                (CAPTCHA_TILE_PX - source.height) // 2,
+            ),
+        )
+        buffer = io.BytesIO()
+        canvas.save(buffer, format="JPEG", quality=85)
+        data = buffer.getvalue()
+    except Exception as e:
+        # vector covers and unreadable files are simply not usable as tiles;
+        # cache the miss briefly so a broken cover is not retried per request
+        logger.debug(f"Captcha tile render failed for item {item.pk}: {e}")
+        cache.set(key, b"", timeout=CAPTCHA_TILE_TTL)
+        return None
+    cache.set(key, data, timeout=CAPTCHA_TILE_TTL)
+    return data
+
+
+def _fail_open(reason: str) -> None:
+    cache.set(_FAIL_OPEN_CACHE_KEY, True, timeout=CAPTCHA_FAIL_OPEN_TTL)
+    if cache.add(_WARN_CACHE_KEY, True, timeout=CAPTCHA_FAIL_OPEN_TTL):
+        logger.warning(f"Registration captcha disabled for now: {reason}")
+
+
+def _build_challenge(started: int, regens: int) -> Challenge | None:
+    """Draw two categories and their tiles, or None to fail open."""
+    total = SiteConfig.system.registration_captcha_items
+    if total < 2:
+        # a single tile cannot be split across two rows; the settings validator
+        # rejects this, so only a hand-edited config reaches here
+        return None
+    categories = eligible_categories()
+    random.shuffle(categories)
+
+    for i, first in enumerate(categories):
+        for second in categories[i + 1 :]:
+            # split the total between the two rows, at least one each
+            a = random.randint(1, total - 1)
+            counts = {first: a, second: total - a}
+            drawn = {c: _draw_items(c, n) for c, n in counts.items()}
+            if any(len(drawn[c]) < n for c, n in counts.items()):
+                continue
+            rows = [first.value, second.value]
+            # shuffle before assigning tokens: drawing per category would
+            # otherwise leave the tiles grouped by row in insertion order,
+            # which hands the answer to anyone reading the page source
+            pairs = [
+                (item.pk, rows.index(c.value))
+                for c, its in drawn.items()
+                for item in its
+            ]
+            random.shuffle(pairs)
+            tiles: dict[str, Tile] = {
+                secrets.token_urlsafe(16): {"pk": pk, "row": row} for pk, row in pairs
+            }
+            return {
+                "started": started,
+                "nonce": secrets.token_urlsafe(16),
+                "regens": regens,
+                "rows": rows,
+                "tiles": tiles,
+                "msg": None,
+            }
+    return None
+
+
+def get_challenge(request: HttpRequest) -> Challenge | None:
+    data = request.session.get(SESSION_KEY)
+    if isinstance(data, dict) and data.get("tiles"):
+        return cast(Challenge, data)
+    return None
+
+
+def _store(request: HttpRequest, challenge: Challenge) -> None:
+    request.session[SESSION_KEY] = challenge
+    request.session.modified = True
+
+
+def ensure_challenge(request: HttpRequest) -> Challenge | None:
+    """Return the live challenge, creating one on first entry.
+
+    A repeat GET must not re-roll: otherwise a caller can keep asking until it
+    draws a pool it has memorized. Returns None when the catalog cannot supply
+    a fair quiz, which means fail open.
+    """
+    existing = get_challenge(request)
+    if existing:
+        return existing
+    if cache.get(_FAIL_OPEN_CACHE_KEY):
+        return None
+    challenge = _build_challenge(started=_now(), regens=0)
+    if not challenge:
+        _fail_open("not enough covered items in two categories")
+        return None
+    _store(request, challenge)
+    return challenge
+
+
+def regenerate(request: HttpRequest, msg: str | None = None) -> Challenge | None:
+    """Spend one regeneration and issue a fresh quiz.
+
+    Returns None when none are left; the caller ends the session. The time
+    budget is deliberately carried over: it covers the whole step.
+    """
+    current = get_challenge(request)
+    if not current:
+        return ensure_challenge(request)
+    if current["regens"] >= CAPTCHA_MAX_REGENERATIONS:
+        return None
+    challenge = _build_challenge(
+        started=current["started"], regens=current["regens"] + 1
+    )
+    if not challenge:
+        _fail_open("not enough covered items in two categories")
+        return None
+    challenge["msg"] = msg
+    _store(request, challenge)
+    return challenge
+
+
+def regenerations_left(challenge: Challenge) -> int:
+    return max(0, CAPTCHA_MAX_REGENERATIONS - challenge["regens"])
+
+
+def seconds_left(challenge: Challenge) -> int:
+    return max(0, challenge["started"] + CAPTCHA_TTL - _now())
+
+
+def expired(challenge: Challenge) -> bool:
+    return seconds_left(challenge) <= 0
+
+
+def pop_message(request: HttpRequest) -> str | None:
+    challenge = get_challenge(request)
+    if not challenge:
+        return None
+    msg = challenge.get("msg")
+    if msg:
+        challenge["msg"] = None
+        _store(request, challenge)
+    return msg
+
+
+def tile_item(request: HttpRequest, token: str) -> Item | None:
+    """Resolve a tile token against the *current* challenge only."""
+    challenge = get_challenge(request)
+    if not challenge:
+        return None
+    tile = challenge["tiles"].get(token)
+    if not tile:
+        return None
+    return Item.objects.filter(pk=tile["pk"]).first()
+
+
+def check_answer(challenge: Challenge, answer: Any) -> bool:
+    """Every tile must be assigned, and to its own row."""
+    if not isinstance(answer, dict):
+        return False
+    tiles = challenge["tiles"]
+    if set(answer.keys()) != set(tiles.keys()):
+        return False
+    for token, row in answer.items():
+        if not isinstance(row, int) or row != tiles[token]["row"]:
+            return False
+    return True
+
+
+def clear(request: HttpRequest) -> None:
+    request.session.pop(SESSION_KEY, None)
+    request.session.pop(PASSED_KEY, None)
+
+
+def mark_passed(request: HttpRequest) -> None:
+    request.session.pop(SESSION_KEY, None)
+    request.session[PASSED_KEY] = True
+
+
+def has_passed(request: HttpRequest) -> bool:
+    return bool(request.session.get(PASSED_KEY))
+
+
+# --- interaction telemetry -------------------------------------------------
+#
+# The trace is client-supplied and therefore forgeable: these checks only cost
+# automation that never simulates a pointer at all. They are kept deliberately
+# loose, because a false rejection costs a real person their signup, and every
+# threshold is a module constant so an operator can relax them. Setting
+# REQUIRE_HUMAN_TRAJECTORY to False skips the path checks entirely.
+
+REQUIRE_HUMAN_TRAJECTORY = True
+CAPTCHA_PAYLOAD_MAX_LENGTH = 16_384
+CAPTCHA_MAX_TRACE_POINTS = 200
+CAPTCHA_MIN_DRAG_POINTS = 3
+CAPTCHA_MIN_DRAG_MS = 100.0
+CAPTCHA_MIN_CLICK_MS = 80.0
+CAPTCHA_MIN_TOTAL_MS = 1500.0
+CAPTCHA_MIN_DEVIATION_PX = 0.5
+
+TRACE_MODES = frozenset({"drag", "click"})
+
+
+def _max_perpendicular_deviation(points: list[tuple[float, float, float]]) -> float:
+    """Largest distance from any sample to the straight start-to-end line.
+
+    Naive automation interpolates linearly between two corners, which puts
+    every sample on that line. No real touch or trackpad drag does.
+    """
+    (x0, y0, _), (x1, y1, _) = points[0], points[-1]
+    dx, dy = x1 - x0, y1 - y0
+    span = (dx * dx + dy * dy) ** 0.5
+    if span == 0:
+        # start and end coincide: any movement in between is deviation
+        return max(((x - x0) ** 2 + (y - y0) ** 2) ** 0.5 for x, y, _ in points)
+    return max(abs(dx * (y0 - y) - dy * (x0 - x)) / span for x, y, _ in points)
+
+
+def _parse_points(raw: Any) -> list[tuple[float, float, float]] | None:
+    if not isinstance(raw, list) or len(raw) > CAPTCHA_MAX_TRACE_POINTS:
+        return None
+    points: list[tuple[float, float, float]] = []
+    for p in raw:
+        if not isinstance(p, list | tuple) or len(p) != 3:
+            return None
+        try:
+            x, y, t = (float(v) for v in p)
+        except TypeError, ValueError:
+            return None
+        points.append((x, y, t))
+    return points
+
+
+def _check_entry(entry: Any) -> tuple[bool, str, float]:
+    """Validate one tile's telemetry. Returns (ok, reason, duration_ms)."""
+    if not isinstance(entry, dict):
+        return False, "malformed", 0.0
+    if entry.get("mode") not in TRACE_MODES:
+        return False, "bad_mode", 0.0
+    mode = entry["mode"]
+    points = _parse_points(entry.get("points", []))
+    if points is None:
+        return False, "malformed", 0.0
+
+    times = [t for _, _, t in points]
+    # equal stamps are legal: coalesced pointer events share a timestamp
+    if any(b < a for a, b in pairwise(times)):
+        return False, "time_travel", 0.0
+    duration = (times[-1] - times[0]) if len(times) > 1 else 0.0
+    if isinstance(entry.get("duration"), int | float):
+        duration = max(duration, float(entry["duration"]))
+
+    if mode == "click":
+        if duration < CAPTCHA_MIN_CLICK_MS:
+            return False, "dwell", duration
+        return True, "", duration
+
+    if not REQUIRE_HUMAN_TRAJECTORY:
+        return True, "", duration
+    if len(points) < CAPTCHA_MIN_DRAG_POINTS:
+        return False, "too_few_samples", duration
+    if duration < CAPTCHA_MIN_DRAG_MS:
+        return False, "dwell", duration
+    intervals = [b - a for a, b in pairwise(times)]
+    if len(intervals) > 1 and len(set(intervals)) <= 1:
+        return False, "uniform_intervals", duration
+    if _max_perpendicular_deviation(points) <= CAPTCHA_MIN_DEVIATION_PX:
+        return False, "collinear", duration
+    return True, "", duration
+
+
+def check_trace(challenge: Challenge, trace: Any) -> tuple[bool, str]:
+    """Validate the telemetry for every tile. Returns (ok, reason)."""
+    if not isinstance(trace, dict):
+        return False, "malformed"
+    if set(trace.keys()) != set(challenge["tiles"].keys()):
+        return False, "incomplete"
+    durations = []
+    for entry in trace.values():
+        ok, reason, duration = _check_entry(entry)
+        if not ok:
+            return False, reason
+        durations.append(duration)
+    if not REQUIRE_HUMAN_TRAJECTORY:
+        return True, ""
+    if sum(durations) < CAPTCHA_MIN_TOTAL_MS:
+        return False, "too_fast"
+    # every tile taking the exact same float duration is a generator
+    if len(durations) > 1 and len(set(durations)) == 1:
+        return False, "duplicate_durations"
+    return True, ""
+
+
+# --- per-address failure cap ----------------------------------------------
+#
+# This, not the telemetry heuristics, is the lever that actually costs an
+# attacker: the sorting answer is resolvable per tile by anyone willing to
+# write a solver for this site, so the useful defence is bounding how many
+# attempts one address gets. Mirrors mastodon.views.email.
+
+CAPTCHA_MAX_FAILS = 10
+CAPTCHA_FAIL_TTL = 3600
+_FAIL_CACHE_PREFIX = "reg_captcha_fails"
+
+
+def fails_exceeded(ip: str) -> bool:
+    if not ip:
+        return False
+    return (cache.get(f"{_FAIL_CACHE_PREFIX}_{ip}") or 0) >= CAPTCHA_MAX_FAILS
+
+
+def record_fail(ip: str) -> None:
+    if not ip:
+        return
+    key = f"{_FAIL_CACHE_PREFIX}_{ip}"
+    if cache.add(key, 1, timeout=CAPTCHA_FAIL_TTL):
+        return
+    try:
+        cache.incr(key)
+    except ValueError:
+        # the entry expired between add and incr
+        cache.set(key, 1, timeout=CAPTCHA_FAIL_TTL)
+
+
+def verify_submission(
+    challenge: Challenge, answer_raw: str, trace_raw: str
+) -> tuple[bool, str, str]:
+    """Check one submitted answer. Returns (ok, outcome, reason)."""
+    if (
+        len(answer_raw) > CAPTCHA_PAYLOAD_MAX_LENGTH
+        or len(trace_raw) > CAPTCHA_PAYLOAD_MAX_LENGTH
+    ):
+        return False, "bad_trace", "oversized"
+    try:
+        answer = json.loads(answer_raw or "null")
+        trace = json.loads(trace_raw or "null")
+    except json.JSONDecodeError, UnicodeDecodeError:
+        return False, "bad_trace", "malformed"
+    if not check_answer(challenge, answer):
+        return False, "wrong_answer", "wrong_answer"
+    ok, reason = check_trace(challenge, trace)
+    if not ok:
+        return False, "bad_trace", reason
+    return True, "passed", ""

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -266,12 +266,19 @@ def render_tile(item: Item, nonce: str) -> bytes | None:
     is the same full-bleed square with all of the cover still visible. A person
     reads a squashed poster as a poster; a bot has to classify the image.
 
-    The transform is also jittered per challenge. A fixed transform would be
+    The transform is also jittered per challenge. A fixed one would be exactly
     reproducible: the anonymous catalog search hands out an item's cover URL
-    alongside its category, so a crawler could run this exact pipeline over the
-    catalog and byte-match each tile, recovering everything the tokens hide.
-    Jitter does not stop perceptual hashing -- nothing here does -- but it does
-    stop a plain checksum join, which is the cheap version of the attack.
+    alongside its category, so a crawler could run this pipeline over the
+    catalog and match each tile by checksum, recovering everything the tokens
+    hide.
+
+    Be honest about what the jitter buys. It draws from a bounded set --
+    CAPTCHA_TILE_JITTER_PX crop insets times the quality range -- so it does
+    not make matching impossible; it multiplies the precompute an attacker
+    needs by the size of that set, and it costs nothing on our side. It does
+    not touch perceptual hashing at all, which no amount of jitter would. On a
+    flat, detail-free cover it may produce identical bytes across challenges,
+    which is fine: such a cover identifies nothing in the first place.
     """
     key = f"{_TILE_CACHE_PREFIX}_{nonce}_{item.pk}"
     data = cache.get(key)

--- a/neodb/users/templates/users/captcha.html
+++ b/neodb/users/templates/users/captcha.html
@@ -125,6 +125,7 @@
           const done = placed.size === tiles.length;
           submit.disabled = !done;
           status.textContent = done ? strings.ready : strings.remaining;
+          document.documentElement.classList.toggle('captcha-ready', done);
           const answer = {};
           const trace = {};
           placed.forEach((v, token) => {
@@ -135,6 +136,14 @@
           traceField.value = JSON.stringify(trace);
         }
 
+        // restart an animation by removing the class, forcing a reflow, and
+        // adding it back; otherwise a second landing in the same row is silent
+        function replay(el, cls) {
+          el.classList.remove(cls);
+          void el.offsetWidth;
+          el.classList.add(cls);
+        }
+
         function place(tile, rowIndex, record) {
           const token = tile.dataset.token;
           const target = rowContainer(rowIndex);
@@ -142,6 +151,8 @@
           target.appendChild(tile);
           tile.setAttribute('aria-pressed', 'false');
           placed.set(token, Object.assign({ row: rowIndex }, record));
+          replay(tile, 'captcha-tile--landed');
+          replay(target, 'captcha-row--took');
           refresh();
         }
 

--- a/neodb/users/templates/users/captcha.html
+++ b/neodb/users/templates/users/captcha.html
@@ -1,0 +1,247 @@
+{% load i18n %}
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+{% translate "Sort every cover to continue." as str_remaining %}
+{% translate "All sorted. Select Confirm." as str_ready %}
+{% translate "Cover selected. Now choose a row." as str_selected %}
+{% translate "Time is up. Reload to try again." as str_expired %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}" class="captcha-page">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans 'Register' %}</title>
+    {% include "common_libs.html" %}
+    <meta name="robots" content="noindex">
+  </head>
+  <body>
+    <div class="container">
+      <article>
+        <header style="text-align: center;">
+          <img src="{{ site_logo }}"
+               class="logo"
+               alt="logo"
+               style="max-height: 20vh">
+        </header>
+        <h4>{% trans "One quick check" %}</h4>
+        <p id="captcha-instructions">
+          {% trans "Put every cover into the row it belongs to. Drag it, or select a cover and then select a row." %}
+        </p>
+        {% if msg %}
+          <p aria-live="polite">
+            <mark>{{ msg }}</mark>
+          </p>
+        {% endif %}
+        <div class="captcha-pool" id="captcha-pool" data-role="pool">
+          {% for token in tokens %}
+            <button type="button"
+                    class="captcha-tile"
+                    data-token="{{ token }}"
+                    aria-pressed="false"
+                    aria-label="{% trans 'Item cover' %}">
+              <img src="{% url 'users:captcha_tile' token %}"
+                   alt="{% trans 'Item cover' %}"
+                   draggable="false"
+                   width="120"
+                   height="120">
+            </button>
+          {% endfor %}
+        </div>
+        {% for row in rows %}
+          <div class="captcha-row"
+               data-role="row"
+               data-row="{{ row.index }}"
+               aria-label="{{ row.label }}">
+            <span class="captcha-row__label">{{ row.label }}</span>
+            <button type="button"
+                    class="captcha-row__drop"
+                    data-row="{{ row.index }}"
+                    aria-label="{% blocktrans with label=row.label %}Move selected cover to {{ label }}{% endblocktrans %}">
+            </button>
+          </div>
+        {% endfor %}
+        <p class="captcha-status"
+           role="status"
+           aria-live="polite"
+           id="captcha-status"></p>
+        <form action="{% url 'users:captcha' %}" method="post" id="captcha-form">
+          {% csrf_token %}
+          <input type="hidden" name="nonce" value="{{ nonce }}">
+          <input type="hidden" name="answer" id="captcha-answer" value="">
+          <input type="hidden" name="trace" id="captcha-trace" value="">
+          <div role="group">
+            <button type="submit"
+                    name="action"
+                    value="submit"
+                    id="captcha-submit"
+                    disabled>{% trans "Confirm" %}</button>
+            {% if regenerations_left %}
+              <button type="submit"
+                      name="action"
+                      value="regenerate"
+                      class="secondary"
+                      id="captcha-regenerate">
+                {% blocktrans count counter=regenerations_left %}Show me another set ({{ counter }} left){% plural %}Show me another set ({{ counter }} left){% endblocktrans %}
+              </button>
+            {% endif %}
+          </div>
+          <small>
+            <span id="captcha-timer" data-seconds="{{ seconds_left }}"></span>
+          </small>
+        </form>
+      </article>
+    </div>
+    {{ seconds_left|json_script:"captcha-seconds" }}
+    <script>
+      (function () {
+        const pool = document.getElementById('captcha-pool');
+        const rows = Array.from(document.querySelectorAll('[data-role="row"]'));
+        const tiles = Array.from(document.querySelectorAll('.captcha-tile'));
+        const answerField = document.getElementById('captcha-answer');
+        const traceField = document.getElementById('captcha-trace');
+        const submit = document.getElementById('captcha-submit');
+        const status = document.getElementById('captcha-status');
+        const timer = document.getElementById('captcha-timer');
+
+        // token -> {row, mode, points:[[x,y,t],...], duration}
+        const placed = new Map();
+        let selected = null;
+        let selectedAt = 0;
+
+        const strings = {
+          remaining: '{{ str_remaining|escapejs }}',
+          ready: '{{ str_ready|escapejs }}',
+          selected: '{{ str_selected|escapejs }}',
+          expired: '{{ str_expired|escapejs }}'
+        };
+
+        function rowContainer(index) {
+          return rows.find((r) => r.dataset.row === String(index));
+        }
+
+        function refresh() {
+          const done = placed.size === tiles.length;
+          submit.disabled = !done;
+          status.textContent = done ? strings.ready : strings.remaining;
+          const answer = {};
+          const trace = {};
+          placed.forEach((v, token) => {
+            answer[token] = v.row;
+            trace[token] = { mode: v.mode, points: v.points, duration: v.duration };
+          });
+          answerField.value = JSON.stringify(answer);
+          traceField.value = JSON.stringify(trace);
+        }
+
+        function place(tile, rowIndex, record) {
+          const token = tile.dataset.token;
+          const target = rowContainer(rowIndex);
+          if (!target) return;
+          target.appendChild(tile);
+          tile.setAttribute('aria-pressed', 'false');
+          placed.set(token, Object.assign({ row: rowIndex }, record));
+          refresh();
+        }
+
+        // --- click / keyboard route: select a cover, then select a row.
+        // Writes the same fields as the drag route, so the server sees one
+        // shape and this path needs no endpoint of its own.
+        function select(tile) {
+          if (selected) selected.setAttribute('aria-pressed', 'false');
+          selected = tile;
+          selectedAt = performance.now();
+          tile.setAttribute('aria-pressed', 'true');
+          status.textContent = strings.selected;
+        }
+
+        tiles.forEach((tile) => {
+          tile.addEventListener('click', function (ev) {
+            if (tile.dataset.dragged === '1') {
+              tile.dataset.dragged = '';
+              return;
+            }
+            ev.preventDefault();
+            select(tile);
+          });
+
+          // --- drag route: pointer events cover mouse, touch and pen in one
+          // path, and the samples they yield are the trajectory evidence.
+          tile.addEventListener('pointerdown', function (ev) {
+            if (ev.button !== 0 && ev.pointerType === 'mouse') return;
+            const points = [[ev.clientX, ev.clientY, performance.now()]];
+            const startedAt = performance.now();
+            let moved = false;
+            tile.setPointerCapture(ev.pointerId);
+            tile.classList.add('captcha-tile--dragging');
+
+            function onMove(e) {
+              if (points.length < 200) {
+                points.push([e.clientX, e.clientY, performance.now()]);
+              }
+              if (Math.abs(e.clientX - points[0][0]) > 4 || Math.abs(e.clientY - points[0][1]) > 4) {
+                moved = true;
+              }
+              tile.style.transform =
+                'translate(' + (e.clientX - points[0][0]) + 'px,' + (e.clientY - points[0][1]) + 'px)';
+            }
+
+            function onUp(e) {
+              tile.removeEventListener('pointermove', onMove);
+              tile.removeEventListener('pointerup', onUp);
+              tile.removeEventListener('pointercancel', onUp);
+              tile.classList.remove('captcha-tile--dragging');
+              tile.style.transform = '';
+              try { tile.releasePointerCapture(e.pointerId); } catch (err) {}
+              if (!moved) return;
+              tile.dataset.dragged = '1';
+              points.push([e.clientX, e.clientY, performance.now()]);
+              const dropped = document.elementFromPoint(e.clientX, e.clientY);
+              const row = dropped && dropped.closest('[data-role="row"]');
+              if (!row) return;
+              place(tile, Number(row.dataset.row), {
+                mode: 'drag',
+                points: points,
+                duration: performance.now() - startedAt
+              });
+            }
+
+            tile.addEventListener('pointermove', onMove);
+            tile.addEventListener('pointerup', onUp);
+            tile.addEventListener('pointercancel', onUp);
+          });
+        });
+
+        document.querySelectorAll('.captcha-row__drop').forEach((drop) => {
+          drop.addEventListener('click', function (ev) {
+            ev.preventDefault();
+            if (!selected) return;
+            const dwell = performance.now() - selectedAt;
+            const tile = selected;
+            selected = null;
+            place(tile, Number(drop.dataset.row), {
+              mode: 'click',
+              points: [],
+              duration: dwell
+            });
+          });
+        });
+
+        let left = JSON.parse(document.getElementById('captcha-seconds').textContent);
+        function tick() {
+          if (left <= 0) {
+            timer.textContent = strings.expired;
+            submit.disabled = true;
+            return;
+          }
+          const m = Math.floor(left / 60);
+          const s = String(left % 60).padStart(2, '0');
+          timer.textContent = m + ':' + s;
+          left -= 1;
+          setTimeout(tick, 1000);
+        }
+        tick();
+        refresh();
+      })();
+    </script>
+  </body>
+</html>

--- a/neodb/users/templates/users/captcha.html
+++ b/neodb/users/templates/users/captcha.html
@@ -92,6 +92,7 @@
       </article>
     </div>
     {{ seconds_left|json_script:"captcha-seconds" }}
+    {{ max_trace_points|json_script:"captcha-max-points" }}
     <script>
       (function () {
         const pool = document.getElementById('captcha-pool');
@@ -105,6 +106,7 @@
 
         // token -> {row, mode, points:[[x,y,t],...], duration}
         const placed = new Map();
+        const maxPoints = JSON.parse(document.getElementById('captcha-max-points').textContent);
         let selected = null;
         let selectedAt = 0;
 
@@ -175,7 +177,9 @@
             tile.classList.add('captcha-tile--dragging');
 
             function onMove(e) {
-              if (points.length < 200) {
+              // leave room for the pointerup sample below: overshooting the
+              // server's cap by even one point rejects the whole submission
+              if (points.length < maxPoints - 1) {
                 points.push([e.clientX, e.clientY, performance.now()]);
               }
               if (Math.abs(e.clientX - points[0][0]) > 4 || Math.abs(e.clientY - points[0][1]) > 4) {
@@ -226,8 +230,14 @@
           });
         });
 
-        let left = JSON.parse(document.getElementById('captcha-seconds').textContent);
+        // Track an absolute deadline rather than decrementing per tick: a
+        // throttled background tab or a suspended device would otherwise leave
+        // the display behind the server clock, and the visitor submits an
+        // answer that is already expired -- which costs them the whole session.
+        const deadline = Date.now() +
+          JSON.parse(document.getElementById('captcha-seconds').textContent) * 1000;
         function tick() {
+          const left = Math.max(0, Math.round((deadline - Date.now()) / 1000));
           if (left <= 0) {
             timer.textContent = strings.expired;
             submit.disabled = true;
@@ -236,7 +246,6 @@
           const m = Math.floor(left / 60);
           const s = String(left % 60).padStart(2, '0');
           timer.textContent = m + ':' + s;
-          left -= 1;
           setTimeout(tick, 1000);
         }
         tick();

--- a/neodb/users/templates/users/captcha_solved.html
+++ b/neodb/users/templates/users/captcha_solved.html
@@ -1,0 +1,53 @@
+{% load i18n %}
+{% load static %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}" class="captcha-page">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ site_name }} - {% trans 'Register' %}</title>
+    {% include "common_libs.html" %}
+    <meta name="robots" content="noindex">
+  </head>
+  <body>
+    <div class="container">
+      <article>
+        <header style="text-align: center;">
+          <img src="{{ site_logo }}"
+               class="logo"
+               alt="logo"
+               style="max-height: 20vh">
+        </header>
+        <div class="captcha-solved" role="status">
+          <svg class="captcha-solved__mark"
+               viewBox="0 0 52 52"
+               aria-hidden="true"
+               focusable="false">
+            <circle class="captcha-solved__circle" cx="26" cy="26" r="23" />
+            <path class="captcha-solved__tick" d="M14 27 L22 35 L38 18" />
+          </svg>
+          <h4>{% trans "Nicely sorted" %}</h4>
+          <p>{% trans "That is all we needed. Let's get you a username." %}</p>
+          <a href="{% url 'users:register' %}" role="button" id="captcha-continue">{% trans "Continue" %}</a>
+        </div>
+      </article>
+    </div>
+    <script>
+      (function () {
+        const link = document.getElementById('captcha-continue');
+        if (!link) return;
+        // Let the mark finish drawing, then move on by itself. The link is
+        // real, so clicking it skips ahead and a no-JS visitor is never stuck;
+        // reduced-motion goes straight through without the flourish.
+        const reduced = window.matchMedia
+          && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (reduced) {
+          window.location = link.href;
+          return;
+        }
+        setTimeout(function () { window.location = link.href; }, 1500);
+      })();
+    </script>
+  </body>
+</html>

--- a/neodb/users/urls.py
+++ b/neodb/users/urls.py
@@ -7,6 +7,12 @@ urlpatterns = [
     path("login", login, name="login"),
     path("login/proof", login_proof, name="login_proof"),
     path("register", register, name="register"),
+    path("captcha", registration_captcha, name="captcha"),
+    path(
+        "captcha/tile/<str:token>",
+        registration_captcha_tile,
+        name="captcha_tile",
+    ),
     path("fetch_refresh", fetch_refresh, name="fetch_refresh"),
     path("data", data, name="data"),
     path("info", account_info, name="info"),

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -193,6 +193,7 @@ def _captcha_context(request: HttpRequest, challenge) -> dict:
         ],
         "nonce": challenge["nonce"],
         "seconds_left": captcha.seconds_left(challenge),
+        "max_trace_points": captcha.CAPTCHA_MAX_TRACE_POINTS,
         "regenerations_left": captcha.regenerations_left(challenge),
         "msg": captcha.pop_message(request),
     }
@@ -221,6 +222,13 @@ def _captcha_end(request: HttpRequest, outcome: str, title, message):
     return _render_error(request, title, message)
 
 
+def _captcha_fail_open(request: HttpRequest):
+    """Let registration through when no fair quiz can be built."""
+    captcha.mark_passed(request)
+    record_registration_captcha("fail_open")
+    return redirect(reverse("users:register"))
+
+
 @require_http_methods(["GET", "POST"])
 def registration_captcha(request: HttpRequest):
     """Sort item covers into two category rows before choosing a username."""
@@ -230,6 +238,16 @@ def registration_captcha(request: HttpRequest):
         return redirect(reverse("users:login"))
     if not captcha.is_enabled() or captcha.has_passed(request):
         return redirect(reverse("users:register"))
+    # mirror register()'s invite gate: without it an uninvited visitor can
+    # solve quizzes on an invite-only site before being turned away anyway
+    if SiteConfig.system.invite_only and not Takahe.verify_invite(
+        str(request.session.get("invite"))
+    ):
+        return _render_error(
+            request,
+            _("Authentication failed"),
+            _("Registration is for invitation only"),
+        )
 
     if request.method == "POST":
         challenge = captcha.get_challenge(request)
@@ -242,21 +260,29 @@ def registration_captcha(request: HttpRequest):
                 _("Time is up"),
                 _("Please log in again to continue registration."),
             )
+        # A stale form -- re-post, back button, double click -- costs nothing
+        # and just re-renders whatever is current.
         if request.POST.get("nonce") != challenge["nonce"]:
-            # stale form: a re-post, the back button, or a double click.
-            # Costs nothing; re-render whatever is current.
+            return redirect(reverse("users:captcha"))
+        # Then claim it atomically. Comparing the nonce and only rotating it in
+        # a later session write would let concurrent posts all pass and collapse
+        # into a single spent regeneration, which is an unlimited-guess hole.
+        # Claiming after the match check keeps junk nonces out of the cache.
+        if not captcha.claim_nonce(challenge["nonce"]):
             return redirect(reverse("users:captcha"))
 
         if request.POST.get("action") == "regenerate":
-            if captcha.regenerations_left(challenge) <= 0:
+            outcome = captcha.regenerate(request)
+            if outcome["exhausted"]:
                 # no-op rather than session-ending: a stray click on a button
                 # that should already be hidden must not cost a signup
                 return redirect(reverse("users:captcha"))
-            captcha.regenerate(request)
+            if not outcome["challenge"]:
+                return _captcha_fail_open(request)
             record_registration_captcha("regenerated")
             return redirect(reverse("users:captcha"))
 
-        ok, outcome, reason = captcha.verify_submission(
+        ok, outcome_name, reason = captcha.verify_submission(
             challenge,
             request.POST.get("answer", ""),
             request.POST.get("trace", ""),
@@ -265,18 +291,23 @@ def registration_captcha(request: HttpRequest):
             captcha.mark_passed(request)
             record_registration_captcha("passed")
             return redirect(reverse("users:register"))
-        record_registration_captcha(outcome, reason)
-        captcha.record_fail(client_ip(request))
-        if captcha.regenerations_left(challenge) <= 0:
+        record_registration_captcha(outcome_name, reason)
+        ip = client_ip(request)
+        captcha.record_fail(ip)
+        # enforce the cap here too, not only when issuing: otherwise a live
+        # challenge keeps serving attempts long past the limit
+        if captcha.regenerations_left(challenge) <= 0 or captcha.fails_exceeded(ip):
             return _captcha_end(
                 request,
                 "exhausted",
                 _("Verification failed"),
                 _("Please log in again to continue registration."),
             )
-        captcha.regenerate(
+        regenerated = captcha.regenerate(
             request, msg=_("That is not quite right. Here is a new set.")
         )
+        if not regenerated["challenge"] and not regenerated["exhausted"]:
+            return _captcha_fail_open(request)
         return redirect(reverse("users:captcha"))
 
     challenge = captcha.get_challenge(request)
@@ -292,9 +323,7 @@ def registration_captcha(request: HttpRequest):
         if not challenge:
             # the catalog cannot supply a fair quiz right now; letting people
             # register matters more than running the check
-            captcha.mark_passed(request)
-            record_registration_captcha("fail_open")
-            return redirect(reverse("users:register"))
+            return _captcha_fail_open(request)
         record_registration_captcha("issued")
     elif captcha.expired(challenge):
         return _captcha_end(
@@ -314,8 +343,8 @@ def registration_captcha_tile(request: HttpRequest, token: str):
     real cover would spell out the answer. Unknown, stale and foreign tokens
     all 404 identically so the response cannot be used as an oracle.
     """
-    item = captcha.tile_item(request, token)
-    data = captcha.render_tile(item) if item else None
+    resolved = captcha.tile_item(request, token)
+    data = captcha.render_tile(*resolved) if resolved else None
     if not data:
         raise Http404
     response = HttpResponse(data, content_type=captcha.CAPTCHA_TILE_CONTENT_TYPE)

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -8,16 +8,17 @@ from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, ValidationError
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
+from catalog.models import ItemCategory
 from common.models import SiteConfig
-from common.sentry import record_activity
-from common.utils import AuthedHttpRequest
+from common.sentry import record_activity, record_registration_captcha
+from common.utils import AuthedHttpRequest, client_ip
 from common.validators import sanitize_next_url
 from mastodon.models import (
     Email,
@@ -30,6 +31,7 @@ from mastodon.models import (
 from takahe.models import Token
 from takahe.utils import Takahe
 
+from .. import registration_captcha as captcha
 from ..login_proof import LOGIN_PROOF_METHODS, create_login_proof_challenge
 from ..models import User
 
@@ -178,6 +180,150 @@ def _handle_new_user_registration(request, form, verified_account, email_readonl
     return render(request, "users/welcome.html")
 
 
+def _captcha_context(request: HttpRequest, challenge) -> dict:
+    tokens = list(challenge["tiles"].keys())
+    # the stored order is already shuffled; reshuffle per render so a reload
+    # cannot be diffed against the first response to infer the grouping
+    secrets.SystemRandom().shuffle(tokens)
+    return {
+        "tokens": tokens,
+        "rows": [
+            {"index": i, "value": v, "label": ItemCategory(v).label}
+            for i, v in enumerate(challenge["rows"])
+        ],
+        "nonce": challenge["nonce"],
+        "seconds_left": captcha.seconds_left(challenge),
+        "regenerations_left": captcha.regenerations_left(challenge),
+        "msg": captcha.pop_message(request),
+    }
+
+
+def _render_error(request: HttpRequest, title, message=""):
+    # common.views.render_error would be the natural call, but importing it
+    # here is circular: common.views imports catalog.views, which imports this
+    # module. register() renders the same template inline for the same reason.
+    return render(
+        request, "common/error.html", {"msg": title, "secondary_msg": message}
+    )
+
+
+def _captcha_end(request: HttpRequest, outcome: str, title, message):
+    """Drop the pending registration and send the visitor back to login.
+
+    There is no logged-in user during registration, so "logged out" means
+    flushing the session: `verified_account` goes with it, and the provider
+    round trip has to be repeated. auth_logout() is the wrong tool here, it
+    reads ?next off a GET and clears a Takahe cookie an anonymous visitor
+    does not have.
+    """
+    record_registration_captcha(outcome)
+    request.session.flush()
+    return _render_error(request, title, message)
+
+
+@require_http_methods(["GET", "POST"])
+def registration_captcha(request: HttpRequest):
+    """Sort item covers into two category rows before choosing a username."""
+    if request.user.is_authenticated:
+        return redirect(reverse("users:info"))
+    if not SocialAccount.from_dict(request.session.get("verified_account")):
+        return redirect(reverse("users:login"))
+    if not captcha.is_enabled() or captcha.has_passed(request):
+        return redirect(reverse("users:register"))
+
+    if request.method == "POST":
+        challenge = captcha.get_challenge(request)
+        if not challenge:
+            return redirect(reverse("users:captcha"))
+        if captcha.expired(challenge):
+            return _captcha_end(
+                request,
+                "expired",
+                _("Time is up"),
+                _("Please log in again to continue registration."),
+            )
+        if request.POST.get("nonce") != challenge["nonce"]:
+            # stale form: a re-post, the back button, or a double click.
+            # Costs nothing; re-render whatever is current.
+            return redirect(reverse("users:captcha"))
+
+        if request.POST.get("action") == "regenerate":
+            if captcha.regenerations_left(challenge) <= 0:
+                # no-op rather than session-ending: a stray click on a button
+                # that should already be hidden must not cost a signup
+                return redirect(reverse("users:captcha"))
+            captcha.regenerate(request)
+            record_registration_captcha("regenerated")
+            return redirect(reverse("users:captcha"))
+
+        ok, outcome, reason = captcha.verify_submission(
+            challenge,
+            request.POST.get("answer", ""),
+            request.POST.get("trace", ""),
+        )
+        if ok:
+            captcha.mark_passed(request)
+            record_registration_captcha("passed")
+            return redirect(reverse("users:register"))
+        record_registration_captcha(outcome, reason)
+        captcha.record_fail(client_ip(request))
+        if captcha.regenerations_left(challenge) <= 0:
+            return _captcha_end(
+                request,
+                "exhausted",
+                _("Verification failed"),
+                _("Please log in again to continue registration."),
+            )
+        captcha.regenerate(
+            request, msg=_("That is not quite right. Here is a new set.")
+        )
+        return redirect(reverse("users:captcha"))
+
+    challenge = captcha.get_challenge(request)
+    if not challenge:
+        if captcha.fails_exceeded(client_ip(request)):
+            record_registration_captcha("rate_limited")
+            return _render_error(
+                request,
+                _("Too many attempts"),
+                _("Please try again later."),
+            )
+        challenge = captcha.ensure_challenge(request)
+        if not challenge:
+            # the catalog cannot supply a fair quiz right now; letting people
+            # register matters more than running the check
+            captcha.mark_passed(request)
+            record_registration_captcha("fail_open")
+            return redirect(reverse("users:register"))
+        record_registration_captcha("issued")
+    elif captcha.expired(challenge):
+        return _captcha_end(
+            request,
+            "expired",
+            _("Time is up"),
+            _("Please log in again to continue registration."),
+        )
+    return render(request, "users/captcha.html", _captcha_context(request, challenge))
+
+
+@require_http_methods(["GET"])
+def registration_captcha_tile(request: HttpRequest, token: str):
+    """Serve one tile image.
+
+    The proxy exists because cover paths are `item/<category>/...`: linking the
+    real cover would spell out the answer. Unknown, stale and foreign tokens
+    all 404 identically so the response cannot be used as an oracle.
+    """
+    item = captcha.tile_item(request, token)
+    data = captcha.render_tile(item) if item else None
+    if not data:
+        raise Http404
+    response = HttpResponse(data, content_type=captcha.CAPTCHA_TILE_CONTENT_TYPE)
+    response["Cache-Control"] = "no-store, private"
+    response["Vary"] = "Cookie"
+    return response
+
+
 @require_http_methods(["GET", "POST"])
 def register(request: AuthedHttpRequest):
     """show registration page and process the submission from it"""
@@ -206,6 +352,11 @@ def register(request: AuthedHttpRequest):
         if not verified_account:
             # kick back to login if no identity verified
             return redirect(reverse("users:login"))
+        if captcha.is_enabled() and not captcha.has_passed(request):
+            # the enforcement point, not the redirect in register_new_user: this
+            # catches a POST straight to /account/register, and sits above the
+            # closed-community branch below, which creates an account outright
+            return redirect(reverse("users:captcha"))
 
     # no registration form for closed community mode
     if (
@@ -288,6 +439,9 @@ def auth_login(request, user):
     auth.login(request, user, backend="mastodon.auth.OAuth2Backend")
     request.session.pop("verified_account", None)
     request.session.pop("invite", None)
+    # a solved captcha is worth exactly one account: dropping it here is what
+    # keeps the pass from outliving the registration it authorised
+    captcha.clear(request)
     clear_preference_cache(request)
 
 

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -236,7 +236,13 @@ def registration_captcha(request: HttpRequest):
         return redirect(reverse("users:info"))
     if not SocialAccount.from_dict(request.session.get("verified_account")):
         return redirect(reverse("users:login"))
-    if not captcha.is_enabled() or captcha.has_passed(request):
+    if not captcha.is_enabled():
+        return redirect(reverse("users:register"))
+    if captcha.has_passed(request):
+        # the moment the answer is accepted, shown once on the page they were
+        # working on rather than as a silent redirect
+        if captcha.pop_celebration(request):
+            return render(request, "users/captcha_solved.html")
         return redirect(reverse("users:register"))
     # mirror register()'s invite gate: without it an uninvited visitor can
     # solve quizzes on an invite-only site before being turned away anyway
@@ -288,9 +294,9 @@ def registration_captcha(request: HttpRequest):
             request.POST.get("trace", ""),
         )
         if ok:
-            captcha.mark_passed(request)
+            captcha.mark_passed(request, celebrate=True)
             record_registration_captcha("passed")
-            return redirect(reverse("users:register"))
+            return redirect(reverse("users:captcha"))
         record_registration_captcha(outcome_name, reason)
         ip = client_ip(request)
         captcha.record_fail(ip)


### PR DESCRIPTION
Adds an optional comprehension step to registration: sort a handful of item covers into two labelled category rows, between identity verification and username selection.

**Off by default.** `registration_captcha_items = 0` disables it entirely; nothing changes for existing instances unless an admin turns it on at `/manage/access/`. 5-6 tiles is the recommended range.

## Why

Registration is currently gated only by identity verification. The ALTCHA proof-of-work in `users/login_proof.py` costs a bot CPU, not comprehension, so a script that can drive an OAuth app or a throwaway mailbox reaches `POST /account/register` unimpeded.

## How it works

Enforcement sits at the top of `register()`, not in the redirect from `register_new_user()` — a bot posting straight to `/account/register` is bounced, and it is above the closed-community branch so that path is covered too.

Two decisions do the actual security work:

- **No titles on the tiles.** `/api/catalog/search` is unauthenticated and returns an item's `category` for any title, so showing one would hand over the answer.
- **"Popular" means marks, not the trending cache.** `/api/trending/<category>/` is also unauthenticated and dumps ~60 items per category verbatim; drawing from it would let a single scrape of seven URLs answer every future quiz. Instead, items with at least `min_marks_for_captcha` marks (default 10), capped at 1000 pks per category, rebuilt by a daily job, falling back to any item when a category is thin.

Tiles are served through an opaque per-challenge proxy because cover paths are literally `item/<category>/...`, and are normalized to one full-bleed square and one mime type — padding or differing aspect ratios would leak the category through geometry alone. The transform is jittered per challenge so a tile is not a checksum of a public cover.

One five-minute budget covers the whole step, with two regenerations; a wrong answer or automated-looking telemetry spends one, and the next failure ends the session. Nonces are single-use via `cache.add`, mirroring the replay guard in `login_proof`.

The pass is deliberately not bound to an identity: `auth_login()` consumes it and `verified_account` is a single overwritten slot, so one solve is worth exactly one account.

## Threat model, stated plainly

The trace checks are client-supplied and forgeable — they only cost automation that never simulates a pointer, and `REQUIRE_HUMAN_TRAJECTORY` disables them without a deploy. The real cost lever is the per-IP failure cap plus the hard 3-attempt limit. A solver written against this specific site still wins; what this stops is generic, off-the-shelf automation, which is the bulk of real signup abuse. Perceptual hashing of crawled covers remains open by design.

## Known limitation

With no titles there is nothing non-visual to reason from, so **this cannot be solved with a screen reader.** The click/keyboard route still serves people who can see the covers but cannot drag, which is a distinct population. The field's help text says so explicitly, and an operator enabling this should keep another route in (an invite link, or an admin-created account on request). The default of `0` keeps it off.

## Config

| Field | Default | Meaning |
| --- | --- | --- |
| `registration_captcha_items` | `0` | Tiles per quiz, split randomly across two rows. `0` disables; `1..3` rejected (guessing passes ~87% at 2, ~42% at 3) |
| `min_marks_for_captcha` | `10` | Marks before an item counts as recognizable |

## Testing

68 tests in `tests/users/test_registration_captcha.py`, covering the gate, the state machine, the time budget, leakage (asserts no title, uuid, pk or extra category string reaches the page), the tile proxy, the pool, the daily job, metrics, and the settings validators.

Full suite green locally (2221 passed; the 3 `test_lexicons.py` failures are a pre-existing docker-mount issue unrelated to this change).

Also verified by hand in a browser, which is where two bugs turned up that the tests had missed: tiles were originally fitted-and-padded, leaving the aspect ratio readable off the flat bars, and the timer decremented per tick rather than tracking an absolute deadline. Both fixed, both now covered.

The fourth commit adds the completion moment: solving shows a brief drawn
check and "Nicely sorted" before handing over to the username form. It is
one-shot (a reload does not replay it), a fail-open pass is not congratulated,
the Continue link is real so no-JS is never stuck, and `prefers-reduced-motion`
skips straight through. Placing a cover also gets a small settle now.

The third commit addresses a review pass over the first two — two unlimited-guess holes in the state machine, a checksum-joinable tile transform, a spurious fail-open, and three checks that risked rejecting legitimate human input. Each has a regression test that was confirmed to fail against the prior code.

## Notes for review

- `client_ip` moves from `mastodon/views/common.py` to `common/utils.py` so the gate can use it without importing back through `mastodon.views` (that would be circular). Re-exported from the old location.
- `AccessSettings.options` gains an explicit `ClassVar[dict]` annotation: the new int options widened the inferred value type and broke narrowing in an existing `test_views_manage` assertion.
