### PR TITLE
fix(mastodon): tolerate social account deleted during sync

### DIFF
--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -448,6 +448,10 @@ class BlueskyAccount(SocialAccount):
         self.last_refresh = timezone.now()
         if save:
             self.save_fields(["access_data", "account_data", "last_refresh", "handle"])
+            if self.pk is None:
+                # disconnected mid-sync; on_disconnect() is purging the PDS
+                # records, so do not republish them here
+                return True
         self.sync_profile_record()
         self.sync_publication_record()
         return True

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -294,7 +294,7 @@ class BlueskyAccount(SocialAccount):
         self._oauth_cache = session
         self.oauth_session = json.dumps(session)
         if save:
-            self.save_fields(["access_data"])
+            self.save_fields("access_data")
 
     def get_dpop_jwk(self) -> dict:
         return self._get_oauth().get("dpop_jwk") or {}
@@ -371,7 +371,7 @@ class BlueskyAccount(SocialAccount):
             session_string = session.export()
             if session_string != self.session_string:
                 self.session_string = session_string
-                self.save_fields(["access_data"])
+                self.save_fields("access_data")
 
     @cached_property
     def _client(self):
@@ -422,7 +422,7 @@ class BlueskyAccount(SocialAccount):
             self.base_url = resolved_pds
         self.last_reachable = timezone.now()
         if save:
-            self.save_fields(["access_data", "handle", "last_reachable"])
+            self.save_fields("access_data", "handle", "last_reachable")
         return True
 
     def refresh(self, save=True, did_check=True):
@@ -447,11 +447,9 @@ class BlueskyAccount(SocialAccount):
         }
         self.last_refresh = timezone.now()
         if save:
-            self.save_fields(["access_data", "account_data", "last_refresh", "handle"])
-            if self.pk is None:
-                # disconnected mid-sync; on_disconnect() is purging the PDS
-                # records, so do not republish them here
-                return True
+            self.save_fields("access_data", "account_data", "last_refresh", "handle")
+            if not self.pk:
+                return True  # disconnected mid-sync; on_disconnect() purges these
         self.sync_profile_record()
         self.sync_publication_record()
         return True
@@ -556,7 +554,7 @@ class BlueskyAccount(SocialAccount):
         if self.publication_icon_hash or self.publication_icon_blob:
             self.publication_icon_hash = ""
             self.publication_icon_blob = ""
