### PR TITLE
Avoid timeout-prone feed, podcast, and collection queries

### DIFF
--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -700,16 +700,8 @@ def get_episodes_in_podcast(
     if guid:
         episodes = episodes.filter(guid=guid)
     episodes = episodes.order_by("-pub_date", "-pk")
-    # Keep the old endpoint semantics for invalid/out-of-range pages: return
-    # an empty data list (rather than Paginator.get_page() silently repeating
-    # the last page). ``allow_empty_first_page=False`` also preserves pages=0
-    # for a podcast with no episodes.
-    paginator = Paginator(episodes, PAGE_SIZE, allow_empty_first_page=False)
-    episode_items = (
-        list(paginator.page(page).object_list)
-        if 1 <= page <= paginator.num_pages
-        else []
-    )
+    paginator = Paginator(episodes, PAGE_SIZE)
+    episode_items = list(paginator.get_page(page).object_list)
     prefetch_related_objects(
         episode_items,
         Item.external_resources_prefetch(),

--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -694,13 +694,33 @@ def get_episodes_in_podcast(
     podcast = _get_item(Podcast, uuid, response, attach_credits=False)
     if not isinstance(podcast, Podcast):
         return podcast
-    episodes = podcast.child_items.filter(is_deleted=False, merged_to_item=None)
+    episodes = podcast.child_items.filter(
+        is_deleted=False, merged_to_item=None
+    ).select_related("program")
     if guid:
         episodes = episodes.filter(guid=guid)
+    episodes = episodes.order_by("-pub_date", "-pk")
+    # Keep the old endpoint semantics for invalid/out-of-range pages: return
+    # an empty data list (rather than Paginator.get_page() silently repeating
+    # the last page). ``allow_empty_first_page=False`` also preserves pages=0
+    # for a podcast with no episodes.
+    paginator = Paginator(episodes, PAGE_SIZE, allow_empty_first_page=False)
+    episode_items = (
+        list(paginator.page(page).object_list)
+        if 1 <= page <= paginator.num_pages
+        else []
+    )
+    prefetch_related_objects(
+        episode_items,
+        Item.external_resources_prefetch(),
+        Item.credits_prefetch(),
+    )
+    Item.attach_localized_credit_names(episode_items)
+    Rating.attach_to_items(episode_items)
     r = {
-        "data": list(episodes)[(page - 1) * PAGE_SIZE : page * PAGE_SIZE],
-        "pages": (episodes.count() + PAGE_SIZE - 1) // PAGE_SIZE,
-        "count": episodes.count(),
+        "data": episode_items,
+        "pages": paginator.num_pages,
+        "count": paginator.count,
     }
     return r
 

--- a/neodb/journal/importers/letterboxd.py
+++ b/neodb/journal/importers/letterboxd.py
@@ -2,6 +2,7 @@ import csv
 import os
 import tempfile
 import zipfile
+from contextlib import ExitStack
 from datetime import timedelta
 from random import randint
 
@@ -177,29 +178,31 @@ class LetterboxdImporter(Task):
             )
             line_no = 0
             collection = None
-            for row in reader:
-                line_no += 1
-                if line_no == 1:
-                    if row["pos"] != "Letterboxd list export v7":
-                        logger.error(
-                            f"Unknown list format: {row['pos']}, skipping {fn}"
+            with ExitStack() as member_updates:
+                for row in reader:
+                    line_no += 1
+                    if line_no == 1:
+                        if row["pos"] != "Letterboxd list export v7":
+                            logger.error(
+                                f"Unknown list format: {row['pos']}, skipping {fn}"
+                            )
+                            break
+                    elif line_no == 3:
+                        collection = Collection.objects.create(
+                            title=row["name"] or "no name",
+                            brief=row["desc"] or "",
+                            owner=self.user.identity,
                         )
-                        break
-                elif line_no == 3:
-                    collection = Collection.objects.create(
-                        title=row["name"] or "no name",
-                        brief=row["desc"] or "",
-                        owner=self.user.identity,
-                    )
-                elif line_no > 4 and collection:
-                    url = row["url"]
-                    item = self.get_item_by_url(url)
-                    if item:
-                        collection.append_item(item, note=row["desc"])
-                        self.progress(1)
-                    else:
-                        logger.error(f"Unable to get item for {url}")
-                        self.progress(-1, url)
+                        member_updates.enter_context(collection.defer_member_updates())
+                    elif line_no > 4 and collection:
+                        url = row["url"]
+                        item = self.get_item_by_url(url)
+                        if item:
+                            collection.append_item(item, note=row["desc"])
+                            self.progress(1)
+                        else:
+                            logger.error(f"Unable to get item for {url}")
+                            self.progress(-1, url)
 
     def run(self):
         uris = set()

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -306,7 +306,6 @@ class NdjsonImporter(BaseImporter):
                         # so a per-item note edited on the source would not replay
                         member.metadata = metadata
                         member.save(update_fields=["metadata"])
-                        collection.member_set_changed()
                         member_notes_changed = True
             # TODO: members removed on the source are not removed here -- a
             # re-import only adds and updates, never deletes. A member note

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -287,34 +287,37 @@ class NdjsonImporter(BaseImporter):
                         os.path.basename(cover_src), File(f), save=True
                     )
             item_data = data.get("items", [])
-            members_changed = False
-            for item_entry in item_data:
-                item_url = item_entry.get("item")
-                if not item_url:
-                    continue
-                item = self.items.get(item_url)
-                if not item:
-                    logger.warning(f"Could not find item for collection: {item_url}")
-                    continue
-                metadata = item_entry.get("metadata", {})
-                member, created = collection.append_item(item, metadata=metadata)
-                if not created and member and member.metadata != metadata:
-                    # append_item is a no-op for an item already on the list,
-                    # so a per-item note edited on the source would not replay
-                    member.metadata = metadata
-                    member.save(update_fields=["metadata"])
-                    members_changed = True
+            member_notes_changed = False
+            with collection.defer_member_updates():
+                for item_entry in item_data:
+                    item_url = item_entry.get("item")
+                    if not item_url:
+                        continue
+                    item = self.items.get(item_url)
+                    if not item:
+                        logger.warning(
+                            f"Could not find item for collection: {item_url}"
+                        )
+                        continue
+                    metadata = item_entry.get("metadata", {})
+                    member, created = collection.append_item(item, metadata=metadata)
+                    if not created and member and member.metadata != metadata:
+                        # append_item is a no-op for an item already on the list,
+                        # so a per-item note edited on the source would not replay
+                        member.metadata = metadata
+                        member.save(update_fields=["metadata"])
+                        collection.member_set_changed()
+                        member_notes_changed = True
             # TODO: members removed on the source are not removed here -- a
             # re-import only adds and updates, never deletes. A member note
             # edited on its own also does not replay: it leaves the parent
             # collection's edited_time untouched, so the record is judged
             # current and skipped before this loop is reached.
             self._restore_edited_time(collection, updated_dt)
-            if members_changed:
-                # the collection's index doc embeds its members' notes, and
-                # saving a member does not reindex the parent -- only the
-                # list_add / list_remove signals do, and a note-only edit
-                # fires neither
+            if member_notes_changed:
+                # NDJSON tasks promise their restored state is searchable when
+                # run() returns. Keep the one final refresh synchronous for a
+                # note-only edit; member additions remain coalesced and async.
                 collection.update_index()
             return "imported"
         except Exception:

--- a/neodb/journal/importers/opml.py
+++ b/neodb/journal/importers/opml.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import listparser
 from django.utils.translation import gettext as _
 from loguru import logger
@@ -50,34 +52,38 @@ class OPMLImporter(Task):
                     title=title,
                     visibility=self.metadata["visibility"],
                 )
-            for feed in feeds:
-                logger.info(f"{self.user} import {feed.url}")
-                try:
-                    res = RSS(feed.url).get_resource_ready()
-                except Exception:
-                    res = None
-                if not res or not res.item:
-                    logger.warning(f"{self.user} feed error {feed.url}")
-                    self.metadata["failed"] += 1
-                    continue
-                item = res.item
-                if self.metadata["mode"] == 0:
-                    mark = Mark(self.user.identity, item)
-                    if mark.shelfmember:
-                        logger.info(f"{self.user} marked, skip {feed.url}")
-                        self.metadata["skipped"] += 1
-                    else:
+            member_updates = (
+                collection.defer_member_updates() if collection else nullcontext()
+            )
+            with member_updates:
+                for feed in feeds:
+                    logger.info(f"{self.user} import {feed.url}")
+                    try:
+                        res = RSS(feed.url).get_resource_ready()
+                    except Exception:
+                        res = None
+                    if not res or not res.item:
+                        logger.warning(f"{self.user} feed error {feed.url}")
+                        self.metadata["failed"] += 1
+                        continue
+                    item = res.item
+                    if self.metadata["mode"] == 0:
+                        mark = Mark(self.user.identity, item)
+                        if mark.shelfmember:
+                            logger.info(f"{self.user} marked, skip {feed.url}")
+                            self.metadata["skipped"] += 1
+                        else:
+                            self.metadata["imported"] += 1
+                            mark.update(
+                                ShelfType.PROGRESS,
+                                None,
+                                None,
+                                visibility=self.metadata["visibility"],
+                            )
+                    elif self.metadata["mode"] == 1 and collection:
                         self.metadata["imported"] += 1
-                        mark.update(
-                            ShelfType.PROGRESS,
-                            None,
-                            None,
-                            visibility=self.metadata["visibility"],
-                        )
-                elif self.metadata["mode"] == 1 and collection:
-                    self.metadata["imported"] += 1
-                    collection.append_item(item)
-                self.metadata["processed"] += 1
-                self.save(update_fields=["metadata"])
+                        collection.append_item(item)
+                    self.metadata["processed"] += 1
+                    self.save(update_fields=["metadata"])
         self.message = f"{self.metadata['imported']} feeds imported, {self.metadata['skipped']} skipped, {self.metadata['failed']} failed."
         self.save(update_fields=["message"])

--- a/neodb/journal/importers/trakt.py
+++ b/neodb/journal/importers/trakt.py
@@ -347,23 +347,24 @@ class TraktImporter(Task):
                 visibility=visibility,
             )
 
