### PR TITLE
fix(federation): treat invalid IDNA hosts as unreachable

### DIFF
--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -346,13 +346,8 @@ class HttpSignature:
                 logger.info("Invalid cert on %s %s", uri, invalid_cert)
                 raise SSLCertVerificationError(invalid_cert) from invalid_cert
             except idna.IDNAError as ex:
-                # httpx IDNA-decodes punycode lazily in httpx.URL.host, which
-                # check_url_safety above is the first to read, so a host that is
-                # valid DNS but invalid IDNA2008 -- an emoji domain such as
-                # xn--4t8h.example -- surfaces as a raw idna error rather than
-                # anything httpx-shaped. Such a host can never be reached, so
-                # report it the way httpx reports one it cannot resolve; every
-                # caller already handles httpx.RequestError.
+                # Emoji and other non-IDNA2008 hosts raise from httpx.URL.host,
+                # outside the httpx.HTTPError tree; they are simply unreachable.
                 raise httpx.ConnectError(f"Invalid IDNA host: {ex}") from None
             except SSRFAttemptError:
                 logger.warning("SSRF blocked on %s %s", method, uri)

--- a/takahe/core/signatures.py
+++ b/takahe/core/signatures.py
@@ -7,6 +7,7 @@ from typing import Literal, NotRequired, TypedDict, cast
 from urllib.parse import urlparse
 
 import httpx
+import idna
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
@@ -15,7 +16,6 @@ from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.http import http_date, parse_http_date
 from httpx._types import TimeoutTypes
-from idna.core import InvalidCodepoint
 from pyld import jsonld
 
 from core import sentry
@@ -345,9 +345,15 @@ class HttpSignature:
                 # Not our problem if the other end doesn't have proper SSL
                 logger.info("Invalid cert on %s %s", uri, invalid_cert)
                 raise SSLCertVerificationError(invalid_cert) from invalid_cert
-            except InvalidCodepoint as ex:
-                # Convert to a more generic error we handle
-                raise httpx.HTTPError(f"InvalidCodepoint: {str(ex)}") from None
+            except idna.IDNAError as ex:
+                # httpx IDNA-decodes punycode lazily in httpx.URL.host, which
+                # check_url_safety above is the first to read, so a host that is
+                # valid DNS but invalid IDNA2008 -- an emoji domain such as
+                # xn--4t8h.example -- surfaces as a raw idna error rather than
+                # anything httpx-shaped. Such a host can never be reached, so
+                # report it the way httpx reports one it cannot resolve; every
+                # caller already handles httpx.RequestError.
+                raise httpx.ConnectError(f"Invalid IDNA host: {ex}") from None
             except SSRFAttemptError:
                 logger.warning("SSRF blocked on %s %s", method, uri)
                 raise

--- a/takahe/tests/core/test_signatures.py
+++ b/takahe/tests/core/test_signatures.py
@@ -1,10 +1,12 @@
 import base64
 import time
 
+import httpx
 import pytest
 from django.test.client import RequestFactory
 from pytest_httpx import HTTPXMock
 
+from core.files import check_url_safety
 from core.signatures import (
     HttpSignature,
     LDSignature,
@@ -280,3 +282,43 @@ def test_verify_request_malformed_date_header(keypair):
     )
     with pytest.raises(VerificationFormatError, match="Invalid Date header"):
         HttpSignature.verify_request(request, keypair["public_key"])
+
+
+# Valid DNS and resolvable in a browser, but idna rejects the emoji codepoint.
+# xn--4t8h is the punycode for a single pager emoji.
+EMOJI_PUNYCODE_URI = "https://xn--4t8h.example/users/test-actor"
+
+
+@pytest.fixture
+def _enable_federation(settings):
+    original = settings.SETUP.NO_FEDERATION
+    settings.SETUP.NO_FEDERATION = False
+    yield
+    settings.SETUP.NO_FEDERATION = original
+
+
+def test_signed_request_invalid_idna_host(keypair, monkeypatch, _enable_federation):
+    """
+    A host that is valid DNS but invalid IDNA2008 must surface inside the
+    httpx.RequestError tree.
+
+    httpx decodes punycode lazily in httpx.URL.host, and the SSRF hook is the
+    first thing to read it, so httpx never gets to wrap the idna error. Every
+    caller of signed_request guards on httpx.RequestError, so a raw idna error
+    -- or a bare httpx.HTTPError, which is RequestError's *parent* -- escapes
+    their handling and reaches Stator.
+    """
+    # conftest's autouse _bypass_ssrf_check stubs the hook out for every test;
+    # restore it, since reading request.url.host is what raises in production.
+    monkeypatch.setattr("core.signatures.check_url_safety", check_url_safety)
+
+    with pytest.raises(httpx.RequestError) as exc_info:
+        HttpSignature.signed_request(
+            uri=EMOJI_PUNYCODE_URI,
+            body=None,
+            private_key=keypair["private_key"],
+            key_id=keypair["public_key_id"],
+            method="get",
+        )
+    assert isinstance(exc_info.value, httpx.ConnectError)
+    assert "Invalid IDNA host" in str(exc_info.value)

