### PR TITLE
Do not let anyone, staff included, delete a catalog item in use

### DIFF
--- a/neodb/catalog/templates/_sidebar_edit.html
+++ b/neodb/catalog/templates/_sidebar_edit.html
@@ -268,7 +268,7 @@
                  value="{% trans 'merge to another item' %}">
         </form>
       </details>
-      {% if item.is_deletable %}
+      {% if item.is_deletable and not item.journal_exists %}
         <details>
           <summary>{% trans 'Delete' %}</summary>
           <form method="post"

--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -216,11 +216,8 @@ def delete(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     if not item.is_editable_by(request.user):
         raise PermissionDenied(_("Editing this item is restricted."))
-    # no staff override: deleting an in-use item strands every piece pointing
-    # at it. Item.clear() nulls the lookup ids and detaches the external
-    # resources, so such a piece can be exported but never re-imported -- the
-    # NDJSON importer has nothing left to match on and will not rebuild a
-    # local url. Merge instead; it keeps the pieces reachable.
+    # no staff override: clear() drops the ids an NDJSON re-import matches on,
+    # so deleting an in-use item strands its pieces for good. Merge instead.
     if item.journal_exists():
         raise PermissionDenied(_("Item in use."))
     if not item.is_deletable():

--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -216,7 +216,12 @@ def delete(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     if not item.is_editable_by(request.user):
         raise PermissionDenied(_("Editing this item is restricted."))
-    if not request.user.is_staff and item.journal_exists():
+    # no staff override: deleting an in-use item strands every piece pointing
+    # at it. Item.clear() nulls the lookup ids and detaches the external
+    # resources, so such a piece can be exported but never re-imported -- the
+    # NDJSON importer has nothing left to match on and will not rebuild a
+    # local url. Merge instead; it keeps the pieces reachable.
+    if item.journal_exists():
         raise PermissionDenied(_("Item in use."))
     if not item.is_deletable():
         raise PermissionDenied(_("Item cannot be deleted."))

--- a/neodb/tests/catalog/test_item_delete.py
+++ b/neodb/tests/catalog/test_item_delete.py
@@ -1,0 +1,88 @@
+import pytest
+from django.test import Client
+
+from catalog.models import Podcast
+from journal.models import Review
+from users.models import User
+
+
+def _login(client: Client, is_staff: bool = False, username: str = "deleter") -> User:
+    user = User.register(email=f"{username}@example.com", username=username)
+    if is_staff:
+        user.is_staff = True
+        user.save(update_fields=["is_staff"])
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    return user
+
+
+def _podcast(title: str = "Pocket Casts") -> Podcast:
+    return Podcast.objects.create(
+        localized_title=[{"lang": "en", "text": title}],
+        official_site="https://example.org/pc",
+    )
+
+
+def _review(item, owner_username: str = "reviewer") -> Review:
+    owner = User.register(
+        email=f"{owner_username}@example.com", username=owner_username
+    )
+    return Review.objects.create(
+        owner=owner.identity, item=item, title="t", body="b", visibility=0
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestItemDeleteInUse:
+    def test_staff_cannot_delete_item_in_use(self):
+        """Deleting an in-use item strands every piece pointing at it: the
+        piece can be exported but never re-imported (NEODB-SOCIAL-7VV)."""
+        item = _podcast()
+        _review(item)
+        client = Client()
+        _login(client, is_staff=True)
+
+        response = client.post(f"{item.url}/delete", {"sure": "1"})
+        assert response.status_code == 403
+        item.refresh_from_db()
+        assert not item.is_deleted
+
+    def test_non_staff_cannot_delete_item_in_use(self):
+        item = _podcast()
+        _review(item)
+        client = Client()
+        _login(client)
+
+        response = client.post(f"{item.url}/delete", {"sure": "1"})
+        assert response.status_code == 403
+        item.refresh_from_db()
+        assert not item.is_deleted
+
+    def test_staff_can_still_delete_unused_item(self):
+        item = _podcast()
+        client = Client()
+        _login(client, is_staff=True)
+
+        response = client.post(f"{item.url}/delete", {"sure": "1"})
+        assert response.status_code == 302
+        item.refresh_from_db()
+        assert item.is_deleted
+
+    def test_sidebar_offers_merge_but_not_delete_for_item_in_use(self):
+        """Staff must not be shown a button that can only 403. Merge stays,
+        since it keeps the pieces reachable."""
+        item = _podcast()
+        _review(item)
+        client = Client()
+        _login(client, is_staff=True)
+
+        content = client.get(f"{item.url}/edit").content.decode()
+        assert f"{item.url}/merge" in content
+        assert f"{item.url}/delete" not in content
+
+    def test_sidebar_offers_delete_for_unused_item(self):
+        item = _podcast()
+        client = Client()
+        _login(client, is_staff=True)
+
+        content = client.get(f"{item.url}/edit").content.decode()
+        assert f"{item.url}/delete" in content


### PR DESCRIPTION
Closes the data condition behind Sentry NEODB-SOCIAL-7VV. The reporting
side of that issue is #1827; this is the cause.

## Why

Deleting an item that journal pieces point at strands every one of them.
`Item.delete(soft=True)` calls `Item.clear()`, which nulls
`primary_lookup_id_type`/`primary_lookup_id_value` **and** detaches every
`ExternalResource` (`res.item = None`). The pieces keep rendering on the
source, but the item is now unreachable by every route the NDJSON
importer has:

- the local-url branch finds the row and rejects it on `is_deleted`
- the external-resource sites no longer point at it
- the isbn/imdb fallback has no lookup id left to match
- `create_item_from_catalog_data` declines by design, since an unresolved
  *local* url means deleted rather than missing

So such a piece can be exported and never re-imported. Reproduced
locally: export a review, soft-delete its item, re-import - the record
comes back `failed`.

The view already refused this for ordinary users and exempted staff, so
the only way to reach the state was a staff deletion of an in-use item -
which is exactly what the `Item in use.` check was protecting against.

## Change

- `catalog/views/edit.py` `delete`: drop the `not request.user.is_staff`
  exemption.
- `_sidebar_edit.html`: stop rendering the Delete block for an in-use
  item, so nobody is handed an action that can only 403. Merge stays
  visible to staff.

`merge` and `unlink_works` keep their staff override deliberately. Merge
is the right tool here: it keeps the pieces reachable by rewriting them
onto the surviving item, which is what
`Item.get_by_url(resolve_merge=True)` follows - a deleted-but-merged item
still resolves and is not broken.

The guard lives in the view rather than `Item.is_deletable()` on purpose.
`Podcast.is_deletable()` and `People.is_deletable()` both reimplement
rather than call `super()`, so a model-level check would silently miss
Podcast - the very type that triggered the Sentry issue.

## Consequence worth a maintainer's eye

Staff lose the UI route for deleting a spam or junk item that already has
journal entries. The remaining options are to merge it into the correct
item, or to remove the offending pieces first and then delete. If that
turns out to be too strict in practice, the natural escape hatch is an
explicit "delete anyway, and drop the pieces" flow rather than a silent
override - happy to add one if you'd prefer.

## Other paths checked

- No catalog API or Django admin delete route exists.
- `catalog prune-podcast-no-audio` already skips episodes with journal
  activity, so the CLI needed no change.
- `remove_unused_seasons` already deletes only seasons with no journal.
- `catalog_delete.html` still carries its "Item has been marked by
  users." warning. That branch is now unreachable, but removing it would
  obsolete a translated string for no gain, and it stays correct if the
  guard is ever relaxed.

## Tests

`tests/catalog/test_item_delete.py`, five cases: staff blocked on an
in-use item, non-staff blocked, staff can still delete an unused item,
and the sidebar offers merge-but-not-delete for an in-use item while
still offering delete for an unused one.

Against `main` these fail with `assert 302 == 403` (staff deletion
succeeds) and with the delete form still present in the sidebar.

`tests/catalog` 750 passed, `tests/journal` 904 passed. No new
translatable strings, so no `makemessages` run.