### PR TITLE
fix(mastodon): start ATProto authorization from the re-authorize link

### DIFF
--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -29,7 +29,7 @@ from catalog.models import (
     item_content_types,
 )
 from common.sentry import count as sentry_count
-from mastodon.models.bluesky_oauth import OAuthError
+from mastodon.models.bluesky_oauth import OAuthError, OAuthRejectedError
 from takahe.utils import Takahe
 from users.middlewares import activate_language_for_user
 from users.models import APIdentity, User
@@ -786,11 +786,12 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             OAuthError,
         ) as e:
             error_message = str(e)
-            # an OAuthError here means the stored session could not be
+            # an OAuthRejectedError means the stored session could not be
             # refreshed (rotated away, revoked or expired refresh token), so
-            # only a new authorization can restore crossposting
+            # only a new authorization can restore crossposting; a plain
+            # OAuthError is a transport failure that a retry may fix
             if (
-                isinstance(e, (exceptions.UnauthorizedError, OAuthError))
+                isinstance(e, (exceptions.UnauthorizedError, OAuthRejectedError))
                 or "ExpiredToken" in error_message
             ):
                 # re-authorize if ATProto token is expired

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -29,6 +29,7 @@ from catalog.models import (
     item_content_types,
 )
 from common.sentry import count as sentry_count
+from mastodon.models.bluesky_oauth import OAuthError
 from takahe.utils import Takahe
 from users.middlewares import activate_language_for_user
 from users.models import APIdentity, User
@@ -779,9 +780,19 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             params["associated_refs"] = refs
         try:
             r = bluesky.post(**params)
-        except (exceptions.UnauthorizedError, exceptions.BadRequestError) as e:
+        except (
+            exceptions.UnauthorizedError,
+            exceptions.BadRequestError,
+            OAuthError,
+        ) as e:
             error_message = str(e)
