### PR TITLE
feat(catalog): let staff undo a catalog item delete

### DIFF
--- a/neodb/catalog/templates/_sidebar_edit.html
+++ b/neodb/catalog/templates/_sidebar_edit.html
@@ -278,6 +278,17 @@
           </form>
         </details>
       {% endif %}
+      {% if item.is_deleted and request.user.is_staff %}
+        <details>
+          <summary>{% trans 'Undo delete' %}</summary>
+          <form method="post"
+                action="{% url 'catalog:undelete' item.url_path item.uuid %}">
+            {% csrf_token %}
+            <input class="contrast" type="submit" value="{% trans 'Undo delete' %}">
+            <small>{% trans "Links to external sites and parent item were removed on delete and will not be restored." %}</small>
+          </form>
+        </details>
+      {% endif %}
     {% endif %}
     {% if item.class_name == 'edition' %}
       {% with item.get_work as work %}

--- a/neodb/catalog/urls.py
+++ b/neodb/catalog/urls.py
@@ -118,6 +118,13 @@ urlpatterns = [
     re_path(
         r"^(?P<item_path>"
         + _get_all_url_paths()
+        + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/undelete$",
+        undelete,
+        name="undelete",
+    ),
+    re_path(
+        r"^(?P<item_path>"
+        + _get_all_url_paths()
         + r")/(?P<item_uuid>[A-Za-z0-9]{21,22})/assign_parent$",
         assign_parent,
         name="assign_parent",

--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -247,9 +247,17 @@ def undelete(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     if not request.user.is_staff:
         raise PermissionDenied(_("Insufficient permission"))
+    if not item.is_deleted:
+        raise BadRequest(_("Item is not deleted"))
     item.is_deleted = False
     item.save()
     record_catalog_edit("update", item.class_name, "undelete")
+    discord_send(
+        "audit",
+        f"{item.absolute_url}\nby [@{request.user.username}]({request.user.absolute_url})",
+        thread_name=f"[undelete] {item.display_title}",
+        username=f"@{request.user.username}",
+    )
     return redirect(item.url)
 
 

--- a/neodb/locale/django.pot
+++ b/neodb/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-02 23:03-0400\n"
+"POT-Creation-Date: 2026-09-04 11:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,44 +18,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: boofilsic/settings.py:506 common/models/lang.py:230
+#: boofilsic/settings.py:491 common/models/lang.py:230
 msgid "English"
 msgstr ""
 
-#: boofilsic/settings.py:507 common/models/lang.py:77
+#: boofilsic/settings.py:492 common/models/lang.py:77
 msgid "Danish"
 msgstr ""
 
-#: boofilsic/settings.py:508 common/models/lang.py:78
+#: boofilsic/settings.py:493 common/models/lang.py:78
 msgid "German"
 msgstr ""
 
-#: boofilsic/settings.py:509 common/models/lang.py:183
+#: boofilsic/settings.py:494 common/models/lang.py:183
 msgid "Spanish"
 msgstr ""
 
-#: boofilsic/settings.py:510 common/models/lang.py:87
+#: boofilsic/settings.py:495 common/models/lang.py:87
 msgid "French"
 msgstr ""
 
-#: boofilsic/settings.py:511 common/models/lang.py:112
+#: boofilsic/settings.py:496 common/models/lang.py:112
 msgid "Italian"
 msgstr ""
 
-#: boofilsic/settings.py:512 common/models/lang.py:166
+#: boofilsic/settings.py:497 common/models/lang.py:166
 #: common/models/lang.py:305
 msgid "Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:513
+#: boofilsic/settings.py:498
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: boofilsic/settings.py:514 common/models/lang.py:316
+#: boofilsic/settings.py:499 common/models/lang.py:316
 msgid "Simplified Chinese"
 msgstr ""
 
-#: boofilsic/settings.py:515 common/models/lang.py:317
+#: boofilsic/settings.py:500 common/models/lang.py:317
 msgid "Traditional Chinese"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgstr ""
 msgid "Edition"
 msgstr ""
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:299
 msgid "Work"
 msgstr ""
 
@@ -1264,13 +1264,13 @@ msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
 #: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
+#: catalog/views/edit.py:218 catalog/views/edit.py:269
+#: catalog/views/edit.py:338 catalog/views/edit.py:342
+#: catalog/views/edit.py:361 catalog/views/edit.py:410
+#: catalog/views/edit.py:435 catalog/views/edit.py:450
+#: catalog/views/edit.py:490 catalog/views/edit.py:500
+#: catalog/views/edit.py:527 catalog/views/edit.py:592
+#: catalog/views/edit.py:647 catalog/views/edit.py:669
 #: catalog/views/search.py:367
 msgid "Editing this item is restricted."
 msgstr ""
@@ -1433,7 +1433,7 @@ msgid "URL of target item, or empty if undo merge"
 msgstr ""
 
 #: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:361
 msgid "merge to another item"
 msgstr ""
 
@@ -1449,73 +1449,82 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:283
+#: catalog/templates/_sidebar_edit.html:289
+msgid "Undo delete"
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:290
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr ""
+
+#: catalog/templates/_sidebar_edit.html:300
 msgid "This edition belongs to the following work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:292
+#: catalog/templates/_sidebar_edit.html:305
 msgid "Sure to unlink?"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:311
 msgid "Unlink from work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:328
 msgid "Link to another edition from same work"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:337
 msgid "Restriction"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:350
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:355
 msgid "Suggest Edits"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:360
 msgid "proposed action"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:362
 msgid "link to another item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:363
 msgid "change item category"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:364
 msgid "change item metadata"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:365
 msgid "remove item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:366
 msgid "other"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:357
+#: catalog/templates/_sidebar_edit.html:370
 msgid "To suggest merging or association, please include the URL of the target item"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:371
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr ""
 
-#: catalog/templates/_sidebar_edit.html:359
+#: catalog/templates/_sidebar_edit.html:372
 msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr ""
 
@@ -2171,7 +2180,7 @@ msgid "Editions"
 msgstr ""
 
 #: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
+#: catalog/views/edit.py:316 catalog/views/edit.py:319
 #: catalog/views/verify.py:197 journal/views/collection.py:78
 #: journal/views/collection.py:103 journal/views/collection.py:557
 #: journal/views/collection.py:653 journal/views/common.py:228
@@ -2184,17 +2193,17 @@ msgstr ""
 msgid "Invalid parameter"
 msgstr ""
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:222
 msgid "Item in use."
 msgstr ""
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:224
 msgid "Item cannot be deleted."
 msgstr ""
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:249 catalog/views/edit.py:313
+#: catalog/views/edit.py:437 catalog/views/edit.py:529
+#: catalog/views/edit.py:562 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:249 journal/views/collection.py:342
@@ -2212,43 +2221,47 @@ msgstr ""
 msgid "Insufficient permission"
 msgstr ""
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:251
+msgid "Item is not deleted"
+msgstr ""
+
+#: catalog/views/edit.py:384
 msgid "TV Season with IMDB id and season number required."
 msgstr ""
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:390
 msgid "Updating episodes"
 msgstr ""
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:415
 msgid "This person has no supported source to fetch works from."
 msgstr ""
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:422
 msgid "Already pulling works for this person, try again later."
 msgstr ""
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:426
 msgid "Pulling works in background."
 msgstr ""
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:448
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:453
 msgid "Cannot merge items in different categories"
 msgstr ""
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:457
 msgid "Cannot merge an item to itself"
 msgstr ""
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:498
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr ""
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:502
 msgid "Cannot link items other than editions"
 msgstr ""
 
@@ -4909,7 +4922,7 @@ msgid "Rating"
 msgstr ""
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:145
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:501
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:502
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr ""
@@ -4919,26 +4932,26 @@ msgstr ""
 msgid "{username}'s podcast subscriptions"
 msgstr ""
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:129
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:130
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:139
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:140
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:185
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:186
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr ""
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:390
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:391
 msgid "Matched file missing; cannot import."
 msgstr ""
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:413
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:414
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr ""
@@ -5732,7 +5745,7 @@ msgstr ""
 msgid "Boost this post?"
 msgstr ""
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:706
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:704
 msgid "Boost"
 msgstr ""
 
@@ -6360,18 +6373,18 @@ msgstr ""
 msgid "Bluesky"
 msgstr ""
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:61
 msgid ""
 "\n"
 "\n"
 "If you did not mean to register or login, please ignore this email. If you are concerned with your account security, please change the email linked with your account, or contact us."
 msgstr ""
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:66 mastodon/models/email.py:71
 msgid "Verification Code"
 msgstr ""
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:68
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6379,7 +6392,7 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:72
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6387,14 +6400,14 @@ msgid ""
 "{code}"
 msgstr ""
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:76 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr ""
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:78
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
@@ -6404,43 +6417,43 @@ msgid ""
 "If you prefer to register a new account with this email, please use this verification code: {code}"
 msgstr ""
 
-#: mastodon/models/mastodon.py:570
+#: mastodon/models/mastodon.py:568
 msgid "site domain name"
 msgstr ""
 
-#: mastodon/models/mastodon.py:571
+#: mastodon/models/mastodon.py:569
 msgid "domain for api call"
 msgstr ""
 
-#: mastodon/models/mastodon.py:572
+#: mastodon/models/mastodon.py:570
 msgid "type and verion"
 msgstr ""
 
-#: mastodon/models/mastodon.py:573
+#: mastodon/models/mastodon.py:571
 msgid "in-site app id"
 msgstr ""
 
-#: mastodon/models/mastodon.py:574
+#: mastodon/models/mastodon.py:572
 msgid "client id"
 msgstr ""
 
-#: mastodon/models/mastodon.py:575
+#: mastodon/models/mastodon.py:573
 msgid "client secret"
 msgstr ""
 
-#: mastodon/models/mastodon.py:576
+#: mastodon/models/mastodon.py:574
 msgid "vapid key"
 msgstr ""
 
-#: mastodon/models/mastodon.py:578
+#: mastodon/models/mastodon.py:576
 msgid "0: unicode moon; 1: custom emoji"
 msgstr ""
 
-#: mastodon/models/mastodon.py:581
+#: mastodon/models/mastodon.py:579
 msgid "max toot len"
 msgstr ""
 
-#: mastodon/models/mastodon.py:707
+#: mastodon/models/mastodon.py:705
 msgid "New Post"
 msgstr ""
 
@@ -6450,7 +6463,7 @@ msgstr ""
 
 #: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
 #: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: users/templates/users/login.html:6 users/views/webauthn.py:134
 msgid "Security check failed. Please try again."
 msgstr ""
 
@@ -6929,7 +6942,7 @@ msgstr ""
 msgid "A user with that username already exists."
 msgstr ""
 
-#: users/models/user.py:394
+#: users/models/user.py:392
 msgid "This username is already taken."
 msgstr ""
 
@@ -7238,7 +7251,7 @@ msgid "Name this passkey:"
 msgstr ""
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:107
 msgid "Passkey"
 msgstr ""
 
@@ -8591,31 +8604,31 @@ msgstr ""
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr ""
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:104
 msgid "Passkey registration failed"
 msgstr ""
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:124
 msgid "Credential already registered"
 msgstr ""
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:166 users/views/webauthn.py:173
+#: users/views/webauthn.py:182
 msgid "Passkey not recognized"
 msgstr ""
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:187
 msgid "Account is inactive"
 msgstr ""
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:203
 msgid "Passkey verification failed"
 msgstr ""
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:229 users/views/webauthn.py:251
 msgid "Passkey not found"
 msgstr ""
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:245
 msgid "Name is required"
 msgstr ""

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-02 23:03-0400\n"
+"POT-Creation-Date: 2026-09-04 11:50-0400\n"
 "PO-Revision-Date: 2026-08-08 21:19+0000\n"
 "Last-Translator: reducedradius <137701630+flytothehighest@users.noreply.github.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/projects/neodb/neodb/zh_Hans/>\n"
@@ -17,44 +17,44 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: boofilsic/settings.py:506 common/models/lang.py:230
+#: boofilsic/settings.py:491 common/models/lang.py:230
 msgid "English"
 msgstr "英语"
 
-#: boofilsic/settings.py:507 common/models/lang.py:77
+#: boofilsic/settings.py:492 common/models/lang.py:77
 msgid "Danish"
 msgstr "丹麦语"
 
-#: boofilsic/settings.py:508 common/models/lang.py:78
+#: boofilsic/settings.py:493 common/models/lang.py:78
 msgid "German"
 msgstr "德语"
 
-#: boofilsic/settings.py:509 common/models/lang.py:183
+#: boofilsic/settings.py:494 common/models/lang.py:183
 msgid "Spanish"
 msgstr "西班牙语"
 
-#: boofilsic/settings.py:510 common/models/lang.py:87
+#: boofilsic/settings.py:495 common/models/lang.py:87
 msgid "French"
 msgstr "法语"
 
-#: boofilsic/settings.py:511 common/models/lang.py:112
+#: boofilsic/settings.py:496 common/models/lang.py:112
 msgid "Italian"
 msgstr "意大利语"
 
-#: boofilsic/settings.py:512 common/models/lang.py:166
+#: boofilsic/settings.py:497 common/models/lang.py:166
 #: common/models/lang.py:305
 msgid "Portuguese"
 msgstr "葡萄牙语"
 
-#: boofilsic/settings.py:513
+#: boofilsic/settings.py:498
 msgid "Brazilian Portuguese"
 msgstr "巴西葡萄牙语"
 
-#: boofilsic/settings.py:514 common/models/lang.py:316
+#: boofilsic/settings.py:499 common/models/lang.py:316
 msgid "Simplified Chinese"
 msgstr "简体中文"
 
-#: boofilsic/settings.py:515 common/models/lang.py:317
+#: boofilsic/settings.py:500 common/models/lang.py:317
 msgid "Traditional Chinese"
 msgstr "繁体中文"
 
@@ -496,7 +496,7 @@ msgstr "MyAnimeList漫画"
 msgid "Edition"
 msgstr "版本"
 
-#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:286
+#: catalog/models/common.py:157 catalog/templates/_sidebar_edit.html:299
 msgid "Work"
 msgstr "作品"
 
@@ -1263,13 +1263,13 @@ msgstr "编辑选项"
 
 #: catalog/templates/_sidebar_edit.html:28 catalog/templates/item_base.html:178
 #: catalog/views/edit.py:82 catalog/views/edit.py:143 catalog/views/edit.py:197
-#: catalog/views/edit.py:218 catalog/views/edit.py:259
-#: catalog/views/edit.py:328 catalog/views/edit.py:332
-#: catalog/views/edit.py:351 catalog/views/edit.py:400
-#: catalog/views/edit.py:425 catalog/views/edit.py:440
-#: catalog/views/edit.py:480 catalog/views/edit.py:490
-#: catalog/views/edit.py:517 catalog/views/edit.py:582
-#: catalog/views/edit.py:637 catalog/views/edit.py:659
+#: catalog/views/edit.py:218 catalog/views/edit.py:269
+#: catalog/views/edit.py:338 catalog/views/edit.py:342
+#: catalog/views/edit.py:361 catalog/views/edit.py:410
+#: catalog/views/edit.py:435 catalog/views/edit.py:450
+#: catalog/views/edit.py:490 catalog/views/edit.py:500
+#: catalog/views/edit.py:527 catalog/views/edit.py:592
+#: catalog/views/edit.py:647 catalog/views/edit.py:669
 #: catalog/views/search.py:367
 msgid "Editing this item is restricted."
 msgstr "这个条目仅管理员可编辑。"
@@ -1432,7 +1432,7 @@ msgid "URL of target item, or empty if undo merge"
 msgstr "目标条目URL，留空则取消现有合并"
 
 #: catalog/templates/_sidebar_edit.html:268
-#: catalog/templates/_sidebar_edit.html:348
+#: catalog/templates/_sidebar_edit.html:361
 msgid "merge to another item"
 msgstr "合并到另一条目"
 
@@ -1448,73 +1448,82 @@ msgstr "合并到另一条目"
 msgid "Delete"
 msgstr "删除"
 
-#: catalog/templates/_sidebar_edit.html:287
+#: catalog/templates/_sidebar_edit.html:283
+#: catalog/templates/_sidebar_edit.html:289
+msgid "Undo delete"
+msgstr "撤销删除"
+
+#: catalog/templates/_sidebar_edit.html:290
+msgid "Links to external sites and parent item were removed on delete and will not be restored."
+msgstr "删除时已移除的外部站点链接和父条目不会被恢复。"
+
+#: catalog/templates/_sidebar_edit.html:300
 msgid "This edition belongs to the following work"
 msgstr "这个图书版本属于以下作品"
 
-#: catalog/templates/_sidebar_edit.html:292
+#: catalog/templates/_sidebar_edit.html:305
 msgid "Sure to unlink?"
 msgstr "确认取消关联吗？"
 
-#: catalog/templates/_sidebar_edit.html:298
+#: catalog/templates/_sidebar_edit.html:311
 msgid "Unlink from work"
 msgstr "取消关联到上述著作"
 
-#: catalog/templates/_sidebar_edit.html:304
+#: catalog/templates/_sidebar_edit.html:317
 msgid "Link"
 msgstr "关联"
 
-#: catalog/templates/_sidebar_edit.html:315
+#: catalog/templates/_sidebar_edit.html:328
 msgid "Link to another edition from same work"
 msgstr "关联到同一著作的另一本书"
 
-#: catalog/templates/_sidebar_edit.html:324
+#: catalog/templates/_sidebar_edit.html:337
 msgid "Restriction"
 msgstr "限制"
 
-#: catalog/templates/_sidebar_edit.html:337
+#: catalog/templates/_sidebar_edit.html:350
 #: journal/templates/collection_update_item_note.html:4
 msgid "Update"
 msgstr "更新"
 
-#: catalog/templates/_sidebar_edit.html:342
+#: catalog/templates/_sidebar_edit.html:355
 msgid "Suggest Edits"
 msgstr "修改建议"
 
-#: catalog/templates/_sidebar_edit.html:347
+#: catalog/templates/_sidebar_edit.html:360
 msgid "proposed action"
 msgstr "请选择建议类型..."
 
-#: catalog/templates/_sidebar_edit.html:349
+#: catalog/templates/_sidebar_edit.html:362
 msgid "link to another item"
 msgstr "关联到另一条目"
 
-#: catalog/templates/_sidebar_edit.html:350
+#: catalog/templates/_sidebar_edit.html:363
 msgid "change item category"
 msgstr "更改条目类型"
 
-#: catalog/templates/_sidebar_edit.html:351
+#: catalog/templates/_sidebar_edit.html:364
 msgid "change item metadata"
 msgstr "更正条目信息"
 
-#: catalog/templates/_sidebar_edit.html:352
+#: catalog/templates/_sidebar_edit.html:365
 msgid "remove item"
 msgstr "删除条目"
 
-#: catalog/templates/_sidebar_edit.html:353
+#: catalog/templates/_sidebar_edit.html:366
 msgid "other"
 msgstr "其它"
 
-#: catalog/templates/_sidebar_edit.html:357
+#: catalog/templates/_sidebar_edit.html:370
 msgid "To suggest merging or association, please include the URL of the target item"
 msgstr "建议详情。如提议合并或关联，请包含目标条目网址"
 
-#: catalog/templates/_sidebar_edit.html:358
+#: catalog/templates/_sidebar_edit.html:371
 #: catalog/templates/catalog_verify.html:116
 msgid "submit"
 msgstr "提交"
 
-#: catalog/templates/_sidebar_edit.html:359
+#: catalog/templates/_sidebar_edit.html:372
 msgid "As a user of this community, you may edit some metadata of items on this site. If you are unsure whether your edits are appropriate or are unable to make a certain change, you can make suggestions here. Moderators will consider each suggestion, although there is no guarantee that they will always be fully adopted; suggestions may also be viewed or discussed by other community users. If you have suggestions that are not related to a specific item, please contact us. Thank you for your support and contribution."
 msgstr "本站由用户共同维护，用户可自主修改部分条目信息。当你不确定自己的修改是否得当或不能做出某种修改时，可在此处向管理员提出建议。管理员会认真考虑处理每一条建议，虽然不保证总是完全采纳；建议也可能被社区其他用户查看或讨论。如果有与具体条目不相关的建议，请访问讨论区或联系我们的社交账号。感谢你的支持和贡献。"
 
@@ -2170,7 +2179,7 @@ msgid "Editions"
 msgstr "版本"
 
 #: catalog/views/edit.py:202 catalog/views/edit.py:205
-#: catalog/views/edit.py:306 catalog/views/edit.py:309
+#: catalog/views/edit.py:316 catalog/views/edit.py:319
 #: catalog/views/verify.py:197 journal/views/collection.py:78
 #: journal/views/collection.py:103 journal/views/collection.py:557
 #: journal/views/collection.py:653 journal/views/common.py:228
@@ -2183,17 +2192,17 @@ msgstr "版本"
 msgid "Invalid parameter"
 msgstr "无效参数"
 
-#: catalog/views/edit.py:220
+#: catalog/views/edit.py:222
 msgid "Item in use."
 msgstr "条目已被引用或标记。"
 
-#: catalog/views/edit.py:222
+#: catalog/views/edit.py:224
 msgid "Item cannot be deleted."
 msgstr "条目不可被删除。"
 
-#: catalog/views/edit.py:247 catalog/views/edit.py:303
-#: catalog/views/edit.py:427 catalog/views/edit.py:519
-#: catalog/views/edit.py:552 catalog/views/verify.py:158
+#: catalog/views/edit.py:249 catalog/views/edit.py:313
+#: catalog/views/edit.py:437 catalog/views/edit.py:529
+#: catalog/views/edit.py:562 catalog/views/verify.py:158
 #: catalog/views/verify.py:206 journal/views/article.py:44
 #: journal/views/article.py:133 journal/views/article.py:153
 #: journal/views/collection.py:249 journal/views/collection.py:342
@@ -2211,43 +2220,47 @@ msgstr "条目不可被删除。"
 msgid "Insufficient permission"
 msgstr "权限不足"
 
-#: catalog/views/edit.py:374
+#: catalog/views/edit.py:251
+msgid "Item is not deleted"
+msgstr "条目未被删除"
+
+#: catalog/views/edit.py:384
 msgid "TV Season with IMDB id and season number required."
 msgstr "必须是电视剧分季，且包含IMDB id和分季序号。"
 
-#: catalog/views/edit.py:380
+#: catalog/views/edit.py:390
 msgid "Updating episodes"
 msgstr "正在更新单集列表"
 
-#: catalog/views/edit.py:405
+#: catalog/views/edit.py:415
 msgid "This person has no supported source to fetch works from."
 msgstr "此人没有可供获取作品的数据源。"
 
-#: catalog/views/edit.py:412
+#: catalog/views/edit.py:422
 msgid "Already pulling works for this person, try again later."
 msgstr "已在获取此人的作品，请稍后再试。"
 
-#: catalog/views/edit.py:416
+#: catalog/views/edit.py:426
 msgid "Pulling works in background."
 msgstr "正在后台获取作品。"
 
-#: catalog/views/edit.py:438
+#: catalog/views/edit.py:448
 msgid "Cannot be merged to an item already deleted or merged"
 msgstr "无法合并到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:443
+#: catalog/views/edit.py:453
 msgid "Cannot merge items in different categories"
 msgstr "无法合并不同类型的条目"
 
-#: catalog/views/edit.py:447
+#: catalog/views/edit.py:457
 msgid "Cannot merge an item to itself"
 msgstr "无法合并条目和它自己"
 
-#: catalog/views/edit.py:488
+#: catalog/views/edit.py:498
 msgid "Cannot be linked to an item already deleted or merged"
 msgstr "无法关联到一个已经被合并或删除的条目"
 
-#: catalog/views/edit.py:492
+#: catalog/views/edit.py:502
 msgid "Cannot link items other than editions"
 msgstr "无法关联到非图书类的条目"
 
@@ -4929,7 +4942,7 @@ msgid "Rating"
 msgstr "评分"
 
 #: journal/importers/goodreads.py:196 journal/importers/letterboxd.py:145
-#: journal/importers/rym.py:442 journal/importers/storygraph.py:501
+#: journal/importers/rym.py:442 journal/importers/storygraph.py:502
 #, python-brace-format
 msgid "a review of {item_title}"
 msgstr "关于 {item_title} 的评论"
@@ -4939,26 +4952,26 @@ msgstr "关于 {item_title} 的评论"
 msgid "{username}'s podcast subscriptions"
 msgstr "{username} 的播客订阅"
 
-#: journal/importers/rym.py:168 journal/importers/storygraph.py:129
+#: journal/importers/rym.py:168 journal/importers/storygraph.py:130
 #, python-brace-format
 msgid "Matching: {done}/{total} — {local} local, {ext} external, {none} unmatched"
 msgstr "匹配中：{done}/{total} — 本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:178 journal/importers/storygraph.py:139
+#: journal/importers/rym.py:178 journal/importers/storygraph.py:140
 #, python-brace-format
 msgid "Importing: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入中：已导入 {imported}，跳过 {skipped}，失败 {failed}"
 
-#: journal/importers/rym.py:233 journal/importers/storygraph.py:185
+#: journal/importers/rym.py:233 journal/importers/storygraph.py:186
 #, python-brace-format
 msgid "Matching complete: {local} local, {ext} external, {none} unmatched"
 msgstr "匹配完成：本地 {local}，外部 {ext}，未匹配 {none}"
 
-#: journal/importers/rym.py:348 journal/importers/storygraph.py:390
+#: journal/importers/rym.py:348 journal/importers/storygraph.py:391
 msgid "Matched file missing; cannot import."
 msgstr "匹配文件丢失，无法导入。"
 
-#: journal/importers/rym.py:376 journal/importers/storygraph.py:413
+#: journal/importers/rym.py:376 journal/importers/storygraph.py:414
 #, python-brace-format
 msgid "Import complete: {imported} imported, {skipped} skipped, {failed} failed"
 msgstr "导入完成：已导入 {imported}，跳过 {skipped}，失败 {failed}"
@@ -5744,7 +5757,7 @@ msgstr "全部分类"
 msgid "Boost this post?"
 msgstr "转播这则帖文吗？"
 
-#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:706
+#: journal/templates/action_boost_post.html:10 mastodon/models/mastodon.py:704
 msgid "Boost"
 msgstr "转播"
 
@@ -6417,7 +6430,7 @@ msgstr "Threads"
 msgid "Bluesky"
 msgstr "Bluesky"
 
-#: mastodon/models/email.py:59
+#: mastodon/models/email.py:61
 msgid ""
 "\n"
 "\n"
@@ -6427,11 +6440,11 @@ msgstr ""
 "\n"
 "如果你没有打算用此电子邮件地址注册或登录本站，请忽略此邮件；如果你确信账号存在安全风险，请更改注册邮件地址或与我们联系。"
 
-#: mastodon/models/email.py:64 mastodon/models/email.py:69
+#: mastodon/models/email.py:66 mastodon/models/email.py:71
 msgid "Verification Code"
 msgstr "验证码"
 
-#: mastodon/models/email.py:66
+#: mastodon/models/email.py:68
 #, python-brace-format
 msgid ""
 "Use this code to verify your email address {email}\n"
@@ -6443,7 +6456,7 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:70
+#: mastodon/models/email.py:72
 #, python-brace-format
 msgid ""
 "Use this code to login as {email}\n"
@@ -6455,14 +6468,14 @@ msgstr ""
 "\n"
 "{code}"
 
-#: mastodon/models/email.py:74 users/templates/users/captcha.html:13
+#: mastodon/models/email.py:76 users/templates/users/captcha.html:13
 #: users/templates/users/captcha_solved.html:9
 #: users/templates/users/login.html:20 users/templates/users/register.html:9
 #: users/templates/users/welcome.html:10
 msgid "Register"
 msgstr "注册"
 
-#: mastodon/models/email.py:76
+#: mastodon/models/email.py:78
 #, python-brace-format
 msgid ""
 "There is no account registered with this email address yet: {email}\n"
@@ -6478,43 +6491,43 @@ msgstr ""
 "\n"
 "如果你确认要使用电子邮件新注册账号，请输入如下验证码： {code}"
 
-#: mastodon/models/mastodon.py:570
+#: mastodon/models/mastodon.py:568
 msgid "site domain name"
 msgstr "站点域名"
 
-#: mastodon/models/mastodon.py:571
+#: mastodon/models/mastodon.py:569
 msgid "domain for api call"
 msgstr "站点API域名"
 
-#: mastodon/models/mastodon.py:572
+#: mastodon/models/mastodon.py:570
 msgid "type and verion"
 msgstr "站点类型和版本"
 
-#: mastodon/models/mastodon.py:573
+#: mastodon/models/mastodon.py:571
 msgid "in-site app id"
 msgstr "实例应用id"
 
-#: mastodon/models/mastodon.py:574
+#: mastodon/models/mastodon.py:572
 msgid "client id"
 msgstr "实例应用Client ID"
 
-#: mastodon/models/mastodon.py:575
+#: mastodon/models/mastodon.py:573
 msgid "client secret"
 msgstr "实例应用Client Secret"
 
-#: mastodon/models/mastodon.py:576
+#: mastodon/models/mastodon.py:574
 msgid "vapid key"
 msgstr "实例应用VAPID Key"
 
-#: mastodon/models/mastodon.py:578
+#: mastodon/models/mastodon.py:576
 msgid "0: unicode moon; 1: custom emoji"
 msgstr "0: 月亮表情; 1: 定制表情"
 
-#: mastodon/models/mastodon.py:581
+#: mastodon/models/mastodon.py:579
 msgid "max toot len"
 msgstr "帖文长度限制"
 
-#: mastodon/models/mastodon.py:707
+#: mastodon/models/mastodon.py:705
 msgid "New Post"
 msgstr "新帖文"
 
@@ -6524,7 +6537,7 @@ msgstr "Bluesky 登录已禁用。"
 
 #: mastodon/views/bluesky.py:28 mastodon/views/email.py:35
 #: mastodon/views/mastodon.py:36 mastodon/views/threads.py:29
-#: users/templates/users/login.html:6 users/views/webauthn.py:133
+#: users/templates/users/login.html:6 users/views/webauthn.py:134
 msgid "Security check failed. Please try again."
 msgstr "安全检查失败，请重试。"
 
@@ -7043,7 +7056,7 @@ msgstr "必填，限英文字母数字下划线，最多30个字符。"
 msgid "A user with that username already exists."
 msgstr "使用该用户名的用户已存在。"
 
-#: users/models/user.py:394
+#: users/models/user.py:392
 msgid "This username is already taken."
 msgstr "用户名已被使用"
 
@@ -7352,7 +7365,7 @@ msgid "Name this passkey:"
 msgstr "为通行密钥命名:"
 
 #: users/templates/users/account.html:227 users/templates/users/login.html:69
-#: users/templates/users/welcome.html:33 users/views/webauthn.py:106
+#: users/templates/users/welcome.html:33 users/views/webauthn.py:107
 msgid "Passkey"
 msgstr "通行密钥"
 
@@ -8710,31 +8723,31 @@ msgstr "CSV 文件中未找到有效条目。"
 msgid "Import of {count} entries received. They will be processed in the background."
 msgstr "已接收 {count} 条导入数据，将在后台处理。"
 
-#: users/views/webauthn.py:103
+#: users/views/webauthn.py:104
 msgid "Passkey registration failed"
 msgstr "通行密钥注册失败"
 
-#: users/views/webauthn.py:123
+#: users/views/webauthn.py:124
 msgid "Credential already registered"
 msgstr "凭据已注册"
 
-#: users/views/webauthn.py:165 users/views/webauthn.py:172
-#: users/views/webauthn.py:181
+#: users/views/webauthn.py:166 users/views/webauthn.py:173
+#: users/views/webauthn.py:182
 msgid "Passkey not recognized"
 msgstr "无法识别此通行密钥"
 
-#: users/views/webauthn.py:186
+#: users/views/webauthn.py:187
 msgid "Account is inactive"
 msgstr "账户未激活"
 
-#: users/views/webauthn.py:202
+#: users/views/webauthn.py:203
 msgid "Passkey verification failed"
 msgstr "通行密钥验证失败"
 
-#: users/views/webauthn.py:228 users/views/webauthn.py:250
+#: users/views/webauthn.py:229 users/views/webauthn.py:251
 msgid "Passkey not found"
 msgstr "通行密钥未找到"
 
-#: users/views/webauthn.py:244
+#: users/views/webauthn.py:245
 msgid "Name is required"
 msgstr "名称不能为空"

--- a/neodb/tests/catalog/test_item_delete.py
+++ b/neodb/tests/catalog/test_item_delete.py
@@ -67,6 +67,48 @@ class TestItemDeleteInUse:
         item.refresh_from_db()
         assert item.is_deleted
 
+    def test_staff_can_undelete(self):
+        item = _podcast()
+        item.delete()
+        client = Client()
+        _login(client, is_staff=True)
+
+        response = client.post(f"{item.url}/undelete")
+        assert response.status_code == 302
+        item.refresh_from_db()
+        assert not item.is_deleted
+
+    def test_non_staff_cannot_undelete(self):
+        item = _podcast()
+        item.delete()
+        client = Client()
+        _login(client)
+
+        response = client.post(f"{item.url}/undelete")
+        assert response.status_code == 403
+        item.refresh_from_db()
+        assert item.is_deleted
+
+    def test_undelete_rejects_live_item(self):
+        item = _podcast()
+        client = Client()
+        _login(client, is_staff=True)
+
+        response = client.post(f"{item.url}/undelete")
+        assert response.status_code == 400
+
+    def test_sidebar_offers_undelete_only_for_deleted_item(self):
+        item = _podcast()
+        client = Client()
+        _login(client, is_staff=True)
+
+        content = client.get(f"{item.url}/edit").content.decode()
+        assert f"{item.url}/undelete" not in content
+        item.delete()
+        content = client.get(f"{item.url}/edit").content.decode()
+        assert f"{item.url}/undelete" in content
+        assert f"{item.url}/delete" not in content
+
     def test_sidebar_offers_merge_but_not_delete_for_item_in_use(self):
         """Staff must not be shown a button that can only 403. Merge stays,
         since it keeps the pieces reachable."""


### PR DESCRIPTION
The `undelete` view already existed in `catalog/views/edit.py` but had no URL route and no button, so staff had no way to reverse a soft delete.

- register `/<path>/<uuid>/undelete` next to `delete`
- show a staff-only Undo delete form in the edit sidebar when the item is deleted
- reject undelete on an item that is not deleted (400)
- send the same Discord audit notice as delete
- tests for staff, non-staff, live item, and sidebar visibility; zh_Hans strings added

Restore is a flag flip. Soft delete runs `clear()`, which detaches external resources and the parent item; those links are not restored, and the sidebar says so. An item that was deleted and then merged stays merged after undelete.