-            for entry in list_entries:
-                result = self._get_media(entry)
-                if not result:
-                    continue
-                media_type, media = result
-                ids = media.get("ids", {})
-                label = self._item_label(entry)
-                item = self._find_item(media_type, ids)
-                if item:
-                    note = entry.get("notes") or ""
-                    collection.append_item(item, note=note)
-                    self.progress(1)
-                else:
-                    logger.warning(
-                        f"Trakt import: could not find item for list entry {label}"
-                    )
-                    self.progress(-1, label)
+            with collection.defer_member_updates():
+                for entry in list_entries:
+                    result = self._get_media(entry)
+                    if not result:
+                        continue
+                    media_type, media = result
+                    ids = media.get("ids", {})
+                    label = self._item_label(entry)
+                    item = self._find_item(media_type, ids)
+                    if item:
+                        note = entry.get("notes") or ""
+                        collection.append_item(item, note=note)
+                        self.progress(1)
+                    else:
+                        logger.warning(
+                            f"Trakt import: could not find item for list entry {label}"
+                        )
+                        self.progress(-1, label)
 
     def run(self) -> None:
         filename = self.metadata["file"]

--- a/neodb/journal/management/commands/collection.py
+++ b/neodb/journal/management/commands/collection.py
@@ -59,7 +59,8 @@ class Command(SiteCommand):
             title=data["title"],
             brief=data["brief"],
         )
