### PR TITLE
perf: fix N+1 queries in AP outbox and item posts API

### DIFF
--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -1,5 +1,6 @@
 from typing import List, Literal, Union
 
+from django.db.models import Prefetch, QuerySet
 from django.http import HttpResponse
 from ninja import Field, Schema
 
@@ -14,9 +15,21 @@ from common.api import (
     resolve_item_for_read,
 )
 from journal.search import JournalIndex, JournalQueryParser
+from takahe.models import Identity
 
 TIMELINE_LINK_MAX_LIMIT = 40
 TIMELINE_LINK_DEFAULT_LIMIT = 20
+
+
+def _with_status_relations(posts: QuerySet) -> QuerySet:
+    """Load every relation Post.to_mastodon_json reads, so a page of posts costs a fixed number of queries."""
+    return posts.select_related(
+        "author", "author__domain", "application"
+    ).prefetch_related(
+        "attachments",
+        "emojis",
+        Prefetch("mentions", queryset=Identity.objects.select_related("domain")),
+    )
 
 
 class CustomEmoji(Schema):
@@ -175,12 +188,7 @@ def list_posts_for_item(
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
     result = {
-        "data": [
-            p.to_mastodon_json()
-            for p in r.posts.prefetch_related("attachments", "author").select_related(
-                "application"
-            )
-        ],
+        "data": [p.to_mastodon_json() for p in _with_status_relations(r.posts)],
         "pages": r.pages,
         "count": r.total,
     }
@@ -218,9 +226,4 @@ def timeline_link(
     query.exclude("piece_class", "Post")
     query.sort(["created:desc"])
     r = JournalIndex.instance().search(query)
-    return [
-        p.to_mastodon_json()
-        for p in r.posts.prefetch_related(
-            "attachments", "author", "mentions", "emojis"
-        ).select_related("application")
-    ]
+    return [p.to_mastodon_json() for p in _with_status_relations(r.posts)]

--- a/neodb/takahe/models.py
+++ b/neodb/takahe/models.py
@@ -1814,12 +1814,13 @@ class Post(models.Model):
         language = self.language
         if self.language == "":
             language = None
+        content = self.safe_content_remote()
         value = {
             "id": str(self.pk),
             "uri": self.object_uri,
             "created_at": format_ld_date(self.published),
             "account": self.author.to_mastodon_json(),
-            "content": self.safe_content_remote(),
+            "content": content,
             "language": language,
             "visibility": visibility_mapping[self.visibility],
             "sensitive": self.sensitive,
@@ -1859,7 +1860,7 @@ class Post(models.Model):
             "reblog": None,
             "poll": None,  # self.type_data.to_mastodon_json(self, identity) if isinstance(self.type_data, QuestionData) else None,
             "card": card.to_mastodon_json() if card else None,
-            "text": self.safe_content_remote(),
+            "text": content,
             "edited_at": format_ld_date(self.edited) if self.edited else None,
             "application": self.application.to_mastodon_status_json()
             if self.application

--- a/neodb/tests/journal/test_n_plus_one.py
+++ b/neodb/tests/journal/test_n_plus_one.py
@@ -1,5 +1,8 @@
 """Tests for N+1 query optimizations."""
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 from django.db import connection, connections
 from django.test import Client
@@ -20,6 +23,7 @@ from catalog.models import (
 from journal.models import Collection, Mark, ShelfType, Tag
 from journal.models.common import prefetch_pieces_for_posts
 from journal.models.shelf import ShelfMember
+from takahe.models import Post
 from takahe.utils import Takahe
 from users.models import User
 
@@ -1441,3 +1445,45 @@ class TestCollectionMemberParent:
         # it again. Members must not add per-member parent dereferences
         # on top of that — that's what this test guards.
         assert len(parent_queries) <= 2
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestItemPostsApiPrefetch:
+    """/api/item/{uuid}/posts/ serialises each post with to_mastodon_json,
+    which reads mentions, emojis and the author's domain; the queryset must
+    load those up front instead of once per post."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.users = [
+            User.register(email=f"ipp{i}@example.com", username=f"ippuser{i}")
+            for i in range(4)
+        ]
+        self.book = Edition.objects.create(title="Item Posts Book")
+        for i, user in enumerate(self.users):
+            Mark(user.identity, self.book).update(
+                ShelfType.COMPLETE, f"comment {i}", i + 5, [], 0
+            )
+
+    def test_item_posts_api_bounded_queries(self):
+        posts = Post.objects.filter(author_id__in=[u.identity.pk for u in self.users])
+        assert posts.count() == 4
+
+        class StubIndex:
+            def search(self, query):
+                return SimpleNamespace(posts=posts, pages=1, total=4)
+
+        with (
+            patch("journal.apis.post.JournalIndex.instance", return_value=StubIndex()),
+            CaptureQueriesContext(connections["takahe"]) as ctx,
+        ):
+            response = Client().get(f"/api/item/{self.book.uuid}/posts/")
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 4
+
+        sql = [q["sql"] for q in ctx.captured_queries]
+        # one prefetch query each, never one per post
+        for table in ('"activities_post_mentions"', '"activities_post_emojis"'):
+            assert sum(table in s for s in sql) <= 1, table
+        # the author domain rides along on the post query via select_related
+        assert [s for s in sql if 'FROM "users_domain"' in s] == []

--- a/takahe/activities/models/post.py
+++ b/takahe/activities/models/post.py
@@ -32,6 +32,7 @@ from django.conf import settings
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVector
 from django.db import models, transaction
+from django.db.models.functions import RowNumber
 from django.db.models.signals import post_delete, post_save
 from django.db.utils import IntegrityError
 from django.template import loader
@@ -1173,9 +1174,49 @@ class Post(StatorModel):
 
     ### ActivityPub (outbound) ###
 
-    def to_ap(self) -> dict:
+    REPLIES_COLLECTION_PAGE_SIZE = 50
+
+    @classmethod
+    def public_replies_uris(cls, posts: Iterable["Post"]) -> dict[str, list[str]]:
+        """
+        Returns the first page of public reply URIs for each post, keyed by
+        the post's object_uri, in a single query. Feed the result to to_ap()
+        when serialising many posts.
+        """
+        uris = [post.object_uri for post in posts if post.object_uri]
+        result: dict[str, list[str]] = {uri: [] for uri in uris}
+        if not uris:
+            return result
+        rows = (
+            cls.objects.filter(
+                in_reply_to__in=uris,
+                visibility__in=[
+                    cls.Visibilities.public,
+                    cls.Visibilities.unlisted,
+                ],
+            )
+            .not_hidden()
+            .annotate(
+                reply_index=models.Window(
+                    RowNumber(),
+                    partition_by=models.F("in_reply_to"),
+                    order_by=models.F("published").asc(),
+                )
+            )
+            .filter(reply_index__lte=cls.REPLIES_COLLECTION_PAGE_SIZE)
+            .order_by("in_reply_to", "published")
+            .values_list("in_reply_to", "object_uri")
+        )
+        for parent_uri, reply_uri in rows:
+            result[parent_uri].append(reply_uri)
+        return result
+
+    def to_ap(self, replies_uris: list[str] | None = None) -> dict:
         """
         Returns the AP JSON for this object
+
+        replies_uris is the post's entry from public_replies_uris(); when
+        omitted it is queried here.
         """
         self.author.ensure_uris()
         value = {
@@ -1279,6 +1320,8 @@ class Post(StatorModel):
         if self.local and self.object_uri:
             replies_uri = self.object_uri + "replies/"
             replies_count = self.stats.get("replies", 0) if self.stats else 0
+            if replies_uris is None:
+                replies_uris = self.public_replies_uris([self])[self.object_uri]
             value["replies"] = {
                 "id": replies_uri,
                 "type": "Collection",
@@ -1286,18 +1329,7 @@ class Post(StatorModel):
                 "first": {
                     "type": "CollectionPage",
                     "partOf": replies_uri,
-                    "items": list(
-                        Post.objects.filter(
-                            in_reply_to=self.object_uri,
-                            visibility__in=[
-                                Post.Visibilities.public,
-                                Post.Visibilities.unlisted,
-                            ],
-                        )
-                        .not_hidden()
-                        .order_by("published")
-                        .values_list("object_uri", flat=True)[:50]
-                    ),
+                    "items": list(replies_uris),
                 },
             }
         # Remove fields if they're empty

--- a/takahe/tests/activities/models/test_post.py
+++ b/takahe/tests/activities/models/test_post.py
@@ -767,3 +767,44 @@ def test_article_cover_url_none_for_non_article():
         type_data={"object": {"image": "https://remote.test/x.jpg"}},
     )
     assert post.article_cover_url is None
+
+
+@pytest.mark.django_db
+def test_public_replies_uris(identity, other_identity, config_system, monkeypatch):
+    """
+    The batched replies lookup must match what to_ap() emits per post:
+    public and unlisted replies only, oldest first, capped per parent.
+    """
+    parents = [Post.create_local(identity, f"<p>Parent {i}</p>") for i in range(2)]
+    replies = {
+        parent.object_uri: [
+            Post.create_local(other_identity, f"<p>Reply {j}</p>", reply_to=parent)
+            for j in range(3)
+        ]
+        for parent in parents
+    }
+    Post.create_local(
+        other_identity,
+        "<p>Private</p>",
+        visibility=Post.Visibilities.followers,
+        reply_to=parents[0],
+    )
+    deleted = Post.create_local(other_identity, "<p>Deleted</p>", reply_to=parents[1])
+    deleted.transition_perform(PostStates.deleted)
+    orphan = Post.create_local(identity, "<p>No replies</p>")
+
+    result = Post.public_replies_uris(parents + [orphan])
+    assert result == {
+        parents[0].object_uri: [r.object_uri for r in replies[parents[0].object_uri]],
+        parents[1].object_uri: [r.object_uri for r in replies[parents[1].object_uri]],
+        orphan.object_uri: [],
+    }
+    for parent in parents:
+        single = Post.objects.get(pk=parent.pk).to_ap()["replies"]["first"]["items"]
+        assert single == result[parent.object_uri]
+
+    monkeypatch.setattr(Post, "REPLIES_COLLECTION_PAGE_SIZE", 2)
+    capped = Post.public_replies_uris(parents)
+    for parent in parents:
+        assert capped[parent.object_uri] == result[parent.object_uri][:2]
+    assert Post.public_replies_uris([]) == {}

--- a/takahe/tests/users/views/test_activitypub.py
+++ b/takahe/tests/users/views/test_activitypub.py
@@ -1,4 +1,7 @@
 import pytest
+from activities.models import Post
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from users.models import InboxMessage
 
@@ -166,3 +169,42 @@ def test_ignore_lemmy(client, identity):
     )
     assert num_inbox_messages == InboxMessage.objects.count()
     assert resp.status_code == 202
+
+
+@pytest.mark.django_db
+def test_outbox_bounded_queries(client, identity, other_identity, config_system):
+    """
+    The outbox serialises many posts: relations must be prefetched and the
+    replies collections loaded in one query rather than one per post.
+    """
+    parent = Post.create_local(identity, "<p>Hello @other@example.com</p>")
+    for i in range(4):
+        Post.create_local(identity, f"<p>Post {i}</p>")
+    reply = Post.create_local(other_identity, "<p>Reply</p>", reply_to=parent)
+    Post.create_local(
+        other_identity,
+        "<p>Private reply</p>",
+        visibility=Post.Visibilities.followers,
+        reply_to=parent,
+    )
+
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(
+            "/@test@example.com/outbox/", HTTP_ACCEPT="application/ld+json"
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["totalItems"] == 5
+    by_id = {item["id"]: item for item in data["orderedItems"]}
+    # canonicalise() compacts a one-item list to a bare string
+    assert by_id[parent.object_uri]["replies"]["first"]["items"] == reply.object_uri
+    assert "https://example.com/@other@example.com/" in by_id[parent.object_uri]["cc"]
+
+    sql = [q["sql"] for q in ctx.captured_queries]
+    for fragment in (
+        '"activities_post_mentions"',
+        '"activities_post_emojis"',
+        '"activities_postattachment"',
+        '"in_reply_to" IN',
+    ):
+        assert sum(fragment in s for s in sql) <= 1, fragment

--- a/takahe/users/views/activitypub.py
+++ b/takahe/users/views/activitypub.py
@@ -569,13 +569,21 @@ class Outbox(FederatedView):
         if not self.identity.local:
             raise Http404("Not a local identity")
         # Return an ordered collection with the most recent 10 public posts
-        posts = list(self.identity.posts.not_hidden().public()[:10])
+        posts = list(
+            self.identity.posts.not_hidden()
+            .public()
+            .prefetch_related("mentions", "emojis", "attachments")[:10]
+        )
+        replies = Post.public_replies_uris(posts)
         return JsonResponse(
             canonicalise(
                 {
                     "type": "OrderedCollection",
                     "totalItems": len(posts),
-                    "orderedItems": [post.to_ap() for post in posts],
+                    "orderedItems": [
+                        post.to_ap(replies_uris=replies.get(post.object_uri, []))
+                        for post in posts
+                    ],
                 }
             ),
             content_type="application/activity+json",
@@ -597,13 +605,17 @@ class FeaturedCollection(FederatedView):
         if not self.identity.local:
             raise Http404("Not a local identity")
         posts = list(TimelineService(self.identity).identity_pinned())
+        replies = Post.public_replies_uris(posts)
         return JsonResponse(
             canonicalise(
                 {
                     "type": "OrderedCollection",
                     "id": self.identity.actor_uri + "collections/featured/",
                     "totalItems": len(posts),
-                    "orderedItems": [post.to_ap() for post in posts],
+                    "orderedItems": [
+                        post.to_ap(replies_uris=replies.get(post.object_uri, []))
+                        for post in posts
+                    ],
                 }
             ),
             content_type="application/activity+json",


### PR DESCRIPTION
Fixes Sentry NEODB-SOCIAL-7W1 and NEODB-SOCIAL-7W0, both N+1 query performance issues.

## NEODB-SOCIAL-7W1: `/@{handle}/outbox/`

`Post.to_ap()` was run on 10 posts with no prefetch. Per post it queried mentions twice (own loop plus `safe_content_remote`), emojis, attachments, and the first page of public reply URIs: 50 queries for 10 posts.

- `Outbox` prefetches `mentions`, `emojis`, `attachments`.
- New `Post.public_replies_uris(posts)` loads the first page of public and unlisted reply URIs for every post in one window query (`ROW_NUMBER() OVER (PARTITION BY in_reply_to ORDER BY published)`, capped at 50 per parent). `to_ap()` takes the prefetched list as an optional argument and falls back to querying itself when called alone, so the other callers are unchanged.
- `FeaturedCollection` uses the same batched replies (its queryset already prefetched the relations).

## NEODB-SOCIAL-7W0: `/api/item/{item_uuid}/posts/`

The queryset prefetched only `attachments` and `author`. `to_mastodon_json` read mentions three times per post, emojis once, and the author's domain once (Domain's primary key is the domain string, so `author.domain` is a query): 89 queries for 18 posts.

- Shared `_with_status_relations()` helper selects `author`, `author__domain`, `application` and prefetches `attachments`, `emojis`, and `mentions` with their domain. Used by both `list_posts_for_item` and `timeline_link`.
- Mirror `Post.to_mastodon_json` renders content once instead of twice for `content` and `text`.

## Tests

- `test_outbox_bounded_queries`: outbox with 5 posts, a mention and two replies (one private); asserts at most one query per relation table and one replies query, and that the private reply is excluded.
- `test_public_replies_uris`: batched result equals what `to_ap()` emits per post; excludes followers-only and deleted replies; respects the per-parent cap.
- `TestItemPostsApiPrefetch`: 4 marks on one item through the API; asserts one mentions and one emojis query and no standalone `users_domain` lookups.

Both endpoint tests were confirmed to fail against the previous code (10 and 8 per-post mention queries).

Verified locally: full takahe suite 530 passed; neodb `tests/journal/test_api.py`, `tests/journal/test_n_plus_one.py`, `tests/mastodon` 214 passed; pre-commit clean.