-            self.save_fields(["access_data"])
+            self.save_fields("access_data")
 
     def _publication_icon(self) -> dict[str, typing.Any] | None:
         """Blob ref for the identity's avatar, uploaded at most once per
@@ -582,7 +580,7 @@ class BlueskyAccount(SocialAccount):
         blob = self._client.upload_blob(data).blob.model_dump(by_alias=True)
         self.publication_icon_hash = digest
         self.publication_icon_blob = json.dumps(blob)
-        self.save_fields(["access_data"])
+        self.save_fields("access_data")
         return blob
 
     def _build_publication_record(self) -> dict[str, typing.Any]:
@@ -727,14 +725,12 @@ class BlueskyAccount(SocialAccount):
             logger.warning(f"{self} refresh_graph error: {e}")
             return False
         if save:
-            self.save_fields(["followers", "following", "mutes"])
+            self.save_fields("followers", "following", "mutes")
         return True
 
     def sync_graph(self):
-        if self.pk is None:
-            # disconnected mid-sync; the in-memory graph is stale, do not
-            # import follows/mutes for an account the user just removed
-            return 0
+        if not self.pk:
+            return 0  # disconnected mid-sync; the in-memory graph is stale
         c = 0
 
         def get_identity_ids(accts: list):

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -293,8 +293,8 @@ class BlueskyAccount(SocialAccount):
     def _set_oauth(self, session: dict, save: bool = False) -> None:
         self._oauth_cache = session
         self.oauth_session = json.dumps(session)
-        if save and self.pk:
-            self.save(update_fields=["access_data"])
+        if save:
+            self.save_fields(["access_data"])
 
     def get_dpop_jwk(self) -> dict:
         return self._get_oauth().get("dpop_jwk") or {}
@@ -371,8 +371,7 @@ class BlueskyAccount(SocialAccount):
             session_string = session.export()
             if session_string != self.session_string:
                 self.session_string = session_string
-                if self.pk:
-                    self.save(update_fields=["access_data"])
+                self.save_fields(["access_data"])
 
     @cached_property
     def _client(self):
@@ -423,13 +422,7 @@ class BlueskyAccount(SocialAccount):
             self.base_url = resolved_pds
         self.last_reachable = timezone.now()
         if save:
-            self.save(
-                update_fields=[
-                    "access_data",
-                    "handle",
-                    "last_reachable",
-                ]
-            )
+            self.save_fields(["access_data", "handle", "last_reachable"])
         return True
 
     def refresh(self, save=True, did_check=True):
@@ -454,14 +447,7 @@ class BlueskyAccount(SocialAccount):
         }
         self.last_refresh = timezone.now()
         if save:
-            self.save(
-                update_fields=[
-                    "access_data",
-                    "account_data",
-                    "last_refresh",
-                    "handle",
-                ]
-            )
+            self.save_fields(["access_data", "account_data", "last_refresh", "handle"])
         self.sync_profile_record()
         self.sync_publication_record()
         return True
@@ -566,8 +552,7 @@ class BlueskyAccount(SocialAccount):
         if self.publication_icon_hash or self.publication_icon_blob:
             self.publication_icon_hash = ""
             self.publication_icon_blob = ""
-            if self.pk:
-                self.save(update_fields=["access_data"])
+            self.save_fields(["access_data"])
 
     def _publication_icon(self) -> dict[str, typing.Any] | None:
         """Blob ref for the identity's avatar, uploaded at most once per
@@ -593,8 +578,7 @@ class BlueskyAccount(SocialAccount):
         blob = self._client.upload_blob(data).blob.model_dump(by_alias=True)
         self.publication_icon_hash = digest
         self.publication_icon_blob = json.dumps(blob)
-        if self.pk:
-            self.save(update_fields=["access_data"])
+        self.save_fields(["access_data"])
         return blob
 
     def _build_publication_record(self) -> dict[str, typing.Any]:
@@ -739,13 +723,7 @@ class BlueskyAccount(SocialAccount):
             logger.warning(f"{self} refresh_graph error: {e}")
             return False
         if save:
-            self.save(
-                update_fields=[
-                    "followers",
-                    "following",
-                    "mutes",
-                ]
-            )
+            self.save_fields(["followers", "following", "mutes"])
         return True
 
     def sync_graph(self):

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -731,6 +731,10 @@ class BlueskyAccount(SocialAccount):
         return True
 
     def sync_graph(self):
+        if self.pk is None:
+            # disconnected mid-sync; the in-memory graph is stale, do not
+            # import follows/mutes for an account the user just removed
+            return 0
         c = 0
 
         def get_identity_ids(accts: list):

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -106,21 +106,18 @@ class SocialAccount(TypedModel):
     def from_dict(cls, d: dict | None):
         return cls(**d) if d else None
 
-    def save_fields(self, update_fields: list[str]) -> bool:
-        """Write some fields back, tolerating the row being deleted meanwhile.
+    def save_fields(self, *fields: str) -> bool:
+        """Write fields back, tolerating a row deleted mid-sync.
 
