### PR TITLE
Fix jsondata lookups on multi-table child models

### DIFF
--- a/neodb/common/models/jsondata.py
+++ b/neodb/common/models/jsondata.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from cryptography.fernet import Fernet, MultiFernet
 from django.conf import settings
 from django.core.exceptions import FieldError
-from django.db.models import DEFERRED, fields
+from django.db.models import DEFERRED, Model, fields
+from django.db.models.signals import class_prepared
 from django.utils import dateparse, timezone
 from django.utils.encoding import force_bytes
 from django_jsonform.forms.fields import ArrayFormField as DJANGO_ArrayFormField
@@ -25,12 +26,15 @@ from django_jsonform.models.fields import JSONField as DJANGO_JSONField
 
 class Patched_DJANGO_JSONField(DJANGO_JSONField):
     def formfield(self, **kwargs):
-        schema = getattr(self.model, self.attname + "_schema", self.schema)
+        # render against the class the field is attached to; JSONFieldMixin
+        # may point model at the multi-table parent holding the JSON column
+        model = getattr(self, "attached_model", None) or self.model
+        schema = getattr(model, self.attname + "_schema", self.schema)
         return super().formfield(
             **{
                 "form_class": DJANGO_JSONFormField,
                 "schema": schema,
-                "model_name": self.model.__name__,
+                "model_name": model.__name__,
                 "file_handler": self.file_handler,
                 **kwargs,
             }
@@ -153,11 +157,15 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
 
     def __init__(self, *args, **kwargs):
         self.json_field_name = kwargs.pop("json_field_name", "metadata")
+        # the class this field is attached to; ``model`` may instead point at
+        # the multi-table parent that holds the JSON column
+        self.attached_model: type[Model] | None = None
         super(JSONFieldMixin, self).__init__(*args, **kwargs)
 
     def contribute_to_class(self: "fields.Field", cls, name, private_only=False):
         self.set_attributes_from_name(name)
         self.model = cls
+        self.attached_model = cls  # ty: ignore[unresolved-attribute]
         self.concrete = False
         self.column = None
         cls._meta.add_field(self, private=True)
@@ -174,6 +182,27 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
             )
 
         self.column = self.json_field_name  # type: ignore
+        # parent links of a child model are wired after its own fields are
+        # contributed, so the JSON column owner is resolved once the class is ready
+        class_prepared.connect(
+            self._bind_json_column_model,  # ty: ignore[unresolved-attribute]
+            sender=cls,
+            weak=False,
+        )
+
+    def _bind_json_column_model(self, sender, **kwargs):
+        """Point ``model`` at the model whose table holds the JSON column.
+
+        Django copies private fields into every multi-table child, and the ORM
+        picks the table to join from ``field.model``. Left at the child, a
+        lookup on ``Movie.orig_title`` reads ``catalog_movie.metadata``, but the
+        column only exists on ``catalog_item``.
+        """
+        class_prepared.disconnect(self._bind_json_column_model, sender=sender)
+        json_field = sender._meta.get_field(self.json_field_name)
+        if json_field.model._meta.concrete_model is not sender._meta.concrete_model:
+            self.model = json_field.model
+            self.__dict__.pop("cached_col", None)
 
     def get_lookup(self, lookup_name):
         # Always return None, to make get_transform been called

--- a/neodb/tests/core/test_jsondata_fields.py
+++ b/neodb/tests/core/test_jsondata_fields.py
@@ -4,14 +4,18 @@ from datetime import timezone as dt_tz
 import pytest
 from django.utils import timezone
 
+from catalog.models import Item, Movie, People, PeopleType
 from common.models.jsondata import (
     DateField,
     DateTimeField,
     EncryptedTextField,
+    JSONField,
+    JSONFieldMixin,
     TimeField,
     decrypt_str,
     encrypt_str,
 )
+from mastodon.models import MastodonAccount
 
 
 class TestEncryptDecrypt:
@@ -178,3 +182,78 @@ class TestTimeField:
     def test_from_json_with_empty_string(self):
         result = self.field.from_json("")
         assert result is None