-        for item in data["items"]:
-            i = Item.get_by_url(item["url"])
-            collection.append_item(i, note=item["note"])
-            self.stderr.write(self.style.SUCCESS(f"Added {i}"))
+        with collection.defer_member_updates():
+            for item in data["items"]:
+                i = Item.get_by_url(item["url"])
+                collection.append_item(i, note=item["note"])
+                self.stderr.write(self.style.SUCCESS(f"Added {i}"))

--- a/neodb/journal/management/commands/top10.py
+++ b/neodb/journal/management/commands/top10.py
@@ -57,5 +57,6 @@ class Command(SiteCommand):
                         brief="*根据用户标记数统计*",
                         defaults={"visibility": 2},
                     )
-                    for i, cat in items:
-                        c.append_item(i)
+                    with c.defer_member_updates():
+                        for i, cat in items:
+                            c.append_item(i)

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -225,8 +225,8 @@ class Collection(List):
 
     def _flush_member_updates(self) -> None:
         # Re-post the lightweight AP collection envelope, but never build the
-        # full search document in the request/import worker. The delayed job
-        # coalesces rapid edits and materializes the members once.
+        # full search document in the request/import worker. Bulk import
+        # contexts collapse member edits before this background job is queued.
         self.save(index_when_save=False)
         piece_id = self.pk
         transaction.on_commit(

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -1,5 +1,7 @@
 import mimetypes
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -194,6 +196,44 @@ class Collection(List):
         # and federates the updated member state.
         list_add.send(sender=self.__class__, instance=self, item=item, member=member)
         return member
+
+    @contextmanager
+    def defer_member_updates(self) -> Iterator[None]:
+        """Collapse many member mutations into one federation/index update."""
+        depth = getattr(self, "_defer_member_updates_depth", 0)
+        if depth == 0:
+            # ``List.append_item`` normally asks the database for the last
+            # member on every append. Cache it within bulk imports so growing
+            # a collection stays O(N), even without a position index.
+            self._append_position_cache = None
+        self._defer_member_updates_depth = depth + 1
+        try:
+            yield
+        finally:
+            self._defer_member_updates_depth -= 1
+            if self._defer_member_updates_depth == 0:
+                self.__dict__.pop("_append_position_cache", None)
+                if getattr(self, "_member_updates_pending", False):
+                    self._member_updates_pending = False
+                    self._flush_member_updates()
+
+    def member_set_changed(self) -> None:
+        if getattr(self, "_defer_member_updates_depth", 0):
+            self._member_updates_pending = True
+            return
+        self._flush_member_updates()
+
+    def _flush_member_updates(self) -> None:
+        # Re-post the lightweight AP collection envelope, but never build the
+        # full search document in the request/import worker. The delayed job
+        # coalesces rapid edits and materializes the members once.
+        self.save(index_when_save=False)
+        piece_id = self.pk
+        transaction.on_commit(
+            lambda: JournalIndex.enqueue_replace_pieces([piece_id]),
+            using=self._state.db,
+            robust=True,
+        )
 
     def get_query(self, viewer, **kwargs):
         if not self.is_dynamic:
@@ -851,7 +891,7 @@ def _collection_member_changed(sender, instance, item, member, **kwargs):
         return
     if not instance.local:
         return
-    instance.save()
+    instance.member_set_changed()
 
 
 class FeaturedCollection(Piece):

--- a/neodb/journal/models/itemlist.py
+++ b/neodb/journal/models/itemlist.py
@@ -105,15 +105,23 @@ class List(Piece):
         member = self.get_member_for_item(item)
         if member:
             return member, False
-        ml = self.ordered_members
+        use_position_cache = "_append_position_cache" in self.__dict__
+        append_position_cache = self.__dict__.get("_append_position_cache")
+        if not use_position_cache:
+            last_member = self.ordered_members.last()
+            position = last_member.position + 1 if last_member else 1
+        else:
+            if append_position_cache is None:
+                last_member = self.ordered_members.last()
+                append_position_cache = last_member.position if last_member else 0
+            position = append_position_cache + 1
         p = {"parent": self}
         p.update(params)
-        lm = ml.last()
         try:
             with transaction.atomic():
                 member = self.MEMBER_CLASS.objects.create(
                     owner=self.owner,
-                    position=lm.position + 1 if lm else 1,
+                    position=position,
                     item=item,
                     **p,
                 )
@@ -126,16 +134,18 @@ class List(Piece):
             if existing is None:
                 raise
             return existing, False
+        if use_position_cache:
+            self._append_position_cache = position
         list_add.send(sender=self.__class__, instance=self, item=item, member=member)
         return member, True
 
     def remove_item(self, item):
         member = self.get_member_for_item(item)
         if member:
+            member.delete()
             list_remove.send(
                 sender=self.__class__, instance=self, item=item, member=member
             )
-            member.delete()
 
     def update_member_order(self, ordered_member_ids):
         position_by_id = {pk: i + 1 for i, pk in enumerate(ordered_member_ids)}

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -1,16 +1,16 @@
 import json
 import re
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import cached_property, reduce
 from random import sample
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import django_rq
 from dateutil.relativedelta import relativedelta
 from django.db.models import QuerySet
-from django_redis import get_redis_connection
 from loguru import logger
+from rq import Retry
 
 from catalog.models import Item, item_categories
 from common.models import int_, uniq
@@ -30,74 +30,13 @@ if TYPE_CHECKING:
 # inline ``from journal.models import …`` calls below are deliberate
 # circular-import workarounds, not laziness.
 
-_PENDING_PIECE_INDEX_KEY = "pending_journal_piece_index_ids"
-_PENDING_PIECE_INDEX_QUEUE = "import"
-_PENDING_PIECE_INDEX_LOCK_KEY = "pending_journal_piece_index_scheduled"
-_PENDING_PIECE_INDEX_LOCK_TTL = 60 * 60
+_PIECE_INDEX_QUEUE = "import"
+_PIECE_INDEX_RETRY_INTERVALS = [30, 120, 300]
 
 
-def _schedule_journal_piece_index_task(delay_seconds: int = 2) -> None:
-    """Ensure exactly one pending-set drain is scheduled at a time.
-
-    A Redis lock is used instead of a fixed RQ job id. RQ retains started /
-    finished job ids, and reusing one while its worker is running can reject
-    the replacement job and strand ids added near the end of a drain.
-    """
-    conn = get_redis_connection("default")
-    scheduled = conn.set(
-        _PENDING_PIECE_INDEX_LOCK_KEY,
-        "1",
-        nx=True,
-        ex=_PENDING_PIECE_INDEX_LOCK_TTL,
-    )
-    if not scheduled:
-        return
-    try:
-        django_rq.get_queue(_PENDING_PIECE_INDEX_QUEUE).enqueue_in(
-            timedelta(seconds=delay_seconds),
-            _update_journal_piece_index_task,
-        )
-    except Exception:
-        # Let a subsequent mutation retry scheduling immediately.
-        conn.delete(_PENDING_PIECE_INDEX_LOCK_KEY)
-        raise
-
-
-def _update_journal_piece_index_task():
-    conn = get_redis_connection("default")
-    updated = 0
-    retry_delay = 2
-    try:
-        index = JournalIndex.instance()
-        piece_ids = cast(list[bytes], conn.spop(_PENDING_PIECE_INDEX_KEY, 1000))
-        while piece_ids:
-            ids = [int(i) for i in piece_ids]
-            try:
-                index.replace_pieces(ids)
-            except Exception:
-                # SPOP claims work before Typesense sees it. Put a failed
-                # chunk back so a transient index outage cannot lose updates.
-                conn.sadd(_PENDING_PIECE_INDEX_KEY, *ids)
-                retry_delay = 30
-                raise
-            updated += len(ids)
-            # Keep the scheduling lock alive during an unusually large drain.
-            conn.expire(
-                _PENDING_PIECE_INDEX_LOCK_KEY,
-                _PENDING_PIECE_INDEX_LOCK_TTL,
-            )
-            piece_ids = cast(list[bytes], conn.spop(_PENDING_PIECE_INDEX_KEY, 1000))
-    finally:
-        # Delete before SCARD. A producer racing after this deletion either
-        # acquires the lock itself, or its id is visible to our SCARD and we
-        # acquire it below; in both cases another drain is guaranteed.
-        conn.delete(_PENDING_PIECE_INDEX_LOCK_KEY)
-        if conn.scard(_PENDING_PIECE_INDEX_KEY):
-            try:
-                _schedule_journal_piece_index_task(retry_delay)
-            except Exception as e:  # noqa: BLE001 - preserve original failure
-                logger.error(f"Unable to reschedule journal index update: {e}")
-    logger.info(f"Journal index updated for {updated} pieces")
+def _update_journal_piece_index_task(piece_ids: list[int]) -> None:
+    JournalIndex.instance().replace_pieces(piece_ids)
+    logger.info(f"Journal index updated for {len(piece_ids)} pieces")
 
 
 def _get_item_ids(doc):
@@ -597,11 +536,14 @@ class JournalIndex(Index):
 
     @classmethod
     def enqueue_replace_pieces(cls, piece_ids: list[int]):
-        """Coalesce repeated piece changes into one delayed index refresh."""
+        """Refresh pieces in the import worker, retrying transient failures."""
         if not piece_ids:
             return
-        get_redis_connection("default").sadd(_PENDING_PIECE_INDEX_KEY, *piece_ids)
-        _schedule_journal_piece_index_task()
+        django_rq.get_queue(_PIECE_INDEX_QUEUE).enqueue(
+            _update_journal_piece_index_task,
+            piece_ids,
+            retry=Retry(max=3, interval=_PIECE_INDEX_RETRY_INTERVALS),
+        )
 
     def delete_by_post(self, post_ids):
         return self.delete_docs("post_id", post_ids)

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -1,12 +1,15 @@
 import json
 import re
-from datetime import datetime
+from collections.abc import Iterable
+from datetime import datetime, timedelta
 from functools import cached_property, reduce
 from random import sample
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, cast
 
+import django_rq
 from dateutil.relativedelta import relativedelta
 from django.db.models import QuerySet
+from django_redis import get_redis_connection
 from loguru import logger
 
 from catalog.models import Item, item_categories
@@ -26,6 +29,75 @@ if TYPE_CHECKING:
 # ``from journal.models import …`` here would deadlock. The handful of
 # inline ``from journal.models import …`` calls below are deliberate
 # circular-import workarounds, not laziness.
+
+_PENDING_PIECE_INDEX_KEY = "pending_journal_piece_index_ids"
+_PENDING_PIECE_INDEX_QUEUE = "import"
+_PENDING_PIECE_INDEX_LOCK_KEY = "pending_journal_piece_index_scheduled"
+_PENDING_PIECE_INDEX_LOCK_TTL = 60 * 60
+
+
+def _schedule_journal_piece_index_task(delay_seconds: int = 2) -> None:
+    """Ensure exactly one pending-set drain is scheduled at a time.
+
+    A Redis lock is used instead of a fixed RQ job id. RQ retains started /
+    finished job ids, and reusing one while its worker is running can reject
+    the replacement job and strand ids added near the end of a drain.
+    """
+    conn = get_redis_connection("default")
+    scheduled = conn.set(
+        _PENDING_PIECE_INDEX_LOCK_KEY,
+        "1",
+        nx=True,
+        ex=_PENDING_PIECE_INDEX_LOCK_TTL,
+    )
+    if not scheduled:
+        return
+    try:
+        django_rq.get_queue(_PENDING_PIECE_INDEX_QUEUE).enqueue_in(
+            timedelta(seconds=delay_seconds),
+            _update_journal_piece_index_task,
+        )
+    except Exception:
+        # Let a subsequent mutation retry scheduling immediately.
+        conn.delete(_PENDING_PIECE_INDEX_LOCK_KEY)
+        raise
+
+
+def _update_journal_piece_index_task():
+    conn = get_redis_connection("default")
+    updated = 0
+    retry_delay = 2
+    try:
+        index = JournalIndex.instance()
+        piece_ids = cast(list[bytes], conn.spop(_PENDING_PIECE_INDEX_KEY, 1000))
+        while piece_ids:
+            ids = [int(i) for i in piece_ids]
+            try:
+                index.replace_pieces(ids)
+            except Exception:
+                # SPOP claims work before Typesense sees it. Put a failed
+                # chunk back so a transient index outage cannot lose updates.
+                conn.sadd(_PENDING_PIECE_INDEX_KEY, *ids)
+                retry_delay = 30
+                raise
+            updated += len(ids)
+            # Keep the scheduling lock alive during an unusually large drain.
+            conn.expire(
+                _PENDING_PIECE_INDEX_LOCK_KEY,
+                _PENDING_PIECE_INDEX_LOCK_TTL,
+            )
+            piece_ids = cast(list[bytes], conn.spop(_PENDING_PIECE_INDEX_KEY, 1000))
+    finally:
+        # Delete before SCARD. A producer racing after this deletion either
+        # acquires the lock itself, or its id is visible to our SCARD and we
+        # acquire it below; in both cases another drain is guaranteed.
+        conn.delete(_PENDING_PIECE_INDEX_LOCK_KEY)
+        if conn.scard(_PENDING_PIECE_INDEX_KEY):
+            try:
+                _schedule_journal_piece_index_task(retry_delay)
+            except Exception as e:  # noqa: BLE001 - preserve original failure
+                logger.error(f"Unable to reschedule journal index update: {e}")
+    logger.info(f"Journal index updated for {updated} pieces")
 
 
 def _get_item_ids(doc):
@@ -513,6 +585,23 @@ class JournalIndex(Index):
 
     def delete_by_piece(self, piece_ids):
         return self.delete_docs("piece_id", piece_ids)
+
+    def replace_pieces(self, piece_ids: list[int]):
+        from journal.models import Piece  # circular; see header
+
+        pieces = Piece.objects.filter(pk__in=piece_ids)
+        docs = self.pieces_to_docs(pieces)
+        self.delete_by_piece(piece_ids)
+        if docs:
+            self.replace_docs(docs)
+
+    @classmethod
+    def enqueue_replace_pieces(cls, piece_ids: list[int]):
+        """Coalesce repeated piece changes into one delayed index refresh."""
+        if not piece_ids:
+            return
+        get_redis_connection("default").sadd(_PENDING_PIECE_INDEX_KEY, *piece_ids)
+        _schedule_journal_piece_index_task()
 
     def delete_by_post(self, post_ids):
         return self.delete_docs("post_id", post_ids)

--- a/neodb/social/views.py
+++ b/neodb/social/views.py
@@ -19,6 +19,7 @@ from takahe.utils import Takahe
 from users.models import APIdentity
 
 PAGE_SIZE = 10
+MAX_UNREAD_DISPLAY = 99
 _all_notification_types = [
     "liked",
     "boosted",
@@ -74,10 +75,15 @@ def _sidebar_context(user):
             )[:10]
         ]
     )