-        A sync job holds this instance across minutes of network calls, so the
-        user may disconnect the account before it writes back. Updating by
-        queryset reports that as a 0 row count; save() would raise instead.
+        A queryset update reports the deleted row as 0 rows; save() would raise.
         """
-        if self.pk is None:
+        if not self.pk:
             return False
-        values = {name: getattr(self, name) for name in update_fields}
+        values = {f: getattr(self, f) for f in fields}
         if type(self).objects.filter(pk=self.pk).update(**values):
             return True
         logger.debug(f"{self} deleted while syncing, update discarded")
-        # drop the pk (as instance.delete() would) so later saves no-op
-        self.pk = None
+        self.pk = None  # as instance.delete() would, so later saves no-op
         return False
 
     def check_alive(self) -> bool:
@@ -227,19 +224,16 @@ class SocialAccount(TypedModel):
         # state independently to avoid blocking healthy accounts on the domain.
         self._record_domain_success()
         refreshed = self.refresh()
-        # a refresh that hit a revoked token also fails, so check for the row
-        # first: the account circuit-breaker keys are keyed on pk, and a
-        # deleted account must not record failures under a stale key
-        if self.pk is not None:
-            if not refreshed:
-                logger.warning(f"{self} refresh failed")
-                self._record_account_failure()
-                self._emit_sync_result("fail_refresh")
-                return False
-            if not skip_graph:
-                self.refresh_graph()
-        if self.pk is None:
+        if refreshed and not skip_graph and self.pk:
+            self.refresh_graph()
+        if not self.pk:
+            # disconnected mid-sync; account failure state is keyed on pk
             self._emit_sync_result("skip_deleted")
+            return False
+        if not refreshed:
+            logger.warning(f"{self} refresh failed")
+            self._record_account_failure()
+            self._emit_sync_result("fail_refresh")
             return False
         logger.debug(f"{self} refreshed")
         self._record_account_success()

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -226,15 +226,19 @@ class SocialAccount(TypedModel):
         # this account's refresh ends up succeeding, so clear domain-level fail
         # state independently to avoid blocking healthy accounts on the domain.
         self._record_domain_success()
-        if not self.refresh():
-            logger.warning(f"{self} refresh failed")
-            self._record_account_failure()
-            self._emit_sync_result("fail_refresh")
-            return False
-        if self.pk is not None and not skip_graph:
-            self.refresh_graph()
+        refreshed = self.refresh()
+        # a refresh that hit a revoked token also fails, so check for the row
+        # first: the account circuit-breaker keys are keyed on pk, and a
+        # deleted account must not record failures under a stale key
+        if self.pk is not None:
+            if not refreshed:
+                logger.warning(f"{self} refresh failed")
+                self._record_account_failure()
+                self._emit_sync_result("fail_refresh")
+                return False
+            if not skip_graph:
+                self.refresh_graph()
         if self.pk is None:
-            # deleted mid-sync; the account circuit-breaker keys are keyed on pk
             self._emit_sync_result("skip_deleted")
             return False
         logger.debug(f"{self} refreshed")

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -106,6 +106,23 @@ class SocialAccount(TypedModel):
     def from_dict(cls, d: dict | None):
         return cls(**d) if d else None
 
+    def save_fields(self, update_fields: list[str]) -> bool:
+        """Write some fields back, tolerating the row being deleted meanwhile.
+
+        A sync job holds this instance across minutes of network calls, so the
+        user may disconnect the account before it writes back. Updating by
+        queryset reports that as a 0 row count; save() would raise instead.
+        """
+        if self.pk is None:
+            return False
+        values = {name: getattr(self, name) for name in update_fields}
+        if type(self).objects.filter(pk=self.pk).update(**values):
+            return True
+        logger.debug(f"{self} deleted while syncing, update discarded")
+        # drop the pk (as instance.delete() would) so later saves no-op
+        self.pk = None
+        return False
+
     def check_alive(self) -> bool:
         return False
 
@@ -214,8 +231,12 @@ class SocialAccount(TypedModel):
             self._record_account_failure()
             self._emit_sync_result("fail_refresh")
             return False
-        if not skip_graph:
+        if self.pk is not None and not skip_graph:
             self.refresh_graph()
+        if self.pk is None:
+            # deleted mid-sync; the account circuit-breaker keys are keyed on pk
+            self._emit_sync_result("skip_deleted")
+            return False
         logger.debug(f"{self} refreshed")
         self._record_account_success()
         self._emit_sync_result("ok")

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -850,7 +850,7 @@ class MastodonAccount(SocialAccount):
             return False
         self.last_reachable = timezone.now()
         if save:
-            self.save(update_fields=["last_reachable"])
+            self.save_fields(["last_reachable"])
         return True
 
     def refresh(self, save=True):
@@ -877,7 +877,7 @@ class MastodonAccount(SocialAccount):
             self.handle = handle
         self.account_data = mastodon_account
         if save:
-            self.save(update_fields=["uid", "handle", "account_data", "last_refresh"])
+            self.save_fields(["uid", "handle", "account_data", "last_refresh"])
         return True
 
     def refresh_graph(self, save=True):
@@ -887,14 +887,8 @@ class MastodonAccount(SocialAccount):
         self.blocks = self.get_related_accounts("blocks")
         self.domain_blocks = self.get_related_accounts("domain_blocks")
         if save:
-            self.save(
-                update_fields=[
-                    "followers",
-                    "following",
-                    "mutes",
-                    "blocks",
-                    "domain_blocks",
-                ]
+            self.save_fields(
+                ["followers", "following", "mutes", "blocks", "domain_blocks"]
             )
         return True
 

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -893,6 +893,10 @@ class MastodonAccount(SocialAccount):
         return True
 
     def sync_graph(self):
+        if self.pk is None:
+            # disconnected mid-sync; the in-memory graph is stale, do not
+            # import follows/blocks/mutes for an account the user just removed
+            return 0
         c = 0
 
         def get_identity_ids(accts: list):

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -850,7 +850,7 @@ class MastodonAccount(SocialAccount):
             return False
         self.last_reachable = timezone.now()
         if save:
-            self.save_fields(["last_reachable"])
+            self.save_fields("last_reachable")
         return True
 
     def refresh(self, save=True):
@@ -877,7 +877,7 @@ class MastodonAccount(SocialAccount):
             self.handle = handle
         self.account_data = mastodon_account
         if save:
-            self.save_fields(["uid", "handle", "account_data", "last_refresh"])
+            self.save_fields("uid", "handle", "account_data", "last_refresh")
         return True
 
     def refresh_graph(self, save=True):
@@ -888,15 +888,13 @@ class MastodonAccount(SocialAccount):
         self.domain_blocks = self.get_related_accounts("domain_blocks")
         if save:
             self.save_fields(
-                ["followers", "following", "mutes", "blocks", "domain_blocks"]
+                "followers", "following", "mutes", "blocks", "domain_blocks"
             )
         return True
 
     def sync_graph(self):
-        if self.pk is None:
-            # disconnected mid-sync; the in-memory graph is stale, do not
-            # import follows/blocks/mutes for an account the user just removed
-            return 0
+        if not self.pk:
+            return 0  # disconnected mid-sync; the in-memory graph is stale
         c = 0
 
         def get_identity_ids(accts: list):

--- a/neodb/mastodon/models/threads.py
+++ b/neodb/mastodon/models/threads.py
@@ -280,7 +280,7 @@ class ThreadsAccount(SocialAccount):
         self.last_reachable = timezone.now()
         self.token_expires_at = self.last_reachable + timedelta(seconds=expire)
         if save:
-            self.save(update_fields=["access_data", "last_reachable"])
+            self.save_fields(["access_data", "last_reachable"])
         return True
 
     def refresh(self, save=True) -> bool:
@@ -301,7 +301,7 @@ class ThreadsAccount(SocialAccount):
         self.account_data = data
         self.last_refresh = timezone.now()
         if save:
-            self.save(update_fields=["account_data", "handle", "last_refresh"])
+            self.save_fields(["account_data", "handle", "last_refresh"])
         return True
 
     def post(

--- a/neodb/mastodon/models/threads.py
+++ b/neodb/mastodon/models/threads.py
@@ -280,7 +280,7 @@ class ThreadsAccount(SocialAccount):
         self.last_reachable = timezone.now()
         self.token_expires_at = self.last_reachable + timedelta(seconds=expire)
         if save:
-            self.save_fields(["access_data", "last_reachable"])
+            self.save_fields("access_data", "last_reachable")
         return True
 
     def refresh(self, save=True) -> bool:
@@ -301,7 +301,7 @@ class ThreadsAccount(SocialAccount):
         self.account_data = data
         self.last_refresh = timezone.now()
         if save:
-            self.save_fields(["account_data", "handle", "last_refresh"])
+            self.save_fields("account_data", "handle", "last_refresh")
         return True
 
     def post(

--- a/neodb/tests/mastodon/test_bluesky.py
+++ b/neodb/tests/mastodon/test_bluesky.py
@@ -230,6 +230,38 @@ def test_on_disconnect_cleans_records_after_row_delete(monkeypatch):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_refresh_stops_republishing_records_after_row_delete(monkeypatch):
+    user = User.register(email="race@example.com", username="raceblue")
+    account = BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:race", handle="race.example"
+    )
+    published: list = []
+    account.__dict__["_client"] = SimpleNamespace(
+        me=SimpleNamespace(handle="race.example")
+    )
+    monkeypatch.setattr(
+        BlueskyAccount, "sync_profile_record", lambda self: published.append("profile")
+    )
+    monkeypatch.setattr(
+        BlueskyAccount,
+        "sync_publication_record",
+        lambda self: published.append("publication"),
+    )
+
+    assert account.refresh(did_check=False) is True
+    assert published == ["profile", "publication"]
+
+    # a concurrent disconnect drops the row while the next sync is in flight;
+    # on_disconnect() is purging these records, so refresh must not rewrite them
+    BlueskyAccount.objects.filter(pk=account.pk).delete()
+    published.clear()
+
+    assert account.refresh(did_check=False) is True
+    assert account.pk is None
+    assert published == []
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_publication_record_synced(monkeypatch):
     user = User.register(email="pub@example.com", username="pubuser")
     account = BlueskyAccount.objects.create(

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -2,6 +2,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.conf import settings
+from django.db import IntegrityError
+from django.utils import timezone
 
 from mastodon.models import MastodonAccount, MastodonApplication, Platform
 from mastodon.models.mastodon import (
@@ -153,6 +155,70 @@ class TestMastodonAccount:
         # MastodonAccount.check_alive() uses network, but sync skips via sleep_hours logic
         result = self.account.sync(skip_graph=True, sleep_hours=24)
         assert result is False
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestSocialAccountSaveFields:
+    """A sync job holds the instance across network calls, so the user may
+    disconnect the account before it writes back (NEODB-SOCIAL-7QM)."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(username="raceuser")
+        self.account = MastodonAccount.objects.create(
+            handle="raceuser@social.example",
+            user=self.user,
+            domain="social.example",
+            uid="54321",
+        )
+
+    def test_save_fields_persists_normally(self):
+        self.account.handle = "renamed@social.example"
+        assert self.account.save_fields(["handle"]) is True
+        self.account.refresh_from_db()
+        assert self.account.handle == "renamed@social.example"
+
+    def test_save_fields_tolerates_concurrent_delete(self):
+        MastodonAccount.objects.filter(pk=self.account.pk).delete()
+        self.account.handle = "gone@social.example"
+        assert self.account.save_fields(["handle"]) is False
+        assert self.account.pk is None
+
+    def test_save_fields_noop_once_pk_cleared(self):
+        self.account.pk = None
+        assert self.account.save_fields(["handle"]) is False
+
+    def test_save_fields_propagates_real_database_errors(self):
+        MastodonAccount.objects.create(
+            handle="taken@social.example",
+            user=User.register(username="raceuser2"),
+            domain="social.example",
+            uid="99999",
+        )
+        self.account.handle = "taken@social.example"
+        with pytest.raises(IntegrityError):
+            self.account.save_fields(["handle"])
+
+    def test_refresh_graph_tolerates_concurrent_delete(self):
+        with patch.object(MastodonAccount, "get_related_accounts", return_value=[]):
+            MastodonAccount.objects.filter(pk=self.account.pk).delete()
+            self.account.refresh_graph()
+        assert self.account.pk is None
+
+    def test_sync_stops_and_skips_graph_when_deleted_mid_sync(self):
+        def _refresh():
+            MastodonAccount.objects.filter(pk=self.account.pk).delete()
+            self.account.last_refresh = timezone.now()
+            self.account.save_fields(["last_refresh"])
+            return True
+
+        with (
+            patch.object(MastodonAccount, "check_alive", return_value=True),
+            patch.object(MastodonAccount, "refresh", side_effect=_refresh),
+            patch.object(MastodonAccount, "refresh_graph") as refresh_graph,
+        ):
+            assert self.account.sync() is False
+        refresh_graph.assert_not_called()
 
 
 class TestDetectConfigurations:

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -174,19 +174,19 @@ class TestSocialAccountSaveFields:
 
     def test_save_fields_persists_normally(self):
         self.account.handle = "renamed@social.example"
