### PR TITLE
fix(catalog): localize credit names in API reads

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -106,7 +106,8 @@ class ItemSummarySchema(Schema):
 
 class CreditDetailSchema(Schema):
     role: str
-    name: str
+    # Localized like person.display_name below, via attach_localized_names.
+    name: str = Field(alias="display_name")
     character_name: str
     person: PeopleSummarySchema | None
 
@@ -119,7 +120,7 @@ class CreditListSchema(Schema):
 
 class PeopleWorkCreditSchema(Schema):
     role: str
-    name: str
+    name: str = Field(alias="display_name")
     character_name: str
 
 
@@ -464,6 +465,13 @@ def _get_item(cls, uuid, response):
     # Public tags are returned for single-item lookups; aggregate for this item
     # only (list endpoints no longer attach tags -- NEODB-SOCIAL-7KW).
     item.tags = TagManager.indexable_tags_for_item(item)
+    if cls is not People:
+        # Item detail responses embed credits (BaseSchema.credits). Prefetch
+        # them without the heavy person metadata, then localize the names in one
+        # bounded query so they follow the request locale like the rest of the
+        # response, as the HTML item page does. PeopleSchema has no credits.
+        prefetch_related_objects([item], Item.credits_prefetch())
+        Item.attach_localized_credit_names([item])
     return item
 
 
@@ -521,10 +529,13 @@ def get_item_credits(
         PAGE_SIZE,
     )
     credit_page = paginator.get_page(page)
+    credits = list(credit_page.object_list)
+    # Follow the request locale, like the embedded person.display_name does.
+    ItemCredit.attach_localized_names(credits)
     return Status(
         200,
         {
-            "data": list(credit_page.object_list),
+            "data": credits,
             "pages": paginator.num_pages,
             "count": paginator.count,
         },
@@ -569,9 +580,15 @@ def get_people_works(request, uuid: str, response: HttpResponse, page: int = 1):
     Item.prefetch_edition_works(items)
 
     credits_by_item: dict[int, list[ItemCredit]] = {}
-    for credit in ItemCredit.objects.filter(
-        person=item, item_id__in=[work.pk for work in items]
-    ).order_by("item_id", "role", "order", "pk"):
+    work_credits = list(
+        ItemCredit.objects.filter(
+            person=item, item_id__in=[work.pk for work in items]
+        ).order_by("item_id", "role", "order", "pk")
+    )
+    # Follow the request locale; these all credit the person being looked up,
+    # whose /api/people/{uuid} name is localized too.
+    ItemCredit.attach_localized_names(work_credits)
+    for credit in work_credits:
         credits_by_item.setdefault(credit.item_id, []).append(credit)
 
     data = [

--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -448,7 +448,7 @@ def trending_verified_podcasts(request, page: int = 1):
     )
 
 
-def _get_item(cls, uuid, response):
+def _get_item(cls, uuid, response, attach_credits: bool = True):
     item = Item.get_by_url(uuid)
     if not item:
         return Status(404, {"message": "Item not found"})
@@ -465,7 +465,7 @@ def _get_item(cls, uuid, response):
     # Public tags are returned for single-item lookups; aggregate for this item
     # only (list endpoints no longer attach tags -- NEODB-SOCIAL-7KW).
     item.tags = TagManager.indexable_tags_for_item(item)
-    if cls is not People:  # PeopleSchema has no credits
+    if attach_credits and cls is not People:  # PeopleSchema has no credits
         # Credit names follow the request locale, as on the HTML item page.
         prefetch_related_objects([item], Item.credits_prefetch())
         Item.attach_localized_credit_names([item])
@@ -614,7 +614,8 @@ def get_book(request, uuid: str, response: HttpResponse):
 )
 @paginate(PageNumberPagination)
 def get_sibling_editions_for_book(request, uuid: str, response: HttpResponse):
-    i = _get_item(Edition, uuid, response)
+    # Only the siblings are serialized, so skip this edition's credit load.
+    i = _get_item(Edition, uuid, response, attach_credits=False)
     if not isinstance(i, Edition):
         return Edition.objects.none()
     return i.sibling_items
@@ -689,7 +690,8 @@ def get_podcast_episode(request, uuid: str, response: HttpResponse):
 def get_episodes_in_podcast(
     request, uuid: str, response: HttpResponse, page: int = 1, guid: str | None = None
 ):
-    podcast = _get_item(Podcast, uuid, response)
+    # Only the episodes are serialized, so skip the podcast's credit load.
+    podcast = _get_item(Podcast, uuid, response, attach_credits=False)
     if not isinstance(podcast, Podcast):
         return podcast
     episodes = podcast.child_items.filter(is_deleted=False, merged_to_item=None)

