### PR TITLE
Reload jsondata fields by attached model and bind via one receiver

### DIFF
--- a/neodb/common/models/jsondata.py
+++ b/neodb/common/models/jsondata.py
@@ -8,10 +8,12 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from cryptography.fernet import Fernet, MultiFernet
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import FieldError
 from django.db.models import DEFERRED, Model, fields
 from django.db.models.signals import class_prepared
+from django.dispatch import receiver
 from django.utils import dateparse, timezone
 from django.utils.encoding import force_bytes
 from django_jsonform.forms.fields import ArrayFormField as DJANGO_ArrayFormField
@@ -22,23 +24,6 @@ from django_jsonform.forms.fields import JSONFormField as DJANGO_JSONFormField
 # from django.contrib.postgres.fields import ArrayField as DJANGO_ArrayField
 from django_jsonform.models.fields import ArrayField as DJANGO_ArrayField
 from django_jsonform.models.fields import JSONField as DJANGO_JSONField
-
-
-class Patched_DJANGO_JSONField(DJANGO_JSONField):
-    def formfield(self, **kwargs):
-        # render against the class the field is attached to; JSONFieldMixin
-        # may point model at the multi-table parent holding the JSON column
-        model = getattr(self, "attached_model", None) or self.model
-        schema = getattr(model, self.attname + "_schema", self.schema)
-        return super().formfield(
-            **{
-                "form_class": DJANGO_JSONFormField,
-                "schema": schema,
-                "model_name": model.__name__,
-                "file_handler": self.file_handler,
-                **kwargs,
-            }
-        )
 
 
 def _get_crypter():
@@ -157,10 +142,19 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
 
     def __init__(self, *args, **kwargs):
         self.json_field_name = kwargs.pop("json_field_name", "metadata")
-        # the class this field is attached to; ``model`` may instead point at
-        # the multi-table parent that holds the JSON column
         self.attached_model: type[Model] | None = None
         super(JSONFieldMixin, self).__init__(*args, **kwargs)
+
+    def __reduce__(self):
+        # Field.__reduce__ reloads by ``model``, which for a multi-table child
+        # is the parent and does not know child-declared fields
+        if self.attached_model is None:
+            return super().__reduce__()
+        return _load_attached_field, (
+            self.attached_model._meta.app_label,
+            self.attached_model._meta.object_name,
+            self.name,  # ty: ignore[unresolved-attribute]
+        )
 
     def contribute_to_class(self: "fields.Field", cls, name, private_only=False):
         self.set_attributes_from_name(name)
@@ -182,23 +176,18 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
             )
 
         self.column = self.json_field_name  # type: ignore
-        # parent links of a child model are wired after its own fields are
-        # contributed, so the JSON column owner is resolved once the class is ready
-        class_prepared.connect(
-            self._bind_json_column_model,  # ty: ignore[unresolved-attribute]
-            sender=cls,
-            weak=False,
-        )
 
-    def _bind_json_column_model(self, sender, **kwargs):
+    def bind_json_column_model(self, sender: type[Model]) -> None:
         """Point ``model`` at the model whose table holds the JSON column.
 
         Django copies private fields into every multi-table child, and the ORM
         picks the table to join from ``field.model``. Left at the child, a
         lookup on ``Movie.orig_title`` reads ``catalog_movie.metadata``, but the
-        column only exists on ``catalog_item``.
+        column only exists on ``catalog_item``. Rebind only when the concrete
+        table differs, the same test ``Query.names_to_path`` makes; proxies
+        share the table and keep ``model``. Runs from ``class_prepared``
+        because child-declared fields are contributed before parent links.
         """
-        class_prepared.disconnect(self._bind_json_column_model, sender=sender)
         json_field = sender._meta.get_field(self.json_field_name)
         if json_field.model._meta.concrete_model is not sender._meta.concrete_model:
             self.model = json_field.model
@@ -247,6 +236,19 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
         if self.has_default() and "initial" not in kwargs:
             kwargs["initial"] = self.default
         return super().formfield(**kwargs)  # type: ignore
+
+
+def _load_attached_field(
+    app_label: str, model_name: str, field_name: str
+) -> "fields.Field":
+    return apps.get_model(app_label, model_name)._meta.get_field(field_name)
+
+
+@receiver(class_prepared)
+def _bind_json_column_models(sender: type[Model], **kwargs: Any) -> None:
+    for field in sender._meta.private_fields:
+        if isinstance(field, JSONFieldMixin):
+            field.bind_json_column_model(sender)
 
 
 class BooleanField(JSONFieldMixin[bool | None, bool | None], fields.BooleanField):  # ty: ignore[invalid-method-override]