--- a/takahe/tests/core/test_signatures.py
+++ b/takahe/tests/core/test_signatures.py
@@ -284,8 +284,7 @@ def test_verify_request_malformed_date_header(keypair):
         HttpSignature.verify_request(request, keypair["public_key"])
 
 
-# Valid DNS and resolvable in a browser, but idna rejects the emoji codepoint.
-# xn--4t8h is the punycode for a single pager emoji.
+# xn--4t8h is punycode for a pager emoji: valid DNS, invalid IDNA2008.
 EMOJI_PUNYCODE_URI = "https://xn--4t8h.example/users/test-actor"
 
 
@@ -299,17 +298,11 @@ def _enable_federation(settings):
 
 def test_signed_request_invalid_idna_host(keypair, monkeypatch, _enable_federation):
     """
-    A host that is valid DNS but invalid IDNA2008 must surface inside the
-    httpx.RequestError tree.
-
-    httpx decodes punycode lazily in httpx.URL.host, and the SSRF hook is the
-    first thing to read it, so httpx never gets to wrap the idna error. Every
-    caller of signed_request guards on httpx.RequestError, so a raw idna error
-    -- or a bare httpx.HTTPError, which is RequestError's *parent* -- escapes
-    their handling and reaches Stator.
+    An unencodable host must stay inside the httpx.RequestError tree every
+    caller guards on. A raw idna error, or a bare httpx.HTTPError (which is
+    RequestError's parent), escapes them and reaches Stator.
     """
-    # conftest's autouse _bypass_ssrf_check stubs the hook out for every test;
-    # restore it, since reading request.url.host is what raises in production.
+    # The autouse _bypass_ssrf_check stubs out the hook that reads url.host.
     monkeypatch.setattr("core.signatures.check_url_safety", check_url_safety)
 
     with pytest.raises(httpx.RequestError) as exc_info:

--- a/takahe/tests/users/models/test_domain.py
+++ b/takahe/tests/users/models/test_domain.py
@@ -51,3 +51,14 @@ def test_recursive_block():
 
     # An unrelated domain should not be blocked
     assert not Domain.get_remote_domain("example.com").recursively_blocked()
+
+
+def test_fetch_nodeinfo_invalid_idna_host():
+    """
+    A domain that is valid DNS but invalid IDNA2008 -- an emoji domain -- can
+    never be fetched. httpx raises a raw idna.IDNAError from httpx.URL.host,
+    outside the httpx.HTTPError tree, so it used to escape to Stator instead of
+    being treated as an unreachable domain.
+    """
+
+    assert Domain(domain="xn--4t8h.example").fetch_nodeinfo() is None

--- a/takahe/tests/users/models/test_domain.py
+++ b/takahe/tests/users/models/test_domain.py
@@ -55,10 +55,8 @@ def test_recursive_block():
 
 def test_fetch_nodeinfo_invalid_idna_host():
     """
-    A domain that is valid DNS but invalid IDNA2008 -- an emoji domain -- can
-    never be fetched. httpx raises a raw idna.IDNAError from httpx.URL.host,
-    outside the httpx.HTTPError tree, so it used to escape to Stator instead of
-    being treated as an unreachable domain.
+    An unencodable host raises from httpx.URL.host while the request is built,
+    outside the httpx.HTTPError tree, so it used to escape to Stator.
     """
 
     assert Domain(domain="xn--4t8h.example").fetch_nodeinfo() is None

--- a/takahe/tests/users/models/test_identity.py
+++ b/takahe/tests/users/models/test_identity.py
@@ -642,16 +642,13 @@ def test_default_icon_migration(identity_factory, domain):
 
 def test_fetch_actor_invalid_idna_host(config_system, monkeypatch, settings):
     """
-    An actor on a domain that is valid DNS but invalid IDNA2008 -- an emoji
-    domain -- is simply unfetchable, so fetch_actor reports failure instead of
-    letting a raw idna error escape to Stator. This kept the deferred signature
-    verification in users.models.inbox_message logging it as an error on every
-    retry (NEODB-SOCIAL-7VE / 7VF).
+    An actor on an unencodable host is unfetchable, so fetch_actor reports
+    failure instead of letting a raw idna error escape to Stator, which had
+    inbox_message logging an error on every retry (NEODB-SOCIAL-7VE / 7VF).
     """
     original = settings.SETUP.NO_FEDERATION
     settings.SETUP.NO_FEDERATION = False
