### PR TITLE
Point Doubak's Douban archives at the NDJSON importer that already reads them

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -39,7 +39,7 @@ NeoDB has various features, and you may imagine it as a mix of Mastodon, Goodrea
     - Letterboxd watch list (ZIP export)
     - RateYourMusic album collection (CSV export)
     - Podcast subscriptions (OPML)
-    - Douban archive (via [Doufen](https://doufen.org/))
+    - Douban archive (via [Doubak](https://doubak.com/) or [Doufen](https://doufen.org/))
 
 
 ## Social

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -14,7 +14,7 @@ The following external sites are supported for importing catalog items.
 | Board Game Geek | Game | |
 | BooksTW 博客來 | Book (Edition) | |
 | Discogs | Music (Album) | |
-| Douban 豆瓣 | Book (Edition, Work) · Music (Album) · Movie · TV (Show, Season, Episode) · Game · Performance (Performance, Production) | Yes — upload [Doufen](https://doufen.org) archive |
+| Douban 豆瓣 | Book (Edition, Work) · Music (Album) · Movie · TV (Show, Season, Episode) · Game · Performance (Performance, Production) | Yes — upload [Doubak](https://doubak.com) or [Doufen](https://doufen.org) archive |
 | Goodreads | Book (Edition, Work) | Yes — upload CSV export |
 | Google Books | Book (Edition) | |
 | IGDB | Game | |

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -7546,6 +7546,10 @@ msgstr ""
 msgid "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -7653,6 +7657,10 @@ msgstr ""
 
 #: users/templates/users/data.html:312
 msgid "Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid "A Douban archive exported by <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -7979,6 +7979,17 @@ msgstr ""
 "选择导出自 <a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">"
 "豆坟</a> 的 <code>.xlsx</code> 文件"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a "
+"href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
+msgstr ""
+"由 <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">豆备 "
+"Doubak</a> 导出的豆瓣档案是 NeoDB 自己的 NDJSON 格式，请用下方的<a "
+"href=\"#import-neodb-archive\">导入NeoDB备份</a>上传。"
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "导入方式"
@@ -8136,6 +8147,15 @@ msgid ""
 msgstr ""
 "上传从NeoDB导出的内含<code>.csv</code>或<code>.ndjson</code>文件<code>.zip</"
 "code>压缩包。"
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and "
+"is imported here."
+msgstr ""
+"由 <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">豆备 "
+"Doubak</a> 导出的豆瓣档案是同一种格式，也在这里导入。"
 
 #: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."

--- a/neodb/users/templates/users/data.html
+++ b/neodb/users/templates/users/data.html
@@ -16,6 +16,18 @@
       let body = response ? response : `Request error: ${event.detail.xhr.statusText}`;
       alert(body);
     });
+    // A cross-reference to a collapsed <details> scrolls to it and leaves it
+    // shut, so the destination lands as nothing but its own title. Browsers
+    // that expand on fragment navigation only open the *ancestors* of the
+    // target, which is no help when the id is on the <details> itself --
+    // hence closest(), so this holds wherever the id ends up sitting.
+    const openLinkedSection = () => {
+      const el = document.getElementById(location.hash.slice(1));
+      const details = el && el.closest('details');
+      if (details) details.open = true;
+    };
+    window.addEventListener('hashchange', openLinkedSection);
+    document.addEventListener('DOMContentLoaded', openLinkedSection);
     </script>
   </head>
   <body>
@@ -29,6 +41,9 @@
                   enctype="multipart/form-data">
               {% csrf_token %}
               {% blocktrans %}Select <code>.xlsx</code> exported from <a href="https://doufen.org" target="_blank" rel="noopener">Doufen</a>{% endblocktrans %}
+              <p>
+                {% blocktrans %}A Douban archive exported by <a href="https://doubak.com" target="_blank" rel="noopener">Doubak</a> is in NeoDB's own NDJSON format instead; upload it under <a href="#import-neodb-archive">Import NeoDB Archive</a> below.{% endblocktrans %}
+              </p>
               <input type="file" name="file" id="excel" required accept=".xlsx">
               <fieldset>
                 <legend>{% trans "Import Method" %}</legend>
@@ -302,7 +317,7 @@
           </details>
         </article>
         <article>
-          <details>
+          <details id="import-neodb-archive">
             <summary>{% trans 'Import NeoDB Archive' %}</summary>
             <form hx-post="{% url 'users:import_neodb' %}"
                   enctype="multipart/form-data">
@@ -310,6 +325,9 @@
               <ul>
                 <li>
                   {% trans 'Upload a <code>.zip</code> file containing <code>.csv</code> or <code>.ndjson</code> files exported from NeoDB.' %}
+                </li>
+                <li>
+                  {% blocktrans %}A Douban archive exported by <a href="https://doubak.com" target="_blank" rel="noopener">Doubak</a> is in the same format and is imported here.{% endblocktrans %}
                 </li>
                 <li>{% trans 'Existing data may be overwritten.' %}</li>
               </ul>


### PR DESCRIPTION
## Summary

Rewritten after your two comments. **The new importer is gone.** [Doubak](https://doubak.com) captures a Douban account in the user's own browser and writes NeoDB's NDJSON archive, so `NdjsonImporter` already reads it — that is how the full archive below was imported. What was missing was never code; it was that nothing on the data page says so.

So this is now a signpost and a documentation line. **No new importer, no migrations, no new view or URL, and not one line of production Python.**

> [!NOTE]
> The previous version — `DoubakImporter` with Merge/Overwrite, two migrations, its own upload form — is preserved at [`MewX/neodb@backup/doubak-ndjson-importer-overwrite`](https://github.com/MewX/neodb/tree/backup/doubak-ndjson-importer-overwrite), should Overwrite ever be wanted.

**Disclosure: I am the author of Doubak.** This is a self-interested contribution, and I would rather state so than have it inferred. **The changes were drafted with Claude Opus 5 and reviewed by me**; commits carry `Co-Authored-By` trailers.

## Answering the two questions

**“why add a new importer?” / “let's make this PR for Merge only.”** Taken together those settle it: Overwrite was the subclass's only reason to exist, and without it the subclass restates nothing at all. Deferring Overwrite until someone asks for it is also the better order — merge-only is what every other importer does, and it is the mode nobody has to be warned about.

**Could a separate progress section survive without a separate importer?** I looked, and no — not without changing code every importer shares. Progress is keyed to the task *type*, and the type comes from the class:

- `Task.latest_task()` filters on the `TypedModel` discriminator; `metadata` is not consulted anywhere,
- `user_task_status.html` builds its polling URL out of `task.type`, and `user_task_status(task_type)` maps that string back to a class.

So two sections of the same type poll one URL and get one answer. Faking a split would mean tagging `metadata`, adding a `latest_task` variant that filters on it, threading a parameter through the status view, and forking the status template — a wider blast radius than the subclass you just declined, bought for a cosmetic split of one queue into two boxes. The page already goes the other way, merging `CsvImporter` and `NdjsonImporter` into one status area; there is no precedent for the reverse, and with one class there genuinely is one queue.

Hence an in-page link instead.

## What is in it

| | |
|---|---|
| `users/templates/users/data.html` | The Douban (Doufen) section names the other format and links down; the NeoDB Archive section gains a matching bullet and an `id`. Six lines of JS open a `<details>` that a fragment points at. |
| `locale/django.pot`, `locale/zh_Hans` | The two new strings, Simplified Chinese filled in. Additions only — the reference comments on untouched entries are left alone, so there is no line-number churn. |
| `docs/sites.md`, `docs/features.md` | Doubak named beside Doufen on the Douban row. |

A fragment link into a collapsed `<details>` scrolls to it without opening it in every browser, so the destination can land as nothing but its own title. The listener runs on load as well as on `hashchange`, so a shared URL carrying the fragment behaves the same.

## Evidence

**A complete archive is imported into neodb.social and the account is public:** <https://neodb.social/users/immewx/>

```
17305 items imported, 0 skipped, 0 failed
```

That is exactly the number of records in the file. The shelves hold 1,774 complete, 71 in progress and 1,098 wishlist, across movie 1,473 · tv 638 · game 598 · book 145 · music 84 · performance 5, with 712 tags, 2,110 comments, 1,788 ratings, 6 collections, 3 articles and 2,519 shelf-log entries.

**It was then exported back out and compared field by field.** Your own NDJSON export is the strongest oracle available, and it reconciles exactly:

```
18560 records exported − 17305 submitted = 1255
    = 1247  marks whose broadcast did not fall on the marking day
    +    8  marks the archive holds no date for
```

2,979 of 2,979 catalogue items resolved, every record type matched, all 2,519 `ShelfLog` entries returned with byte-identical metadata, and the private collection came back private.

**This is now stronger evidence than it was**, not weaker. The old description had to caveat that both uploads went through the *existing* `NdjsonImporter` and therefore established only the format. That code path is the one being documented here, so the caveat is gone: the thing verified at full scale is the thing this pull request points users at.

**That comparison also found a real defect, fixed on my side.** `import_shelf_member` → `Mark.update` → `ensure_log_entry()` already writes a `ShelfLogEntry` keyed on `created_time`, into which `_update_log_entry` puts the mark's current comment and rating. Douban's marking date carries no clock time whereas a broadcast does, and `timestamp` is in that row's unique key — so one event rendered as two lines, 2,345 of 3,174. Doubak now writes such a broadcast at the mark's own timestamp, so `update_or_create` lands on the row NeoDB has already made and supplies only what the broadcast froze. **Nothing is required on your side**; I mention it because it explains why the shelf-log count fell from 3,174 to 2,519, which a reviewer could otherwise read as data loss.

## Naming, and what I dropped

The earlier version renamed the Douban section to `... (Doufen)` so it could sit beside a `... (Doubak)` one. **With only one Douban-named section left there is nothing to disambiguate it from**, and renaming a msgid orphans its translation in nine locales, so the label is untouched. The disambiguation now lives in the sentence, which names both tools and says which file each takes.

Locale changes are confined to `django.pot` and `zh_Hans`, matching your own recent feature commits; the rest is Weblate's.

## Relationship to #1801

#1801 builds the same thing on the CSV importer and still defines `journal.DoubakImporter`. It is superseded by this — say the word and I will close it. The correction it needs either way: it reports the movie/TV split as differing from your catalogue "by 5", inferred from shelf totals. Comparing the two catalogue exports item by item gives the exact figure — **they disagree on 25 of 2,111**, a net difference of 3, in both directions. Several are television specials Douban renders on its film template; a few are series your catalogue files as films. Neither side is uniformly right, and I would rather correct my own favourable number than leave it standing.

## Caveats

1. **The template change has not been exercised on a running instance.** A fragment matching no `id` scrolls nowhere and raises nothing, so the two halves of the link are worth a glance in review.
2. **The `<details>` listener is a progressive nicety.** If it fails, the link still scrolls to the right section; it just arrives closed.
3. **The coupling is to your NDJSON format, not to Doubak.** Doubak writes what `NdjsonExporter` writes; if the format moves, the archive follows it.
4. **Happy to squash** the two commits into one.

---

# 简体中文

## 这个 PR 现在做什么

按你那两条回复重写了。**新的导入器没有了。**[豆备（Doubak）](https://doubak.com)在用户自己的浏览器里抓豆瓣，写出来的就是 NeoDB 的 NDJSON 归档，`NdjsonImporter` 本来就读得懂——下面那份完整档案就是这么进去的。缺的从来不是代码，而是**数据页上没有任何一句话这么说**。

所以现在只剩一块路牌和一行文档：**没有新导入器，没有迁移，没有新的视图和 URL，一行生产代码都没有。**

> [!NOTE]
> 之前那版（`DoubakImporter` 加合并/覆盖、两个迁移、自己的上传表单）留在 [`MewX/neodb@backup/doubak-ndjson-importer-overwrite`](https://github.com/MewX/neodb/tree/backup/doubak-ndjson-importer-overwrite)，将来真要「覆盖」的话在那儿。

**利益声明：我是豆备的作者。** 与其让你推断出来，不如我先说。**代码由 Claude Opus 5 协助撰写、我审阅**，提交都带 `Co-Authored-By`。

## 回答那两个问题

**「为什么要加一个新导入器？」／「这个 PR 就做合并吧。」** 这两句合起来就定了：子类存在的唯一理由就是「覆盖」，没有它，子类什么都没重写。而且先不做「覆盖」本身顺序也更好——只做合并跟其它导入器一致，也是唯一不需要给用户加警告的模式。

**不要单独的导入器，还能不能有单独的进度区？** 我查了，不能——除非动所有导入器共用的代码。进度是挂在任务**类型**上的，而类型来自类本身：

- `Task.latest_task()` 按 `TypedModel` 的判别值过滤，`metadata` 在任何地方都没参与过滤；
- `user_task_status.html` 用 `task.type` 拼出轮询 URL，`user_task_status(task_type)` 再把这个字符串映射回类。

所以同一个类型的两个区块，轮询同一个 URL、拿到同一个答案。要硬造出两个区，就得往 `metadata` 里塞标记、加一个按它过滤的 `latest_task`、给状态视图加参数、再把状态模板复制一份——**波及面比你刚否掉的那个子类还大**，换来的只是把一个队列拆成两个框。而且这一页现在是反着来的：`CsvImporter` 和 `NdjsonImporter` 合用一个状态区；反过来拆没有先例，何况同一个类本来就只有一个队列。

所以改成页内跳转。

## 具体内容

| | |
|---|---|
| `users/templates/users/data.html` | 豆瓣（豆伴）那一节说清另一种格式并向下链接；「导入 NeoDB 备份」那一节加一条对应说明和一个 `id`。六行 JS 负责把被链接到的 `<details>` 展开。 |
| `locale/django.pot`、`locale/zh_Hans` | 两条新字符串，简体中文已填。纯新增——没碰的条目的引用注释一律不动，所以没有行号噪音。 |
| `docs/sites.md`、`docs/features.md` | 豆瓣那一行在豆伴旁边补上豆备。 |

指向折叠 `<details>` 的锚点，在有些浏览器里只滚过去、不展开，于是「到了」看起来就只有一个标题。那段监听在页面加载时也跑一次，所以别人分享的带锚点的链接行为一致。

## 证据

**整份档案已经真的导进 neodb.social，账号是公开的：** <https://neodb.social/users/immewx/>

```
17305 items imported, 0 skipped, 0 failed
```

这个数正好等于文件里的记录数。书架上是 看过 1774 · 在看 71 · 想看 1098，电影 1473 · 剧集 638 · 游戏 598 · 图书 145 · 音乐 84 · 舞台剧 5，另有 712 个标签、2110 条短评、1788 个评分、6 份收藏单、3 篇文章、2519 条状态历史。

**然后又导出来逐字段对了一遍。** 你们自己的 NDJSON 导出是能拿到的最强判据，而它对得平：

```
导出 18560 − 送进 17305 = 1255
    = 1247  标记那天没有对应广播的
    +    8  档案里根本没有标记日期的
```

2979 个条目全部对上，每一类记录一条不差，2519 条 `ShelfLog` 元数据逐字节相同，私密收藏单回来还是私密的。

**而且这份证据现在比之前更硬，不是更软。** 旧描述里得写一句：那两次上传走的都是**现有的** `NdjsonImporter`，所以只能证明格式。而那条路径正是这个 PR 要指给用户的东西，所以这句注意事项没有了——**全量验证过的，就是这个 PR 指过去的那一条路**。

**那次比对还查出一个真的缺陷，已经在我这边修掉。** `import_shelf_member` → `Mark.update` → `ensure_log_entry()` 本来就会按 `created_time` 建一行 `ShelfLogEntry`，`_update_log_entry` 再把标记当前的短评和评分写进去。豆瓣的标记日期没有时刻而广播有，`timestamp` 又在那一行的唯一键里，于是同一件事排成两行——3174 条里 2345 条。现在豆备把这类广播写成**标记自己那个时间戳**，让 `update_or_create` 落到 NeoDB 已经建好的那一行上，只补进广播冻住的部分。**你们这边不需要改任何东西**；我写出来是因为它解释了状态历史为什么从 3174 降到 2519，否则审阅时容易读成丢数据。

## 命名，以及我去掉了什么

上一版把豆瓣那一节改名成 `…（Doufen）`，是为了跟 `…（Doubak）` 并排。**现在页面上只剩一个写着豆瓣的区块，没有需要区分的对象了**，而改一个已有的 msgid 会让九种语言的译文变成孤儿，所以标题一个字没动。区分改由那句话来做：它同时点名两个工具，并说明各自要什么文件。

语言文件只动 `django.pot` 和 `zh_Hans`，跟你自己最近几个功能提交的做法一致，其余交给 Weblate。

## 跟 #1801 的关系

#1801 是在 CSV 导入器上做同一件事，而且仍然定义 `journal.DoubakImporter`，已被这个 PR 取代——你说一声我就关掉。无论如何要更正它里面的一个数：它按书架汇总数说电影／剧集的判定跟你们目录「差 5 条」。这次把两边目录导出逐条对了一遍，精确值是 **2111 条里差 25 条**，净差 3，而且**两个方向都有**：有几条是豆瓣用电影模板渲染的电视特别篇，也有几条是你们目录里把剧集归成了电影。两边都不是权威。我宁可自己把这个偏向我的数字改过来。

## 需要注意的

1. **模板改动没有在运行的实例上跑过。** 指向不存在的锚点既不会滚到任何地方，也不会报任何错，所以链接的两头值得审阅时扫一眼。
2. **那段展开 `<details>` 的 JS 是锦上添花。** 就算它不生效，链接照样滚到正确的位置，只是到的时候是折叠的。
3. **耦合的是你们的 NDJSON 格式，不是豆备。** 豆备写的就是 `NdjsonExporter` 写的东西；格式变了，跟着变的是档案。
4. **两个提交可以压成一个。**