@@ -401,8 +403,17 @@ class ArrayField(JSONFieldMixin[list[Any] | None, list[Any]], DJANGO_ArrayField)
         return []
 
 
-class JSONField(JSONFieldMixin[Any, Any], Patched_DJANGO_JSONField):
-    pass
+class JSONField(JSONFieldMixin[Any, Any], DJANGO_JSONField):
+    def formfield(self, **kwargs: Any):
+        # render against the attached class, not the JSON column owner
+        model = self.attached_model or self.model
+        kwargs.setdefault("form_class", DJANGO_JSONFormField)
+        kwargs.setdefault(
+            "schema", getattr(model, self.attname + "_schema", self.schema)
+        )
+        kwargs.setdefault("model_name", model.__name__)
+        kwargs.setdefault("file_handler", self.file_handler)
+        return super().formfield(**kwargs)
 
 
 class DurationField(JSONFieldMixin[Any, Any], fields.DurationField):

--- a/neodb/common/models/jsondata.py
+++ b/neodb/common/models/jsondata.py
@@ -138,6 +138,10 @@ class JSONFieldMixin(_TypedDescriptor[_ST, _GT]):
     """
     Override django.db.model.fields.Field.contribute_to_class
     to make a field always private, and register custom access descriptor
+
+    Only filter lookups are rewritten to a JSON key expression. values(),
+    order_by() and update() use the raw column and act on the whole JSON
+    object; read and write these fields through the model instance instead.
     """
 
     def __init__(self, *args, **kwargs):

--- a/neodb/tests/core/test_jsondata_fields.py
+++ b/neodb/tests/core/test_jsondata_fields.py
@@ -1,3 +1,4 @@
+import pickle
 from datetime import date, datetime, time
 from datetime import timezone as dt_tz
 
@@ -207,6 +208,13 @@ class TestChildModelFieldBinding:
         formfield = field.formfield()
         assert formfield is not None
         assert getattr(formfield.widget, "model_name") == "Movie"
+
+    def test_pickle_reloads_attached_copy(self):
+        for name in ("orig_title", "localized_title"):
+            field = Movie._meta.get_field(name)
+            assert pickle.loads(pickle.dumps(field)) is field
+        query = Movie.objects.values("orig_title").query
+        assert str(pickle.loads(pickle.dumps(query))) == str(query)
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Follow-up to #1831 from a code-review pass over that change.

## Changes

- **Pickling.** #1831 points `field.model` of a `jsondata` virtual field on a multi-table child at the parent that owns the JSON column. `Field.__reduce__` reloads a field by `field.model`, so a child-declared field such as `Movie.orig_title`, and any `Query` projecting it, failed to unpickle with `FieldDoesNotExist`. `JSONFieldMixin.__reduce__` now reloads through the attached class. Regression test added.
- **One `class_prepared` receiver.** The per-field `connect(weak=False)` plus self-disconnect is replaced by a single module-level receiver that walks `sender._meta.private_fields`. This drops the strong references and the receivers that could never fire for abstract senders. A test asserts no per-field receivers linger.
- **Form-field override folded into `JSONField`.** `Patched_DJANGO_JSONField` is removed; `JSONField.formfield` renders against the attached class as before. Type hints added, repeated comments trimmed.

## Verification

- `tests/core/test_jsondata_fields.py`: 39 passed in the worktree Docker cluster, on top of current `main`.
- With `main`'s `jsondata.py` swapped in, the five DB tests fail with `UndefinedColumn: catalog_movie.metadata`, so the regression tests stay meaningful.
- On the pre-rebase branch: `tests/catalog` 785 passed; `tests/core tests/journal tests/mastodon tests/users tests/social` 1581 passed, 3 failed (the known `tests/mastodon/test_lexicons.py` cases that need `/docs` mounted).
- `uv run pre-commit run -a` (ruff, ruff-format, ty) passes.

## Known, pre-existing, not changed here

`values()` / `values_list()` / `order_by()` on a virtual field return or sort by the whole `metadata` jsonb, and `QuerySet.update(<virtual field>=...)` writes the whole `metadata` column. This was already the behaviour on base `Item`; since #1831 subclasses behave like `Item` instead of raising. No caller in the repo does either. A `get_col` returning a `KeyTransform` would be the proper fix and is out of scope.