--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -106,7 +106,7 @@ class ItemSummarySchema(Schema):
 
 class CreditDetailSchema(Schema):
     role: str
-    # Localized like person.display_name below, via attach_localized_names.
+    # Localized like person.display_name below.
     name: str = Field(alias="display_name")
     character_name: str
     person: PeopleSummarySchema | None
@@ -465,11 +465,8 @@ def _get_item(cls, uuid, response):
     # Public tags are returned for single-item lookups; aggregate for this item
     # only (list endpoints no longer attach tags -- NEODB-SOCIAL-7KW).
     item.tags = TagManager.indexable_tags_for_item(item)
-    if cls is not People:
-        # Item detail responses embed credits (BaseSchema.credits). Prefetch
-        # them without the heavy person metadata, then localize the names in one
-        # bounded query so they follow the request locale like the rest of the
-        # response, as the HTML item page does. PeopleSchema has no credits.
+    if cls is not People:  # PeopleSchema has no credits
+        # Credit names follow the request locale, as on the HTML item page.
         prefetch_related_objects([item], Item.credits_prefetch())
         Item.attach_localized_credit_names([item])
     return item
@@ -530,7 +527,7 @@ def get_item_credits(
     )
     credit_page = paginator.get_page(page)
     credits = list(credit_page.object_list)
-    # Follow the request locale, like the embedded person.display_name does.
+    # Follow the request locale, as the embedded person.display_name does.
     ItemCredit.attach_localized_names(credits)
     return Status(
         200,
@@ -585,8 +582,7 @@ def get_people_works(request, uuid: str, response: HttpResponse, page: int = 1):
             person=item, item_id__in=[work.pk for work in items]
         ).order_by("item_id", "role", "order", "pk")
     )
-    # Follow the request locale; these all credit the person being looked up,
-    # whose /api/people/{uuid} name is localized too.
+    # Follow the request locale, as /api/people/{uuid} does for this person.
     ItemCredit.attach_localized_names(work_credits)
     for credit in work_credits:
         credits_by_item.setdefault(credit.item_id, []).append(credit)

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -152,7 +152,7 @@ class ItemCredit(models.Model):
         person_id: int | None
 
     #: Per-request localized display name, set by
-    #: ``Item.attach_localized_credit_names``; not a DB field. Empty means
+    #: ``ItemCredit.attach_localized_names``; not a DB field. Empty means
     #: "use the stored ``name`` snapshot" (see ``display_name``).
     _localized_name: str = ""
 
@@ -185,16 +185,51 @@ class ItemCredit(models.Model):
 
     @property
     def display_name(self) -> str:
-        """Request-localized name for HTML display, else the stored snapshot.
+        """Request-localized name for display, else the stored snapshot.
 
         ``name`` is frozen at sync time (under the source's locale). The
-        localized value is populated only when ``Item.attach_localized_credit_names``
-        has run for this render (detail pages); otherwise this returns ``name``.
-        This property never issues a query on its own -- it reads an attribute
-        set by that bounded batch helper, so card/list/API surfaces that skip it
-        pay nothing and keep the snapshot.
+        localized value is populated only when ``attach_localized_names`` (or
+        ``Item.attach_localized_credit_names``) has run for this render -- the
+        item detail page and the item/credit API reads; otherwise this returns
+        ``name``. This property never issues a query on its own -- it reads an
+        attribute set by that bounded batch helper, so card/list surfaces that
+        skip it pay nothing and keep the snapshot.
         """
         return self._localized_name or self.name
+
+    @staticmethod
+    def attach_localized_names(credits: "Iterable[ItemCredit]") -> None:
+        """Attach request-localized display names to ``credits``, in one query.
+
+        Credit rows store ``name`` as a snapshot frozen at sync time (under the
+        source's locale), so an English viewer could see a Chinese director. The
+        linked ``People`` carries a localized name, but it lives in the heavy,
+        deliberately-deferred person ``metadata`` JSON (EGGPLANT-1EF), so we
+        must not select it via ``Item.credits_prefetch``. Instead fetch only the
+        ``localized_name`` sub-key for every credited person in ONE bounded
+        query (flat regardless of how many credits) and stash the localized
+        string on each credit; ``display_name`` then prefers it over ``name``.
+
+        Credits with no linked person keep their snapshot -- there is nothing
+        else to localize from.
+        """
+        from .people import People
+
+        by_person: dict[int, list[ItemCredit]] = {}
+        for credit in credits:
+            if credit.person_id:
+                by_person.setdefault(credit.person_id, []).append(credit)
+        if not by_person:
+            return
+        locales = get_current_locales()
+        rows = People.objects.filter(pk__in=by_person).values_list(
+            "pk", "metadata__localized_name"
+        )
+        for pk, localized in rows:
+            name = localized_label_text(localized, locales)
+            if name:
+                for credit in by_person[pk]:
+                    credit._localized_name = name
 
     def __str__(self):
         linked = f" -> {self.person}" if self.person else ""
@@ -207,9 +242,11 @@ class ExternalResourceSchema(Schema):
 
 class CreditSchema(Schema):
     role: str
-    # Stored snapshot, not display_name: this schema backs ap_object (served as
-    # activity+json) and catalog backups, which must stay locale-independent.
-    name: str
+    # Follows the request locale on API reads, which call
+    # Item.attach_localized_credit_names; falls back to the stored snapshot
+    # everywhere else, so ap_object (served as activity+json) and catalog
+    # backups -- which never attach -- stay locale-independent.
+    name: str = Field(alias="display_name")
     character_name: str = ""
     person_url: str | None = Field(None, alias="person_api_url")
 
@@ -820,8 +857,8 @@ class Item(PolymorphicModel):
         """Optimized ``Prefetch`` for ``item.credits`` used by templates/APIs.
 
         ``_credits.html`` and the API ``CreditSchema`` only read
-        ``credit.name``/``role`` and ``credit.person.url`` (which needs the
-        person's ``uid``/``people_type``). Restrict the ``select_related``
+        ``credit.display_name``/``role`` and ``credit.person.url`` (which needs
+        the person's ``uid``/``people_type``). Restrict the ``select_related``
         join to those columns so the batch prefetch no longer pulls the large
         ``metadata`` JSON on each credited person, which made it a slow DB
         query (EGGPLANT-1EF).
@@ -849,40 +886,23 @@ class Item(PolymorphicModel):
     def attach_localized_credit_names(items: "Iterable[Item]") -> None:
         """Attach request-localized display names to each item's credits.
 
-        Credit rows store ``name`` as a snapshot frozen at sync time (under the
-        source's locale), so an English viewer could see a Chinese director. The
-        linked ``People`` carries a localized name, but it lives in the heavy,
-        deliberately-deferred person ``metadata`` JSON (EGGPLANT-1EF), so we must
-        not select it via ``credits_prefetch``. Instead fetch only the
-        ``localized_name`` sub-key for every credited person in ONE bounded
-        query (flat regardless of cast size) and stash the localized string on
-        each credit; ``ItemCredit.display_name`` then prefers it over ``name``.
+        Thin wrapper over ``ItemCredit.attach_localized_names`` (still one
+        bounded query for all items) that collects the credits of every item.
+        ``role_credits`` and ``api_credits`` share one list of credit objects,
+        so both the templates and the API schema see the localized names.
 
-        Call this on HTML display surfaces (item detail) after credits are
-        loaded. Surfaces that skip it keep the stored snapshot -- and canonical
-        outputs (ap_object, backups, schema.org, import matching) always do.
+        Call this on display surfaces after credits are loaded: the item detail
+        page and the item detail API. Surfaces that skip it keep the stored
+        snapshot -- and canonical outputs (ap_object, backups, schema.org,
+        import matching) always do.
         """
-        from .people import People
-
-        by_person: dict[int, list[ItemCredit]] = {}
+        credits: list[ItemCredit] = []
         for it in items:
             if it is None:
                 continue
             for group in it.role_credits.values():
-                for credit in group:
-                    if credit.person_id:
-                        by_person.setdefault(credit.person_id, []).append(credit)
-        if not by_person:
-            return
-        locales = get_current_locales()
-        rows = People.objects.filter(pk__in=by_person).values_list(
-            "pk", "metadata__localized_name"
-        )
-        for pk, localized in rows:
-            name = localized_label_text(localized, locales)
-            if name:
-                for credit in by_person[pk]:
-                    credit._localized_name = name
+                credits.extend(group)
+        ItemCredit.attach_localized_names(credits)
 
     @staticmethod
     def external_resources_prefetch(
@@ -1306,6 +1326,7 @@ class Item(PolymorphicModel):
             self.save(update_fields=["metadata"])
         # Invalidate cached credits so subsequent reads reflect the new data
         self.__dict__.pop("role_credits", None)
+        self.__dict__.pop("api_credits", None)
 
     def process_fetched_item(
         self, fetched: Self, link_type: "ExternalResource.LinkType"
@@ -1372,8 +1393,15 @@ class Item(PolymorphicModel):
 
     @cached_property
     def api_credits(self) -> list["ItemCredit"]:
-        """Credits for API serialization."""
-        return self._credits_with_person()
+        """Credits for API serialization.
+
+        Flattens ``role_credits`` rather than re-reading the relation: both must
+        hold the SAME credit objects, otherwise ``attach_localized_credit_names``
+        (which walks ``role_credits``) would localize objects the API schema
+        never serializes. Credits are stored ordered by ``role``, ``order``, so
+        flattening the per-role groups keeps that order.
+        """
+        return [c for group in self.role_credits.values() for c in group]
 
     def credit_names_by_role(self, role: str) -> list[str]:
         """Return credit names as list[str] from the credits table.

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -187,13 +187,10 @@ class ItemCredit(models.Model):
     def display_name(self) -> str:
         """Request-localized name for display, else the stored snapshot.
 
-        ``name`` is frozen at sync time (under the source's locale). The
-        localized value is populated only when ``attach_localized_names`` (or
-        ``Item.attach_localized_credit_names``) has run for this render -- the
-        item detail page and the item/credit API reads; otherwise this returns
-        ``name``. This property never issues a query on its own -- it reads an
-        attribute set by that bounded batch helper, so card/list surfaces that
-        skip it pay nothing and keep the snapshot.
+        ``name`` is frozen at sync time, under the source's locale. The
+        localized value is set by ``attach_localized_names``, which the item
+        detail page and the item/credit API reads call; this never queries on
+        its own, so card/list surfaces that skip it keep the snapshot.
         """
         return self._localized_name or self.name
 
@@ -201,17 +198,10 @@ class ItemCredit(models.Model):
     def attach_localized_names(credits: "Iterable[ItemCredit]") -> None:
         """Attach request-localized display names to ``credits``, in one query.
 
-        Credit rows store ``name`` as a snapshot frozen at sync time (under the
-        source's locale), so an English viewer could see a Chinese director. The
-        linked ``People`` carries a localized name, but it lives in the heavy,
-        deliberately-deferred person ``metadata`` JSON (EGGPLANT-1EF), so we
-        must not select it via ``Item.credits_prefetch``. Instead fetch only the
-        ``localized_name`` sub-key for every credited person in ONE bounded
-        query (flat regardless of how many credits) and stash the localized
-        string on each credit; ``display_name`` then prefers it over ``name``.
-
-        Credits with no linked person keep their snapshot -- there is nothing
-        else to localize from.
+        The linked ``People``'s localized name lives in the heavy, deliberately
+        deferred person ``metadata`` JSON (EGGPLANT-1EF), so fetch only that
+        sub-key for all credited people at once instead of selecting it through
+        ``Item.credits_prefetch``. Credits with no person keep their snapshot.
         """
         from .people import People
 
@@ -242,10 +232,8 @@ class ExternalResourceSchema(Schema):
 
 class CreditSchema(Schema):
     role: str
-    # Follows the request locale on API reads, which call
-    # Item.attach_localized_credit_names; falls back to the stored snapshot
-    # everywhere else, so ap_object (served as activity+json) and catalog
-    # backups -- which never attach -- stay locale-independent.
+    # Localized on API reads, which attach; ap_object and backups never
+    # attach, so they keep the snapshot and stay locale-independent.
     name: str = Field(alias="display_name")
     character_name: str = ""
     person_url: str | None = Field(None, alias="person_api_url")
@@ -886,15 +874,10 @@ class Item(PolymorphicModel):
     def attach_localized_credit_names(items: "Iterable[Item]") -> None:
         """Attach request-localized display names to each item's credits.
 
-        Thin wrapper over ``ItemCredit.attach_localized_names`` (still one
-        bounded query for all items) that collects the credits of every item.
-        ``role_credits`` and ``api_credits`` share one list of credit objects,
-        so both the templates and the API schema see the localized names.
-
-        Call this on display surfaces after credits are loaded: the item detail
-        page and the item detail API. Surfaces that skip it keep the stored
-        snapshot -- and canonical outputs (ap_object, backups, schema.org,
-        import matching) always do.
+        Collects every item's credits into one ``ItemCredit.attach_localized_names``
+        call. For display surfaces -- the item detail page and API -- after
+        credits are loaded; canonical outputs (ap_object, backups, schema.org,
+        import matching) never call it and keep the snapshot.
         """
         credits: list[ItemCredit] = []
         for it in items:
@@ -1395,11 +1378,10 @@ class Item(PolymorphicModel):
     def api_credits(self) -> list["ItemCredit"]:
         """Credits for API serialization.
 
-        Flattens ``role_credits`` rather than re-reading the relation: both must
-        hold the SAME credit objects, otherwise ``attach_localized_credit_names``
-        (which walks ``role_credits``) would localize objects the API schema
-        never serializes. Credits are stored ordered by ``role``, ``order``, so
-        flattening the per-role groups keeps that order.
+        Flattens ``role_credits`` (same ordering: credits are stored by
+        ``role``, ``order``) rather than re-reading the relation, so both hold
+        the same objects and ``attach_localized_credit_names``, which walks
+        ``role_credits``, reaches what the API serializes.
         """
         return [c for group in self.role_credits.values() for c in group]
 

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -876,8 +876,8 @@ class Item(PolymorphicModel):
 
         Collects every item's credits into one ``ItemCredit.attach_localized_names``
         call. For display surfaces -- the item detail page and API -- after
-        credits are loaded; canonical outputs (ap_object, backups, schema.org,
-        import matching) never call it and keep the snapshot.
+        credits are loaded; canonical outputs (ap_object, backups, import
+        matching) never call it and keep the snapshot.
         """
         credits: list[ItemCredit] = []
         for it in items:
@@ -1388,13 +1388,12 @@ class Item(PolymorphicModel):
     def credit_names_by_role(self, role: str) -> list[str]:
         """Return credit names as list[str] from the credits table.
 
-        Uses the stored ``name`` snapshot (not the localized display name):
-        this feeds canonical/locale-independent surfaces -- ActivityPub
-        ``ap_object``, catalog backups, schema.org markup and StoryGraph
-        import matching. Localization happens only at the HTML display layer
-        via ``ItemCredit.display_name``.
+        Follows ``display_name``, so the per-role schema fields and the
+        schema.org markup match the localized ``credits`` beside them wherever
+        the request attached. Callers that never attach -- ``ap_object``,
+        catalog backups, StoryGraph import matching -- keep the snapshot.
         """
-        return [c.name for c in self.role_credits.get(role, [])]
+        return [c.display_name for c in self.role_credits.get(role, [])]
 
     @cached_property
     def role_credits(self) -> dict[str, list["ItemCredit"]]:

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -442,9 +442,9 @@ def test_item_api_localizes_credit_names(live_server):
     """credits[].name follows the request language, as /api/people/{uuid} does.
 
     Credit rows freeze ``name`` at sync time (under the source's locale), so an
-    English reader used to get a localized title next to a Chinese director
-    (upstream #1760). Credits with no linked person stay frozen -- there is
-    nothing to localize them from.
+    English reader used to get a localized title next to a Chinese director.
+    Credits with no linked person stay frozen -- there is nothing to localize
+    them from.
     """
     zh_name = "沃什·威斯特摩兰"
     with patch("catalog.models.item.Item.update_index"):

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -438,6 +438,80 @@ def test_item_credit_endpoints_include_linked_and_name_only_credits(live_server)
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)
+def test_item_api_localizes_credit_names(live_server):
+    """credits[].name follows the request language, as /api/people/{uuid} does.
+
+    Credit rows freeze ``name`` at sync time (under the source's locale), so an
+    English reader used to get a localized title next to a Chinese director
+    (upstream #1760). Credits with no linked person stay frozen -- there is
+    nothing to localize them from.
+    """
+    zh_name = "沃什·威斯特摩兰"
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(
+            title="Obsession",
+            localized_title=[{"lang": "en", "text": "Obsession"}],
+        )
+        person = People.objects.create(
+            localized_name=[
+                {"lang": "zh-cn", "text": zh_name},
+                {"lang": "en", "text": "Wash Westmoreland"},
+            ],
+            people_type="person",
+        )
+        ItemCredit.objects.create(
+            item=movie, person=person, role="director", name=zh_name
+        )
+        ItemCredit.objects.create(item=movie, role="actor", name="Name Only Actor")
+
+    def credit_names(lang: str) -> dict[str, str]:
+        response = requests.get(
+            f"{live_server.url}/api/movie/{movie.uuid}",
+            headers={"Accept-Language": lang},
+            timeout=5,
+        )
+        assert response.status_code == 200
+        return {c["role"]: c["name"] for c in response.json()["credits"]}
+
+    assert credit_names("en")["director"] == "Wash Westmoreland"
+    assert credit_names("zh-Hans")["director"] == zh_name
+    assert credit_names("en")["actor"] == "Name Only Actor"
+
+    # ap_object (activity+json, and the payload catalog backups store) is
+    # canonical: it keeps the frozen snapshot whatever the reader asks for.
+    response = requests.get(
+        f"{live_server.url}{movie.url}",
+        headers={"Accept": "application/activity+json", "Accept-Language": "en"},
+        timeout=5,
+    )
+    assert response.status_code == 200
+    ap_credits = {c["role"]: c["name"] for c in response.json()["credits"]}
+    assert ap_credits["director"] == zh_name
+
+    # The credit listing endpoint localizes too: its name used to disagree with
+    # the person.display_name embedded in the same object.
+    response = requests.get(
+        f"{live_server.url}/api/catalog/movie/{movie.uuid}/credit/?lang=en",
+        timeout=5,
+    )
+    assert response.status_code == 200
+    listed = {c["role"]: c for c in response.json()["data"]}
+    assert listed["director"]["name"] == "Wash Westmoreland"
+    assert listed["director"]["person"]["display_name"] == "Wash Westmoreland"
+    assert listed["actor"]["name"] == "Name Only Actor"
+
+    # ... and so does the person's work listing.
+    response = requests.get(
+        f"{live_server.url}/api/people/{person.uuid}/work/",
+        headers={"Accept-Language": "en"},
+        timeout=5,
+    )
+    assert response.status_code == 200
+    works = {entry["item"]["uuid"]: entry for entry in response.json()["data"]}
+    assert [c["name"] for c in works[movie.uuid]["credits"]] == ["Wash Westmoreland"]
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
 def test_people_work_endpoint_groups_all_credits_by_item(live_server):
     with patch("catalog.models.item.Item.update_index"):
         person = People.objects.create(

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -441,10 +441,8 @@ def test_item_credit_endpoints_include_linked_and_name_only_credits(live_server)
 def test_item_api_localizes_credit_names(live_server):
     """credits[].name follows the request language, as /api/people/{uuid} does.
 
-    Credit rows freeze ``name`` at sync time (under the source's locale), so an
-    English reader used to get a localized title next to a Chinese director.
-    Credits with no linked person stay frozen -- there is nothing to localize
-    them from.
+    Names frozen at sync time gave an English reader a localized title next to
+    a Chinese director. Credits with no linked person stay frozen.
     """
     zh_name = "沃什·威斯特摩兰"
     with patch("catalog.models.item.Item.update_index"):

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -462,18 +462,23 @@ def test_item_api_localizes_credit_names(live_server):
         )
         ItemCredit.objects.create(item=movie, role="actor", name="Name Only Actor")
 
-    def credit_names(lang: str) -> dict[str, str]:
+    def detail(lang: str) -> dict:
         response = requests.get(
             f"{live_server.url}/api/movie/{movie.uuid}",
             headers={"Accept-Language": lang},
             timeout=5,
         )
         assert response.status_code == 200
-        return {c["role"]: c["name"] for c in response.json()["credits"]}
+        payload = response.json()
+        payload["credit_names"] = {c["role"]: c["name"] for c in payload["credits"]}
+        return payload
 
-    assert credit_names("en")["director"] == "Wash Westmoreland"
-    assert credit_names("zh-Hans")["director"] == zh_name
-    assert credit_names("en")["actor"] == "Name Only Actor"
+    assert detail("en")["credit_names"]["director"] == "Wash Westmoreland"
+    assert detail("zh-Hans")["credit_names"]["director"] == zh_name
+    assert detail("en")["credit_names"]["actor"] == "Name Only Actor"
+    # The per-role field must agree with credits[] in the same payload.
+    assert detail("en")["director"] == ["Wash Westmoreland"]
+    assert detail("zh-Hans")["director"] == [zh_name]
 
     # ap_object (activity+json, and the payload catalog backups store) is
     # canonical: it keeps the frozen snapshot whatever the reader asks for.
@@ -483,8 +488,9 @@ def test_item_api_localizes_credit_names(live_server):
         timeout=5,
     )
     assert response.status_code == 200
-    ap_credits = {c["role"]: c["name"] for c in response.json()["credits"]}
-    assert ap_credits["director"] == zh_name
+    ap = response.json()
+    assert {c["role"]: c["name"] for c in ap["credits"]}["director"] == zh_name
+    assert ap["director"] == [zh_name]
 
     # The credit listing endpoint localizes too: its name used to disagree with
     # the person.display_name embedded in the same object.

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -256,7 +256,9 @@ class TestCreditDisplayNameLocalization:
 
     Regression: a Douban-sourced movie froze the director credit name in
     Chinese, so the movie page rendered Chinese even for English viewers, while
-    the person page (which localizes live) showed English.
+    the person page (which localizes live) showed English. The item detail API
+    had the same split (upstream #1760) and now attaches too, so ``api_credits``
+    must hold the same credit objects ``role_credits`` does.
     """
 
     def _linked_movie(self, n: int = 1) -> Movie:
@@ -304,8 +306,8 @@ class TestCreditDisplayNameLocalization:
             assert self._localized_director(m).display_name == "吉尔莫·德尔·托罗"
 
     def test_without_attach_display_name_is_frozen_and_issues_no_query(self):
-        # Surfaces that don't call attach (cards/lists/API) keep the snapshot,
-        # and display_name must never trigger a query on its own.
+        # Surfaces that don't call attach (cards/lists) keep the snapshot, and
+        # display_name must never trigger a query on its own.
         base = self._linked_movie()
         with translation.override("en"):
             m = Movie.objects.get(pk=base.pk)
@@ -314,6 +316,30 @@ class TestCreditDisplayNameLocalization:
             with CaptureQueriesContext(connection) as ctx:
                 assert credit.display_name == "吉尔莫·德尔·托罗"
             assert len(ctx) == 0
+
+    def test_attach_reaches_api_credits(self):
+        # api_credits feeds CreditSchema.name; it must share objects with
+        # role_credits (which attach walks), prefetched or not.
+        base = self._linked_movie()
+        with translation.override("en"):
+            m = Movie.objects.get(pk=base.pk)
+            Item.attach_localized_credit_names([m])
+            assert [c.display_name for c in m.api_credits] == ["Guillermo del Toro"]
+            m = Movie.objects.get(pk=base.pk)
+            prefetch_related_objects([m], Item.credits_prefetch())
+            Item.attach_localized_credit_names([m])
+            assert [c.display_name for c in m.api_credits] == ["Guillermo del Toro"]
+
+    def test_ap_object_keeps_snapshot(self):
+        # ap_object never attaches, so the activity+json / backup payload keeps
+        # the frozen name whatever the active language is.
+        base = self._linked_movie()
+        for lang in ("en", "zh-hans"):
+            with translation.override(lang):
+                m = Movie.objects.get(pk=base.pk)
+                assert [c["name"] for c in m.ap_object["credits"]] == [
+                    "吉尔莫·德尔·托罗"
+                ]
 
     def test_credit_names_by_role_stays_canonical(self):
         # ap_object / backups / schema.org / import matching must not localize.

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -250,9 +250,8 @@ class TestCreditDisplayNameLocalization:
     display once Item.attach_localized_credit_names has run, instead of the
     snapshot frozen at sync time. attach_localized_credit_names fetches only the
     localized_name JSON sub-key in one bounded query -- never the heavy person
-    metadata blob (EGGPLANT-1EF) and never a per-credit query. Canonical
-    surfaces (credit_names_by_role, which feeds ap_object / backups / schema.org
-    / import matching) always keep the snapshot.
+    metadata blob (EGGPLANT-1EF) and never a per-credit query. Surfaces that
+    never attach (ap_object, backups, import matching) keep the snapshot.
 
     Regression: a Douban-sourced movie froze the director credit name in
     Chinese, so the movie page rendered Chinese even for English viewers, while
@@ -339,13 +338,25 @@ class TestCreditDisplayNameLocalization:
                     "吉尔莫·德尔·托罗"
                 ]
 
-    def test_credit_names_by_role_stays_canonical(self):
-        # ap_object / backups / schema.org / import matching must not localize.
+    def test_credit_names_by_role_without_attach_stays_canonical(self):
+        # ap_object / backups / import matching never attach: no localization.
         base = self._linked_movie()
         for lang in ("en", "zh-hans"):
             with translation.override(lang):
                 m = Movie.objects.get(pk=base.pk)
                 assert m.credit_names_by_role("director") == ["吉尔莫·德尔·托罗"]
+
+    def test_credit_names_by_role_follows_attach(self):
+        # The per-role schema fields and schema.org markup must agree with the
+        # localized credits beside them.
+        base = self._linked_movie()
+        with translation.override("en"):
+            m = Movie.objects.get(pk=base.pk)
+            Item.attach_localized_credit_names([m])
+            assert m.credit_names_by_role("director") == ["Guillermo del Toro"]
+            assert m.to_schema_org()["director"] == [
+                {"@type": "Person", "name": "Guillermo del Toro"}
+            ]
 
     def test_attach_uses_single_query_regardless_of_cast_size(self):
         # One bounded query for all credited people -- flat, not an N+1, and it

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -257,8 +257,8 @@ class TestCreditDisplayNameLocalization:
     Regression: a Douban-sourced movie froze the director credit name in
     Chinese, so the movie page rendered Chinese even for English viewers, while
     the person page (which localizes live) showed English. The item detail API
-    had the same split (upstream #1760) and now attaches too, so ``api_credits``
-    must hold the same credit objects ``role_credits`` does.
+    had the same split and now attaches too, so ``api_credits`` must hold the
+    same credit objects ``role_credits`` does.
     """
 
     def _linked_movie(self, n: int = 1) -> Movie:

--- a/neodb/tests/catalog/test_model.py
+++ b/neodb/tests/catalog/test_model.py
@@ -256,9 +256,8 @@ class TestCreditDisplayNameLocalization:
 
     Regression: a Douban-sourced movie froze the director credit name in
     Chinese, so the movie page rendered Chinese even for English viewers, while
-    the person page (which localizes live) showed English. The item detail API
-    had the same split and now attaches too, so ``api_credits`` must hold the
-    same credit objects ``role_credits`` does.
+    the person page (which localizes live) showed English. The API reads attach
+    too, so ``api_credits`` must hold the same objects ``role_credits`` does.
     """
 
     def _linked_movie(self, n: int = 1) -> Movie:
@@ -318,8 +317,8 @@ class TestCreditDisplayNameLocalization:
             assert len(ctx) == 0
 
     def test_attach_reaches_api_credits(self):
-        # api_credits feeds CreditSchema.name; it must share objects with
-        # role_credits (which attach walks), prefetched or not.
+        # api_credits feeds CreditSchema.name, so it must share objects with
+        # role_credits, prefetched or not.
         base = self._linked_movie()
         with translation.override("en"):
             m = Movie.objects.get(pk=base.pk)
@@ -331,8 +330,7 @@ class TestCreditDisplayNameLocalization:
             assert [c.display_name for c in m.api_credits] == ["Guillermo del Toro"]
 
     def test_ap_object_keeps_snapshot(self):
-        # ap_object never attaches, so the activity+json / backup payload keeps
-        # the frozen name whatever the active language is.
+        # ap_object never attaches: activity+json and backups keep the snapshot.
         base = self._linked_movie()
         for lang in ("en", "zh-hans"):
             with translation.override(lang):


### PR DESCRIPTION
## Problem

Item detail API responses resolve `display_title` / `display_description` for the request locale, but `credits[].name` came from the snapshot frozen on the credit row at sync time (under the source's locale). An English reader got a localized title next to a Chinese director, while `/api/people/{uuid}` returned the English name for the very same person.

`/api/catalog/{type}/{uuid}/credit/` was inconsistent within a single object: a frozen `name` beside a localized `person.display_name`.

The localized value already existed -- `ItemCredit.display_name`, populated by `Item.attach_localized_credit_names` -- but only the HTML item page attached it.

## Fix

- `CreditSchema`, `CreditDetailSchema` and `PeopleWorkCreditSchema` read `display_name`.
- The item detail endpoint, `/api/catalog/{type}/{uuid}/credit/` and `/api/people/{uuid}/work/` attach localized names, one bounded query each. Item detail also gets the `credits_prefetch` that keeps the heavy person `metadata` JSON out of the join (EGGPLANT-1EF).
- `credit_names_by_role` follows `display_name` too, so the per-role schema fields (`director`, `actor`, `author`, `host`, ...) agree with the `credits` beside them in the same payload, and the schema.org JSON-LD on the detail page matches the names the page renders. The template-facing `host_names` / `publisher_name` follow along on detail pages and stay frozen in sibling lists, where nothing attaches.
- `display_name` still falls back to the stored snapshot when nothing attached, so `ap_object` (activity+json), catalog backups and StoryGraph import matching stay locale-independent -- none of them attach. The search index is unaffected either way: `to_indexable_doc` reads `credit.name` directly.

Two supporting changes:

- `ItemCredit.attach_localized_names(credits)` now holds the single bounded query (person `localized_name` sub-key only); `Item.attach_localized_credit_names` is a wrapper over it, so the endpoints that serialize bare credit querysets can localize too.
- `api_credits` flattens `role_credits` instead of re-reading the relation. Without a prefetch the two built *separate* `ItemCredit` objects, so attaching (which walks `role_credits`) localized objects the API schema never serialized. Ordering is unchanged: credits are stored ordered by `role`, `order`, so flattening the per-role groups reproduces the same sequence.

## Scope

Only single-item reads attach. List and card surfaces (search, trending, shelf, collection) still serve the snapshot, so this adds no per-list query; `get_sibling_editions_for_book` and `get_episodes_in_podcast`, which call `_get_item` only to validate the parent, opt out via `attach_credits=False`. Happy to extend to the list endpoints if that is wanted -- third-party clients that render credits on browse cards read from those.

## Testing

- New `tests/catalog/test_api.py::test_item_api_localizes_credit_names` covers the reported case end to end: `credits[].name` and the per-role `director` field per `Accept-Language` on the item detail endpoint, the `/credit/` listing agreeing with its own embedded `person.display_name`, the person work listing, a name-only credit staying frozen, and `ap_object` over content negotiation still returning the snapshot for an English reader.
- New unit tests: `test_attach_reaches_api_credits` (with and without prefetch), `test_ap_object_keeps_snapshot`, and `test_credit_names_by_role_follows_attach` (which also pins the schema.org output).
- The new tests fail on the unpatched tree with the reported symptom (`assert '沃什·威斯特摩兰' == 'Wash Westmoreland'`).
- Full suite passes locally (2265 passed; the only 3 failures are the pre-existing `tests/mastodon/test_lexicons.py` ones that need `/docs` mounted), and `pre-commit run -a` is clean.
