### PR TITLE
fix(catalog): keep Wikidata blurbs from replacing item descriptions

### DIFF
--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -567,20 +567,11 @@ class Item(PolymorphicModel):
     def class_name(self) -> str:
         return self.__class__.__name__.lower()
 
-    @staticmethod
-    def _pick_localized_text(entries: list[dict[str, str]]) -> str | None:
-        for loc in get_current_locales():
-            for t in entries:
-                if t["lang"] == loc and t.get("text"):
-                    return t["text"]
-
     def get_localized_title(self) -> str | None:
-        if self.localized_title:
-            return self._pick_localized_text(self.localized_title)
+        return localized_label_text(self.localized_title)
 
     def get_localized_description(self) -> str | None:
-        if self.localized_description:
-            return self._pick_localized_text(self.localized_description)
+        return localized_label_text(self.localized_description)
 
     @cached_property
     def display_resources(self) -> "list[ExternalResource]":
@@ -1052,7 +1043,7 @@ class Item(PolymorphicModel):
         """
         lookup_ids = {}
         r = None
-        resources = override_resources or self.external_resources.all()
+        resources = self._resources_for_normalize(override_resources)
         for res in resources:
             r = res
             lookup_ids.update(res.other_lookup_ids or {})
@@ -1084,9 +1075,9 @@ class Item(PolymorphicModel):
         not outrank a richer source that merged later (#1806). Matching on the
         stored resource metadata keeps this independent of fetch order.
         """
-        if not getattr(self, "localized_description", None):
+        if not self.localized_description:
             return False
