### PR TITLE
feat(import): build items from bundled metadata when every fetch fails

### DIFF
--- a/neodb/catalog/sites/fedi.py
+++ b/neodb/catalog/sites/fedi.py
@@ -145,8 +145,17 @@ class FediverseInstance(AbstractSite):
             raise ValueError(f"ID mismatch: {j.get('id')} != {url}")
         return j
 
-    def scrape(self):
-        data = self.get_json_from_url(self.url)
+    def content_from_json(
+        self, data: dict, detect_redirection: bool = True
+    ) -> ResourceContent:
+        """Build a ResourceContent from an item payload already in hand.
+
+        Split out of scrape() so a caller that already holds the payload --
+        the catalog.ndjson of a NeoDB backup -- can build the item without
+        going back to the origin server, which may be unreachable or gone.
+        That caller turns ``detect_redirection`` off: its external links have
+        already been tried and failed, so each HEAD only adds a timeout.
+        """
         img_url = data.get("cover_image_url")
         raw_img, img_ext = (
             BasicImageDownloader.download_image(img_url, None, headers={})
@@ -160,10 +169,10 @@ class FediverseInstance(AbstractSite):
         if not model_cls:
             raise ParseError(self, "preferred_model")
         for ext in data.get("external_resources", []):
-            u = ext.get("url")
+            u = ext.get("url") if isinstance(ext, dict) else None
             if not u or self.is_local_item_url(u):
                 continue
-            site = SiteManager.get_site_by_url(u)
+            site = SiteManager.get_site_by_url(u, detect_redirection=detect_redirection)
             if not site:
                 logger.error(f"FediverseInstance: {self.url} unsupported url {u}")
                 continue
@@ -185,6 +194,10 @@ class FediverseInstance(AbstractSite):
             lookup_ids=ids,
         )
         return d
+
+    def scrape(self):
+        data = self.get_json_from_url(self.url)
+        return self.content_from_json(data)
 
     @classmethod
     async def peer_search_task(cls, host, q, page, category=None, page_size=5):