-    # conftest's autouse _bypass_ssrf_check stubs the hook out for every test;
-    # restore it, since reading request.url.host is what raises in production.
+    # The autouse _bypass_ssrf_check stubs out the hook that reads url.host.
     monkeypatch.setattr("core.signatures.check_url_safety", check_url_safety)
     try:
         identity = Identity(

--- a/takahe/tests/users/models/test_identity.py
+++ b/takahe/tests/users/models/test_identity.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+from core.files import check_url_safety
 from core.models import Config
 from users.models import Domain, Identity, User
 from users.views.identity import CreateIdentity
@@ -637,3 +638,26 @@ def test_default_icon_migration(identity_factory, domain):
     remote.refresh_from_db()
     assert remote.icon_uri == "https://remote.example/s/img/avatar.svg"
     assert remote.state == "updated"
+
+
+def test_fetch_actor_invalid_idna_host(config_system, monkeypatch, settings):
+    """
+    An actor on a domain that is valid DNS but invalid IDNA2008 -- an emoji
+    domain -- is simply unfetchable, so fetch_actor reports failure instead of
+    letting a raw idna error escape to Stator. This kept the deferred signature
+    verification in users.models.inbox_message logging it as an error on every
+    retry (NEODB-SOCIAL-7VE / 7VF).
+    """
+    original = settings.SETUP.NO_FEDERATION
+    settings.SETUP.NO_FEDERATION = False
+    # conftest's autouse _bypass_ssrf_check stubs the hook out for every test;
+    # restore it, since reading request.url.host is what raises in production.
+    monkeypatch.setattr("core.signatures.check_url_safety", check_url_safety)
+    try:
+        identity = Identity(
+            actor_uri="https://xn--4t8h.example/users/test-actor",
+            local=False,
+        )
+        assert identity.fetch_actor() is False
+    finally:
+        settings.SETUP.NO_FEDERATION = original

--- a/takahe/users/models/domain.py
+++ b/takahe/users/models/domain.py
@@ -226,9 +226,7 @@ class Domain(StatorModel):
                 UnicodeDecodeError,
                 idna.IDNAError,
             ):
-                # idna.IDNAError: host is valid DNS but invalid IDNA2008 (e.g.
-                # an emoji domain), so it can never be fetched. httpx raises it
-                # raw from httpx.URL.host, outside the httpx.HTTPError tree.
+                # idna.IDNAError: non-IDNA2008 host, raised from httpx.URL.host.
                 return None
             else:
                 try:

--- a/takahe/users/models/domain.py
+++ b/takahe/users/models/domain.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import Optional
 
 import httpx
+import idna
 import pydantic
 import urlman
 from django.conf import settings
@@ -219,7 +220,15 @@ class Domain(StatorModel):
                 )
             except httpx.HTTPError:
                 pass
-            except ssl.SSLCertVerificationError, ssl.SSLError, UnicodeDecodeError:
+            except (
+                ssl.SSLCertVerificationError,
+                ssl.SSLError,
+                UnicodeDecodeError,
+                idna.IDNAError,
+            ):
+                # idna.IDNAError: host is valid DNS but invalid IDNA2008 (e.g.
+                # an emoji domain), so it can never be fetched. httpx raises it
+                # raw from httpx.URL.host, outside the httpx.HTTPError tree.
                 return None
             else:
                 try:
@@ -245,6 +254,7 @@ class Domain(StatorModel):
                 httpx.HTTPError,
                 ssl.SSLCertVerificationError,
                 UnicodeDecodeError,