-        resources = override_resources or self.external_resources.all()
+        resources = self._resources_for_normalize(override_resources)
         wikidata = {
             (d.get("lang"), d.get("text"))
             for res in resources
@@ -1165,15 +1156,24 @@ class Item(PolymorphicModel):
                 return True
         return False
 
+    def _resources_for_normalize(
+        self, override_resources: "list[ExternalResource] | None"
+    ) -> "list[ExternalResource]":
+        if override_resources is None:
+            return list(self.external_resources.all())
+        return override_resources
+
     def normalize_metadata(self, override_resources=None) -> bool:
-        r = self._update_primary_lookup_id(override_resources)
+        # resolve the resource list once; several normalizers consume it
+        resources = self._resources_for_normalize(override_resources)
+        r = self._update_primary_lookup_id(resources)
         r |= self._normalize_languages()
         r |= self._normalize_genres()
         r |= self._normalize_countries()
         r |= self._normalize_music_formats()
         r |= self._normalize_platforms()
         r |= self._normalize_release_date()
-        r |= self._demote_wikidata_descriptions(override_resources)
+        r |= self._demote_wikidata_descriptions(resources)
         return r
 
     def merge_data_from_external_resource(

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -567,25 +567,27 @@ class Item(PolymorphicModel):
     def class_name(self) -> str:
         return self.__class__.__name__.lower()
 
+    @staticmethod
+    def _pick_localized_text(entries: list[dict[str, str]]) -> str | None:
+        """First non-empty text among ``entries`` for the most preferred locale.
+
+        Every entry of a locale is scanned, not just the first one: entries
+        accrete from multiple external resources (and from the edit form, which
+        seeds an empty one), so an empty or placeholder entry must not mask a
+        later one for the same language.
+        """
+        for loc in get_current_locales():
+            for t in entries:
+                if t["lang"] == loc and t.get("text"):
+                    return t["text"]
+
     def get_localized_title(self) -> str | None:
         if self.localized_title:
-            locales = get_current_locales()
-            for loc in locales:
-                v = next(
-                    filter(lambda t: t["lang"] == loc, self.localized_title), {}
-                ).get("text")
-                if v:
-                    return v
+            return self._pick_localized_text(self.localized_title)
 
     def get_localized_description(self) -> str | None:
         if self.localized_description:
-            locales = get_current_locales()
-            for loc in locales:
-                v = next(
-                    filter(lambda t: t["lang"] == loc, self.localized_description), {}
-                ).get("text")
-                if v:
-                    return v
+            return self._pick_localized_text(self.localized_description)
 
     @cached_property
     def display_resources(self) -> "list[ExternalResource]":
@@ -1082,6 +1084,39 @@ class Item(PolymorphicModel):
             return True
         return False
 
+    def _demote_wikidata_descriptions(self, override_resources=None) -> bool:
+        """Move Wikidata-sourced entries to the end of ``localized_description``.
+
+        Wikidata descriptions are short disambiguators ("2009 visual novel
+        game"), not synopses. ``localized_description`` accretes entries from
+        every external resource, and ``get_localized_description()`` returns the
+        first non-empty one for the locale, so a Wikidata entry that merged
+        before a richer source would win (#1806). Matching against the stored
+        Wikidata resource metadata makes this independent of fetch order; the
+        entries are kept, so a Wikidata-only item still shows its blurb.
+        """
+        if not getattr(self, "localized_description", None):
+            return False
+        resources = override_resources or self.external_resources.all()
+        wikidata = {
+            (d.get("lang"), d.get("text"))
+            for res in resources
+            if res.id_type == IdType.WikiData
+            for d in (res.metadata or {}).get("localized_description") or []
+        }
+        if not wikidata:
+            return False
+        kept = []
+        demoted = []
+        for d in self.localized_description:
+            target = demoted if (d.get("lang"), d.get("text")) in wikidata else kept
+            target.append(d)
+        reordered = kept + demoted
+        if reordered == self.localized_description:
+            return False
+        self.localized_description = reordered
+        return True
+
     def _normalize_languages(self):
         changed = False
         if hasattr(self, "language"):  # normalize language list
@@ -1149,6 +1184,7 @@ class Item(PolymorphicModel):
         r |= self._normalize_music_formats()
         r |= self._normalize_platforms()
         r |= self._normalize_release_date()
+        r |= self._demote_wikidata_descriptions(override_resources)
         return r
 
     def merge_data_from_external_resource(

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -569,13 +569,6 @@ class Item(PolymorphicModel):
 
     @staticmethod
     def _pick_localized_text(entries: list[dict[str, str]]) -> str | None:
-        """First non-empty text among ``entries`` for the most preferred locale.
-
-        Every entry of a locale is scanned, not just the first one: entries
-        accrete from multiple external resources (and from the edit form, which
-        seeds an empty one), so an empty or placeholder entry must not mask a
-        later one for the same language.
-        """
         for loc in get_current_locales():
             for t in entries:
                 if t["lang"] == loc and t.get("text"):

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -1080,13 +1080,9 @@ class Item(PolymorphicModel):
     def _demote_wikidata_descriptions(self, override_resources=None) -> bool:
         """Move Wikidata-sourced entries to the end of ``localized_description``.
 
-        Wikidata descriptions are short disambiguators ("2009 visual novel
-        game"), not synopses. ``localized_description`` accretes entries from
-        every external resource, and ``get_localized_description()`` returns the
-        first non-empty one for the locale, so a Wikidata entry that merged
-        before a richer source would win (#1806). Matching against the stored
-        Wikidata resource metadata makes this independent of fetch order; the
-        entries are kept, so a Wikidata-only item still shows its blurb.
+        Wikidata descriptions are short disambiguators, not synopses, and must
+        not outrank a richer source that merged later (#1806). Matching on the
+        stored resource metadata keeps this independent of fetch order.
         """
         if not getattr(self, "localized_description", None):
             return False

--- a/neodb/common/models/lang.py
+++ b/neodb/common/models/lang.py
@@ -440,17 +440,21 @@ def get_current_locales() -> list[str]:
 def localized_label_text(
     labels: list[dict] | None, locales: list[str] | None = None
 ) -> str | None:
-    """First matching ``text`` from a ``[{lang, text}]`` label list for the
+    """First non-empty ``text`` from a ``[{lang, text}]`` label list for the
     given locale preference (defaults to the request's ``get_current_locales``).
+
+    Every entry of a locale is scanned: lists accrete from multiple external
+    resources (and the edit form seeds an empty one), so an empty entry must
+    not mask a later one for the same language.
     """
     if not labels:
         return None
     if locales is None:
         locales = get_current_locales()
     for loc in locales:
-        v = next((t.get("text") for t in labels if t.get("lang") == loc), None)
-        if v:
-            return v
+        for t in labels:
+            if t.get("lang") == loc and t.get("text"):
+                return t["text"]
     return None
 
 

--- a/neodb/tests/catalog/test_item_description.py
+++ b/neodb/tests/catalog/test_item_description.py
@@ -1,0 +1,123 @@
+"""Regression tests for neodb-social/neodb#1806.
+
+Wikidata descriptions are short disambiguators, not synopses. They must not
+win over a richer source, whichever order the resources were fetched in.
+"""
+
+import pytest
+from django.utils import translation
+
+from catalog.models import ExternalResource, Game, IdType
+
+WIKIDATA_BLURB = "2009 visual novel game"
+IGDB_SYNOPSIS = "Steins;Gate is a Japanese visual novel developed by 5pb."
+
+
+def _make_game() -> Game:
+    return Game.objects.create(
+        title="Steins;Gate",
+        localized_title=[{"lang": "en", "text": "Steins;Gate"}],
+    )
+
+
+def _add_resource(
+    item: Game, id_type: str, id_value: str, description: str
+) -> ExternalResource:
+    res = ExternalResource.objects.create(
+        item=item,
+        id_type=id_type,
+        id_value=id_value,
+        url=f"https://example.org/{id_type}/{id_value}",
+    )
+    res.metadata = {
+        "title": "Steins;Gate",
+        "localized_title": [{"lang": "en", "text": "Steins;Gate"}],
+        "localized_description": [{"lang": "en", "text": description}],
+    }
+    res.save()
+    return res
+
+
+def _reload(item: Game) -> Game:
+    """display_description is a cached_property; re-read the item so an
+    assertion never sees a value cached before the last merge."""
+    return Game.objects.get(pk=item.pk)
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestWikidataDescriptionDemotion:
+    def test_richer_source_first_then_wikidata(self):
+        game = _make_game()
+        igdb = _add_resource(game, IdType.IGDB, "steins-gate", IGDB_SYNOPSIS)
+        game.merge_data_from_external_resource(igdb)
+        wd = _add_resource(game, IdType.WikiData, "Q482494", WIKIDATA_BLURB)
+        game.merge_data_from_external_resource(wd)
+        with translation.override("en"):
+            assert _reload(game).display_description == IGDB_SYNOPSIS
+
+    def test_wikidata_first_then_richer_source(self):
+        """The order that actually broke neodb.social: Wikidata merged first,
+        so its blurb sat ahead of the synopsis in localized_description."""
+        game = _make_game()
+        wd = _add_resource(game, IdType.WikiData, "Q482494", WIKIDATA_BLURB)
+        game.merge_data_from_external_resource(wd)
+        with translation.override("en"):
+            assert _reload(game).display_description == WIKIDATA_BLURB
+        igdb = _add_resource(game, IdType.IGDB, "steins-gate", IGDB_SYNOPSIS)
+        game.merge_data_from_external_resource(igdb)
+        with translation.override("en"):
+            assert _reload(game).display_description == IGDB_SYNOPSIS
+
+    def test_wikidata_only_item_keeps_blurb(self):
+        game = _make_game()
+        wd = _add_resource(game, IdType.WikiData, "Q482494", WIKIDATA_BLURB)
+        game.merge_data_from_external_resource(wd)
+        fresh = _reload(game)
+        assert fresh.localized_description == [{"lang": "en", "text": WIKIDATA_BLURB}]
+        with translation.override("en"):
+            assert fresh.display_description == WIKIDATA_BLURB
+
+    def test_user_authored_description_survives_merge(self):
+        """Demotion reorders, it never drops entries not backed by a resource."""
+        game = _make_game()
+        game.localized_description = [{"lang": "en", "text": "hand written"}]
+        game.save()
+        wd = _add_resource(game, IdType.WikiData, "Q482494", WIKIDATA_BLURB)
+        game.merge_data_from_external_resource(wd)
+        fresh = _reload(game)
+        texts = [d["text"] for d in fresh.localized_description]
+        assert texts == ["hand written", WIKIDATA_BLURB]
+        with translation.override("en"):
+            assert fresh.display_description == "hand written"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestLocalizedTextMasking:
+    def test_empty_entry_does_not_mask_later_entry(self):
+        """catalog/forms.py seeds an empty localized_description entry when an
+        item is edited with no description; it must not hide a later one."""
+        game = _make_game()
+        game.localized_description = [
+            {"lang": "en", "text": ""},
+            {"lang": "en", "text": IGDB_SYNOPSIS},
+        ]
+        with translation.override("en"):
+            assert game.display_description == IGDB_SYNOPSIS
+
+    def test_empty_title_entry_does_not_mask_later_entry(self):
+        game = Game.objects.create(title="Steins;Gate")
+        game.localized_title = [
+            {"lang": "en", "text": ""},
+            {"lang": "en", "text": "Steins;Gate"},
+        ]
+        with translation.override("en"):
+            assert game.get_localized_title() == "Steins;Gate"
+
+    def test_falls_through_to_next_locale_when_all_empty(self):
+        game = _make_game()
+        game.localized_description = [
+            {"lang": "zh-cn", "text": ""},
+            {"lang": "en", "text": IGDB_SYNOPSIS},
+        ]
+        with translation.override("zh-hans"):
+            assert game.display_description == IGDB_SYNOPSIS

--- a/neodb/tests/core/test_lang_coverage.py
+++ b/neodb/tests/core/test_lang_coverage.py
@@ -8,7 +8,11 @@ import catalog.models.common as catalog_common
 import catalog.sites.tmdb as tmdb
 import common.models.lang as lang
 from catalog.common.downloaders import BasicDownloader
-from common.models.lang import get_current_locales, localize_number
+from common.models.lang import (
+    get_current_locales,
+    localize_number,
+    localized_label_text,
+)
 
 
 class TestLocalizeNumber:
@@ -191,3 +195,26 @@ class TestLanguageCacheRefresh:
 
         assert one_of[0]["const"] == "ja"
         assert one_of[-1] == {"title": "Other", "type": "string"}
+
+
+class TestLocalizedLabelText:
+    """An empty entry must not mask a later one for the same language;
+    label lists accrete from several external resources (#1806)."""
+
+    def test_empty_entry_does_not_mask_later_entry(self):
+        labels = [
+            {"lang": "en", "text": ""},
+            {"lang": "en", "text": "Real Name"},
+        ]
+        assert localized_label_text(labels, ["en"]) == "Real Name"
+
+    def test_falls_through_to_next_locale(self):
+        labels = [{"lang": "en", "text": "Real Name"}]
+        assert localized_label_text(labels, ["fr", "en"]) == "Real Name"
+
+    def test_none_when_no_locale_matches(self):
+        labels = [{"lang": "en", "text": ""}]
+        assert localized_label_text(labels, ["en"]) is None
+
+    def test_none_for_empty_list(self):
+        assert localized_label_text([], ["en"]) is None


### PR DESCRIPTION
Fixes #1806.

## The bug is real, but not where the report guessed

`IdealIdTypes` only drives `primary_lookup_id`, and the view's
`prefetch_related_objects` plays no part. The Wikidata text is physically
stored in `item.localized_description`.

`localized_description` is in `METADATA_MERGE_LIST`, so it accretes an entry
from every external resource. `get_localized_description()` then returned the
**first** entry matching the locale, and that ordering is just resource merge
order.

Wikidata `descriptions` are short disambiguators, not synopses. On
[the item from the report](https://neodb.social/game/5CfSs4EMO2gFUekXohjFIJ)
the stored list is, in order:

| # | lang | text |
|---|------|------|
| 0 | zh-cn | (Douban synopsis) |
| 5 | en | `2009 visual novel game` (Wikidata) |
| 12 | en | `Steins;Gate is a Japanese visual novel developed by 5pb. and Nitroplus...` (IGDB) |

Wikidata was fetched before IGDB and Steam, so entry 5 wins and entry 12 is
never reached.

## Second, related defect

The lookup took only the first entry per locale, so an entry with empty `text`
masked a later non-empty one for the same language and fell through to the next
locale. `catalog/forms.py:96-103` seeds exactly such an empty entry when an item
is edited with no description, which is where the "empty description" wording in
the report comes from.

## The fix

1. `_demote_wikidata_descriptions()`, a new normalizer in `normalize_metadata`,
   stably moves `localized_description` entries that match the item's Wikidata
   `ExternalResource` metadata to the end of the list.
2. `localized_label_text()` (`common/models/lang.py`) now scans **every** entry
   of a locale and returns the first non-empty one. `get_localized_title` and
   `get_localized_description` delegate to it, so item titles, item descriptions
   and credit display names share one implementation.

Why demotion at this layer:

- **Order-robust.** Matching against the stored Wikidata resource metadata works
  whether Wikidata merged first or last. An "append Wikidata last at merge time"
  fix does not: when Wikidata is fetched first it is already the *existing* list
  by the time a better source merges.
- **Non-destructive.** `localized_description` is user-editable, and
  `normalize_metadata` runs on every merge, so rebuilding the list from resource
  provenance would silently drop hand-written descriptions on the next refetch.
  Demotion only reorders. A Wikidata-only item still shows its blurb.
- **Free at render time.** `Item.external_resources_prefetch` deliberately strips
  `metadata` (EGGPLANT-1DX), so a display-time provenance check would either
  break that optimization or go N+1.

## Known limitations

- Existing rows self-heal on the item's next refetch or merge; this change does
  not backfill.
- Demotion matches on exact `(lang, text)` against the Wikidata resource's
  *current* metadata. `catalog backfill_people` rescrapes a resource without
  touching the parent item ("It does NOT touch the parent Item",
  `catalog.py:627`), so if a Wikidata blurb changes upstream after that command
  has run, the item keeps the old text, which no longer matches and is not
  demoted. Closing that needs per-entry provenance on `localized_description`;
  a stale Wikidata entry and a hand-written one are otherwise indistinguishable.
- Skipping empty entries means a description a user deliberately blanked will
  reappear once a later merge appends a scraped one. The empty entry is seeded
  automatically by the edit form, so it reads as "nothing entered" rather than
  "suppress this", but it is a behavior change worth noting.

## Tests

`neodb/tests/catalog/test_item_description.py` (7 cases) and
`TestLocalizedLabelText` in `neodb/tests/core/test_lang_coverage.py` (4 cases).
Four fail on `main` and pass with this change:

- `test_wikidata_first_then_richer_source` -- the ordering that broke the live item
- `test_empty_entry_does_not_mask_later_entry` (item level and helper level)
- `test_empty_title_entry_does_not_mask_later_entry`

The rest guard against regressions: richer source first, Wikidata-only item keeps
its blurb, a hand-written description survives a later merge, and the fall-through
to the next locale still works.

Full suite: 2268 passed. The 3 failures in `tests/mastodon/test_lexicons.py` are
pre-existing and environmental -- `dev-shell` does not mount `/docs`.