+
+
+class TestChildModelFieldBinding:
+    """Virtual fields on a multi-table child point at the JSON column's model."""
+
+    def test_model_is_json_column_owner(self):
+        assert Item._meta.get_field("localized_title").model is Item
+        assert Movie._meta.get_field("localized_title").model is Item
+        orig_title = Movie._meta.get_field("orig_title")
+        assert isinstance(orig_title, JSONFieldMixin)
+        assert orig_title.model is Item
+        assert orig_title.attached_model is Movie
+
+    def test_proxy_model_is_unchanged(self):
+        field = MastodonAccount._meta.get_field("access_token")
+        assert isinstance(field, JSONFieldMixin)
+        assert field.model is MastodonAccount
+        assert field.attached_model is MastodonAccount
+
+    def test_formfield_uses_attached_model(self):
+        field = Movie._meta.get_field("localized_title")
+        assert isinstance(field, JSONField)
+        formfield = field.formfield()
+        assert formfield is not None
+        assert getattr(formfield.widget, "model_name") == "Movie"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestChildModelLookups:
+    """Lookups on virtual fields of Item subclasses must join catalog_item."""
+
+    def _movies(self):
+        movie = Movie.objects.create(
+            title="Movie A",
+            orig_title="Orig A",
+            localized_title=[{"lang": "en", "text": "Movie A"}],
+        )
+        other = Movie.objects.create(
+            title="Movie B",
+            orig_title="Orig B",
+            localized_title=[{"lang": "en", "text": "Movie B"}],
+        )
+        return movie, other
+
+    def test_field_declared_on_child(self):
+        movie, _ = self._movies()
+        assert list(Movie.objects.filter(orig_title="Orig A")) == [movie]
+
+    def test_field_inherited_from_parent(self):
+        movie, other = self._movies()
+        qs = Movie.objects.filter(
+            is_deleted=False,
+            merged_to_item__isnull=True,
+            localized_title__contains=[{"text": "Movie A"}],
+        ).exclude(pk=other.pk)[:5]
+        assert list(qs) == [movie]
+
+    def test_count_and_values_join_parent(self):
+        movie, _ = self._movies()
+        qs = Movie.objects.filter(orig_title="Orig A")
+        assert qs.count() == 1
+        assert list(qs.values_list("pk", flat=True)) == [movie.pk]
+
+    def test_base_model_lookup(self):
+        movie, _ = self._movies()
+        qs = Item.objects.filter(localized_title__contains=[{"text": "Movie A"}])
+        assert list(qs) == [movie]
+
+    def test_people_localized_name(self):
+        person = People.objects.create(
+            people_type=PeopleType.PERSON,
+            localized_name=[{"lang": "en", "text": "Some One"}],
+        )
+        qs = People.objects.filter(localized_name__contains=[{"text": "Some One"}])
+        assert list(qs) == [person]


### PR DESCRIPTION
## Problem

Sentry NEODB-SOCIAL-7VW: `ProgrammingError: column catalog_movie.metadata does not exist`, raised by

```python
Movie.objects.filter(
    is_deleted=False, merged_to_item__isnull=True,
    localized_title__contains=[{"text": title}],
).exclude(pk=item.pk)[:5]
```

`localized_title` is a `jsondata` virtual field stored in `Item.metadata`. Django deep-copies private fields into every multi-table child, so on `Movie` the field reports `model = Movie`. `Query.names_to_path` decides whether to join the parent table from `field.model`, so it never joined `catalog_item`, and the key transform was compiled against the child alias:

```sql
... WHERE ("catalog_movie"."metadata" -> 'localized_title') @> %s
```

Only lookups on the base `Item` worked. Every virtual-field lookup on an `Item` subclass was broken, whether the field is inherited (`localized_title`, `localized_description`) or declared on the child (`Movie.orig_title`, `Edition.pub_year`, `People.localized_name`, `Game.platform`, ...). With `.values()` / `.count()` the parent table was not joined at all. This is why existing code spells such lookups as `metadata__localized_name__contains=...`.

## Fix

`JSONFieldMixin` now binds `field.model` to the model whose table holds the JSON column. This has to happen on `class_prepared`: for fields declared on a child model, `contribute_to_class` runs before the parent links are wired, so the JSON column cannot be resolved eagerly. Proxy models share the concrete table and are left unchanged. The class the field is attached to is kept as `attached_model` and used for form rendering (`*_schema` lookup and django_jsonform `model_name`), so edit forms are unaffected.

Trade-off: a child-declared virtual field now reports the parent as `model`, so pickling a queryset or `Col` that references one would not unpickle. The repo only pickles model instances (RQ jobs), which are unaffected. A follow-up PR from a code-review pass addresses this with a `__reduce__` override and a single module-level `class_prepared` receiver.

## Verification

- New tests in `tests/core/test_jsondata_fields.py`: child-declared and inherited field lookups on `Movie`, the exact Sentry query shape, `count()` / `values_list()` join registration, base `Item` lookup, `People.localized_name`, field binding attributes, proxy unchanged, formfield `model_name`. Six of them fail on `main` with the Sentry error text and pass with the fix.
- Full neodb suite in the worktree Docker cluster: 2324 passed, 3 failed, the 3 being the pre-existing `tests/mastodon/test_lexicons.py` cases that need `/docs` mounted.
- `uv run pre-commit run` (ruff, ruff-format, ty) passes.

Fixes NEODB-SOCIAL-7VW.