-    unread = (
+    unread_ids = list(
         Takahe.get_events(user.identity.pk, _all_notification_types)
-        .filter(seen=False)
-        .count()
+        .filter(seen=False, dismissed=False)
+        .values_list("pk", flat=True)[: MAX_UNREAD_DISPLAY + 1]
+    )
+    unread = (
+        f"{MAX_UNREAD_DISPLAY}+"
+        if len(unread_ids) > MAX_UNREAD_DISPLAY
+        else len(unread_ids)
     )
     return {
         "unread": unread,
@@ -164,6 +170,7 @@ def data(request):
     events = TimelineEvent.objects.filter(
         identity_id=identity_id,
         type__in=[TimelineEvent.Types.post, TimelineEvent.Types.boost],
+        dismissed=False,
     )
     match typ:
         case 1:

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -1,11 +1,17 @@
+from datetime import timedelta
 from unittest.mock import ANY, patch
 
 import pytest
 import requests
 from django.conf import settings
 from django.core.cache import cache
+from django.db import connection
+from django.http import HttpResponse
+from django.test import Client, RequestFactory
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
+from catalog.apis import get_episodes_in_podcast
 from catalog.models import (
     Album,
     Edition,
@@ -377,6 +383,57 @@ def test_podcast_episode_list_endpoint(live_server):
     payload = response.json()
     assert payload["count"] == 1
     assert payload["data"][0]["uuid"] == episode1.uuid
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_podcast_episode_list_is_paginated_in_database():
+    """The endpoint must not materialize every episode before slicing."""
+    now = timezone.now()
+    with patch("catalog.models.item.Item.update_index"):
+        podcast = Podcast.objects.create(title="Large Podcast", host=["Host"])
+        for i in range(25):
+            PodcastEpisode.objects.create(
+                title=f"Episode {i}",
+                program=podcast,
+                guid=f"large-episode-{i}",
+                pub_date=now - timedelta(days=i),
+            )
+
+    request = RequestFactory().get(f"/api/podcast/{podcast.uuid}/episode/")
+    with CaptureQueriesContext(connection) as ctx:
+        payload = get_episodes_in_podcast(
+            request, str(podcast.uuid), HttpResponse(), page=1
+        )
+
+    assert payload["count"] == 25
+    assert payload["pages"] == 2
+    assert len(payload["data"]) == 20
+
+    payload = get_episodes_in_podcast(
+        request, str(podcast.uuid), HttpResponse(), page=3
+    )
+    assert payload["data"] == []
+
+    episode_queries = [
+        q["sql"] for q in ctx.captured_queries if "catalog_podcastepisode" in q["sql"]
+    ]
+    count_queries = [q for q in episode_queries if "COUNT(" in q.upper()]
+    page_queries = [
+        q for q in episode_queries if "COUNT(" not in q.upper() and "LIMIT 20" in q
+    ]
+    assert len(count_queries) == 1, episode_queries
+    assert page_queries, episode_queries
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_empty_podcast_episode_list_has_zero_pages():
+    with patch("catalog.models.item.Item.update_index"):
+        podcast = Podcast.objects.create(title="Empty Podcast", host=["Host"])
+
+    response = Client().get(f"/api/podcast/{podcast.uuid}/episode/")
+
+    assert response.status_code == 200
+    assert response.json() == {"data": [], "pages": 0, "count": 0}
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
 from django.http import HttpResponse
-from django.test import Client, RequestFactory
+from django.test import RequestFactory
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
@@ -409,11 +409,6 @@ def test_podcast_episode_list_is_paginated_in_database():
     assert payload["pages"] == 2
     assert len(payload["data"]) == 20
 
-    payload = get_episodes_in_podcast(
-        request, str(podcast.uuid), HttpResponse(), page=3
-    )
-    assert payload["data"] == []
-
     episode_queries = [
         q["sql"] for q in ctx.captured_queries if "catalog_podcastepisode" in q["sql"]
     ]
@@ -423,17 +418,6 @@ def test_podcast_episode_list_is_paginated_in_database():
     ]
     assert len(count_queries) == 1, episode_queries
     assert page_queries, episode_queries
-
-
-@pytest.mark.django_db(databases="__all__")
-def test_empty_podcast_episode_list_has_zero_pages():
-    with patch("catalog.models.item.Item.update_index"):
-        podcast = Podcast.objects.create(title="Empty Podcast", host=["Host"])
-
-    response = Client().get(f"/api/podcast/{podcast.uuid}/episode/")
-
-    assert response.status_code == 200
-    assert response.json() == {"data": [], "pages": 0, "count": 0}
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)

--- a/neodb/tests/journal/test_collection.py
+++ b/neodb/tests/journal/test_collection.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -57,6 +58,51 @@ class TestCollectionListOperations:
         assert m1.position == 1
         assert m2.position == 2
         assert m3.position == 3
+
+    def test_member_change_queues_full_index_rebuild(
+        self, django_capture_on_commit_callbacks
+    ):
+        with (
+            patch.object(self.collection, "update_index") as update_index,
+            patch(
+                "journal.models.collection.JournalIndex.enqueue_replace_pieces"
+            ) as enqueue,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            self.collection.append_item(self.book1)
+
+        update_index.assert_not_called()
+        enqueue.assert_called_once_with([self.collection.pk])
+
+    def test_deferred_member_updates_flush_once(self):
+        with (
+            patch.object(self.collection, "_flush_member_updates") as flush,
+            self.collection.defer_member_updates(),
+        ):
+            self.collection.append_item(self.book1)
+            self.collection.append_item(self.book2)
+            self.collection.append_item(self.book3)
+
+        flush.assert_called_once_with()
+
+    def test_deferred_appends_only_find_last_position_once(self):
+        with (
+            patch("journal.models.collection.JournalIndex.enqueue_replace_pieces"),
+            CaptureQueriesContext(connection) as ctx,
+            self.collection.defer_member_updates(),
+        ):
+            self.collection.append_item(self.book1)
+            self.collection.append_item(self.book2)
+            self.collection.append_item(self.book3)
+
+        last_position_queries = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "journal_collectionmember" in q["sql"]
+            and 'ORDER BY "journal_collectionmember"."position" DESC' in q["sql"]
+            and "LIMIT 1" in q["sql"]
+        ]
+        assert len(last_position_queries) == 1, last_position_queries
 
     def test_remove_item(self):
         self.collection.append_item(self.book1)

--- a/neodb/tests/journal/test_index_queue.py
+++ b/neodb/tests/journal/test_index_queue.py
@@ -1,62 +1,38 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from journal.search.index import (
-    _PENDING_PIECE_INDEX_KEY,
-    _PENDING_PIECE_INDEX_LOCK_KEY,
+    _PIECE_INDEX_RETRY_INTERVALS,
     JournalIndex,
-    _schedule_journal_piece_index_task,
     _update_journal_piece_index_task,
 )
 
 
-def test_piece_index_schedule_uses_lock_not_reused_job_id():
-    redis = MagicMock()
-    redis.set.return_value = True
+def test_piece_index_task_replaces_requested_pieces():
+    index = MagicMock(spec=JournalIndex)
+    with patch.object(JournalIndex, "instance", return_value=index):
+        _update_journal_piece_index_task([41, 42])
+
+    index.replace_pieces.assert_called_once_with([41, 42])
+
+
+def test_piece_index_enqueue_uses_worker_retries():
     queue = MagicMock()
+    retry = object()
     with (
-        patch("journal.search.index.get_redis_connection", return_value=redis),
-        patch("journal.search.index.django_rq.get_queue", return_value=queue),
+        patch(
+            "journal.search.index.django_rq.get_queue", return_value=queue
+        ) as get_queue,
+        patch("journal.search.index.Retry", return_value=retry) as retry_class,
     ):
-        _schedule_journal_piece_index_task()
+        JournalIndex.enqueue_replace_pieces([41, 42])
 
-    redis.set.assert_called_once()
-    queue.enqueue_in.assert_called_once()
-    assert "job_id" not in queue.enqueue_in.call_args.kwargs
-
-
-def test_piece_index_drain_reschedules_ids_added_while_finishing():
-    redis = MagicMock()
-    redis.spop.side_effect = [[b"41"], []]
-    # Models an id added after the worker's final empty SPOP.
-    redis.scard.return_value = 1
-    index = MagicMock(spec=JournalIndex)
-    with (
-        patch("journal.search.index.get_redis_connection", return_value=redis),
-        patch.object(JournalIndex, "instance", return_value=index),
-        patch("journal.search.index._schedule_journal_piece_index_task") as schedule,
-    ):
-        _update_journal_piece_index_task()
-
-    index.replace_pieces.assert_called_once_with([41])
-    redis.delete.assert_called_once_with(_PENDING_PIECE_INDEX_LOCK_KEY)
-    schedule.assert_called_once_with(2)
-
-
-def test_piece_index_drain_restores_failed_chunk_before_retry():
-    redis = MagicMock()
-    redis.spop.return_value = [b"41", b"42"]
-    redis.scard.return_value = 1
-    index = MagicMock(spec=JournalIndex)
-    index.replace_pieces.side_effect = RuntimeError("search unavailable")
-    with (
-        patch("journal.search.index.get_redis_connection", return_value=redis),
-        patch.object(JournalIndex, "instance", return_value=index),
-        patch("journal.search.index._schedule_journal_piece_index_task") as schedule,
-        pytest.raises(RuntimeError, match="search unavailable"),
-    ):
-        _update_journal_piece_index_task()
-
-    redis.sadd.assert_called_once_with(_PENDING_PIECE_INDEX_KEY, 41, 42)
-    schedule.assert_called_once_with(30)
+    get_queue.assert_called_once_with("import")
+    retry_class.assert_called_once_with(
+        max=3,
+        interval=_PIECE_INDEX_RETRY_INTERVALS,
+    )
+    queue.enqueue.assert_called_once_with(
+        _update_journal_piece_index_task,
+        [41, 42],
+        retry=retry,
+    )

--- a/neodb/tests/journal/test_index_queue.py
+++ b/neodb/tests/journal/test_index_queue.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from journal.search.index import (
+    _PENDING_PIECE_INDEX_KEY,
+    _PENDING_PIECE_INDEX_LOCK_KEY,
+    JournalIndex,
+    _schedule_journal_piece_index_task,
+    _update_journal_piece_index_task,
+)
+
+
+def test_piece_index_schedule_uses_lock_not_reused_job_id():
+    redis = MagicMock()
+    redis.set.return_value = True
+    queue = MagicMock()
+    with (
+        patch("journal.search.index.get_redis_connection", return_value=redis),
+        patch("journal.search.index.django_rq.get_queue", return_value=queue),
+    ):
+        _schedule_journal_piece_index_task()
+
+    redis.set.assert_called_once()
+    queue.enqueue_in.assert_called_once()
+    assert "job_id" not in queue.enqueue_in.call_args.kwargs
+
+
+def test_piece_index_drain_reschedules_ids_added_while_finishing():
+    redis = MagicMock()
+    redis.spop.side_effect = [[b"41"], []]
+    # Models an id added after the worker's final empty SPOP.
+    redis.scard.return_value = 1
+    index = MagicMock(spec=JournalIndex)
+    with (
+        patch("journal.search.index.get_redis_connection", return_value=redis),
+        patch.object(JournalIndex, "instance", return_value=index),
+        patch("journal.search.index._schedule_journal_piece_index_task") as schedule,
+    ):
+        _update_journal_piece_index_task()
+
+    index.replace_pieces.assert_called_once_with([41])
+    redis.delete.assert_called_once_with(_PENDING_PIECE_INDEX_LOCK_KEY)
+    schedule.assert_called_once_with(2)
+
+
+def test_piece_index_drain_restores_failed_chunk_before_retry():
+    redis = MagicMock()
+    redis.spop.return_value = [b"41", b"42"]
+    redis.scard.return_value = 1
+    index = MagicMock(spec=JournalIndex)
+    index.replace_pieces.side_effect = RuntimeError("search unavailable")
+    with (
+        patch("journal.search.index.get_redis_connection", return_value=redis),
+        patch.object(JournalIndex, "instance", return_value=index),
+        patch("journal.search.index._schedule_journal_piece_index_task") as schedule,
+        pytest.raises(RuntimeError, match="search unavailable"),
+    ):
+        _update_journal_piece_index_task()
+
+    redis.sadd.assert_called_once_with(_PENDING_PIECE_INDEX_KEY, 41, 42)
+    schedule.assert_called_once_with(30)

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1741,9 +1741,14 @@ class TestNdjsonExportImport:
         collection.save()
         exporter2 = NdjsonExporter.create(user=self.user1)
         exporter2.run()
-        NdjsonImporter.create(
-            user=self.user2, file=exporter2.metadata["file"], visibility=0
-        ).run()
+        with mock.patch.object(Collection, "sync_to_timeline") as sync_collection:
+            NdjsonImporter.create(
+                user=self.user2, file=exporter2.metadata["file"], visibility=0
+            ).run()
+
+        # Re-saving the changed collection body updates its AP envelope once.
+        # Replaying an embedded member note must not trigger a second post.
+        assert sync_collection.call_count == 1
 
         dest = Collection.objects.get(owner=self.user2.identity, title="Indexed")
         assert dest.get_member_for_item(self.book1).note == "second note"

--- a/neodb/tests/journal/test_trakt.py
+++ b/neodb/tests/journal/test_trakt.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from catalog.common.downloaders import use_local_response
@@ -28,7 +30,16 @@ class TestTraktImporter:
     def test_trakt_import(self):
         zip_path = "test_data/trakt-export-test.zip"
         task = TraktImporter.create(self.user, visibility=0, file=zip_path)
-        task.run()
+        with (
+            patch(
+                "journal.models.collection.JournalIndex.enqueue_replace_pieces"
+            ) as enqueue_collection_index,
+            patch(
+                "journal.models.collection.transaction.on_commit",
+                side_effect=lambda callback, **kwargs: callback(),
+            ),
+        ):
+            task.run()
 
         # Verify basic completion
         assert task.metadata["failed"] == 0, (
@@ -74,6 +85,7 @@ class TestTraktImporter:
         first_member = members[0]
         assert isinstance(first_member, CollectionMember)
         assert first_member.note == "Great movie"
+        enqueue_collection_index.assert_called_once_with([collection.pk])
 
     @use_local_response
     def test_trakt_import_list_visibility(self):

--- a/neodb/tests/social/test_timeline_n_plus_one.py
+++ b/neodb/tests/social/test_timeline_n_plus_one.py
@@ -49,6 +49,36 @@ class TestTimelineDataNPlusOne:
             + "; ".join(q["sql"][:120] for q in individual_piecepost)
         )
 
+    def test_main_query_matches_undismissed_ordering_index(self):
+        """The feed predicate must match Takahe's partial identity/-id index."""
+        with CaptureQueriesContext(connections["takahe"]) as ctx:
+            response = self.client.get("/timeline/data")
+        assert response.status_code == 200
+        timeline_queries = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if 'FROM "activities_timelineevent"' in q["sql"]
+            and "ORDER BY" in q["sql"]
+            and "LIMIT 10" in q["sql"]
+        ]
+        assert timeline_queries
+        where_clause = timeline_queries[0].split("WHERE", 1)[1]
+        assert 'NOT "activities_timelineevent"."dismissed"' in where_clause
+
+    def test_sidebar_unread_count_is_bounded(self):
+        """Sidebar rendering must issue a bounded ID read, never COUNT(*)."""
+        with CaptureQueriesContext(connections["takahe"]) as ctx:
+            response = self.client.get("/timeline/")
+        assert response.status_code == 200
+        unread_queries = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if 'FROM "activities_timelineevent"' in q["sql"] and "seen" in q["sql"]
+        ]
+        assert unread_queries
+        assert all("COUNT(" not in q.upper() for q in unread_queries)
+        assert any("LIMIT 100" in q for q in unread_queries)
+
     def test_no_per_post_domain_queries(self):
         """Author domain should be select_related, not queried per post."""
         with CaptureQueriesContext(connections["takahe"]) as ctx:


### PR DESCRIPTION
Summary:
- paginate public podcast episodes in SQL and prefetch only the selected page
- coalesce collection index rebuilds, defer importer updates, and keep bulk appends linear
- match the timeline query to the existing undismissed ordering index
- replace exact unread counts with a bounded 99+ badge query
- add no database indexes or migrations

Safety:
- schedule collection indexing after transaction commit
- prevent RQ debounce races and restore failed index chunks
- preserve empty and out-of-range podcast pagination behavior

Tests:
- 152 focused catalog, collection, importer, queue, and timeline tests passed
- Ruff targeted correctness checks and formatting passed
- ty passed on all changed implementation files

Supersedes #1822, which GitHub closed automatically when the cross-fork source branch was renamed.