### PR TITLE
Warn instead of raising when an imported record names a missing item

### DIFF
--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -231,13 +231,8 @@ class NdjsonImporter(BaseImporter):
         return RE_MD_IMAGE.sub(_replace, body)
 
     def _lookup_item(self, data: Dict[str, Any], url: str) -> Item | None:
-        """The catalog item a journal record refers to, or None.
-
-        A missing item is a data condition, not a defect: the item may have
-        been deleted since the export, or its catalog entry may have resolved
-        to nothing. The record is counted as failed and the import goes on,
-        so this warns with the url rather than raising.
-        """
+        """None when the item was deleted after the export, or its catalog
+        entry resolved to nothing -- expected, so the record fails quietly."""
         item = self.items.get(url)
         if not item:
             logger.warning(

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -230,6 +230,21 @@ class NdjsonImporter(BaseImporter):
 
         return RE_MD_IMAGE.sub(_replace, body)
 
+    def _lookup_item(self, data: Dict[str, Any], url: str) -> Item | None:
+        """The catalog item a journal record refers to, or None.
+
+        A missing item is a data condition, not a defect: the item may have
+        been deleted since the export, or its catalog entry may have resolved
+        to nothing. The record is counted as failed and the import goes on,
+        so this warns with the url rather than raising.
+        """
+        item = self.items.get(url)
+        if not item:
+            logger.warning(
+                f"Item not found for {data.get('type') or 'record'}: {url or '(none)'}"
+            )
+        return item
+
     def import_collection(self, data: Dict[str, Any]) -> BaseImporter.ImportResult:
         """Import a collection from NDJSON data."""
         try:
@@ -332,9 +347,9 @@ class NdjsonImporter(BaseImporter):
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             updated_dt = self._archive_updated(content_data)
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             shelf_type = content_data.get("status", ShelfType.WISHLIST)
             mark = Mark(owner, item)
             if self._is_current(mark.shelfmember, updated_dt, published_dt):
@@ -389,9 +404,9 @@ class NdjsonImporter(BaseImporter):
     def import_shelf_log(self, data: Dict[str, Any]) -> BaseImporter.ImportResult:
         """Import a shelf log entry from NDJSON data."""
         try:
-            item = self.items.get(data.get("item", ""))
+            item = self._lookup_item(data, data.get("item", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             owner = self.user.identity
             shelf_type = data.get("status", ShelfType.WISHLIST)
             # TODO: data["posts"] carries the source post ids for this entry;
@@ -527,9 +542,9 @@ class NdjsonImporter(BaseImporter):
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             updated_dt = self._archive_updated(content_data)
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             name = content_data.get("name", "")
             content = content_data.get("content", "")
             # TODO: identity is (owner, item, title), so a review retitled on
@@ -576,9 +591,9 @@ class NdjsonImporter(BaseImporter):
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             updated_dt = self._archive_updated(content_data)
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             title = content_data.get("title", "")
             content = content_data.get("content", "")
             sensitive = content_data.get("sensitive", False)
@@ -665,9 +680,9 @@ class NdjsonImporter(BaseImporter):
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             updated_dt = self._archive_updated(content_data)
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             content = content_data.get("content", "")
             existing_comment = Comment.objects.filter(owner=owner, item=item).first()
             if existing_comment:
@@ -712,9 +727,9 @@ class NdjsonImporter(BaseImporter):
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
             updated_dt = self._archive_updated(content_data)
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             rating_grade = int(float(content_data.get("value") or 0))
             if not rating_grade:
                 # a rating with no grade carries nothing to restore, and
@@ -777,9 +792,9 @@ class NdjsonImporter(BaseImporter):
             metadata = data.get("metadata") or {}
             content_data = data.get("content", {})
             published_dt = self.parse_datetime(content_data.get("published"))
-            item = self.items.get(content_data.get("withRegardTo", ""))
+            item = self._lookup_item(data, content_data.get("withRegardTo", ""))
             if not item:
-                raise KeyError(f"Could not find item: {data.get('item', '')}")
+                return "failed"
             tag_title = Tag.cleanup_title(content_data.get("tag", ""))
             # created_time is not nullable, so only pass it when the bundle
             # carries one; inserting NULL raises IntegrityError, which marks

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1434,13 +1434,8 @@ class TestNdjsonExportImport:
         assert Mark(self.user2.identity, item).shelf_type == ShelfType.COMPLETE
 
     def test_ndjson_unresolved_item_warns_with_the_url(self):
-        """An item the catalog could not resolve is a data condition.
-
-        It used to raise KeyError, so a deleted item was reported as an
-        error with a traceback -- and the message named ``data["item"]``,
-        a key these records do not carry, so it read "Could not find item: "
-        with nothing after it.
-        """
+        """Used to raise KeyError, reported as an error naming ``data["item"]``
+        -- a key these records lack, so it read "Could not find item: "."""
         url = "https://gone-review.invalid/podcast/xyz"
         importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
         importer.items = {url: None}
@@ -1450,7 +1445,6 @@ class TestNdjsonExportImport:
             review = importer.import_review(
                 {"type": "Review", "content": {"withRegardTo": url, "content": "x"}}
             )
-            # shelf logs name the item at the top level, not in ``content``
             log = importer.import_shelf_log({"type": "ShelfLog", "item": url})
         finally:
             logger.remove(sink)

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1454,6 +1454,27 @@ class TestNdjsonExportImport:
         assert all(url in r["message"] for r in records)
         assert [r["exception"] for r in records] == [None, None]
 
+    def test_ndjson_unresolved_item_still_counts_as_failed(self, tmp_path):
+        """Warning instead of raising must not hide the record from the user:
+        task.message is what user_task_status.html renders."""
+        url = "https://gone-count.invalid/podcast/xyz"
+        path = tmp_path / "journal.ndjson"
+        path.write_text(
+            json.dumps({"server": "x"})
+            + "\n"
+            + json.dumps(
+                {"type": "Review", "content": {"withRegardTo": url, "content": "x"}}
+            )
+            + "\n"
+        )
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.process_journal(str(path))
+        assert importer.metadata["total"] == 1
+        assert importer.metadata["processed"] == 1
+        assert importer.metadata["failed"] == 1
+        assert importer.metadata["imported"] == 0
+        assert "1 failed" in importer.message
+
     def test_ndjson_import_without_published_timestamp(self):
         """created_time is not nullable; a bundle without `published` must
         fall back to the model default instead of raising IntegrityError."""

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1433,6 +1433,33 @@ class TestNdjsonExportImport:
         assert item is not None
         assert Mark(self.user2.identity, item).shelf_type == ShelfType.COMPLETE
 
+    def test_ndjson_unresolved_item_warns_with_the_url(self):
+        """An item the catalog could not resolve is a data condition.
+
+        It used to raise KeyError, so a deleted item was reported as an
+        error with a traceback -- and the message named ``data["item"]``,
+        a key these records do not carry, so it read "Could not find item: "
+        with nothing after it.
+        """
+        url = "https://gone-review.invalid/podcast/xyz"
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {url: None}
+        records = []
+        sink = logger.add(lambda m: records.append(m.record), level="WARNING")
+        try:
+            review = importer.import_review(
+                {"type": "Review", "content": {"withRegardTo": url, "content": "x"}}
+            )
+            # shelf logs name the item at the top level, not in ``content``
+            log = importer.import_shelf_log({"type": "ShelfLog", "item": url})
+        finally:
+            logger.remove(sink)
+        assert review == "failed"
+        assert log == "failed"
+        assert [r["level"].name for r in records] == ["WARNING", "WARNING"]
+        assert all(url in r["message"] for r in records)
+        assert [r["exception"] for r in records] == [None, None]
+
     def test_ndjson_import_without_published_timestamp(self):
         """created_time is not nullable; a bundle without `published` must
         fall back to the model default instead of raising IntegrityError."""


### PR DESCRIPTION
Fixes Sentry NEODB-SOCIAL-7VV (`KeyError: 'Could not find item: '`).

## What happened

One review in an NDJSON import named a catalog item that could not be
resolved. `import_review` raised `KeyError`, the surrounding
`except Exception: logger.exception(...)` turned it into an ERROR with a
full traceback, and it landed in Sentry as an application defect.

It is not one. An item can be missing for ordinary reasons: it was
deleted from the catalog after the export was taken, or its
`catalog.ndjson` entry resolved to nothing (a local url for an item since
deleted, a blocked peer, an unsupported type). The importer already
handles this correctly - it counts the record as `failed` and carries on -
so the traceback reports a normal outcome as a crash.

The message was also empty, and always would be. Six of the seven lookups
read the url from `content["withRegardTo"]` but named `data["item"]` in
the message. Review, Note, Comment, Rating, ShelfMember and TagMember
records carry no top-level `item` key (see `NdjsonExporter.run`), so the
message could only ever read `Could not find item: ` with nothing after
it. Only `import_shelf_log`, which genuinely looks up `data["item"]`, was
consistent.

## Change

All seven lookups go through a new `_lookup_item`, which warns with the
record type and the actual url and lets the caller `return "failed"`.
This is what `import_collection` already does for its member items.

The import summary, the `failed` count and everything the user sees are
unchanged. What changes is that a missing item now produces one
actionable warning line naming the url, instead of a Sentry error with an
empty message.

## Tests

- `test_ndjson_unresolved_item_warns_with_the_url` covers both key shapes
  (`withRegardTo` and top-level `item`) and asserts the record is
  `failed`, the log is a WARNING carrying the url, and no exception is
  attached. Against the unfixed importer it fails with
  `assert ['ERROR', 'ERROR'] == ['WARNING', 'WARNING']`.
- `test_ndjson_unresolved_item_still_counts_as_failed` drives the record
  through `process_journal` and asserts it still reaches
  `metadata["failed"]` and `task.message`, which is what
  `users/user_task_status.html` renders.

Full `tests/journal` suite passes (906 passed).

## Noted, not changed

The likeliest way a record reaches this state is a genuine round-trip
gap, confirmed locally against this branch: the exporter applies no
`is_deleted` filter to `p.item`, so a review whose item was soft-deleted
after the export is exported along with a `catalog.ndjson` entry for that
item - and the importer can then never accept it.

`Item.delete(soft=True)` calls `Item.clear()`, which nulls
`primary_lookup_id_type`/`primary_lookup_id_value` and detaches every
`ExternalResource` (`res.item = None`). That severs every route
`get_item_by_info_and_links` has at once: the local-url branch finds the
row but rejects it on `is_deleted`, the external-resource sites no longer
point at it, and the isbn/imdb fallback has no id left to match. The
`create_item_from_catalog_data` fallback then declines by design, since
an unresolved local url means deleted rather than missing. Net effect:
such a piece can be exported but never re-imported.

Also noted: `PodcastEpisode` is absent from
`FediverseInstance.supported_types`, so `create_item_from_catalog_data`
cannot rebuild one from bundled metadata even for a remote archive.

Both are separate tickets; this PR only stops the condition from being
reported as a defect, and makes the log name the item so the next
occurrence is diagnosable.