### PR TITLE
feat(api): make quoting explicit via quoted_status_id only

### DIFF
--- a/takahe/api/views/statuses.py
+++ b/takahe/api/views/statuses.py
@@ -1,4 +1,3 @@
-import re
 from datetime import timedelta
 from typing import Literal
 
@@ -22,7 +21,6 @@ from activities.models.post_types import (
 )
 from activities.services import PostService
 from core import sentry
-from users.models import Identity
 from api import schemas
 from api.decorators import scope_required
 from api.pagination import MastodonPaginator, PaginatingApiResponse, PaginationResult
@@ -162,30 +160,6 @@ def _resolve_owned_attachments(
     return attachments
 
 
-def _extract_quote_from_trailing_url(
-    text: str, identity: "Identity | None" = None
-) -> tuple["Post | None", str]:
-    """
-    Detect a trailing URL in the status text that matches a known post
-    visible to the given identity.
-    Returns (quote_post, cleaned_text) if found, or (None, original_text).
-    """
-    match = re.search(r"(^|\n)(https?://\S+)\s*$", text)
-    if not match:
-        return None, text
-    url = match.group(2)
-    # Look up by object_uri first (unique index), then fall back to url.
-    # Avoids an OR query that causes a full table scan on large tables.
-    base_qs = Post.objects.not_hidden().visible_to(identity, include_replies=True)
-    post = base_qs.filter(object_uri=url).first()
-    if post is None:
-        post = base_qs.filter(url=url).first()
-    if not post:
-        return None, text
-    cleaned = text[: match.start(2)].rstrip("\n ")
-    return post, cleaned
-
-
 @scope_required("write:statuses")
 @api_view.post
 def post_status(request, details: PostStatusSchema) -> schemas.Status:
@@ -215,6 +189,8 @@ def post_status(request, details: PostStatusSchema) -> schemas.Status:
             reply_post = Post.objects.get(pk=details.in_reply_to_id)
         except Post.DoesNotExist:
             pass
+    # Quoting is explicit only: the client must pass quoted_status_id
+    # (Mastodon 4.5+) or its quote_id alias. URLs in the text stay text.
     quote_post = None
     quote_id = details.quoted_status_id or details.quote_id
     if quote_id:
@@ -224,12 +200,9 @@ def post_status(request, details: PostStatusSchema) -> schemas.Status:
             .filter(pk=quote_id)
             .first()
         )
-    # If no explicit quote ID, detect a trailing URL that matches a known post
+        if quote_post is None:
+            raise ApiError(404, "Quoted status not found")
     status_text = details.status or ""
-    if not quote_post and status_text:
-        quote_post, status_text = _extract_quote_from_trailing_url(
-            status_text, request.identity
-        )
     # Enforce: quoting post visibility must not exceed quoted post visibility
     visibility = visibility_map[details.visibility]
     if quote_post:

--- a/takahe/tests/api/test_statuses.py
+++ b/takahe/tests/api/test_statuses.py
@@ -220,6 +220,34 @@ def test_post_status_with_quote(api_client, identity):
 
 
 @pytest.mark.django_db
+def test_post_status_trailing_url_is_not_a_quote(api_client, identity):
+    """A trailing post URL stays plain text; quoting is explicit only."""
+    original = Post.create_local(author=identity, content="Original post")
+    status_id = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={"status": f"Look at this\n{original.object_uri}"},
+    ).json()["id"]
+    response = api_client.get(f"/api/v1/statuses/{status_id}").json()
+    assert response["quote"] is None
+    assert (
+        original.object_uri
+        in api_client.get(f"/api/v1/statuses/{status_id}/source").json()["text"]
+    )
+
+
+@pytest.mark.django_db
+def test_post_status_with_unknown_quote_id(api_client, identity):
+    """An unresolvable quoted_status_id is an error, not a silent no-op."""
+    response = api_client.post(
+        "/api/v1/statuses",
+        content_type="application/json",
+        data={"status": "Quoting nothing", "quoted_status_id": "123456789"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_get_quotes_of_status(api_client, identity):
     """List quotes of a status."""
     original = Post.create_local(author=identity, content="Original post")


### PR DESCRIPTION
## What

Quoting via the Mastodon API is now driven only by an explicit parameter. The trailing-URL heuristic is removed.

Mastodon 4.5.0 (API version 7) added [`quoted_status_id`](https://docs.joinmastodon.org/client/quotes/) to `POST /api/v1/statuses`, so clients now have a real flag for quoting. Before this change, a status whose text ended in the URL of a known post was silently converted into a quote and the URL was stripped from the text. That guessed at user intent and had no way to opt out.

## Changes

`takahe/api/views/statuses.py`:

- Remove `_extract_quote_from_trailing_url` and its only call site in `post_status`. A URL at the end of a status stays a plain URL and stays in the post text.
- An unresolvable `quoted_status_id` now returns 404 instead of silently posting with no quote. With the heuristic gone the parameter is the only mechanism, so a silently ignored flag would be the worst outcome. The Mastodon docs specify this case as an error: it "will raise an error if the current user does not have access to this status".
- `quoted_status_id` and the older `quote_id` alias are both still accepted; the schema already had both.

Nothing else in the codebase used the heuristic. NeoDB's own web quote flow (`journal:post_quote`) passes `quote_url` directly and is unaffected.

## Tests

Two tests added to `takahe/tests/api/test_statuses.py`:

- `test_post_status_trailing_url_is_not_a_quote` - a status ending in a post URL does not become a quote, and the URL remains in the source text.
- `test_post_status_with_unknown_quote_id` - an unknown `quoted_status_id` returns 404.

Both were confirmed to fail against the previous code (the trailing URL came back as an accepted quote; the bogus id returned 200) before the fix was restored. 343 tests pass across `tests/api/` and `tests/activities/`, and `pre-commit run -a` is clean.

## Note for reviewers

The heuristic was what let any Mastodon client quote on a NeoDB instance. After this change only clients that send `quoted_status_id` can, and mainstream 4.5 clients gate their quote composer on the server advertising API version 7. This instance reports `4.0.4 (compatible; NeoDB ...)` with no `api_versions` field, so API quoting will be unreachable from stock clients until that is advertised. Advertising `api_versions` felt like a separate decision, so it is not included here. Two other 4.5 gaps also left alone: `quote_approval_policy` is not in the schema and is silently dropped, and the edit path is already compliant since `edit_status` never touches the quote.
