### PR TITLE
fix(search): stop a backtick from escaping a Typesense filter value

### DIFF
--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -37,8 +37,14 @@ TYPESENSE_ERRORS = (
 
 
 def _backtick(s: str | int) -> str:
-    """Escape a string with backticks for Typesense filter syntax"""
-    return str(s) if isinstance(s, int) else f"`{str(s).replace('`', '\\`')}`"
+    """Quote a value for Typesense filter syntax.
+
+    Typesense ignores a backslash-escaped backtick in the pass that balances
+    parentheses and splits on && / ||, so an escaped backtick still ends the
+    quoted value there and leaks the rest of it into the filter grammar.
+    Drop the backtick instead of escaping it.
+    """
+    return str(s) if isinstance(s, int) else f"`{str(s).replace('`', ' ')}`"
 
 
 class QueryParser:

--- a/neodb/journal/importers/rym.py
+++ b/neodb/journal/importers/rym.py
@@ -283,9 +283,9 @@ class RymImporter(Task):
     def _local_match(self, title: str, artist: str, year: str | None) -> Item | None:
         if not title:
             return None
-        q = f'"{_escape_quotes(title)}"'
+        q = f'"{_strip_quotes(title)}"'
         if artist:
-            q += f' people:"{_escape_quotes(artist)}"'
+            q += f' people:"{_strip_quotes(artist)}"'
         if year:
             q += f" year:{year}"
         q += " category:music"
@@ -476,8 +476,9 @@ class RymImporter(Task):
         return os.path.join(out_dir, f"{stem}-matched.csv")
 
 
-def _escape_quotes(s: str) -> str:
-    return s.replace('"', '\\"')
+def _strip_quotes(s: str) -> str:
+    # QueryParser has no escape syntax, so a quote would truncate the value
+    return s.replace('"', " ")
 
 
 def int_or_zero(v) -> int:

--- a/neodb/journal/importers/storygraph.py
+++ b/neodb/journal/importers/storygraph.py
@@ -52,8 +52,9 @@ def _titles_match(a: str, b: str) -> bool:
     return bool(a) and bool(b) and (a in b or b in a)
 
 
-def _escape_quotes(s: str) -> str:
-    return s.replace('"', '\\"')
+def _strip_quotes(s: str) -> str:
+    # QueryParser has no escape syntax, so a quote would truncate the value
+    return s.replace('"', " ")
 
 
 def _parse_collect_date(raw: str | None) -> datetime.datetime | None:
@@ -306,9 +307,9 @@ class StoryGraphImporter(Task):
     @classmethod
     def _match_via_local_index(cls, title: str, authors: str) -> Item | None:
         first_author = _first_author(authors)
-        q = f'"{_escape_quotes(title)}"'
+        q = f'"{_strip_quotes(title)}"'
         if first_author:
-            q += f' people:"{_escape_quotes(first_author)}"'
+            q += f' people:"{_strip_quotes(first_author)}"'
         q += " category:book"
         try:
             parser = CatalogQueryParser(q, page=1, page_size=5)

--- a/neodb/tests/catalog/test_index.py
+++ b/neodb/tests/catalog/test_index.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,11 @@ from catalog.search.index import (
     CatalogQueryParser,
     _cat_to_class,
 )
+
+
+def _outside_quotes(filter_by: str) -> str:
+    """Drop every backtick-quoted span, leaving only what Typesense parses."""
+    return re.sub(r"`[^`]*`", "", filter_by)
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -228,6 +234,27 @@ class TestCatalogQueryParser:
 
         assert parser.q == "Tolkien"
         assert "lookup_id:=`9780618640157`" in parser.filter_by.get("_", [])
+
+    def test_backtick_in_filter_value_cannot_unbalance_parens(self):
+        """A backtick plus a paren used to reach Typesense as filter grammar.
+
+        Typesense ignores a backslash-escaped backtick while it balances
+        parentheses, so `sci`fi(x` produced "unbalanced parentheses".
+        """
+        parser = CatalogQueryParser("dune genre:sci`fi(x", 1, 20)
+        filter_by = parser.to_search_params()["filter_by"]
+
+        assert parser.q == "dune"
+        assert "\\`" not in filter_by
+        assert _outside_quotes(filter_by) == "genre:"
+
+    def test_filter_value_cannot_inject_boolean_clause(self):
+        """Operators in a filter value must stay inside the quoted value."""
+        parser = CatalogQueryParser('genre:"zzz` || language:`en"', 1, 20)
+        filter_by = parser.to_search_params()["filter_by"]
+
+        assert "||" not in _outside_quotes(filter_by)
+        assert "language" not in _outside_quotes(filter_by)
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_rym.py
+++ b/neodb/tests/journal/test_rym.py
@@ -4,11 +4,13 @@ import io
 import pytest
 
 from catalog.models import Album
+from catalog.search.index import CatalogQueryParser
 from journal.importers.rym import (
     RymCancelled,
     RymImporter,
     _bbcode_to_md,
     _row_artist,
+    _strip_quotes,
     update_row_in_matched_file,
 )
 from journal.models import Mark, ShelfType
@@ -482,3 +484,13 @@ class TestExternalSearchFieldQueries:
 
         q = Spotify.build_field_query("X", "Y", "abcd")
         assert "year:" not in q
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_artist_with_quotes_survives_query_parsing():
+    """A quote in the artist used to truncate the parsed filter value."""
+    artist = 'Bruce "The Boss" Springsteen'
+    q = f'"{_strip_quotes("Born to Run")}" people:"{_strip_quotes(artist)}" category:music'
+    parser = CatalogQueryParser(q, page=1, page_size=5)
+
+    assert parser.filter_by["people"] == ["bruce  the boss  springsteen"]

--- a/neodb/tests/journal/test_storygraph.py
+++ b/neodb/tests/journal/test_storygraph.py
@@ -8,7 +8,9 @@ from django.utils import timezone
 
 from catalog.common.downloaders import set_mock_mode, use_local_response
 from catalog.models import Edition, ExternalResource, IdType
+from catalog.search.index import CatalogQueryParser
 from journal.importers import StoryGraphImporter
+from journal.importers.storygraph import _strip_quotes
 from journal.models import Mark, ShelfType
 from users.models import User
 
@@ -233,3 +235,17 @@ class TestStoryGraphImporter:
             "Fantastic Mr Fox", "Roald Dahl"
         )
         assert url == "https://openlibrary.org/books/OL7353617M"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_author_with_quotes_survives_query_parsing():