--- a/neodb/catalog/sites/fedi.py
+++ b/neodb/catalog/sites/fedi.py
@@ -150,11 +150,10 @@ class FediverseInstance(AbstractSite):
     ) -> ResourceContent:
         """Build a ResourceContent from an item payload already in hand.
 
-        Split out of scrape() so a caller that already holds the payload --
-        the catalog.ndjson of a NeoDB backup -- can build the item without
-        going back to the origin server, which may be unreachable or gone.
-        That caller turns ``detect_redirection`` off: its external links have
-        already been tried and failed, so each HEAD only adds a timeout.
+        Split out of scrape() so a caller holding the payload -- the
+        catalog.ndjson of a backup -- can build the item without the origin
+        server, which may be gone. Such a caller turns ``detect_redirection``
+        off: its links already failed, so each HEAD only adds a timeout.
         """
         img_url = data.get("cover_image_url")
         raw_img, img_ext = (
@@ -168,8 +167,7 @@ class FediverseInstance(AbstractSite):
         model_cls = self.supported_types.get(data["preferred_model"].lower())
         if not model_cls:
             raise ParseError(self, "preferred_model")
-        # `or []`: external_resources is nullable in the item schema, so a
-        # literal null is representable in a payload we are handed
+        # `or []`: external_resources is nullable in the item schema
         for ext in data.get("external_resources") or []:
             u = ext.get("url") if isinstance(ext, dict) else None
             if not u or self.is_local_item_url(u):

--- a/neodb/catalog/sites/fedi.py
+++ b/neodb/catalog/sites/fedi.py
@@ -168,7 +168,9 @@ class FediverseInstance(AbstractSite):
         model_cls = self.supported_types.get(data["preferred_model"].lower())
         if not model_cls:
             raise ParseError(self, "preferred_model")
-        for ext in data.get("external_resources", []):
+        # `or []`: external_resources is nullable in the item schema, so a
+        # literal null is representable in a payload we are handed
+        for ext in data.get("external_resources") or []:
             u = ext.get("url") if isinstance(ext, dict) else None
             if not u or self.is_local_item_url(u):
                 continue

--- a/neodb/common/validators.py
+++ b/neodb/common/validators.py
@@ -18,8 +18,14 @@ _HOST_TTL = 300
 _host_cache: TTLCache = TTLCache(maxsize=4096, ttl=_HOST_TTL)
 
 
-def _hostname_is_public(hostname: str) -> bool:
-    """Return True if `hostname` resolves only to public IPs."""
+def _resolve_hostname(hostname: str) -> bool | None:
+    """Tri-state resolution of `hostname`.
+
+    True when it resolves only to public IPs, False when any answer is
+    private/reserved, and None when the resolver gives no answer at all.
+    The last is what separates "points inside our network" from "does not
+    exist any more", which callers weigh differently.
+    """
     cached = _host_cache.get(hostname)
     if cached is not None:
         return cached
@@ -27,9 +33,9 @@ def _hostname_is_public(hostname: str) -> bool:
         results = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
     except socket.gaierror, socket.timeout, OSError:
         # Don't cache transient resolver failures so they recover quickly.
-        return False
+        return None
     if not results:
-        return False
+        return None
     for _family, _type, _proto, _canonname, sockaddr in results:
         ip = ipaddress.ip_address(sockaddr[0])
         if ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local:
@@ -40,11 +46,15 @@ def _hostname_is_public(hostname: str) -> bool:
     return True
 
 
-def is_valid_url(url: str | None) -> bool:
-    """Validate that a URL is well-formed, uses HTTP(S), and does not resolve
-    to a private/reserved IP address (DNS rebinding / SSRF)."""
+def _hostname_is_public(hostname: str) -> bool:
+    """Return True if `hostname` resolves only to public IPs."""
+    return _resolve_hostname(hostname) is True
+
+
+def _url_host_and_scheme(url: str | None) -> tuple[str, str] | None:
+    """(hostname, scheme) of a well-formed URL, or None. Resolver not consulted."""
     if not url:
-        return False
+        return None
     if not _url_validate(
         url,
         skip_ipv6_addr=True,
@@ -52,11 +62,45 @@ def is_valid_url(url: str | None) -> bool:
         may_have_port=False,
         strict_query=False,
     ):
-        return False
-    hostname = urlparse(url).hostname
+        return None
+    parsed = urlparse(url)
+    hostname = parsed.hostname
     if not hostname:
+        return None
+    return hostname, parsed.scheme
+
+
+def is_valid_url(url: str | None) -> bool:
+    """Validate that a URL is well-formed, uses HTTP(S), and does not resolve
+    to a private/reserved IP address (DNS rebinding / SSRF)."""
+    parts = _url_host_and_scheme(url)
+    if not parts:
         return False
-    return _hostname_is_public(hostname)
+    return _hostname_is_public(parts[0])
+
+
+def is_storable_url(url: str | None) -> bool:
+    """Like `is_valid_url`, but a host the resolver cannot find is admitted.
+
+    For URLs that are recorded rather than fetched -- the origin URL of an
+    item rebuilt from a backup, whose server may no longer exist. A dead
+    hostname is unreachable, not internal, so rejecting it would throw away
+    exactly the data this is for. Literal private IPs and hostnames that do
+    resolve into private space are still rejected.
+
+    Admission here is not authorization to fetch: anything that later
+    dereferences the URL must gate on `is_valid_url` itself.
+
+    The http(s) restriction is enforced here, unlike in `is_valid_url`, whose
+    underlying validator also accepts ftp and whose callers predate this.
+    """
+    parts = _url_host_and_scheme(url)
+    if not parts:
+        return False
+    hostname, scheme = parts
+    if scheme not in ("http", "https"):
+        return False
+    return _resolve_hostname(hostname) is not False
 
 
 def is_safe_url(url: str | None, allowed_hosts: set[str] | None = None) -> bool:

--- a/neodb/common/validators.py
+++ b/neodb/common/validators.py
@@ -22,9 +22,8 @@ def _resolve_hostname(hostname: str) -> bool | None:
     """Tri-state resolution of `hostname`.
 
     True when it resolves only to public IPs, False when any answer is
-    private/reserved, and None when the resolver gives no answer at all.
-    The last is what separates "points inside our network" from "does not
-    exist any more", which callers weigh differently.
+    private/reserved, None when the resolver answers not at all -- which
+    callers weigh differently from "points inside our network".
     """
     cached = _host_cache.get(hostname)
     if cached is not None:
@@ -82,17 +81,13 @@ def is_valid_url(url: str | None) -> bool:
 def is_storable_url(url: str | None) -> bool:
     """Like `is_valid_url`, but a host the resolver cannot find is admitted.
 
-    For URLs that are recorded rather than fetched -- the origin URL of an
-    item rebuilt from a backup, whose server may no longer exist. A dead
-    hostname is unreachable, not internal, so rejecting it would throw away
-    exactly the data this is for. Literal private IPs and hostnames that do
-    resolve into private space are still rejected.
+    For URLs recorded rather than fetched -- the origin URL of an item
+    rebuilt from a backup, whose server may no longer exist. A dead hostname
+    is unreachable, not internal; private IPs are still rejected, and http(s)
+    is required here though `is_valid_url` also accepts ftp.
 
-    Admission here is not authorization to fetch: anything that later
-    dereferences the URL must gate on `is_valid_url` itself.
-
-    The http(s) restriction is enforced here, unlike in `is_valid_url`, whose
-    underlying validator also accepts ftp and whose callers predate this.
+    Admission is not authorization to fetch: whatever later dereferences the
+    URL must gate on `is_valid_url` itself.
     """
     parts = _url_host_and_scheme(url)
     if not parts:

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -7,10 +7,12 @@ import tempfile
 import uuid
 import zipfile
 from typing import Any, Callable, Dict
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import default_storage
+from django.db import transaction
 from django.utils import timezone
 from loguru import logger
 
@@ -928,6 +930,13 @@ class NdjsonImporter(BaseImporter):
             # ExternalResource of our own site would be rejected anyway
             logger.debug(f"Not recreating local item {url}")
             return None
+        # both checks FediverseInstance.validate_url_fallback would have made.
+        # Building the site directly skips that, and an archive must not be a
+        # way to seed this catalog from an instance the admin has defederated.
+        host = urlparse(url).hostname or ""
+        if host in Takahe.get_blocked_peers():
+            logger.debug(f"Not recreating item from blocked peer {host}")
+            return None
         typ = data.get("type")
         if not isinstance(typ, str) or typ.lower() not in (
             FediverseInstance.supported_types
@@ -940,10 +949,18 @@ class NdjsonImporter(BaseImporter):
             return None
         data = dict(data, localized_title=titles)
         try:
-            site = FediverseInstance(url=url)
-            content = site.content_from_json(data, detect_redirection=False)
-            site.get_resource_ready(preloaded_content=content)
-            item = site.get_item()
+            # atomic: create_from_external_resource saves the Item before
+            # validating it against the AP schema, so metadata of the wrong
+            # shape (a str where a list belongs) leaves an item-less Item and
+            # ExternalResource behind, one more per reimport, once the except
+            # below swallows the error.
+            with transaction.atomic():
+                site = FediverseInstance(url=url)
+                content = site.content_from_json(data, detect_redirection=False)
+                # get_resource_ready creates and links the item itself; asking
+                # the site for it again would re-run the match for nothing
+                resource = site.get_resource_ready(preloaded_content=content)
+                item = resource.item if resource else None
         except Exception:
             logger.exception(f"Error creating item from catalog data for {url}")
             return None
@@ -974,7 +991,16 @@ class NdjsonImporter(BaseImporter):
                             for r in i.get("external_resources") or []
                             if isinstance(r, dict) and r.get("url")
                         ]
-                        item = self.get_item_by_info_and_links("", "", links)
+                        # the bundled ids let an item already in this catalog
+                        # be matched here, before the rebuild below, which
+                        # would merge the archive's metadata into it on the
+                        # way past
+                        info = " ".join(
+                            f"{k}:{i[k]}"
+                            for k in ("isbn", "imdb")
+                            if isinstance(i.get(k), str) and i[k]
+                        )
+                        item = self.get_item_by_info_and_links("", info, links)
                         if not item:
                             # every link failed: the source server may be gone
                             # or offline. Rebuild from the bundled entry rather

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -888,9 +888,8 @@ class NdjsonImporter(BaseImporter):
     def _catalog_localized_title(data: Dict[str, Any]) -> list[dict[str, str]] | None:
         """The entry's localized_title, or one synthesized from its title.
 
-        Returns None when the entry names the item nowhere: display_title
-        would be blank, and Item.create_from_external_resource validates
-        against the AP schema, so a nameless item cannot be built.
+        None when the entry names the item nowhere: the AP schema validation
+        in create_from_external_resource rejects a nameless item.
         """
         titles = [
             {"lang": t["lang"], "text": t["text"]}
@@ -926,31 +925,22 @@ class NdjsonImporter(BaseImporter):
         """Build a catalog item out of the metadata bundled in catalog.ndjson.
 
         Last resort, once every link in the entry has failed to resolve. The
-        bundled entry is the same payload FediverseInstance would have
-        downloaded from the source server, so it is replayed through that same
-        path with the fetch skipped. Its isbn/imdb/barcode become the
-        resource's lookup ids, so an item already in this catalog is matched
-        rather than duplicated.
-
-        Returns None when the entry is too thin to build from, leaving the
-        caller's "could not find item" behaviour unchanged.
+        entry is the same payload FediverseInstance would have downloaded, so
+        it is replayed through that path with the fetch skipped. None when the
+        entry is too thin to build from, leaving the caller unchanged.
         """
         url = data.get("id")
-        # is_storable_url, not is_valid_url: the server being unreachable --
-        # its hostname no longer resolving included -- is the case this whole
-        # fallback exists for. Nothing here dereferences the url.
+        # is_storable_url: a hostname that no longer resolves is the case this
+        # exists for, and nothing here dereferences the url
         if not isinstance(url, str) or not is_storable_url(url):
             logger.debug(f"Catalog entry has no usable id: {data.get('id')!r}")
             return None
         if FediverseInstance.is_local_item_url(url):
-            # a local url that get_item_by_info_and_links could not resolve is
-            # a deleted or never-existing item, not something to recreate: an
-            # ExternalResource of our own site would be rejected anyway
+            # unresolved local url means deleted, not missing
             logger.debug(f"Not recreating local item {url}")
             return None
-        # both checks FediverseInstance.validate_url_fallback would have made.
-        # Building the site directly skips that, and an archive must not be a
-        # way to seed this catalog from an instance the admin has defederated.
+        # checks validate_url_fallback would have made; building the site
+        # directly skips it
         host = urlparse(url).hostname or ""
         if host in Takahe.get_blocked_peers():
             logger.debug(f"Not recreating item from blocked peer {host}")
@@ -967,28 +957,19 @@ class NdjsonImporter(BaseImporter):
             return None
         data = dict(data, localized_title=titles)
         try:
-            # atomic: create_from_external_resource saves the Item before
-            # validating it against the AP schema, so metadata of the wrong
-            # shape (a str where a list belongs) leaves an item-less Item and
-            # ExternalResource behind, one more per reimport, once the except
-            # below swallows the error.
+            # atomic: the Item is saved before it is validated, so a later
+            # raise would strand an item-less row, one more per reimport
             with transaction.atomic():
                 site = FediverseInstance(url=url)
                 content = site.content_from_json(data, detect_redirection=False)
-                # Stop at an item that already exists. Going on would reach
-                # match_and_link_item, which merges the archive's metadata
-                # into whatever it matched -- filling empty fields, appending
-                # to localized_title/description, setting a missing cover --
-                # on an item this user does not own and may not even be
-                # allowed to edit (is_protected is enforced on the edit form,
-                # not here). Creating what is missing is the job; rewriting
-                # what is already here is not.
+                # going on would reach match_and_link_item, merging this into
+                # a shared item the uploader may not be allowed to edit
                 existing = self._existing_item_for_ids(content.lookup_ids)
                 if existing:
                     logger.debug(f"Catalog entry {url} matches existing {existing}")
                     return existing
-                # get_resource_ready creates and links the item itself; asking
-                # the site for it again would re-run the match for nothing
+                # get_resource_ready links the item itself; asking again would
+                # re-run the match for nothing
                 resource = site.get_resource_ready(preloaded_content=content)
                 item = resource.item if resource else None
         except Exception:
@@ -1021,10 +1002,8 @@ class NdjsonImporter(BaseImporter):
                             for r in i.get("external_resources") or []
                             if isinstance(r, dict) and r.get("url")
                         ]
-                        # the bundled ids let an item already in this catalog
-                        # be matched here, before the rebuild below, which
-                        # would merge the archive's metadata into it on the
-                        # way past
+                        # bundled ids, so an item already here is matched by
+                        # the ordinary lookup
                         info = " ".join(
                             f"{k}:{i[k]}"
                             for k in ("isbn", "imdb")
@@ -1032,9 +1011,8 @@ class NdjsonImporter(BaseImporter):
                         )
                         item = self.get_item_by_info_and_links("", info, links)
                         if not item:
-                            # every link failed: the source server may be gone
-                            # or offline. Rebuild from the bundled entry rather
-                            # than failing every record that references it.
+                            # every link failed, so rebuild from the bundled
+                            # entry rather than failing every record for it
                             item = self.create_item_from_catalog_data(i)
                         self.items[u] = item
                     except Exception:

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -15,6 +15,9 @@ from django.utils import timezone
 from loguru import logger
 
 from catalog.models import Item
+from catalog.sites.fedi import FediverseInstance
+from common.models.lang import detect_language
+from common.validators import is_storable_url
 from journal.models import (
     Article,
     Attachment,
@@ -879,6 +882,77 @@ class NdjsonImporter(BaseImporter):
             f"Imported {self.metadata['imported']}, skipped {self.metadata['skipped']}, failed {self.metadata['failed']}"
         )
 
+    @staticmethod
+    def _catalog_localized_title(data: Dict[str, Any]) -> list[dict[str, str]] | None:
+        """The entry's localized_title, or one synthesized from its title.
+
+        Returns None when the entry names the item nowhere: display_title
+        would be blank, and Item.create_from_external_resource validates
+        against the AP schema, so a nameless item cannot be built.
+        """
+        titles = [
+            {"lang": t["lang"], "text": t["text"]}
+            for t in data.get("localized_title") or []
+            if isinstance(t, dict) and t.get("lang") and t.get("text")
+        ]
+        if titles:
+            return titles
+        title = data.get("title") or data.get("display_title")
+        if isinstance(title, str) and title.strip():
+            return [{"lang": detect_language(title), "text": title.strip()}]
+        return None
+
+    def create_item_from_catalog_data(self, data: Dict[str, Any]) -> Item | None:
+        """Build a catalog item out of the metadata bundled in catalog.ndjson.
+
+        Last resort, once every link in the entry has failed to resolve. The
+        bundled entry is the same payload FediverseInstance would have
+        downloaded from the source server, so it is replayed through that same
+        path with the fetch skipped. Its isbn/imdb/barcode become the
+        resource's lookup ids, so an item already in this catalog is matched
+        rather than duplicated.
+
+        Returns None when the entry is too thin to build from, leaving the
+        caller's "could not find item" behaviour unchanged.
+        """
+        url = data.get("id")
+        # is_storable_url, not is_valid_url: the server being unreachable --
+        # its hostname no longer resolving included -- is the case this whole
+        # fallback exists for. Nothing here dereferences the url.
+        if not isinstance(url, str) or not is_storable_url(url):
+            logger.debug(f"Catalog entry has no usable id: {data.get('id')!r}")
+            return None
+        if FediverseInstance.is_local_item_url(url):
+            # a local url that get_item_by_info_and_links could not resolve is
+            # a deleted or never-existing item, not something to recreate: an
+            # ExternalResource of our own site would be rejected anyway
+            logger.debug(f"Not recreating local item {url}")
+            return None
+        typ = data.get("type")
+        if not isinstance(typ, str) or typ.lower() not in (
+            FediverseInstance.supported_types
+        ):
+            logger.debug(f"Catalog entry {url} has unsupported type {typ!r}")
+            return None
+        titles = self._catalog_localized_title(data)
+        if not titles:
+            logger.debug(f"Catalog entry {url} has no title")
+            return None
+        data = dict(data, localized_title=titles)
+        try:
+            site = FediverseInstance(url=url)
+            content = site.content_from_json(data, detect_redirection=False)
+            site.get_resource_ready(preloaded_content=content)
+            item = site.get_item()
+        except Exception:
+            logger.exception(f"Error creating item from catalog data for {url}")
+            return None
+        if item:
+            logger.info(f"Created {item} from bundled catalog metadata")
+        else:
+            logger.error(f"Unable to create item from catalog data for {url}")
+        return item
+
     def parse_catalog(self, file_path: str) -> None:
         """Parse the catalog.ndjson file and build item lookup tables."""
         logger.debug(f"Parsing catalog file: {file_path}")
@@ -894,18 +968,19 @@ class NdjsonImporter(BaseImporter):
                         u = i.get("id")
                         if not u:
                             continue
-                        # TODO: the entry itself is not kept, so an item
-                        # that cannot be resolved (source server gone, no
-                        # external ids) fails every record referencing it
-                        # instead of being rebuilt from the bundled data.
-                        # self.catalog_items[u] = i
                         item_count += 1
                         links = [u] + [
                             r["url"]
                             for r in i.get("external_resources") or []
                             if isinstance(r, dict) and r.get("url")
                         ]
-                        self.items[u] = self.get_item_by_info_and_links("", "", links)
+                        item = self.get_item_by_info_and_links("", "", links)
+                        if not item:
+                            # every link failed: the source server may be gone
+                            # or offline. Rebuild from the bundled entry rather
+                            # than failing every record that references it.
+                            item = self.create_item_from_catalog_data(i)
+                        self.items[u] = item
                     except Exception:
                         logger.exception("Error processing catalog item")
             logger.info(f"Loaded {item_count} items from catalog")

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -16,7 +16,7 @@ from django.db import transaction
 from django.utils import timezone
 from loguru import logger
 
-from catalog.models import Item
+from catalog.models import ExternalResource, Item
 from catalog.sites.fedi import FediverseInstance
 from common.models.lang import detect_language
 from common.validators import is_storable_url
@@ -904,6 +904,24 @@ class NdjsonImporter(BaseImporter):
             return [{"lang": detect_language(title), "text": title.strip()}]
         return None
 
+    @staticmethod
+    def _existing_item_for_ids(lookup_ids: Dict[str, str]) -> Item | None:
+        """An item already in this catalog carrying any of these ids."""
+        for id_type, id_value in lookup_ids.items():
+            if not id_value:
+                continue
+            resource = ExternalResource.objects.filter(
+                id_type=id_type, id_value=id_value
+            ).first()
+            if resource and resource.item and not resource.item.is_deleted:
+                return resource.item
+            item = Item.objects.filter(
+                primary_lookup_id_type=id_type, primary_lookup_id_value=id_value
+            ).first()
+            if item and not item.is_deleted:
+                return item
+        return None
+
     def create_item_from_catalog_data(self, data: Dict[str, Any]) -> Item | None:
         """Build a catalog item out of the metadata bundled in catalog.ndjson.
 
@@ -957,6 +975,18 @@ class NdjsonImporter(BaseImporter):
             with transaction.atomic():
                 site = FediverseInstance(url=url)
                 content = site.content_from_json(data, detect_redirection=False)
+                # Stop at an item that already exists. Going on would reach
+                # match_and_link_item, which merges the archive's metadata
+                # into whatever it matched -- filling empty fields, appending
+                # to localized_title/description, setting a missing cover --
+                # on an item this user does not own and may not even be
+                # allowed to edit (is_protected is enforced on the edit form,
+                # not here). Creating what is missing is the job; rewriting
+                # what is already here is not.
+                existing = self._existing_item_for_ids(content.lookup_ids)
+                if existing:
+                    logger.debug(f"Catalog entry {url} matches existing {existing}")
+                    return existing
                 # get_resource_ready creates and links the item itself; asking
                 # the site for it again would re-run the match for nothing
                 resource = site.get_resource_ready(preloaded_content=content)

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1221,6 +1221,139 @@ class TestNdjsonExportImport:
         importer.parse_catalog(str(path))
         assert importer.items.get(self.book1.absolute_url) == self.book1
 
+    @staticmethod
+    def _write_catalog(path, *entries) -> None:
+        """Write a catalog.ndjson holding `entries`, header included."""
+        path.write_text(
+            "\n".join([json.dumps({"server": "x"})] + [json.dumps(e) for e in entries])
+            + "\n"
+        )
+
+    def _parse_catalog(self, tmp_path, *entries) -> NdjsonImporter:
+        path = tmp_path / "catalog.ndjson"
+        self._write_catalog(path, *entries)
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.parse_catalog(str(path))
+        return importer
+
+    def test_ndjson_catalog_rebuilds_item_from_bundled_metadata(self, tmp_path):
+        """Every link failed, so the bundled entry itself becomes the item.
+
+        The archive already carries each item's full metadata; without this,
+        a source server that is gone (the .invalid host below never resolves)
+        stranded every journal record referencing its items.
+        """
+        entry = {
+            "id": "https://gone-rebuild.invalid/movie/aabbcc",
+            "type": "Movie",
+            "title": "A Lost Film",
+            "localized_title": [{"lang": "en", "text": "A Lost Film"}],
+            "localized_description": [{"lang": "en", "text": "Nowhere to fetch."}],
+            "director": ["Someone"],
+            "external_resources": [
+                {"url": "https://gone-rebuild.invalid/movie/aabbcc"}
+            ],
+        }
+        importer = self._parse_catalog(tmp_path, entry)
+        item = importer.items[entry["id"]]
+        assert isinstance(item, Movie)
+        assert item.display_title == "A Lost Film"
+        assert item.director == ["Someone"]
+
+    def test_ndjson_catalog_rebuild_matches_existing_item_by_id(self, tmp_path):
+        """The bundled ids dedup against this catalog instead of duplicating.
+
+        parse_catalog passes no info string, so a bundled isbn/imdb used to be
+        ignored entirely. Routed through the resource's lookup ids, an item
+        already here is matched.
+        """
+        before = Edition.objects.count()
+        entry = {
+            "id": "https://gone-dedup.invalid/book/ddeeff",
+            "type": "Edition",
+            "localized_title": [{"lang": "en", "text": "Hyperion"}],
+            "isbn": self.book1.isbn,
+            "external_resources": [],
+        }
+        importer = self._parse_catalog(tmp_path, entry)
+        assert importer.items[entry["id"]] == self.book1
+        assert Edition.objects.count() == before
+
+    def test_ndjson_catalog_rebuild_needs_sufficient_metadata(self, tmp_path):
+        """Entries too thin to build from stay unresolved rather than half-built."""
+        no_title = {"id": "https://gone-a.invalid/book/1", "type": "Edition"}
+        unsupported = {
+            "id": "https://gone-b.invalid/p/1",
+            "type": "People",
+            "localized_title": [{"lang": "en", "text": "Someone"}],
+        }
+        bad_url = {
+            "id": "not a url at all",
+            "type": "Edition",
+            "localized_title": [{"lang": "en", "text": "Nowhere"}],
+        }
+        importer = self._parse_catalog(tmp_path, no_title, unsupported, bad_url)
+        assert importer.items[no_title["id"]] is None
+        assert importer.items[unsupported["id"]] is None
+        assert importer.items[bad_url["id"]] is None
+
+    def test_ndjson_catalog_rebuild_skips_local_urls(self, tmp_path):
+        """A local url that did not resolve is a deleted item, not a new one."""
+        before = Movie.objects.count()
+        entry = {
+            "id": settings.SITE_INFO["site_url"] + "/movie/nosuchitem",
+            "type": "Movie",
+            "localized_title": [{"lang": "en", "text": "Deleted Locally"}],
+        }
+        importer = self._parse_catalog(tmp_path, entry)
+        assert importer.items[entry["id"]] is None
+        assert Movie.objects.count() == before
+
+    def test_ndjson_marks_import_against_a_rebuilt_item(self, tmp_path):
+        """End to end: a mark on an unfetchable item still imports.
+
+        This is the failure the rebuild exists to fix -- the mark used to be
+        counted as failed with "Could not find item".
+        """
+        url = "https://gone-marks.invalid/book/xyz"
+        catalog = tmp_path / "catalog.ndjson"
+        self._write_catalog(
+            catalog,
+            {
+                "id": url,
+                "type": "Edition",
+                "localized_title": [{"lang": "en", "text": "Vanished Volume"}],
+                "author": ["Nobody"],
+                "external_resources": [],
+            },
+        )
+        journal = tmp_path / "journal.ndjson"
+        journal.write_text(
+            json.dumps({"server": "x"})
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "ShelfMember",
+                    "content": {
+                        "withRegardTo": url,
+                        "status": ShelfType.COMPLETE,
+                        "published": "2021-01-01T00:00:00Z",
+                    },
+                    "visibility": 0,
+                    "metadata": {},
+                }
+            )
+            + "\n"
+        )
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.parse_catalog(str(catalog))
+        importer.process_journal(str(journal))
+        assert importer.metadata["failed"] == 0
+        assert importer.metadata["imported"] == 1
+        item = importer.items[url]
+        assert item is not None
+        assert Mark(self.user2.identity, item).shelf_type == ShelfType.COMPLETE
+
     def test_ndjson_import_without_published_timestamp(self):
         """created_time is not nullable; a bundle without `published` must
         fall back to the model default instead of raising IntegrityError."""

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -3,6 +3,7 @@ import os
 import zipfile
 from io import BytesIO
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import pytest
 from django.conf import settings
@@ -16,6 +17,7 @@ from PIL import Image
 
 from catalog.models import (
     Edition,
+    ExternalResource,
     IdType,
     Movie,
     Podcast,
@@ -1287,6 +1289,51 @@ class TestNdjsonExportImport:
         importer = self._parse_catalog(tmp_path, entry)
         assert importer.items[entry["id"]] == self.book1
         assert Edition.objects.count() == before
+
+    def test_ndjson_catalog_rebuild_skips_blocked_peers(self, tmp_path):
+        """An archive is not a way around a defederated instance.
+
+        Building the site directly skips FediverseInstance.validate_url_
+        fallback, which is where the blocked-peer list is enforced.
+        """
+        before = Movie.objects.count()
+        entry = {
+            "id": "https://blocked-peer.invalid/movie/x",
+            "type": "Movie",
+            "localized_title": [{"lang": "en", "text": "From A Blocked Peer"}],
+        }
+        with mock.patch.object(
+            Takahe, "get_blocked_peers", return_value=["blocked-peer.invalid"]
+        ):
+            importer = self._parse_catalog(tmp_path, entry)
+        assert importer.items[entry["id"]] is None
+        assert Movie.objects.count() == before
+
+    def test_ndjson_catalog_rebuild_leaves_nothing_behind_on_bad_metadata(
+        self, tmp_path
+    ):
+        """A failure part-way through the build must not leave a half-built item.
+
+        create_from_external_resource saves the Item and only then validates
+        it against the AP schema and syncs credits, so anything raising after
+        that save stranded an item-less row -- one more per reimport, since
+        the rebuild swallows the error. sync_credits_from_metadata stands in
+        here for any of those post-save steps.
+        """
+        before = Movie.objects.count()
+        resources_before = ExternalResource.objects.count()
+        entry = {
+            "id": "https://gone-badshape.invalid/movie/x",
+            "type": "Movie",
+            "localized_title": [{"lang": "en", "text": "Malformed"}],
+        }
+        with mock.patch.object(
+            Movie, "sync_credits_from_metadata", side_effect=ValueError("boom")
+        ):
+            importer = self._parse_catalog(tmp_path, entry)
+        assert importer.items[entry["id"]] is None
+        assert Movie.objects.count() == before
+        assert ExternalResource.objects.count() == resources_before
 
     def test_ndjson_catalog_rebuild_needs_sufficient_metadata(self, tmp_path):
         """Entries too thin to build from stay unresolved rather than half-built."""

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1254,11 +1254,20 @@ class TestNdjsonExportImport:
                 {"url": "https://gone-rebuild.invalid/movie/aabbcc"}
             ],
         }
+        before = Movie.objects.count()
         importer = self._parse_catalog(tmp_path, entry)
         item = importer.items[entry["id"]]
         assert isinstance(item, Movie)
         assert item.display_title == "A Lost Film"
         assert item.director == ["Someone"]
+        assert Movie.objects.count() == before + 1
+
+        # reimporting the same archive must land on the item it built, not a
+        # second copy: the dead url still fails every lookup get_item_by_info_
+        # and_links does, so the rebuild runs again and has to converge
+        again = self._parse_catalog(tmp_path, entry)
+        assert again.items[entry["id"]] == item
+        assert Movie.objects.count() == before + 1
 
     def test_ndjson_catalog_rebuild_matches_existing_item_by_id(self, tmp_path):
         """The bundled ids dedup against this catalog instead of duplicating.

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1290,6 +1290,37 @@ class TestNdjsonExportImport:
         assert importer.items[entry["id"]] == self.book1
         assert Edition.objects.count() == before
 
+    def test_ndjson_catalog_rebuild_never_edits_an_existing_item(self):
+        """An archive must not rewrite catalog items it merely matches.
+
+        Reaching match_and_link_item would merge the bundled metadata into
+        whatever it matched -- appending to localized_title, filling empty
+        fields, setting a missing cover -- on an item the importing user does
+        not own and may not be allowed to edit at all: is_protected is
+        enforced on the edit form, not on this path.
+        """
+        self.movie1.is_protected = True
+        self.movie1.save()
+        titles_before = list(self.movie1.localized_title)
+        descriptions_before = list(self.movie1.localized_description)
+        before = Movie.objects.count()
+
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        item = importer.create_item_from_catalog_data(
+            {
+                "id": "https://gone-merge.invalid/movie/x",
+                "type": "Movie",
+                "imdb": self.movie1.imdb,
+                "localized_title": [{"lang": "en", "text": "Bogus Injected Title"}],
+                "localized_description": [{"lang": "en", "text": "Injected."}],
+            }
+        )
+        assert item == self.movie1
+        assert Movie.objects.count() == before
+        self.movie1.refresh_from_db()
+        assert self.movie1.localized_title == titles_before
+        assert self.movie1.localized_description == descriptions_before
+
     def test_ndjson_catalog_rebuild_skips_blocked_peers(self, tmp_path):
         """An archive is not a way around a defederated instance.
 

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1241,9 +1241,8 @@ class TestNdjsonExportImport:
     def test_ndjson_catalog_rebuilds_item_from_bundled_metadata(self, tmp_path):
         """Every link failed, so the bundled entry itself becomes the item.
 
-        The archive already carries each item's full metadata; without this,
-        a source server that is gone (the .invalid host below never resolves)
-        stranded every journal record referencing its items.
+        A gone source server (the .invalid host never resolves) used to
+        strand every journal record referencing its items.
         """
         entry = {
             "id": "https://gone-rebuild.invalid/movie/aabbcc",
@@ -1264,9 +1263,8 @@ class TestNdjsonExportImport:
         assert item.director == ["Someone"]
         assert Movie.objects.count() == before + 1
 
-        # reimporting the same archive must land on the item it built, not a
-        # second copy: the dead url still fails every lookup get_item_by_info_
-        # and_links does, so the rebuild runs again and has to converge
+        # the dead url still fails every lookup, so reimporting rebuilds
+        # again and has to land on the same item
         again = self._parse_catalog(tmp_path, entry)
         assert again.items[entry["id"]] == item
         assert Movie.objects.count() == before + 1
@@ -1274,9 +1272,8 @@ class TestNdjsonExportImport:
     def test_ndjson_catalog_rebuild_matches_existing_item_by_id(self, tmp_path):
         """The bundled ids dedup against this catalog instead of duplicating.
 
-        parse_catalog passes no info string, so a bundled isbn/imdb used to be
-        ignored entirely. Routed through the resource's lookup ids, an item
-        already here is matched.
+        parse_catalog passed no info string, so a bundled isbn/imdb used to
+        be ignored entirely.
         """
         before = Edition.objects.count()
         entry = {
@@ -1293,11 +1290,8 @@ class TestNdjsonExportImport:
     def test_ndjson_catalog_rebuild_never_edits_an_existing_item(self):
         """An archive must not rewrite catalog items it merely matches.
 
-        Reaching match_and_link_item would merge the bundled metadata into
-        whatever it matched -- appending to localized_title, filling empty
-        fields, setting a missing cover -- on an item the importing user does
-        not own and may not be allowed to edit at all: is_protected is
-        enforced on the edit form, not on this path.
+        match_and_link_item would merge the bundled metadata into whatever it
+        matched, and is_protected guards the edit form, not this path.
         """
         self.movie1.is_protected = True
         self.movie1.save()
@@ -1324,8 +1318,8 @@ class TestNdjsonExportImport:
     def test_ndjson_catalog_rebuild_skips_blocked_peers(self, tmp_path):
         """An archive is not a way around a defederated instance.
 
-        Building the site directly skips FediverseInstance.validate_url_
-        fallback, which is where the blocked-peer list is enforced.
+        Building the site directly skips validate_url_fallback, where the
+        blocked-peer list is enforced.
         """
         before = Movie.objects.count()
         entry = {
@@ -1345,11 +1339,9 @@ class TestNdjsonExportImport:
     ):
         """A failure part-way through the build must not leave a half-built item.
 
-        create_from_external_resource saves the Item and only then validates
-        it against the AP schema and syncs credits, so anything raising after
-        that save stranded an item-less row -- one more per reimport, since
-        the rebuild swallows the error. sync_credits_from_metadata stands in
-        here for any of those post-save steps.
+        The Item is saved before it is validated, so anything raising after
+        that stranded an item-less row, one more per reimport. The patched
+        sync_credits_from_metadata stands in for any such post-save step.
         """
         before = Movie.objects.count()
         resources_before = ExternalResource.objects.count()


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] You, as a human, have fully reviewed every single line of this PR
- [ ] You, as a human, have fully tested this PR

<sub>(left unticked deliberately: these attest to human review and testing, so they are the author's to tick, not the drafter's.)</sub>


* **What kind of change does this PR introduce?**
- [x] bug fix, including security or performance improvements
- [x] feature


* **What is the current behavior?** (Link to an open issue if applicable)

`NdjsonImporter.parse_catalog` uses each `catalog.ndjson` entry only for its links, then discards the entry. When none of those links resolve -- the source server is gone or offline, or the item has no usable external ids -- the item is left unresolved and **every journal record referencing it fails to import**: marks, ratings, comments, reviews, notes, tags.

The archive already carries each item's full metadata, so the data needed to rebuild it is sitting right there unused. There was a `TODO` in `parse_catalog` saying exactly this.

Two smaller things in the same area: the bundled `isbn`/`imdb` were never used for matching, because `parse_catalog` passes an empty info string to `get_item_by_info_and_links`; and `external_resources` is nullable in the item schema, but `FediverseInstance.scrape` read it with `.get(key, [])`, so a literal `null` raised `TypeError`.


* **What is the new behavior?**

When every link fails, the item is rebuilt from the bundled entry. That entry is the same payload `FediverseInstance` would have downloaded from the source server, so it is replayed through the same path with the fetch skipped.

- **`catalog/sites/fedi.py`** -- `scrape()` split into `get_json_from_url()` + `content_from_json()`, so a caller already holding the payload can build a `ResourceContent` from it. Redirect detection is switchable: the import path turns it off, since its links have already been tried and each `HEAD` would only add a timeout.
- **`common/validators.py`** -- new `is_storable_url()`, for urls that are *recorded* rather than *fetched*. `is_valid_url()` treats a hostname the resolver cannot find as invalid, which is precisely the "source server is gone" case this feature exists for, so `_hostname_is_public` gains a tri-state form separating "resolves into private space" (still rejected) from "does not resolve at all" (admitted). **`is_valid_url()` is unchanged for every existing caller** -- verified value-by-value against the original, including its pre-existing acceptance of `ftp://`.
- **`journal/importers/ndjson.py`** -- rebuild only from an entry with a non-local url, a non-blocked host, a supported type and a title; anything thinner stays unresolved exactly as before.

Guards worth calling out, each with a test that fails without it:

- **Never edits an existing item.** Falling through to `match_and_link_item` would merge the archive's metadata into whatever item it matched -- filling empty fields, appending to `localized_title`/`localized_description`, setting a missing cover -- on an item belonging to the shared catalog rather than to the importing user, and `is_protected` is enforced on the edit form, not on this path. The rebuild now stops at an item that already exists and returns it untouched. Creating what is missing is the job; rewriting what is already in the catalog is not.
- **Honours the blocked-peer list.** Constructing `FediverseInstance` directly skips `validate_url_fallback`, which is where `Takahe.get_blocked_peers()` is enforced, so an archive must not become a way to seed the catalog from a defederated instance.
- **Leaves nothing behind on failure.** `create_from_external_resource` saves the `Item` before validating it against the AP schema and before syncing credits, so anything raising after that save stranded an item-less row -- one more per reimport, since the rebuild swallows the error. The build is wrapped in a transaction.

The bundled `isbn`/`imdb` now go through `get_item_by_info_and_links`, so an item already in this catalog is matched by the ordinary lookup path.


* **Does this PR introduce a breaking change?**

No. The rebuild is a fallback that only runs where the import previously gave up, so an archive that imports cleanly today takes exactly the same path. `is_valid_url()` keeps its current behaviour for all existing callers; the new permissiveness is confined to the new `is_storable_url()`.


* **Other information**:

**Testing.** Full suite 2291 passed / 3 failed, the 3 being only `tests/mastodon/test_lexicons.py`, which fails because the dev container does not mount `/docs` (verified with `ls /docs`; unrelated to this change). 42 tests in `tests/journal/test_ndjson.py`, 10 of them new: rebuild, reimport convergence, id-based dedup, no-merge-into-existing, blocked peers, transactional cleanup, three insufficient-metadata shapes, local-url skip, and an end-to-end mark import against a rebuilt item. `pre-commit run -a` clean.

**Two pre-existing issues noticed while working here, deliberately left alone** -- both predate this PR and neither is made worse by it, but they are worth a maintainer's judgement:

1. `merge_data_from_external_resource` does not consult `is_protected`. Any scrape whose lookup ids match a protected item -- a refetch, or a user pasting that item's Goodreads/TMDB url -- still fills its empty fields, appends to its title/description lists, and sets a cover if it has none. `is_protected` currently locks the edit form only. Narrowing this affects every import path, so it did not belong in this change.
2. `BasicDownloader.download` has no `is_valid_url` gate, so a later refetch of *any* stored `ExternalResource` url is ungated. `is_storable_url`'s contract says admission is not authorization to fetch and that anything dereferencing the url must re-gate; that is true of the image downloader, but not of this one.

**Known characteristic, not fixed.** `_resolve_hostname` deliberately does not cache resolver failures. On an archive full of items from a dead domain, each entry pays a lookup. This predates the PR -- `get_item_by_info_and_links` already resolves per link per entry -- and the rebuild adds roughly one more on that path; caching negative results would mean loosening policy in security-sensitive code, which felt out of scope here.
