### PR TITLE
fix(search): do not let TryAgainLater escape as a 500

### DIFF
--- a/takahe/activities/services/search.py
+++ b/takahe/activities/services/search.py
@@ -1,11 +1,16 @@
+import logging
+
 import httpx
 from core.files import SSRFAttemptError
 from core.json import find_ap_alternate, json_from_response
 from core.ld import canonicalise, get_first_concrete_type
+from stator.exceptions import TryAgainLater
 from users.models.system_actor import SystemActor
 
 from activities.models import Hashtag, Post
 from users.models import Domain, Identity, IdentityStates
+
+logger = logging.getLogger(__name__)
 
 
 class SearchService:
@@ -50,12 +55,19 @@ class SearchService:
                     results.add(identity)
             if not results and self.identity is not None:
                 # Allow authenticated users to fetch remote
-                prio_result = Identity.by_username_and_domain(
-                    username, domain_instance or domain, fetch=True
-                )
-                if prio_result:
-                    if prio_result.state == IdentityStates.outdated:
-                        prio_result.fetch_actor()
+                try:
+                    prio_result = Identity.by_username_and_domain(
+                        username, domain_instance or domain, fetch=True
+                    )
+                    if prio_result:
+                        if prio_result.state == IdentityStates.outdated:
+                            prio_result.fetch_actor()
+                except TryAgainLater:
+                    # The remote is slow or rate-limiting us. Stator will
+                    # retry in the background; return what we have locally
+                    # rather than failing the whole search.
+                    logger.info("Timed out fetching identity for %r", self.query)
+                    prio_result = None
 
         else:
             prio_result = Identity.objects.filter(local=True, username=handle).first()
@@ -127,9 +139,13 @@ class SearchService:
         # Is it an identity?
         if type in Identity.ACTOR_TYPES:
             # Try and retrieve the profile by actor URI
-            identity = Identity.by_actor_uri(document["id"], create=True)
-            if identity and identity.state == IdentityStates.outdated:
-                identity.fetch_actor()
+            try:
+                identity = Identity.by_actor_uri(document["id"], create=True)
+                if identity and identity.state == IdentityStates.outdated:
+                    identity.fetch_actor()
+            except TryAgainLater:
+                logger.info("Timed out fetching identity at %r", uri)
+                return None
             return identity
 
         # Is it a post?
@@ -141,6 +157,12 @@ class SearchService:
                     document["id"], fetch=True, fetch_as=self.identity
                 )
             except Post.DoesNotExist:
+                return None
+            except TryAgainLater:
+                # Raised when the post's author cannot be fetched yet.
+                # TryAgainLater is a BaseException, so it would otherwise
+                # escape the view and turn the search into a 500.
+                logger.info("Timed out fetching post at %r", uri)
                 return None
 
         # Dunno what it is

--- a/takahe/tests/activities/services/test_search.py
+++ b/takahe/tests/activities/services/test_search.py
@@ -3,6 +3,7 @@ import pytest
 
 from activities.models import Post
 from activities.services.search import SearchService
+from stator.exceptions import TryAgainLater
 from users.models import Identity
 from users.models.system_actor import SystemActor
 
@@ -179,3 +180,85 @@ def test_search_url_handles_list_type(monkeypatch, config_system):
     assert SearchService(url, None).search_url() is None
     # Routed to the identity branch, not dropped as an unknown type
     assert captured["uri"] == url