+                idna.IDNAError,
             ) as ex:
                 response = getattr(ex, "response", None)
                 if (


### PR DESCRIPTION
## Problem

A remote actor on an emoji domain, `https://xn--4t8h.dwk.io/users/dwk` (`xn--4t8h` decodes to a single pager emoji), makes every outbound fetch for that host raise a raw `idna.IDNAError`. The domain is valid DNS and loads in a browser, but it is invalid IDNA2008, and `idna` refuses the codepoint.

`httpx` decodes punycode lazily in the `httpx.URL.host` property, so the error comes from deep inside `httpx` and is **not** part of the `httpx.HTTPError` tree:

```
httpx/_urls.py:191 in host   ->   host = idna.decode(host)
idna/core.py:512 in check_label   ->   raise InvalidCodepoint
```

This produced three unresolved Sentry issues on the same actor, 200+ events in under a day:

| Issue | Events | Path |
| --- | --- | --- |
| `NEODB-SOCIAL-7VE` | 159 | `users.inboxmessage` from `received` -> `_ensure_key` -> `fetch_actor`, logged as `logger.error("Key fetch failed for %s: %s")` on every 300s retry for 3 days |
| `NEODB-SOCIAL-7VF` | 14 | `users.identity` from `outdated` -> `fetch_actor`, uncaught `httpx.HTTPError` |
| `NEODB-SOCIAL-7VG` | 27 | `users.domain` from `outdated` -> `fetch_nodeinfo`, uncaught raw `InvalidCodepoint` |

### Root cause

`HttpSignature.signed_request` already caught this, but converted it to a **bare `httpx.HTTPError`**:

```python
except InvalidCodepoint as ex:
    raise httpx.HTTPError(f"InvalidCodepoint: {str(ex)}") from None
```

`httpx.HTTPError` is the *parent* of `httpx.RequestError`, not a child:

```
HTTPError
├── RequestError        <- what ~26 call sites actually catch
│   ├── TransportError -> TimeoutException, NetworkError (ConnectError), ...
│   └── ...
└── HTTPStatusError
```

So a bare `HTTPError` slips straight through `except httpx.RequestError` in `Identity.fetch_actor`, and on up into Stator. That is 7VF. It is also 7VE: `InboxMessageStates._ensure_key` catches the escapee with a broad `except Exception` and logs it at error level on every retry.

`Domain.fetch_nodeinfo` is a separate path. It does not use `signed_request`, and it builds its request with no `Host` header, so `httpx` itself reads `URL.host` in `Request._prepare` to add one, and the raw `idna` error escapes there. That is 7VG.

## Fix

1. `core/signatures.py` -- raise `httpx.ConnectError` instead of a bare `httpx.HTTPError`. It is inside `RequestError`, so all existing `except httpx.RequestError` and `except httpx.HTTPError` call sites now handle it with no further changes, and it is what `httpx` itself raises for a host it cannot resolve. Widen the catch from `InvalidCodepoint` to the `idna.IDNAError` base, which also covers `Label too long`, `Invalid A-label` and `IDNABidiError`:

   ```
   'xn--4t8h.dwk.io' -> InvalidCodepoint  Codepoint U+1F4DF at position 1 of '📟' not allowed
   'aaa...(70)....com' -> IDNAError       Label too long
   'xn--0.com'        -> IDNAError        Invalid A-label
   '٠abcא.com'        -> IDNABidiError    First codepoint in label must be directionality L, R or AL
   ```

2. `users/models/domain.py` -- add `idna.IDNAError` to both `return None` arms of `fetch_nodeinfo`. The second arm also covers a `links[].href` in the discovery document that points at such a host.

Net behaviour: an actor or domain on an unencodable host is now treated as unreachable, exactly like any other host we cannot contact, instead of raising into Stator or logging an error on every retry.

## Tests

Three regression tests, none of which need a database, network or mocking, because the raise happens while the request is built:

- `test_signed_request_invalid_idna_host` -- the error stays inside `httpx.RequestError`.
- `test_fetch_actor_invalid_idna_host` -- `fetch_actor` returns `False` (7VE / 7VF).
- `test_fetch_nodeinfo_invalid_idna_host` -- `fetch_nodeinfo` returns `None` (7VG).

Each was confirmed to fail on the parent commit with the exact production signature (`httpx.HTTPError: InvalidCodepoint` at `signatures.py:350`, and raw `idna.core.InvalidCodepoint` via `_prepare` -> `_urls.py:191 host`).

Note for reviewers: `tests/conftest.py` has an autouse `_bypass_ssrf_check` fixture that stubs `check_url_safety` to a no-op. That hook is the first thing to read `request.url.host` on the `signed_request` path, so the two tests that exercise it restore the real function via `monkeypatch`; without that they silently pass through to real DNS and never reach the idna error.

Full takahe suite: 523 passed, 0 failed. `pre-commit run -a` clean.

## Possible follow-up, not in this PR

`Identity.fetch_webfinger_url`, `Identity.fetch_webfinger` and `Identity.fetch_collection` build `https://{domain}/...` the same way and can leak the same raw `idna.IDNAError`. They have no Sentry events for this actor, so they are left alone here to keep the diff small.

If you would rather close the whole class at once, an `httpx.Client` subclass that overrides `request()` covers every path, including a redirect *into* such a host, since the raise happens inside the wrapped call. Verified locally:

```python
class SafeClient(httpx.Client):
    def request(self, method, url, **kwargs):
        try:
            return super().request(method, url, **kwargs)
        except idna.IDNAError as ex:
            raise httpx.ConnectError(f"Invalid IDNA host: {ex}") from None
```

Happy to switch this PR to that shape if you prefer it.