-        assert self.account.save_fields(["handle"]) is True
+        assert self.account.save_fields("handle") is True
         self.account.refresh_from_db()
         assert self.account.handle == "renamed@social.example"
 
     def test_save_fields_tolerates_concurrent_delete(self):
         MastodonAccount.objects.filter(pk=self.account.pk).delete()
         self.account.handle = "gone@social.example"
-        assert self.account.save_fields(["handle"]) is False
+        assert self.account.save_fields("handle") is False
         assert self.account.pk is None
 
     def test_save_fields_noop_once_pk_cleared(self):
         self.account.pk = None
-        assert self.account.save_fields(["handle"]) is False
+        assert self.account.save_fields("handle") is False
 
     def test_save_fields_propagates_real_database_errors(self):
         MastodonAccount.objects.create(
@@ -197,7 +197,7 @@ class TestSocialAccountSaveFields:
         )
         self.account.handle = "taken@social.example"
         with pytest.raises(IntegrityError):
-            self.account.save_fields(["handle"])
+            self.account.save_fields("handle")
 
     def test_refresh_graph_tolerates_concurrent_delete(self):
         with patch.object(MastodonAccount, "get_related_accounts", return_value=[]):
@@ -228,7 +228,7 @@ class TestSocialAccountSaveFields:
     def test_sync_does_not_record_failure_for_deleted_account(self):
         def _refresh():
             MastodonAccount.objects.filter(pk=self.account.pk).delete()