+    """CatalogQueryParser has no escape syntax, so a quote must be dropped.
+
+    Escaping it as a backslash-quote left the regex capturing a truncated
+    author name that also ended in a stray backslash.
+    """
+    author = 'Ellen "Nellie" Bly'
+    q = f'"{_strip_quotes("Ten Days")}" people:"{_strip_quotes(author)}" category:book'
+    parser = CatalogQueryParser(q, page=1, page_size=5)
+
+    assert parser.filter_by["people"] == ["ellen  nellie  bly"]


### PR DESCRIPTION
## Problem

`_backtick()` in `neodb/common/search/index.py` quoted a Typesense `filter_by` value as `` `v` `` and escaped an embedded backtick as `` \` ``. Typesense honors that escape when it reads the value, but **not** in the earlier pass that balances parentheses and splits on `&&` / `||`. The escaped backtick still ends the quoted span there, so the rest of the value leaks into the filter grammar.

Reproduced against `typesense/typesense:30.2` straight from the public catalog search box:

```
dune genre:sci`fi(x
  -> filter_by = genre:`sci\`fi(x`
  -> Could not parse the filter query: unbalanced parentheses.
```

That is the error behind the `unbalanced parentheses` search failures in Sentry (`NEODB-SOCIAL-7VQ`).

It is not only a parse error. A payload carrying operators is evaluated as filter syntax rather than matched as text:

```
people:`zzz\` || visibility:>=0 || people:\`zzz` && visibility:0
  -> returned the visibility:0 document
```

The injected `||` clause ran and the `people:` predicate was cancelled.

## Impact

Bounded, and **not** a disclosure bug today:

- Only `CatalogQueryParser` puts raw user strings into filter values (`tag`, `format`, `genre`, `people`, `company`, `language`). The catalog index holds public metadata and carries no visibility or owner predicate, so there is nothing to escalate to.
- `JournalQueryParser`, which does guard private data, validates every field: `tag` goes through `Tag.deep_cleanup_title` (`\W+` becomes `_`, which removes backticks and parens), `status` / `type` / `sort` / `category` are whitelist intersections, `rating` and `date` are integers.
- `PeopleQueryParser` gates `id` on `isalnum()`.

So the effect is broken search results and Sentry noise. It becomes an authorization problem the day a raw string field is added to the journal parser, or a security predicate is added to a catalog filter.

## Fix

Backslash escaping cannot make this safe, because the escape is not honored where it matters. Drop the backtick instead, the way `Tag.deep_cleanup_title` already does for journal tags. A value that contains no backtick cannot end its own quoted span, and parens or operators inside an intact span are inert.

I fuzzed every ASCII punctuation character across both the catalog and journal filter shapes (228 filters):

| | parse errors | guard bypasses |
| --- | --- | --- |
| before | 12 | 0 |
| after | 0 | 0 |

The second commit fixes a related bug in the same code path. The RYM and StoryGraph importers built their local index query with `_escape_quotes()`, writing `\"`. `QueryParser` has no escape syntax, so the field regex stopped at that quote and captured a truncated value that also ended in a stray backslash. An author or artist name containing a quote never matched the local index. The helper now replaces the quote with a space and is renamed `_strip_quotes`.

## Tests

Four regression tests. The two in `tests/catalog/test_index.py` were confirmed to fail against the old `_backtick` and pass with the new one.

`tests/catalog` and `tests/journal` pass in full (1635 passed), and `pre-commit run -a` is clean.

## Not changed

`lookup_id:=` in `catalog/search/index.py` and `catalog/search/people_index.py` builds its own quoting rather than calling `_backtick`, but both are already gated to alphanumerics, so they cannot carry a backtick. I left them alone to keep the diff focused. Happy to route them through `_backtick` if you would rather have one quoting path.