-            if isinstance(e, exceptions.UnauthorizedError) or "ExpiredToken" in str(e):
+            # an OAuthError here means the stored session could not be
+            # refreshed (rotated away, revoked or expired refresh token), so
+            # only a new authorization can restore crossposting
+            if (
+                isinstance(e, (exceptions.UnauthorizedError, OAuthError))
+                or "ExpiredToken" in error_message
+            ):
                 # re-authorize if ATProto token is expired
                 error_type = CrosspostRetry.ErrorType.auth
                 messages.error(

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -28,6 +28,7 @@ from takahe.utils import Takahe
 from .bluesky_oauth import (
     DpopRequest,
     OAuthError,
+    OAuthRejectedError,
     fetch_authserver_metadata,
     fetch_pds_authserver,
     generate_dpop_jwk,
@@ -312,7 +313,7 @@ class BlueskyAccount(SocialAccount):
     def get_access_token(self, force_refresh: bool = False) -> str:
         session = self._get_oauth()
         if not session.get("access_token"):
-            raise OAuthError("no OAuth session for this account")
+            raise OAuthRejectedError("no OAuth session for this account")
         if (
             force_refresh
             or int(session.get("expires_at") or 0) < time.time() + _TOKEN_EXPIRY_MARGIN
@@ -349,7 +350,9 @@ class BlueskyAccount(SocialAccount):
             ):
                 return  # already refreshed by another worker
             if not session.get("refresh_token"):
-                raise OAuthError("OAuth session expired, re-authorization needed")
+                raise OAuthRejectedError(
+                    "OAuth session expired, re-authorization needed"
+                )
             tokens, nonce = refresh_token_request(
                 session["token_endpoint"],
                 session["issuer"],

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -275,9 +275,11 @@ class BlueskyAccount(SocialAccount):
     _oauth_cache: dict | None = None
 
     def get_reauthorize_url(self) -> str:
-        url = reverse("users:login") + "?method=bluesky"
+        # a GET starts the authorization flow for the logged-in owner right
+        # away; a logged-out visitor is sent on to the prefilled login form
+        url = reverse("mastodon:bluesky_login")
         if self.handle:
-            url += "&username=" + quote(self.handle)
+            url += "?username=" + quote(self.handle)
         return url
 
     def _get_oauth(self) -> dict:

--- a/neodb/mastodon/models/bluesky_oauth.py
+++ b/neodb/mastodon/models/bluesky_oauth.py
@@ -36,6 +36,12 @@ class OAuthError(Exception):
     pass
 
 
+class OAuthRejectedError(OAuthError):
+    """The authorization server refused the credentials presented to it, or
+    there are none left to present. Unlike a transport failure this never
+    recovers on a retry: the user has to authorize again."""
+
+
 def _b64url(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
 
@@ -241,7 +247,10 @@ def _authserver_post(
                 continue
         break
     if r.status_code not in (200, 201):
-        raise OAuthError(f"{url} returned {r.status_code}: {r.text[:200]}")
+        # a 4xx is the server refusing what we sent (an expired refresh token
+        # answers invalid_grant); 5xx is worth retrying with the same session
+        error = OAuthRejectedError if r.status_code < 500 else OAuthError
+        raise error(f"{url} returned {r.status_code}: {r.text[:200]}")
     return r.json(), nonce
 
 

--- a/neodb/mastodon/views/bluesky.py
+++ b/neodb/mastodon/views/bluesky.py
@@ -1,7 +1,10 @@
+from urllib.parse import urlencode
+
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpRequest, JsonResponse
 from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -10,7 +13,7 @@ from common.sentry import count as sentry_count
 from common.views import render_error
 from users.login_proof import verify_login_proof
 
-from ..models import Bluesky
+from ..models import Bluesky, BlueskyAccount
 from ..models.bluesky_oauth import get_client_metadata
 from .common import client_ip, disconnect_identity, process_verified_account
 
@@ -20,10 +23,29 @@ _MAX_AUTH_FAILS = 10
 _AUTH_FAIL_TTL = 60 * 60
 
 
-@require_http_methods(["POST"])
+@require_http_methods(["GET", "POST"])
 def bluesky_login(request: HttpRequest):
     if not request.user.is_authenticated and not SiteConfig.system.enable_login_bluesky:
         return render_error(request, _("Bluesky login is disabled."))
+    if request.method == "GET":
+        # a re-authorization link, e.g. from a failed crosspost: start the
+        # flow right away for the identity already linked to the logged-in
+        # user, or hand a logged-out visitor the prefilled login form
+        if not request.user.is_authenticated:
+            query = urlencode(
+                {"method": "bluesky", "username": request.GET.get("username", "")}
+            )
+            return redirect(f"{reverse('users:login')}?{query}")
+        # the handle comes from the linked account, never from the URL:
+        # linking another identity stays a POST from account settings
+        account = BlueskyAccount.objects.filter(user=request.user).first()
+        if not account:
+            return render_error(
+                request, _("Authentication failed"), _("Identity not found.")
+            )
+        username = account.handle
+    else:
+        username = request.POST.get("username", "")
     if not verify_login_proof(request, "bluesky"):
         return render_error(request, _("Security check failed. Please try again."))
     sentry_count("login.attempt", attributes={"type": "bluesky"})
@@ -34,7 +56,7 @@ def bluesky_login(request: HttpRequest):
             _("Authentication failed"),
             _("Too many attempts, please try again later."),
         )
-    username = request.POST.get("username", "").strip().lstrip("@")
+    username = username.strip().lstrip("@")
     if not username:
         return render_error(
             request, _("Authentication failed"), _("ATProto handle is required.")

--- a/neodb/mastodon/views/bluesky.py
+++ b/neodb/mastodon/views/bluesky.py
@@ -7,6 +7,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
+from loguru import logger
 
 from common.models import SiteConfig
 from common.sentry import count as sentry_count
@@ -64,6 +65,15 @@ def bluesky_login(request: HttpRequest):
     try:
         login_url = Bluesky.generate_auth_url(username, request)
     except Exception as e:
+        if request.method == "GET":
+            # the stored handle no longer resolves, most likely renamed while
+            # the token was dead, since sync() stops refreshing it once the
+            # account circuit opens: offer the login form so the owner can
+            # correct the handle instead of dead-ending on an error page. No
+            # fail_key either, a handle read from the database is not probing
+            logger.warning(f"ATProto reauthorization for {username} failed: {e}")
+            query = urlencode({"method": "bluesky", "username": username})
+            return redirect(f"{reverse('users:login')}?{query}")
         try:
             cache.incr(fail_key)
         except ValueError:

--- a/neodb/tests/journal/test_crosspost.py
+++ b/neodb/tests/journal/test_crosspost.py
@@ -11,7 +11,7 @@ from catalog.models import Edition
 from journal.models import Comment, CrosspostRetry, Piece, Review
 from journal.models.atproto import DOCUMENT_NSID
 from mastodon.models import BlueskyAccount, MastodonAccount, ThreadsAccount
-from mastodon.models.bluesky_oauth import OAuthError
+from mastodon.models.bluesky_oauth import OAuthError, OAuthRejectedError
 from users.jobs.cleanup import prune_crosspost_retries
 from users.models import User
 
@@ -143,17 +143,34 @@ class TestCrosspostRetryRecording:
         self, user, comment, monkeypatch
     ):
         # the usual expiry: the authorization server refuses the refresh
-        # token, which surfaces as OAuthError rather than an XRPC error
+        # token, which surfaces as an OAuth error rather than an XRPC one
         _link_bluesky(user)
 
         def fail(self, **kwargs):
-            raise OAuthError("https://auth.example/token returned 400: invalid_grant")
+            raise OAuthRejectedError(
+                "https://auth.example/token returned 400: invalid_grant"
+            )
 
         monkeypatch.setattr(BlueskyAccount, "post", fail)
         comment._sync_to_social_accounts(0)
         failure = CrosspostRetry.objects.get(piece=comment, platform="bluesky")
         assert failure.error_type == CrosspostRetry.ErrorType.auth
         assert "invalid_grant" in failure.message
+
+    def test_bluesky_token_endpoint_outage_is_not_auth(
+        self, user, comment, monkeypatch
+    ):
+        # a transport failure keeps the session valid, so it must not tell
+        # the owner their authorization expired
+        _link_bluesky(user)
+
+        def fail(self, **kwargs):
+            raise OAuthError("error requesting https://auth.example/token: timed out")
+
+        monkeypatch.setattr(BlueskyAccount, "post", fail)
+        comment._sync_to_social_accounts(0)
+        failure = CrosspostRetry.objects.get(piece=comment, platform="bluesky")
+        assert failure.error_type == CrosspostRetry.ErrorType.other
 
     def test_threads_failure_recorded(self, user, comment, monkeypatch):
         _link_threads(user)

--- a/neodb/tests/journal/test_crosspost.py
+++ b/neodb/tests/journal/test_crosspost.py
@@ -11,6 +11,7 @@ from catalog.models import Edition
 from journal.models import Comment, CrosspostRetry, Piece, Review
 from journal.models.atproto import DOCUMENT_NSID
 from mastodon.models import BlueskyAccount, MastodonAccount, ThreadsAccount
+from mastodon.models.bluesky_oauth import OAuthError
 from users.jobs.cleanup import prune_crosspost_retries
 from users.models import User
 
@@ -137,6 +138,22 @@ class TestCrosspostRetryRecording:
         comment._sync_to_social_accounts(0)
         failure = CrosspostRetry.objects.get(piece=comment, platform="bluesky")
         assert failure.error_type == CrosspostRetry.ErrorType.auth
+
+    def test_bluesky_unrefreshable_session_recorded_as_auth(
+        self, user, comment, monkeypatch
+    ):
+        # the usual expiry: the authorization server refuses the refresh
+        # token, which surfaces as OAuthError rather than an XRPC error
+        _link_bluesky(user)
+
+        def fail(self, **kwargs):
+            raise OAuthError("https://auth.example/token returned 400: invalid_grant")
+
+        monkeypatch.setattr(BlueskyAccount, "post", fail)
+        comment._sync_to_social_accounts(0)
+        failure = CrosspostRetry.objects.get(piece=comment, platform="bluesky")
+        assert failure.error_type == CrosspostRetry.ErrorType.auth
+        assert "invalid_grant" in failure.message
 
     def test_threads_failure_recorded(self, user, comment, monkeypatch):
         _link_threads(user)

--- a/neodb/tests/mastodon/test_bluesky_oauth.py
+++ b/neodb/tests/mastodon/test_bluesky_oauth.py
@@ -27,6 +27,7 @@ from mastodon.models.bluesky_oauth import (
     public_jwk,
     sign_jwt,
 )
+from users.models import User
 
 
 def _b64url_decode(data: str) -> bytes:
@@ -523,8 +524,6 @@ def test_account_force_refresh_rotates_unexpired_token(monkeypatch):
 def test_oauth_callback_persists_tokens_even_if_refresh_fails(
     client, monkeypatch, bluesky_enabled
 ):
-    from users.models import User
-
     user = User.register(email="cb@example.com", username="cbuser")
     account = BlueskyAccount.objects.create(
         user=user, domain="-", uid="did:plc:alice", handle="alice.test"
@@ -558,3 +557,73 @@ def test_oauth_callback_persists_tokens_even_if_refresh_fails(
     stored = BlueskyAccount.objects.get(pk=account.pk)._get_oauth()
     assert stored["access_token"] == "fresh"
     assert stored["refresh_token"] == "rt-2"
+
+
+def _link_bluesky(client, monkeypatch, handle: str = "alice.test") -> list[str]:
+    """Log a client in with a linked ATProto identity and stub out the
+    authorization request; returns the handles it is called with."""
+    user = User.register(email="reauth@example.com", username="reauthuser")
+    BlueskyAccount.objects.create(
+        user=user, domain="-", uid="did:plc:alice", handle=handle
+    )
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    calls = []
+    monkeypatch.setattr(
+        Bluesky,
+        "generate_auth_url",
+        lambda handle, request: (
+            calls.append(handle) or "https://auth.example/authorize?req=1"
+        ),
+    )
+    return calls
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_reauthorize_starts_flow_for_linked_identity(client, monkeypatch):
+    # no bluesky_enabled fixture: re-authorizing an identity a user already
+    # linked does not depend on the site-wide login switch
+    calls = _link_bluesky(client, monkeypatch)
+
+    response = client.get(reverse("mastodon:bluesky_login"))
+
+    assert response.status_code == 302
+    assert response.url == "https://auth.example/authorize?req=1"
+    assert calls == ["alice.test"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_reauthorize_uses_linked_handle_not_url(client, monkeypatch):
+    calls = _link_bluesky(client, monkeypatch)
+
+    response = client.get(
+        reverse("mastodon:bluesky_login"), {"username": "mallory.test"}
+    )
+
+    assert response.status_code == 302
+    assert calls == ["alice.test"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_reauthorize_without_linked_identity_is_refused(client, monkeypatch):
+    user = User.register(email="nolink@example.com", username="nolinkuser")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    monkeypatch.setattr(
+        Bluesky, "generate_auth_url", lambda handle, request: "https://auth.example/"
+    )
+
+    response = client.get(
+        reverse("mastodon:bluesky_login"), {"username": "mallory.test"}
+    )
+
+    assert response.status_code == 200
+    assert b"Authentication failed" in response.content
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_reauthorize_sends_logged_out_visitor_to_login_form(client, bluesky_enabled):
+    response = client.get(reverse("mastodon:bluesky_login"), {"username": "alice.test"})
+
+    assert response.status_code == 302
+    assert (
+        response.url == reverse("users:login") + "?method=bluesky&username=alice.test"
+    )

--- a/neodb/tests/mastodon/test_bluesky_oauth.py
+++ b/neodb/tests/mastodon/test_bluesky_oauth.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from django.conf import settings
+from django.core.cache import cache
 from django.test import RequestFactory
 from django.urls import reverse
 
@@ -22,6 +23,7 @@ from mastodon.models.bluesky_oauth import (
     SCOPE,
     DpopRequest,
     OAuthError,
+    OAuthRejectedError,
     dpop_proof,
     generate_dpop_jwk,
     public_jwk,
@@ -135,10 +137,26 @@ def test_authserver_post_error_raises(monkeypatch):
             400, json={"error": "invalid_grant"}
         ),
     )
-    with pytest.raises(OAuthError):
+    # a refused grant is final, callers use it to ask for re-authorization
+    with pytest.raises(OAuthRejectedError):
         bluesky_oauth._authserver_post(
             "https://auth.example/token", {}, generate_dpop_jwk(), ""
         )
+
+
+def test_authserver_post_server_error_stays_retriable(monkeypatch):
+    monkeypatch.setattr(
+        bluesky_oauth.httpx,
+        "post",
+        lambda url, data=None, headers=None, timeout=None: httpx.Response(
+            503, text="upstream unavailable"
+        ),
+    )
+    with pytest.raises(OAuthError) as caught:
+        bluesky_oauth._authserver_post(
+            "https://auth.example/token", {}, generate_dpop_jwk(), ""
+        )
+    assert not isinstance(caught.value, OAuthRejectedError)
 
 
 @pytest.fixture
@@ -601,6 +619,30 @@ def test_reauthorize_uses_linked_handle_not_url(client, monkeypatch):
 
     assert response.status_code == 302
     assert calls == ["alice.test"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_reauthorize_falls_back_to_form_on_unresolvable_handle(client, monkeypatch):
+    # the handle can be renamed while the token is dead, and sync() stops
+    # refreshing it then, so the stored one must not be a dead end
+    _link_bluesky(client, monkeypatch)
+
+    def unresolvable(handle, request):
+        raise OAuthError(f"handle {handle} not found")
+
+    monkeypatch.setattr(Bluesky, "generate_auth_url", unresolvable)
+    fail_key = "bluesky_login_fails_127.0.0.1"
+    cache.delete(fail_key)
+
+    response = client.get(reverse("mastodon:bluesky_login"))
+
+    assert response.status_code == 302
+    assert (
+        response.url == reverse("users:login") + "?method=bluesky&username=alice.test"
+    )
+    # re-authorizing an identity read from the database is not probing, so
+    # the per-IP cap must not be spent on it
+    assert not cache.get(fail_key)
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/users/test_login_view.py
+++ b/neodb/tests/users/test_login_view.py
@@ -118,13 +118,13 @@ class TestLoginMethodSelection:
 
 @pytest.mark.django_db(databases="__all__")
 class TestReauthorizeUrl:
-    def test_bluesky_points_to_bluesky_login_form(self):
+    def test_bluesky_points_to_authorization_start(self):
         user = User.register(email="reauth@example.com", username="reauthuser")
         account = BlueskyAccount.objects.create(
             handle="reauth.bsky.social", user=user, domain="bsky.social", uid="1"
         )
-        assert account.get_reauthorize_url() == reverse("users:login") + (
-            "?method=bluesky&username=reauth.bsky.social"
+        assert account.get_reauthorize_url() == reverse("mastodon:bluesky_login") + (
+            "?username=reauth.bsky.social"
         )
 
     def test_mastodon_points_to_oauth_flow(self):


### PR DESCRIPTION
The "Re-authorize" link offered next to a Bluesky crosspost that failed with an expired authorization pointed at `users:login?method=bluesky&username=<handle>`, the public login page. That page only preselects the Bluesky tab and prefills the handle from JS, so the flow started only if the owner then pressed the submit button, and the tab is not rendered at all when site-wide Bluesky login is off. Mastodon does not work that way: its reauthorize URL hits `mastodon_login`, which accepts GET and redirects an authenticated visitor straight to the instance's consent screen (`verify_login_proof` returns True for authenticated users, so no proof widget is involved).

- `bluesky_login` accepts GET: an authenticated owner is redirected to their PDS authorization server, a logged-out visitor keeps landing on the prefilled login form, so reauthorize URLs persisted in older notifications still behave
- the handle comes from the linked `BlueskyAccount`, not the query string, so linking another identity stays a POST from account settings; a user with nothing linked gets "Identity not found."
- `BlueskyAccount.get_reauthorize_url()` targets `mastodon:bluesky_login`
- record an unrefreshable OAuth session as an authorization failure: a rotated, revoked or expired refresh token surfaces as `OAuthError`, not as an XRPC error, so it fell into the generic branch and was stored as a plain error with no re-authorize link and no notification
- tests for the redirect, handle-from-account, no linked identity, the logged-out bounce, and `OAuthError` classification; no new translatable strings

Re-authorizing now also works on a site where Bluesky login is disabled. The view already permitted an authenticated user there; only the login template hid the form.

After consent, `reconnect_account` lands on the account page as before, so retrying a failed crosspost still needs a visit to Pending. The notification wording ("please login NeoDB using ATProto again to re-authorize") is unchanged.