+
+
+@pytest.mark.django_db
+def test_search_url_handles_try_again_later_from_post(monkeypatch, config_system):
+    """A post whose author cannot be fetched yet must yield no result.
+
+    Regression: ``TryAgainLater`` subclasses ``BaseException``, so it slipped
+    past every ``except Exception`` and escaped the search view as a 500.
+    """
+    url = "https://social.example/notes/1"
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "id": url,
+            "type": "Note",
+            "attributedTo": "https://social.example/users/test",
+            "content": "<p>Hello</p>",
+        },
+        request=httpx.Request("GET", url),
+    )
+
+    def fake_signed_request(self, method, uri, body=None):
+        return response
+
+    monkeypatch.setattr(SystemActor, "signed_request", fake_signed_request)
+
+    def fake_by_object_uri(cls, uri, fetch=False, fetch_as=None):
+        raise TryAgainLater()
+
+    monkeypatch.setattr(Post, "by_object_uri", classmethod(fake_by_object_uri))
+
+    assert SearchService(url, None).search_url() is None
+
+
+@pytest.mark.django_db
+def test_search_url_handles_try_again_later_from_identity(monkeypatch, config_system):
+    """An actor URL whose refresh times out must yield no result rather than
+    escaping the search view as a 500."""
+    url = "https://social.example/users/test"
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/activity+json"},
+        json={
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "id": url,
+            "type": "Person",
+            "inbox": f"{url}/inbox",
+            "preferredUsername": "test",
+        },
+        request=httpx.Request("GET", url),
+    )
+
+    def fake_signed_request(self, method, uri, body=None):
+        return response
+
+    monkeypatch.setattr(SystemActor, "signed_request", fake_signed_request)
+
+    def fake_by_actor_uri(cls, uri, create=False):
+        raise TryAgainLater()
+
+    monkeypatch.setattr(Identity, "by_actor_uri", classmethod(fake_by_actor_uri))
+
+    assert SearchService(url, None).search_url() is None
+
+
+@pytest.mark.django_db
+def test_search_identities_handle_handles_try_again_later(
+    monkeypatch, identity, config_system
+):
+    """A WebFinger lookup that times out must not fail the whole search."""
+
+    def fake_by_username_and_domain(cls, username, domain, fetch=False, local=False):
+        raise TryAgainLater()
+
+    monkeypatch.setattr(
+        Identity, "by_username_and_domain", classmethod(fake_by_username_and_domain)
+    )
+
+    service = SearchService("nobody@remote.example", identity)
+    assert service.search_identities_handle() == []


### PR DESCRIPTION
## Problem

`stator.exceptions.TryAgainLater` subclasses `BaseException`, so it slips past
every `except Exception` and propagates out of `SearchService` into the view.

`SearchService.search_url()` calls `Post.by_object_uri(..., fetch=True)`, which
raises `TryAgainLater` from `Post.by_ap()` whenever the post's author actor
cannot be fetched yet. `Identity.fetch_actor()` and `Identity.fetch_webfinger()`
raise it too, on a timeout or a 408/429/504 from the remote.

The result is an unhandled 500 whenever a remote is slow or rate-limiting us
while resolving a searched URL or handle, on all four entry points:

- `/api/v1/search`
- `/api/v2/search`
- `/api/v1/accounts/search`
- the web search page (`users/views/identity.py`)

Reproduced against a live Bridgy Fed post URL, whose author actor could not be
fetched:

```
File "activities/services/search.py", line 140, in search_url
    return Post.by_object_uri(document["id"], fetch=True, fetch_as=self.identity)
File "activities/models/post.py", line 1869, in by_object_uri
    post = cls.by_ap(ap_data, create=True, update=True, fetch_author=True)
File "activities/models/post.py", line 1576, in by_ap
    raise TryAgainLater()
stator.exceptions.TryAgainLater
```

## Fix

Catch it in `SearchService`, which is the single choke point for all four
callers:

- `search_url()` returns `None` for both the identity branch and the post
  branch.
- `search_identities_handle()` falls back to the local matches it already
  found.

This matches Mastodon, which resolves synchronously and simply returns no
result when the fetch fails. Stator still retries the fetch in the background,
so the post or identity shows up on a later search.

Both paths log at info level, so the transient failures stay diagnosable rather
than vanishing silently.

Note one deliberate trade-off: when `fetch_actor()` times out on an identity we
already know locally, `search_url()` returns `None` rather than the stale row.
That keeps the two branches consistent, and the identity is refreshed by Stator
shortly afterwards.

`TryAgainLater` was left as a `BaseException` on purpose. Changing its base
would fix this and every other escape at once, but every existing
`except Exception` in the codebase would then start swallowing it, which could
silently change Stator's retry behaviour.

## Tests

Three regression tests in `takahe/tests/activities/services/test_search.py`,
covering `TryAgainLater` raised from `Post.by_object_uri`, from
`Identity.by_actor_uri` in the identity branch, and from
`Identity.by_username_and_domain` in the handle search.

Verified fail-without / pass-with: with the fix reverted all three fail with
`stator.exceptions.TryAgainLater` while the five pre-existing tests in the file
still pass; with the fix all eight pass.

Full takahe suite: 523 passed. `pre-commit run -a` clean.
