### PR TITLE
fix(logging): reduce log noise

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -435,11 +435,34 @@ AUTHENTICATION_BACKENDS = [
 
 LOG_LEVEL = env("NEODB_LOG_LEVEL", default="DEBUG" if DEBUG else "INFO")
 
+
+def _hide_client_error_traceback(record: logging.LogRecord) -> bool:
+    """Keep the one-line record for a 4xx response, but drop its traceback.
+
+    Django logs PermissionDenied and BadRequest through log_response() with
+    exc_info set, so each client error prints a stack trace that tells no more
+    than the message. Records without a status_code, and 5xx, keep the trace.
+    """
+    if getattr(record, "status_code", 500) < 500:
+        record.exc_info = None
+        record.exc_text = None
+    return True
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "hide_client_error_traceback": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": _hide_client_error_traceback,
+        },
+    },
     "handlers": {
-        "console": {"class": "logging.StreamHandler"},
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["hide_client_error_traceback"],
+        },
         "null": {"class": "logging.NullHandler"},
     },
     "loggers": {

--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -703,6 +703,10 @@ if _SENTRY_DSN:
     from sentry_sdk.integrations.loguru import LoguruIntegration
 
     ignore_logger("podcastparser")
+    # A bad Host header is a client error, not a bug. The null handler in
+    # LOGGING does not keep it out of Sentry: the SDK patches
+    # Logger.callHandlers, so it sees the record even when no handler does.
+    ignore_logger("django.security.DisallowedHost")
 
     sentry_env = sys.argv[0].split("/")[-1]
     if len(sys.argv) > 1 and sentry_env in ("manage.py", "django-admin"):


### PR DESCRIPTION
Two independent fixes for client-error noise, one in Sentry and one in the console log. They are separate commits and can be cherry-picked on their own.

## 1. `DisallowedHost` is no longer reported to Sentry

Every scanner that probes the server with an unknown `Host` header currently opens a Sentry issue. Two things make this slip through the configuration that looks like it should already stop it:

- Django never fires `got_request_exception` for a `SuspiciousOperation`. It converts the exception into a 400 and logs it to `django.security.DisallowedHost`. `DjangoIntegration` auto-ignores `django.request`, `django.server` and `django.db.backends`, because it reports request exceptions through that signal, but it does not ignore `django.security.*`.
- The `null` handler already configured for that logger in `LOGGING` does not help. The SDK patches `logging.Logger.callHandlers`, so it sees the record even when no handler is attached to it.

`ignore_logger()` is the documented fix for this.

## 2. A 4xx response no longer dumps a traceback in the console

`django.utils.log.log_response()` passes `exc_info` when it turns `PermissionDenied` into a 403 or `BadRequest` into a 400. Each client error therefore prints a stack trace that tells no more than the message line does. This repo raises those two exceptions from 154 places, so real errors get buried.

A `CallbackFilter` on the console handler clears `exc_info` when the record carries a `status_code` below 500. The one-line record stays, only the traceback goes:

```
Forbidden (Permission denied): /some/path
```

5xx keeps its full traceback, and so does any record with no `status_code` at all. `Http404` was never affected, because Django logs a 404 without `exc_info`.

### Note on interaction with Sentry

The SDK's patched `callHandlers` runs the real handlers first and captures afterwards, so a record stripped by this filter is what Sentry receives. In practice that only touches `django.security.*` entries other than `DisallowedHost`, for example a mid-request `SuspiciousFileOperation`. Those would arrive without a traceback. `django.request` is auto-ignored by `DjangoIntegration`, so its 4xx warnings never reached Sentry anyway. If preserving those tracebacks matters, the filter can move from the handler to a `django.request`-only logger entry.

## Verification

- `DisallowedHost`: with a stubbed transport, 1 event captured before the ignore and 0 after.
- 4xx filter: exercised through the real settings module. 403 and 400 print one line each with no traceback, 500 keeps its full traceback, and a record with `exc_info` but no `status_code` keeps its traceback.
- `neodb-manage check` reports no issues, and `pre-commit run -a` passes.
- Fork CI is green on both commits.

Takahe needs no change. Its `ALLOWED_HOSTS` defaults to `["*"]`, so it cannot raise `DisallowedHost`.