-            self.account.save_fields(["last_refresh"])
+            self.account.save_fields("last_refresh")
             return False
 
         with (
@@ -245,7 +245,7 @@ class TestSocialAccountSaveFields:
         def _refresh():
             MastodonAccount.objects.filter(pk=self.account.pk).delete()
             self.account.last_refresh = timezone.now()
-            self.account.save_fields(["last_refresh"])
+            self.account.save_fields("last_refresh")
             return True
 
         with (

--- a/neodb/tests/mastodon/test_models.py
+++ b/neodb/tests/mastodon/test_models.py
@@ -205,6 +205,42 @@ class TestSocialAccountSaveFields:
             self.account.refresh_graph()
         assert self.account.pk is None
 
+    def test_sync_graph_skips_deleted_account(self):
+        # sync_accounts() runs a second pass over the same instances, so a
+        # stale graph must not be imported for an account the user removed
+        other = MastodonAccount.objects.create(
+            handle="friend@social.example",
+            user=User.register(username="racefriend"),
+            domain="social.example",
+            uid="77777",
+        )
+        self.account.following = [other.handle]
+
+        with patch("mastodon.models.mastodon.Takahe.follow") as follow:
+            assert self.account.sync_graph() == 1
+            follow.assert_called_once()
+
+            follow.reset_mock()
+            self.account.pk = None
+            assert self.account.sync_graph() == 0
+            follow.assert_not_called()
+
+    def test_sync_does_not_record_failure_for_deleted_account(self):
+        def _refresh():
+            MastodonAccount.objects.filter(pk=self.account.pk).delete()
+            self.account.save_fields(["last_refresh"])
+            return False
+
+        with (
+            patch.object(MastodonAccount, "check_alive", return_value=True),
+            patch.object(MastodonAccount, "refresh", side_effect=_refresh),
+            patch.object(MastodonAccount, "_record_account_failure") as record_fail,
+            patch.object(MastodonAccount, "_emit_sync_result") as emit,
+        ):
+            assert self.account.sync() is False
+        record_fail.assert_not_called()
+        assert emit.call_args.args == ("skip_deleted",)
+
     def test_sync_stops_and_skips_graph_when_deleted_mid_sync(self):
         def _refresh():
             MastodonAccount.objects.filter(pk=self.account.pk).delete()


### PR DESCRIPTION
Fixes Sentry `NEODB-SOCIAL-7QM` — `DatabaseError: Save with update_fields did not affect any rows.`

## Cause

`User.sync_accounts_task` runs in an rq worker and holds `SocialAccount` instances across minutes of network calls — `MastodonAccount.refresh_graph` alone makes five paginated API requests for followers, following, mutes, blocks and domain blocks. If the user disconnects the account or deactivates in that window, the row is deleted by the web request. The write-back then matches no rows and Django raises `DatabaseError`, killing the job.

Both events on the issue are this path: `sync_accounts_task` -> `sync_accounts` -> `SocialAccount.sync` -> `MastodonAccount.refresh_graph`.

There are four places that delete these rows behind a running sync: the disconnect views for mastodon and threads, `User.clear`, and `User.reconnect_account`.

## Fix

`SocialAccount.save_fields()` writes through a queryset update, so a vanished row reports a 0 row count instead of raising. It then clears the pk the way `instance.delete()` would, so any later write in the same sync no-ops — the same dead-row idiom already used at `users/models/user.py:246` and `:424`.

The update is equivalent to the `save(update_fields=[...])` it replaces: `SocialAccount` has no `post_save` receivers, and the `modified` `auto_now` field was already untouched by those calls, since Django only runs `pre_save` for fields named in `update_fields`. Because there is no `except` clause, genuine database errors still propagate untouched.

Every save the sync chain reaches now goes through it, across mastodon, threads and bluesky, including the bluesky OAuth token callbacks that fire mid-request. Login and view path saves keep using `save()`.

`sync()` stops once the row is gone: it skips the pointless graph fetch and reports `skip_deleted` rather than `ok`, which also keeps the account circuit breaker from writing cache keys for a null pk.

## Second commit

Tolerating the save exposed a latent problem in `BlueskyAccount.refresh()`, which republishes the profile and publication records to the user's PDS after persisting. The crash used to stop that by accident; without it, refresh would recreate the very records `on_disconnect()` is purging. It now returns early when the write-back finds the row gone. The login path calls `refresh(save=False)` on an account that has no pk yet, so the guard applies only when a save was expected.

## Third commit

Two more cases the first two commits left half handled, both found in review.

`check_alive()` can clear the pk before `refresh()` runs, and `refresh()` is the call most likely to fail right after a disconnect, since the token was just revoked. `sync()` recorded that as an account failure, writing circuit-breaker cache keys under a null pk and reporting `fail_refresh` instead of `skip_deleted`. It now checks for the row before recording anything.

`User.sync_accounts` makes a second pass over the same instances to import the graph. The `DatabaseError` used to abort the whole task before that pass ran; now that `sync()` returns quietly, `sync_graph()` would import a disconnected account's stale `following`, `blocks` and `mutes` into Takahe as real relationships. It returns 0 once the row is gone.

## Tests

`TestSocialAccountSaveFields` covers the normal save, the concurrent delete, the no-op once the pk is cleared, real database errors still propagating, `refresh_graph` surviving a delete, and `sync()` skipping the graph fetch and returning False. `test_refresh_stops_republishing_records_after_row_delete` covers the bluesky guard, `test_sync_does_not_record_failure_for_deleted_account` the failure ordering, and `test_sync_graph_skips_deleted_account` the graph import. Each of the three carries a positive control or was checked by reverting its fix, so none of them passes without the code it guards.

Full suite: 2296 passed. The 3 `tests/mastodon/test_lexicons.py` failures are pre-existing — that file loads `/docs/lexicons/publish.py`, which is not mounted in the dev-shell container.
