### PR TITLE
Break created_time ties in shelf listings

### DIFF
--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -986,7 +986,8 @@ class ShelfManager:
     def get_latest_members(
         self, shelf_type: ShelfType, item_category: ItemCategory | None = None
     ):
-        qs = self.shelf_list[shelf_type].members.all().order_by("-created_time")
+        # -id breaks ties so paginated callers do not drop or repeat rows
+        qs = self.shelf_list[shelf_type].members.all().order_by("-created_time", "-id")
         if item_category:
             return qs.filter(q_item_in_category(item_category))
         else:

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -986,7 +986,6 @@ class ShelfManager:
     def get_latest_members(
         self, shelf_type: ShelfType, item_category: ItemCategory | None = None
     ):
-        # -id breaks ties so paginated callers do not drop or repeat rows
         qs = self.shelf_list[shelf_type].members.all().order_by("-created_time", "-id")
         if item_category:
             return qs.filter(q_item_in_category(item_category))

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -246,8 +246,6 @@ def render_list(
             rating_grade=Subquery(rating.values("grade"))
         ).order_by(F("rating_grade").desc(nulls_last=True), "id")
     else:
-        # -id breaks ties: imported marks often share created_time, and an
-        # incomplete order lets LIMIT/OFFSET pages drop or repeat rows
         queryset = queryset.order_by("-created_time", "-id")
     if year:
         year = int(year)

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -246,7 +246,9 @@ def render_list(
             rating_grade=Subquery(rating.values("grade"))
         ).order_by(F("rating_grade").desc(nulls_last=True), "id")
     else:
-        queryset = queryset.order_by("-created_time")
+        # -id breaks ties: imported marks often share created_time, and an
+        # incomplete order lets LIMIT/OFFSET pages drop or repeat rows
+        queryset = queryset.order_by("-created_time", "-id")
     if year:
         year = int(year)
         queryset = queryset.filter(created_time__year=year)

--- a/neodb/tests/journal/test_shelf.py
+++ b/neodb/tests/journal/test_shelf.py
@@ -1,7 +1,11 @@
 import pytest
+from django.db import connection
+from django.test import Client
+from django.test.utils import CaptureQueriesContext
 
 from catalog.models import Edition, Game, IdType, ItemCategory, Movie, TVShow
 from journal.models.common import q_owned_piece_visible_to_user
+from journal.models.mark import Mark
 from journal.models.review import Review
 from journal.models.shelf import ShelfManager, ShelfMember, ShelfType
 from users.models import User
@@ -159,3 +163,39 @@ class TestShelfManager:
         assert stats2[ItemCategory.Book]["reviewed"] == 1
         assert stats2[ItemCategory.Movie]["reviewed"] == 1
         assert stats2[ItemCategory.Game]["reviewed"] == 0
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfOrdering:
+    """Bulk-imported marks share created_time, so ordering by it alone lets
+    LIMIT/OFFSET pages drop or repeat rows. Every paged shelf query must
+    carry a unique tiebreaker."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="sort@example.com", username="sortuser")
+        self.book = Edition.objects.create(title="Sort Book")
+        Mark(self.user.identity, self.book).update(ShelfType.COMPLETE, None, None)
+
+    def test_latest_members_ordering_is_total(self):
+        qs = ShelfManager(self.user.identity).get_latest_members(ShelfType.COMPLETE)
+        assert qs.query.order_by == ("-created_time", "-id")
+
+    def test_shelf_list_ordering_is_total(self):
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/users/{self.user.username}/complete/book/")
+        assert response.status_code == 200
+        paged = [
+            q["sql"].split("ORDER BY")[-1]
+            for q in ctx.captured_queries
+            if "journal_shelfmember" in q["sql"]
+            and "ORDER BY" in q["sql"]
+            and "LIMIT" in q["sql"]
+        ]
+        assert paged
+        for order_by in paged:
+            assert "created_time" in order_by
+            # ShelfMember inherits from Piece, so its pk column is piece_ptr_id
+            assert "piece_ptr_id" in order_by


### PR DESCRIPTION
Reported by a user: several books marked as read never appeared in the shelf list sorted by time, but did appear when sorted by rating. The user also asked whether movies and TV shows could be affected.

## Cause

`render_list` ordered the time-sorted list by `created_time` alone:

```python
queryset = queryset.order_by("-created_time")
```

That order is not total. The list is paged with a plain `Paginator`, so each page is a separate `LIMIT`/`OFFSET` query, and Postgres may place tied rows differently in each one. A mark can then land on two pages, or on none. The rating branch already carried an `id` tiebreaker, which is why the same mark stayed visible there.

Ties are common after a bulk import. The Goodreads importer stamps every mark with the read date at 22:00:00, so all books read on one day share a timestamp:

```python
dt = make_aware(datetime.strptime(date_str, "%Y/%m/%d").replace(hour=22))
```

The defect itself is not category-specific. `render_list` serves every category, plus the tag and review lists. Movies and TV shows are exposed too, they just tie less often, because the Letterboxd importer adds random seconds and Trakt supplies full timestamps.

`ShelfManager.get_latest_members` had the same incomplete order, and it backs the paginated `/user/{handle}/shelf/{type}` and `/me/shelf/{type}` endpoints, so API clients could drop marks the same way.

## Change

Add `-id` at both call sites. No migration, no index change: the existing `(parent_id, visibility, created_time)` index plus incremental sort covers the extra key.

Exporters were checked and are unaffected. They read the whole queryset in one query with no `LIMIT`/`OFFSET`.

The Goodreads `hour=22` stamp is left alone. It is a data-semantics choice, and the tiebreaker repairs already-imported data at display time.

## Tests

`TestShelfOrdering` asserts a total order on both the `get_latest_members` queryset and the SQL the shelf list page actually runs. Both tests fail without the fix.

Full `tests/journal`, `tests/social`, `tests/users` and `tests/catalog` pass locally, apart from two pre-existing failures that need live network for a Google Books fetch (`test_storygraph.py::test_import_phase` and `test_book.py::test_scrape_without_language`). Both fail on a clean tree as well.
