### PR TITLE
fix(api): make the API agree with itself on shapes, codes and access

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -77,5 +77,16 @@ curl -H "Authorization: Bearer ACCESS_TOKEN" -X GET https://neodb.social/api/me
 and the response will be returned accordingly:
 
 ```
-{"url": "https://neodb.social/users/xxx/", "external_acct": "xxx@yyy.zzz", "display_name": "XYZ", "avatar": "https://yyy.zzz/xxx.gif"}
+{
+	"username": "xxx",
+	"url": "/users/xxx/",
+	"display_name": "XYZ",
+	"avatar": "https://neodb.social/xxx.gif",
+	"external_acct": "xxx@yyy.zzz",
+	"external_accounts": [{"platform": "mastodon", "handle": "xxx@yyy.zzz", "url": "https://yyy.zzz/@xxx"}],
+	"roles": []
+}
 ```
+
+`url` is relative to the site; `external_acct` is deprecated in favour of
+`external_accounts`.

--- a/neodb/catalog/apis.py
+++ b/neodb/catalog/apis.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 from urllib.parse import urlparse
 
 from django.core.cache import cache
@@ -10,7 +9,14 @@ from django.utils import timezone
 from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
-from common.api import PageNumberPagination, RedirectedResult, Result, api
+from common.api import (
+    NO_DATA,
+    OptionalOAuthAccessTokenAuth,
+    PageNumberPagination,
+    RedirectedResult,
+    Result,
+    api,
+)
 from journal.models.mark import Mark
 from journal.models.rating import Rating
 from journal.models.tag import TagManager
@@ -54,7 +60,7 @@ PAGE_SIZE = 20
 
 
 class SearchResult(Schema):
-    data: List[
+    data: list[
         EditionSchema
         | TVShowSchema
         | TVSeasonSchema
@@ -71,13 +77,13 @@ class SearchResult(Schema):
 
 
 class EpisodeList(Schema):
-    data: List[PodcastEpisodeSchema]
+    data: list[PodcastEpisodeSchema]
     pages: int
     count: int
 
 
 class PodcastList(Schema):
-    data: List[PodcastSchema]
+    data: list[PodcastSchema]
     pages: int
     count: int
 
@@ -88,7 +94,9 @@ class PeopleSummarySchema(Schema):
     url: str
     api_url: str
     people_type: str
-    display_name: str
+    # display_name is deprecated, use name instead (as in PeopleSchema)
+    display_name: str = Field(deprecated=True)
+    name: str = Field(alias="display_name")
     cover_image_url: str | None
 
 
@@ -100,7 +108,9 @@ class ItemSummarySchema(Schema):
     api_url: str
     category: str
     parent_uuid: str | None
-    display_title: str
+    # display_title is deprecated, use title instead (as in BaseSchema)
+    display_title: str = Field(deprecated=True)
+    title: str = Field(alias="display_title")
     cover_image_url: str | None
 
 
@@ -200,7 +210,7 @@ _CANONICAL_CREDIT_ITEM_TYPES: dict[type[Item], CreditItemType] = {
 
 class Gallery(Schema):
     name: str
-    items: List[ItemSchema]
+    items: list[ItemSchema]
 
 
 @api.get(
@@ -448,18 +458,25 @@ def trending_verified_podcasts(request, page: int = 1):
     )
 
 
-def _get_item(cls, uuid, response, attach_credits: bool = True):
+def _get_item(cls, uuid, response, attach_credits: bool = True, subresource: str = ""):
+    """Resolve the item a catalog read is about, redirecting merged/recast ones.
+
+    `subresource` is appended to the redirect target, so a route under an item
+    ("/sibling/", "/episode/") points at the same subresource of the item it
+    redirects to rather than at that item's detail route, which would answer
+    with a different shape than the caller asked for.
+    """
     item = Item.get_by_url(uuid)
     if not item:
         return Status(404, {"message": "Item not found"})
     if item.merged_to_item:
-        response["Location"] = item.merged_to_item.api_url
-        return Status(
-            302, {"message": "Item merged", "url": item.merged_to_item.api_url}
-        )
+        url = f"{item.merged_to_item.api_url}{subresource}"
+        response["Location"] = url
+        return Status(302, {"message": "Item merged", "url": url})
     if item.is_deleted:
         return Status(404, {"message": "Item not found"})
     if item.__class__ != cls:
+        # a recast item may not have this subresource, so point at its detail
         response["Location"] = item.api_url
         return Status(302, {"message": "Item recasted", "url": item.api_url})
     # Public tags are returned for single-item lookups; aggregate for this item
@@ -473,17 +490,17 @@ def _get_item(cls, uuid, response, attach_credits: bool = True):
 
 
 @api.get(
-    "/people/{uuid}",
+    "/people/{people_uuid}",
     response={200: PeopleSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_people(request, uuid: str, response: HttpResponse):
-    return _get_item(People, uuid, response)
+def get_people(request, people_uuid: str, response: HttpResponse):
+    return _get_item(People, people_uuid, response)
 
 
 @api.get(
-    "/catalog/{item_type}/{uuid}/credit/",
+    "/catalog/{item_type}/{item_uuid}/credit/",
     response={200: CreditListSchema, 302: RedirectedResult, 404: Result},
     summary="List all credits for a catalog item",
     auth=None,
@@ -492,11 +509,11 @@ def get_people(request, uuid: str, response: HttpResponse):
 def get_item_credits(
     request,
     item_type: CreditItemType,
-    uuid: str,
+    item_uuid: str,
     response: HttpResponse,
     page: int = 1,
 ):
-    item = Item.get_by_url(uuid)
+    item = Item.get_by_url(item_uuid)
     if not item or item.is_deleted:
         return Status(404, {"message": "Item not found"})
     expected_cls = _CREDIT_ITEM_MODELS[item_type]
@@ -540,20 +557,20 @@ def get_item_credits(
 
 
 @api.get(
-    "/people/{uuid}/work/",
+    "/people/{people_uuid}/work/",
     response={200: PeopleWorkListSchema, 302: RedirectedResult, 404: Result},
     summary="List all catalog works credited to a person or organization",
     auth=None,
     tags=["catalog"],
 )
-def get_people_works(request, uuid: str, response: HttpResponse, page: int = 1):
-    item = Item.get_by_url(uuid)
+def get_people_works(request, people_uuid: str, response: HttpResponse, page: int = 1):
+    item = Item.get_by_url(people_uuid)
     if not item or item.is_deleted:
-        return Status(404, {"message": "People not found"})
+        return Status(404, {"message": "Item not found"})
     if item.merged_to_item:
         url = f"{item.merged_to_item.api_url}/work/"
         response["Location"] = url
-        return Status(302, {"message": "People merged", "url": url})
+        return Status(302, {"message": "Item merged", "url": url})
     if item.__class__ is not People:
         response["Location"] = item.api_url
         return Status(302, {"message": "Item recasted", "url": item.api_url})
@@ -582,7 +599,7 @@ def get_people_works(request, uuid: str, response: HttpResponse, page: int = 1):
             person=item, item_id__in=[work.pk for work in items]
         ).order_by("item_id", "role", "order", "pk")
     )
-    # Follow the request locale, as /api/people/{uuid} does for this person.
+    # Follow the request locale, as /api/people/{people_uuid} does for this person.
     ItemCredit.attach_localized_names(work_credits)
     for credit in work_credits:
         credits_by_item.setdefault(credit.item_id, []).append(credit)
@@ -597,101 +614,115 @@ def get_people_works(request, uuid: str, response: HttpResponse, page: int = 1):
 
 
 @api.get(
-    "/book/{uuid}",
+    "/book/{item_uuid}",
     response={200: EditionSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_book(request, uuid: str, response: HttpResponse):
-    return _get_item(Edition, uuid, response)
+def get_book(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Edition, item_uuid, response)
 
 
 @api.get(
-    "/book/{uuid}/sibling/",
-    response={200: List[EditionSchema]},
+    "/book/{item_uuid}/sibling/",
+    response={
+        200: list[EditionSchema],
+        302: RedirectedResult,
+        404: Result,
+    },
     auth=None,
     tags=["catalog"],
 )
 @paginate(PageNumberPagination)
-def get_sibling_editions_for_book(request, uuid: str, response: HttpResponse):
+def get_sibling_editions_for_book(request, item_uuid: str, response: HttpResponse):
     # Only the siblings are serialized, so skip this edition's credit load.
-    i = _get_item(Edition, uuid, response, attach_credits=False)
+    i = _get_item(
+        Edition, item_uuid, response, attach_credits=False, subresource="/sibling/"
+    )
     if not isinstance(i, Edition):
-        return Edition.objects.none()
+        # Hand the 302/404 back rather than an empty page; ninja unwraps it
+        # before paginating and PageNumberPagination passes the payload through.
+        return i
     return i.sibling_items
 
 
 @api.get(
-    "/movie/{uuid}",
+    "/movie/{item_uuid}",
     response={200: MovieSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_movie(request, uuid: str, response: HttpResponse):
-    return _get_item(Movie, uuid, response)
+def get_movie(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Movie, item_uuid, response)
 
 
 @api.get(
-    "/tv/{uuid}",
+    "/tv/{item_uuid}",
     response={200: TVShowSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_tv_show(request, uuid: str, response: HttpResponse):
-    return _get_item(TVShow, uuid, response)
+def get_tv_show(request, item_uuid: str, response: HttpResponse):
+    return _get_item(TVShow, item_uuid, response)
 
 
 @api.get(
-    "/tv/season/{uuid}",
+    "/tv/season/{item_uuid}",
     response={200: TVSeasonSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_tv_season(request, uuid: str, response: HttpResponse):
-    return _get_item(TVSeason, uuid, response)
+def get_tv_season(request, item_uuid: str, response: HttpResponse):
+    return _get_item(TVSeason, item_uuid, response)
 
 
 @api.get(
-    "/tv/episode/{uuid}",
+    "/tv/episode/{item_uuid}",
     response={200: TVEpisodeSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_tv_episode(request, uuid: str, response: HttpResponse):
-    return _get_item(TVEpisode, uuid, response)
+def get_tv_episode(request, item_uuid: str, response: HttpResponse):
+    return _get_item(TVEpisode, item_uuid, response)
 
 
 @api.get(
-    "/podcast/{uuid}",
+    "/podcast/{item_uuid}",
     response={200: PodcastSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_podcast(request, uuid: str, response: HttpResponse):
-    return _get_item(Podcast, uuid, response)
+def get_podcast(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Podcast, item_uuid, response)
 
 
 @api.get(
-    "/podcast/episode/{uuid}",
+    "/podcast/episode/{item_uuid}",
     response={200: PodcastEpisodeSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_podcast_episode(request, uuid: str, response: HttpResponse):
-    return _get_item(PodcastEpisode, uuid, response)
+def get_podcast_episode(request, item_uuid: str, response: HttpResponse):
+    return _get_item(PodcastEpisode, item_uuid, response)
 
 
 @api.get(
-    "/podcast/{uuid}/episode/",
+    "/podcast/{item_uuid}/episode/",
     response={200: EpisodeList, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
 def get_episodes_in_podcast(
-    request, uuid: str, response: HttpResponse, page: int = 1, guid: str | None = None
+    request,
+    item_uuid: str,
+    response: HttpResponse,
+    page: int = 1,
+    guid: str | None = None,
 ):
     # Only the episodes are serialized, so skip the podcast's credit load.
-    podcast = _get_item(Podcast, uuid, response, attach_credits=False)
+    podcast = _get_item(
+        Podcast, item_uuid, response, attach_credits=False, subresource="/episode/"
+    )
     if not isinstance(podcast, Podcast):
         return podcast
     episodes = podcast.child_items.filter(
@@ -718,47 +749,48 @@ def get_episodes_in_podcast(
 
 
 @api.get(
-    "/album/{uuid}",
+    "/album/{item_uuid}",
     response={200: AlbumSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_album(request, uuid: str, response: HttpResponse):
-    return _get_item(Album, uuid, response)
+def get_album(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Album, item_uuid, response)
 
 
 @api.get(
-    "/game/{uuid}",
+    "/game/{item_uuid}",
     response={200: GameSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_game(request, uuid: str, response: HttpResponse):
-    return _get_item(Game, uuid, response)
+def get_game(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Game, item_uuid, response)
 
 
 @api.get(
-    "/performance/{uuid}",
+    "/performance/{item_uuid}",
     response={200: PerformanceSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_performance(request, uuid: str, response: HttpResponse):
-    return _get_item(Performance, uuid, response)
+def get_performance(request, item_uuid: str, response: HttpResponse):
+    return _get_item(Performance, item_uuid, response)
 
 
 @api.get(
-    "/performance/production/{uuid}",
+    "/performance/production/{item_uuid}",
     response={200: PerformanceProductionSchema, 302: RedirectedResult, 404: Result},
     auth=None,
     tags=["catalog"],
 )
-def get_performance_production(request, uuid: str, response: HttpResponse):
-    return _get_item(PerformanceProduction, uuid, response)
+def get_performance_production(request, item_uuid: str, response: HttpResponse):
+    return _get_item(PerformanceProduction, item_uuid, response)
 
 
 class RecommendationResult(Schema):
-    data: List[ItemSchema]
+    data: list[ItemSchema]
+    pages: int
     count: int
 
 
@@ -789,21 +821,25 @@ def _prepare_reco_items(request, items: list) -> None:
 
 
 @api.get(
-    "/catalog/item/{uuid}/similar",
-    response={200: RecommendationResult, 404: Result},
+    "/catalog/item/{item_uuid}/similar",
+    response={200: RecommendationResult, 401: Result, 404: Result},
     summary="Items similar to the given item",
+    # optional rather than auth=None: the body reads request.user for the
+    # viewer's opt-out, their shelved items and their mark state, so a token
+    # has to keep being honoured even though anonymous callers are allowed
+    auth=OptionalOAuthAccessTokenAuth(),
     tags=["recommendation"],
 )
-def similar_for_item(request, uuid: str, limit: int = 10):
+def similar_for_item(request, item_uuid: str, limit: int = 10):
     if not can_show_reco(request.user, "similar_items"):
-        return Status(200, {"data": [], "count": 0})
-    item = Item.get_by_url(uuid)
+        return Status(200, NO_DATA)
+    item = Item.get_by_url(item_uuid)
     if not item or item.is_deleted:
         return Status(404, {"message": "Item not found"})
     target = item.merged_to_item or item
     items = similar_items(target, request.user, limit=min(max(limit, 1), 50))
     _prepare_reco_items(request, items)
-    return Status(200, {"data": items, "count": len(items)})
+    return Status(200, {"data": items, "pages": 1 if items else 0, "count": len(items)})
 
 
 @api.get(
@@ -819,7 +855,7 @@ def me_recommendations(request, limit: int = 30):
         can_show_reco(request.user, "for_you")
         or can_show_reco(request.user, "from_circles")
     ):
-        return Status(200, {"data": [], "count": 0})
+        return Status(200, NO_DATA)
     items = blended_for_discover(request.user, limit=min(max(limit, 1), 60))
     _prepare_reco_items(request, items)
-    return Status(200, {"data": items, "count": len(items)})
+    return Status(200, {"data": items, "pages": 1 if items else 0, "count": len(items)})

--- a/neodb/common/api.py
+++ b/neodb/common/api.py
@@ -1,11 +1,12 @@
-from typing import Any, List
+from typing import Any
 
 from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.utils.functional import lazy
 from loguru import logger
-from ninja import NinjaAPI, Schema, Status
+from ninja import Field, NinjaAPI, Schema, Status
+from pydantic import AliasChoices
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
 from ninja.security import HttpBearer
 
@@ -83,11 +84,35 @@ class RedirectedResult(Schema):
     url: str
 
 
+def renamed_field(new: str, old: str) -> Any:
+    """Field that accepts either name of a renamed input field.
+
+    For the in-schemas whose text field was renamed (`body` -> `content`,
+    `brief` -> `description`). `new` comes first, so it wins when a caller
+    sends both, and it is the name the OpenAPI request schema requires;
+    declare `old` alongside as `deprecated_field()` so it stays visible.
+
+    A model validator cannot do this: ninja's own root validator is
+    mode="wrap" and hands subclass validators a DjangoGetter, not the payload.
+    """
+    return Field(validation_alias=AliasChoices(new, old))
+
+
+def deprecated_field() -> Any:
+    """The old name of a `renamed_field`, kept only to document it.
+
+    Its value is read through the new field's alias, so views never read
+    this one; it exists so the Swagger page still lists the name older
+    clients send.
+    """
+    return Field(None, deprecated=True)
+
+
 class PageNumberPagination(NinjaPageNumberPagination):
     items_attribute = "data"
 
     class Output(Schema):
-        data: List[Any]
+        data: list[Any]
         pages: int
         count: int
 

--- a/neodb/journal/apis/article.py
+++ b/neodb/journal/apis/article.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any
 
 from django import forms
 from django.conf import settings
@@ -15,9 +15,13 @@ from common.api import (
     OptionalOAuthAccessTokenAuth,
     PageNumberPagination,
     Result,
+    deprecated_field,
+    renamed_field,
     api,
 )
 from common.sentry import record_activity
+from takahe.utils import Takahe
+from users.apis import UserIdentitySchema
 
 from ..models import Article
 from ..models.collection import COVER_MAX_BYTES
@@ -25,14 +29,18 @@ from ..models.common import prefetch_latest_posts
 
 
 class ArticleSchema(Schema):
+    id: str = Field(alias="absolute_url")
     uuid: str
     url: str
     api_url: str
     visibility: int = Field(ge=0, le=2)
     post_id: int | None = Field(alias="latest_post_id")
+    owner: UserIdentitySchema
     created_time: datetime
     title: str
-    body: str
+    # body is deprecated, use content instead (as in NoteSchema)
+    body: str = Field(deprecated=True)
+    content: str = Field(alias="body")
     summary: str
     sensitive: bool = False
     language: str = ""
@@ -44,9 +52,10 @@ class ArticleSchema(Schema):
 class ArticleInSchema(Schema):
     # title/language are bounded to the model's CharField limits so over-long
     # input returns a clean 422 instead of an uncaught DB DataError (500).
-    # body/summary are unbounded TextFields, so no cap here.
+    # content/summary are unbounded TextFields, so no cap here.
     title: str = Field(max_length=500)
-    body: str
+    content: str = renamed_field("content", "body")
+    body: str | None = deprecated_field()
     summary: str = ""
     sensitive: bool = False
     visibility: int = Field(ge=0, le=2)
@@ -61,7 +70,7 @@ class ArticlePageNumberPagination(PageNumberPagination):
     Plain ``PageNumberPagination`` serializes each Article one at a time, and
     ``ArticleSchema.post_id`` (``latest_post_id``) would then trigger its own
     ``PiecePost`` query per row (N+1). This hook resolves the whole page's
-    latest posts in one batched query.
+    latest posts in one batched query, and the same for ``owner``.
     """
 
     def paginate_queryset(
@@ -74,13 +83,15 @@ class ArticlePageNumberPagination(PageNumberPagination):
         val = super().paginate_queryset(queryset, pagination, request, **params)
         data = val.get("data")
         if data:
-            prefetch_latest_posts(list(data))
+            articles = list(data)
+            prefetch_latest_posts(articles)
+            Takahe.prefetch_takahe_identities([a.owner for a in articles])
         return val
 
 
 @api.get(
     "/me/article/",
-    response={200: List[ArticleSchema], 401: Result, 403: Result},
+    response={200: list[ArticleSchema], 401: Result, 403: Result},
     tags=["article"],
 )
 @paginate(ArticlePageNumberPagination)
@@ -88,7 +99,11 @@ def list_articles(request):
     """
     Get articles by current user
     """
-    return Article.objects.filter(owner=request.user.identity).order_by("-created_time")
+    return (
+        Article.objects.filter(owner=request.user.identity)
+        .select_related("owner")
+        .order_by("-created_time")
+    )
 
 
 @api.get(
@@ -118,14 +133,16 @@ def create_article(request, a_in: ArticleInSchema):
     """
     Create an article for current user.
 
-    `title` and `body` (markdown formatted) are required; `visibility` is
+    `title` and `content` (markdown formatted) are required; `visibility` is
     required (0: public, 1: followers only, 2: private). `language` defaults
     to the user's preferred language when omitted.
+
+    `body` is accepted as a deprecated alias of `content`.
     """
     article = Article.update_local_article(
         owner=request.user.identity,
         title=a_in.title,
-        body=a_in.body,
+        body=a_in.content,
         summary=a_in.summary,
         sensitive=a_in.sensitive,
         visibility=a_in.visibility,
@@ -153,7 +170,7 @@ def update_article(request, article_uuid: str, a_in: ArticleInSchema):
     article = Article.update_local_article(
         owner=request.user.identity,
         title=a_in.title,
-        body=a_in.body,
+        body=a_in.content,
         summary=a_in.summary,
         sensitive=a_in.sensitive,
         visibility=a_in.visibility,

--- a/neodb/journal/apis/attachment.py
+++ b/neodb/journal/apis/attachment.py
@@ -9,7 +9,6 @@ upload first, embed second.
 
 import uuid
 from datetime import datetime
-from typing import List
 
 from django import forms
 from ninja import File, Form, Schema, Status
@@ -41,7 +40,7 @@ class AttachmentSchema(Schema):
 
 @api.get(
     "/me/attachment/",
-    response={200: List[AttachmentSchema], 401: Result, 403: Result},
+    response={200: list[AttachmentSchema], 401: Result, 403: Result},
     tags=["attachment"],
 )
 @paginate(PageNumberPagination)

--- a/neodb/journal/apis/collection.py
+++ b/neodb/journal/apis/collection.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any
 
 from django import forms
 from django.conf import settings
@@ -17,10 +17,13 @@ from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
 from common.api import (
+    INVALID_PAGE,
     OptionalOAuthAccessTokenAuth,
     PageNumberPagination,
     RedirectedResult,
     Result,
+    deprecated_field,
+    renamed_field,
     api,
 )
 from common.sentry import record_activity
@@ -68,7 +71,7 @@ class CollectionPageNumberPagination(PageNumberPagination):
         return val
 
 
-def _prefetch_collection_owners(collections: List[Collection]) -> None:
+def _prefetch_collection_owners(collections: list[Collection]) -> None:
     """Batch-load takahe identities so owner (``UserIdentitySchema``)
     serialization (display_name/avatar) does not fire a cross-db query per
     collection.
@@ -79,6 +82,7 @@ def _prefetch_collection_owners(collections: List[Collection]) -> None:
 
 
 class CollectionSchema(Schema):
+    id: str = Field(alias="absolute_url")
     uuid: str
     url: str
     api_url: str
@@ -86,7 +90,9 @@ class CollectionSchema(Schema):
     post_id: int | None = Field(alias="latest_post_id")
     created_time: datetime
     title: str
-    brief: str
+    # brief is deprecated, use description instead (as in ItemSchema)
+    brief: str = Field(deprecated=True)
+    description: str = Field(alias="brief")
     cover_image_url: str | None
     cover: str = Field(deprecated=True)
     html_content: str
@@ -98,7 +104,8 @@ class CollectionSchema(Schema):
 
 class CollectionInSchema(Schema):
     title: str
-    brief: str
+    description: str = renamed_field("description", "brief")
+    brief: str | None = deprecated_field()
     visibility: int = Field(ge=0, le=2)
     query: str | None = None
 
@@ -169,6 +176,24 @@ class CollectionItemPageNumberPagination(PageNumberPagination):
         return val
 
 
+class CollectionListSchema(Schema):
+    data: list[CollectionSchema]
+    pages: int
+    count: int
+
+
+class CollectionItemResult(Result):
+    """``Result``, as every other collection write returns.
+
+    ``item``/``note`` are the pre-``Result`` body of
+    ``PUT /me/collection/{uuid}/item/{item_uuid}``, kept so clients reading
+    them keep working; re-fetch the item list instead.
+    """
+
+    item: ItemSchema | None = Field(None, deprecated=True)
+    note: str = Field("", deprecated=True)
+
+
 class CollectionItemInSchema(Schema):
     item_uuid: str
     note: str
@@ -192,7 +217,7 @@ class FeaturedCollectionStatsSchema(Schema):
 
 @api.get(
     "/me/collection/",
-    response={200: List[CollectionSchema], 401: Result, 403: Result},
+    response={200: list[CollectionSchema], 401: Result, 403: Result},
     tags=["collection"],
 )
 @paginate(CollectionPageNumberPagination)
@@ -208,17 +233,15 @@ def list_user_collections(request):
 
 @api.get(
     "/user/{handle}/collection/",
-    response={200: List[CollectionSchema], 401: Result, 404: Result},
+    response={200: list[CollectionSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
-    auth=OptionalOAuthAccessTokenAuth(),
 )
 @paginate(CollectionPageNumberPagination)
 def list_collections_of_user(request, handle: str):
     """
     Get collections created by a specific user
 
-    Only collections visible to the requesting identity are returned;
-    anonymous access is allowed if the user's profile is anonymous viewable.
+    Only collections visible to the requesting identity are returned.
     """
     try:
         target = APIdentity.get_by_handle(handle)
@@ -232,30 +255,26 @@ def list_collections_of_user(request, handle: str):
 
 @api.get(
     "/user/{handle}/collection/liked/",
-    response={200: List[CollectionSchema], 401: Result, 404: Result},
+    response={200: list[CollectionSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
-    auth=OptionalOAuthAccessTokenAuth(),
 )
 @paginate(CollectionPageNumberPagination)
 def list_liked_collections_of_user(request, handle: str):
     """
     Get collections liked by a specific user
 
-    Only collections visible to the requesting identity are returned;
-    anonymous access is allowed if the user's profile is anonymous viewable.
+    Only collections visible to the requesting identity are returned.
     """
     try:
         target = APIdentity.get_by_handle(handle)
     except APIdentity.DoesNotExist:
         raise Http404("User not found")
-    viewer = request.user.identity if request.user.is_authenticated else None
+    viewer = request.user.identity
     # gate on the target like the created-collections endpoint above:
     # hide the list rather than 403, so it's indistinguishable from empty
     if target.restricted:
         return Collection.objects.none()
-    if viewer is None and not target.anonymous_viewable:
-        return Collection.objects.none()
-    if viewer and viewer != target and viewer.is_blocked_by(target):
+    if viewer != target and viewer.is_blocked_by(target):
         return Collection.objects.none()
     queryset = Collection.objects.filter(
         interactions__identity=target,
@@ -304,7 +323,7 @@ def get_collection(request, collection_uuid: str):
 
 @api.get(
     "/collection/{collection_uuid}/item/",
-    response={200: List[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
+    response={200: list[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
@@ -328,20 +347,21 @@ def collection_list_items(request, collection_uuid: str):
 
 @api.post(
     "/me/collection/",
-    response={200: CollectionSchema, 401: Result, 403: Result, 404: Result},
+    response={200: CollectionSchema, 401: Result, 403: Result},
     tags=["collection"],
 )
 def create_collection(request, c_in: CollectionInSchema):
     """
     Create collection.
 
-    `title`, `brief` (markdown formatted) and `visibility` are required;
+    `title`, `description` (markdown formatted) and `visibility` are required;
+    `brief` is accepted as a deprecated alias of `description`.
     """
     q = (c_in.query or "").strip() or None
     c = Collection(
         owner=request.user.identity,
         title=c_in.title,
-        brief=c_in.brief,
+        brief=c_in.description,
         visibility=c_in.visibility,
         query=q,
     )
@@ -377,7 +397,7 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     ):
         return Status(403, {"message": "Only owner can change visibility or query"})
     c.title = c_in.title
-    c.brief = c_in.brief
+    c.brief = c_in.description
     c.visibility = c_in.visibility
     c.query = q
     c.application_id_when_save = getattr(request, "application_id", None)
@@ -481,7 +501,7 @@ def delete_collection(request, collection_uuid: str):
 
 @api.get(
     "/me/collection/{collection_uuid}/item/",
-    response={200: List[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
+    response={200: list[CollectionItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
 )
 @paginate(CollectionItemPageNumberPagination)
@@ -538,7 +558,7 @@ def collection_add_item(
 
 @api.put(
     "/me/collection/{collection_uuid}/item/{item_uuid}",
-    response={200: CollectionItemSchema, 401: Result, 403: Result, 404: Result},
+    response={200: CollectionItemResult, 401: Result, 403: Result, 404: Result},
     tags=["collection"],
 )
 def collection_update_item(
@@ -552,7 +572,7 @@ def collection_update_item(
 
     The item must already be in the collection; 404 is returned otherwise
     (position is preserved, unlike remove + re-add). Set `note` to an empty
-    string to clear it. Returns the updated member.
+    string to clear it.
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
@@ -569,7 +589,9 @@ def collection_update_item(
     member = c.update_item_note(item, collection_item.note)
     if not member:
         return Status(404, {"message": "Item not in collection"})
-    return member
+    return Status(
+        200, {"message": "OK", "item": member.item, "note": member.note or ""}
+    )
 
 
 @api.post(
@@ -642,7 +664,7 @@ def collection_delete_item(request, collection_uuid: str, item_uuid: str):
 
 @api.get(
     "/item/{item_uuid}/collection/",
-    response={200: List[CollectionSchema], 401: Result, 404: Result},
+    response={200: list[CollectionSchema], 401: Result, 403: Result, 404: Result},
     tags=["collection"],
     auth=OptionalOAuthAccessTokenAuth(),
 )
@@ -701,13 +723,23 @@ def collection_unset_featured(request, collection_uuid: str):
 
 @api.get(
     "/me/collection/featured/",
-    response={200: list[CollectionSchema], 401: Result, 403: Result},
+    response={
+        200: list[CollectionSchema] | CollectionListSchema,
+        400: Result,
+        401: Result,
+        403: Result,
+    },
     tags=["featured collection"],
 )
-def list_featured_collections(request):
+def list_featured_collections(request, page: int | None = None):
     """
     List featured collections for current user.
+
+    Omitting `page` returns a bare list; that shape is deprecated, pass `page`
+    to get the `{data, pages, count}` envelope the other list endpoints use.
     """
+    if page is not None and page < 1:
+        return INVALID_PAGE
     collections = list(
         Collection.objects.filter(featured_by=request.user.identity)
         .filter(q_piece_visible_to_user(request.user))
@@ -715,7 +747,20 @@ def list_featured_collections(request):
     )
     Collection.attach_item_count_by_category(collections)
     _prefetch_collection_owners(collections)
-    return collections
+    if page is None:
+        return collections
+    # page_size is set in __init__, so read it off an instance
+    page_size = CollectionPageNumberPagination().page_size
+    count = len(collections)
+    offset = (page - 1) * page_size
+    return Status(
+        200,
+        {
+            "data": collections[offset : offset + page_size],
+            "pages": (count + page_size - 1) // page_size,
+            "count": count,
+        },
+    )
 
 
 @api.get(

--- a/neodb/journal/apis/note.py
+++ b/neodb/journal/apis/note.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from typing import List
+from typing import Any
 
-from django.http import HttpResponse
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from ninja import Field, Schema
 from ninja.pagination import paginate
 
@@ -17,14 +18,20 @@ from common.api import (
     resolve_item_for_write,
 )
 from common.sentry import record_activity
+from takahe.utils import Takahe
+from users.apis import UserIdentitySchema
 
 from ..models import Note
 
 
 class NoteSchema(Schema):
     uuid: str
+    # No url/id here: a note has no page of its own, so it keeps the `Piece`
+    # default url_path and Piece.url/absolute_url point at nothing.
+    api_url: str
     post_id: int | None = Field(alias="latest_post_id")
     item: ItemSchema
+    owner: UserIdentitySchema
     title: str | None
     content: str
     sensitive: bool = False
@@ -32,6 +39,11 @@ class NoteSchema(Schema):
     progress_value: str | None = None
     visibility: int = Field(ge=0, le=2)
     created_time: datetime
+
+    @staticmethod
+    def resolve_api_url(obj: Note) -> str:
+        # the owner-scoped route is the one that resolves (PUT / DELETE)
+        return f"/api/me/note/{obj.uuid}"
 
 
 class NoteInSchema(Schema):
@@ -44,10 +56,32 @@ class NoteInSchema(Schema):
     post_to_fediverse: bool = False
 
 
+class NotePageNumberPagination(PageNumberPagination):
+    """Pagination that batch-loads takahe identities after slicing.
+
+    ``select_related("owner")`` hands each row its own ``APIdentity``, so
+    ``NoteSchema.owner`` would resolve display_name/avatar with one cross-db
+    lookup per row.
+    """
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        data = val.get("data")
+        if data:
+            Takahe.prefetch_takahe_identities([n.owner for n in data])
+        return val
+
+
 @api.get(
     "/me/note/item/{item_uuid}/",
     response={
-        200: List[NoteSchema],
+        200: list[NoteSchema],
         302: RedirectedResult,
         401: Result,
         403: Result,
@@ -55,7 +89,7 @@ class NoteInSchema(Schema):
     },
     tags=["note"],
 )
-@paginate(PageNumberPagination)
+@paginate(NotePageNumberPagination)
 def list_notes_for_item(request, item_uuid: str, response: HttpResponse):
     """
     List notes by current user for an item
@@ -67,7 +101,9 @@ def list_notes_for_item(request, item_uuid: str, response: HttpResponse):
     )
     if not item:
         return redirect
-    queryset = Note.objects.filter(owner=request.user.identity, item=item)
+    queryset = Note.objects.filter(
+        owner=request.user.identity, item=item
+    ).select_related("owner")
     return queryset.prefetch_related("item")
 
 

--- a/neodb/journal/apis/post.py
+++ b/neodb/journal/apis/post.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Union
+from typing import Literal, Union
 
 from django.db.models import Prefetch, QuerySet
 from django.http import HttpResponse
@@ -7,7 +7,6 @@ from ninja import Field, Schema
 from catalog.models import Item
 from common.api import (
     INVALID_PAGE,
-    OAuthAccessTokenAuth,
     OptionalOAuthAccessTokenAuth,
     RedirectedResult,
     Result,
@@ -133,7 +132,7 @@ class Post(Schema):
 
 
 class PaginatedPostList(Schema):
-    data: List[Post]
+    data: list[Post]
     pages: int
     count: int
 
@@ -148,6 +147,7 @@ PostTypes = {"mark", "comment", "review", "collection", "note"}
         302: RedirectedResult,
         400: Result,
         401: Result,
+        403: Result,
         404: Result,
     },
     tags=["catalog"],
@@ -195,11 +195,14 @@ def list_posts_for_item(
     return result
 
 
+# The one versioned path in an otherwise unversioned API: it fills in a
+# timeline Mastodon defines but takahe does not serve, so it has to keep
+# Mastodon's own path and its bare-list, `limit`-based contract.
 @api.get(
     "/v1/timelines/link",
-    response={200: list[Post]},
+    response={200: list[Post], 401: Result},
     tags=["mastodon"],
-    auth=OAuthAccessTokenAuth(),
+    auth=OptionalOAuthAccessTokenAuth(),
 )
 def timeline_link(
     request,
@@ -211,14 +214,16 @@ def timeline_link(
 
     Returns posts visible to the requesting user that are about the catalog item
     identified by `url`, which may be a NeoDB item URL or an external resource
-    URL (e.g. a Douban or Goodreads page).
+    URL (e.g. a Douban or Goodreads page). Anonymous callers see public posts.
     """
     limit = min(max(1, limit), TIMELINE_LINK_MAX_LIMIT)
     item = Item.get_by_remote_url(url)
     if not item:
         return []
     query = JournalQueryParser("", page_size=limit)
-    query.filter_by_viewer(request.user.identity)
+    query.filter_by_viewer(
+        request.user.identity if request.user.is_authenticated else None
+    )
     query.filter("item_id", item.pk)
     # posts orphaned by a shelf change carry item fields too; keep them
     # out to preserve pre-enrichment behavior (surfacing old mark posts

--- a/neodb/journal/apis/review.py
+++ b/neodb/journal/apis/review.py
@@ -1,22 +1,27 @@
 from datetime import datetime
-from typing import List
+from typing import Any
 
-from django.http import HttpResponse
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema, Status
 from ninja.pagination import paginate
 
-from catalog.models import AvailableItemCategory, Item, ItemSchema
+from catalog.models import AvailableItemCategory, ItemSchema
 from common.api import (
     OptionalOAuthAccessTokenAuth,
     PageNumberPagination,
     RedirectedResult,
     Result,
+    deprecated_field,
+    renamed_field,
     api,
     resolve_item_for_read,
     resolve_item_for_write,
 )
 from common.sentry import record_activity
+from takahe.utils import Takahe
+from users.apis import UserIdentitySchema
 
 from ..models import (
     Review,
@@ -25,14 +30,19 @@ from ..models import (
 
 
 class ReviewSchema(Schema):
+    id: str = Field(alias="absolute_url")
+    uuid: str
     url: str
     api_url: str
     visibility: int = Field(ge=0, le=2)
     post_id: int | None = Field(alias="latest_post_id")
     item: ItemSchema
+    owner: UserIdentitySchema
     created_time: datetime
     title: str
-    body: str
+    # body is deprecated, use content instead (as in NoteSchema)
+    body: str = Field(deprecated=True)
+    content: str = Field(alias="body")
     html_content: str
 
 
@@ -40,23 +50,48 @@ class ReviewInSchema(Schema):
     visibility: int = Field(ge=0, le=2)
     created_time: datetime | None = None
     title: str
-    body: str
+    content: str = renamed_field("content", "body")
+    body: str | None = deprecated_field()
     post_to_fediverse: bool = False
+
+
+class ReviewPageNumberPagination(PageNumberPagination):
+    """Pagination that batch-loads takahe identities after slicing.
+
+    ``select_related("owner")`` hands each row its own ``APIdentity``, so
+    ``ReviewSchema.owner`` would resolve display_name/avatar with one
+    cross-db lookup per row.
+    """
+
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        data = val.get("data")
+        if data:
+            Takahe.prefetch_takahe_identities([r.owner for r in data])
+        return val
 
 
 @api.get(
     "/me/review/",
-    response={200: List[ReviewSchema], 401: Result, 403: Result},
+    response={200: list[ReviewSchema], 401: Result, 403: Result},
     tags=["review"],
 )
-@paginate(PageNumberPagination)
+@paginate(ReviewPageNumberPagination)
 def list_reviews(request, category: AvailableItemCategory | None = None):
     """
     Get reviews by current user
 
     `category` is optional, reviews for all categories will be returned if not specified.
     """
-    queryset = Review.objects.filter(owner=request.user.identity)
+    queryset = Review.objects.filter(owner=request.user.identity).select_related(
+        "owner"
+    )
     if category:
         queryset = queryset.filter(q_item_in_category(category))
     return queryset.prefetch_related("item")
@@ -107,9 +142,11 @@ def review_item(
     """
     Create or update a review about an item for current user.
 
-    `title`, `body` (markdown formatted) and`visibility` are required;
+    `title`, `content` (markdown formatted) and `visibility` are required;
     `created_time` is optional, default to now.
     if the item is already reviewed, this will update the review.
+
+    `body` is accepted as a deprecated alias of `content`.
 
     If the item was merged into another one, HTTP 307 is returned; repeat the
     request against the returned url.
@@ -125,7 +162,7 @@ def review_item(
         item,
         request.user.identity,
         review.title,
-        review.body,
+        review.content,
         review.visibility,
         created_time=review.created_time,
         share_to_mastodon=review.post_to_fediverse,
@@ -137,16 +174,27 @@ def review_item(
 
 @api.delete(
     "/me/review/item/{item_uuid}",
-    response={200: Result, 401: Result, 403: Result, 404: Result},
+    response={
+        200: Result,
+        307: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["review"],
 )
-def delete_review(request, item_uuid: str):
+def delete_review(request, item_uuid: str, response: HttpResponse):
     """
     Remove a review about an item for current user.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/review/item/{uuid}", response
+    )
     if not item:
-        return Status(404, {"message": "Item not found"})
+        return redirect
     Review.update_item_review(item, request.user.identity, None, None)
     return Status(200, {"message": "OK"})
 

--- a/neodb/journal/apis/shelf.py
+++ b/neodb/journal/apis/shelf.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List
+from typing import Any
 
 from django.core.cache import cache
 from django.db.models import QuerySet, prefetch_related_objects
@@ -31,6 +31,8 @@ from journal.models.common import (
 )
 from journal.models.rating import Rating
 from journal.models.shelf import ShelfMember
+from takahe.utils import Takahe
+from users.apis import UserIdentitySchema
 from users.models.apidentity import APIdentity
 
 from ..models import (
@@ -62,6 +64,9 @@ def _prefetch_shelf_members(members: list[ShelfMember]):
     # Batch-fetch latest_post_id for all members to avoid N+1 queries
     # when MarkSchema accesses latest_post_id
     prefetch_latest_posts(members)
+    # select_related("owner") gives each row its own APIdentity instance, so
+    # MarkSchema.owner would fire a takahe lookup per row without this.
+    Takahe.prefetch_takahe_identities([m.owner for m in members])
     # Batch-fetch user's tags for MarkSchema.tags
     owner = members[0].owner
     item_ids = [m.item_id for m in members]
@@ -89,6 +94,10 @@ class MarkSchema(Schema):
     visibility: int = Field(ge=0, le=2)
     post_id: int | None = Field(alias="latest_post_id")
     item: ItemSchema
+    # No uuid/url/api_url/id here, unlike the other content schemas: a mark is
+    # not individually addressable (ShelfMember keeps the `Piece` default
+    # url_path, which resolves to nothing), it is addressed by its item.
+    owner: UserIdentitySchema
     created_time: datetime.datetime
     comment_text: str | None
     rating_grade: int | None = Field(ge=1, le=10)
@@ -165,7 +174,7 @@ def get_user_calendar_data(request, handle: str):
 
 @api.get(
     "/user/{handle}/shelf/{type}",
-    response={200: List[MarkSchema], 401: Result, 403: Result, 404: Result},
+    response={200: list[MarkSchema], 401: Result, 403: Result, 404: Result},
     tags=["shelf"],
 )
 @paginate(ShelfPageNumberPagination)
@@ -199,7 +208,7 @@ def list_marks_on_user_shelf(
 
 @api.get(
     "/me/shelf/{type}",
-    response={200: List[MarkSchema], 401: Result, 403: Result},
+    response={200: list[MarkSchema], 401: Result, 403: Result},
     tags=["shelf"],
 )
 @paginate(ShelfPageNumberPagination)
@@ -353,7 +362,7 @@ def delete_item_progress(request, item_uuid: str, response: HttpResponse):
 
 @api.get(
     "/me/shelf/items/{item_uuids}",
-    response={200: List[MarkSchema], 401: Result},
+    response={200: list[MarkSchema], 401: Result, 403: Result, 404: Result},
     tags=["shelf"],
 )
 def get_marks_by_item_list(request, item_uuids: str, response: HttpResponse):
@@ -424,16 +433,27 @@ def mark_item(request, item_uuid: str, mark: MarkInSchema, response: HttpRespons
 
 @api.delete(
     "/me/shelf/item/{item_uuid}",
-    response={200: Result, 401: Result, 403: Result, 404: Result},
+    response={
+        200: Result,
+        307: RedirectedResult,
+        401: Result,
+        403: Result,
+        404: Result,
+    },
     tags=["shelf"],
 )
-def delete_mark(request, item_uuid: str):
+def delete_mark(request, item_uuid: str, response: HttpResponse):
     """
     Remove a holding mark about an item for current user, unlike the web behavior, this does not clean up tags.
+
+    If the item was merged into another one, HTTP 307 is returned; repeat the
+    request against the returned url.
     """
-    item = Item.get_by_url(item_uuid)
+    item, redirect = resolve_item_for_write(
+        item_uuid, "/api/me/shelf/item/{uuid}", response
+    )
     if not item:
-        return Status(404, {"message": "Item not found"})
+        return redirect
     m = Mark(request.user.identity, item)
     m.delete(keep_tags=True)
     return Status(200, {"message": "OK"})
@@ -442,9 +462,10 @@ def delete_mark(request, item_uuid: str):
 @api.get(
     "/me/shelf/item/{item_uuid}/logs",
     response={
-        200: List[MarkLogSchema],
+        200: list[MarkLogSchema],
         302: RedirectedResult,
         401: Result,
+        403: Result,
         404: Result,
     },
     tags=["shelf"],

--- a/neodb/journal/apis/tag.py
+++ b/neodb/journal/apis/tag.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.core.cache import cache
 from django.http import Http404
 from ninja import Field, Schema, Status
@@ -20,6 +18,9 @@ class TagSchema(Schema):
 
 class TagInSchema(Schema):
     title: str
+    # Bounded like every other visibility field, but a tag has only two
+    # states: there is no followers-only tag, so 1 is stored as 2 (private)
+    # rather than rejected. See _tag_visibility().
     visibility: int = Field(ge=0, le=2)
 
 
@@ -31,9 +32,18 @@ class TagItemInSchema(Schema):
     item_uuid: str
 
 
+def _tag_visibility(visibility: int) -> int:
+    """Collapse the requested visibility to the two a tag can hold.
+
+    Tags are public (0) or private (2); followers-only tags do not exist, so
+    1 is stored as private rather than rejected.
+    """
+    return 2 if visibility else 0
+
+
 @api.get(
     "/me/tag/",
-    response={200: List[TagSchema], 401: Result, 403: Result},
+    response={200: list[TagSchema], 401: Result, 403: Result},
     tags=["tag"],
 )
 @paginate(PageNumberPagination)
@@ -68,17 +78,19 @@ def get_tag(request, tag_uuid: str):
 
 @api.post(
     "/me/tag/",
-    response={200: TagSchema, 401: Result, 403: Result, 404: Result},
+    response={200: TagSchema, 401: Result, 403: Result},
     tags=["tag"],
 )
 def create_tag(request, t_in: TagInSchema):
     """
     Create tag.
 
-    `title` is required, `visibility` can only be 0 or 2; if tag with same title exists, existing tag will be returned.
+    `title` is required. `visibility` is only 0 (public) or 2 (private); 1 is
+    accepted but stored as 2. If a tag with the same title exists, the
+    existing tag is returned.
     """
     title = Tag.cleanup_title(t_in.title)
-    visibility = 2 if t_in.visibility else 0
+    visibility = _tag_visibility(t_in.visibility)
     tag, created = Tag.objects.get_or_create(
         owner=request.user.identity,
         title=title,
@@ -107,7 +119,7 @@ def update_tag(request, tag_uuid: str, t_in: TagInSchema):
     if tag.owner != request.user.identity:
         return Status(403, {"message": "Not owner"})
     title = Tag.cleanup_title(t_in.title)
-    visibility = 2 if t_in.visibility else 0
+    visibility = _tag_visibility(t_in.visibility)
     if title != tag.title:
         try:
             tag.title = title
@@ -138,7 +150,7 @@ def delete_tag(request, tag_uuid: str):
 
 @api.get(
     "/me/tag/{tag_uuid}/item/",
-    response={200: List[TagItemSchema], 401: Result, 403: Result, 404: Result},
+    response={200: list[TagItemSchema], 401: Result, 403: Result, 404: Result},
     tags=["tag"],
 )
 @paginate(PageNumberPagination)

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -228,7 +228,9 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
 
     @property
     def api_url(self):
-        return f"/api/{self.url}" if self.url_path else None
+        # url is already rooted, so no separator here (it used to emit
+        # "/api//review/x"); same form as Item.api_url
+        return f"/api{self.url}" if self.url_path else None
 
     @property
     def like_count(self):

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -1,6 +1,6 @@
 import io
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from blurhash_rs import blurhash_encode
 from django.conf import settings
@@ -180,12 +180,15 @@ class Takahe:
         display_name, avatar, restricted, etc.) fires a single-row lookup on
         users_identity — one per unique APIdentity in the list.
         """
-        seen: dict[int, object] = {}
+        # keyed by pk, but every instance is kept: select_related("owner")
+        # hands each row its own APIdentity, and priming only the first one
+        # leaves the rest of a single-owner page firing a lookup each
+        seen: dict[int, list[Any]] = {}
         to_load: set[int] = set()
         for owner in owners:
-            if owner is None or owner.pk in seen:
+            if owner is None:
                 continue
-            seen[owner.pk] = owner
+            seen.setdefault(owner.pk, []).append(owner)
             if "takahe_identity" not in owner.__dict__:
                 to_load.add(owner.pk)
         if not to_load:
@@ -194,10 +197,11 @@ class Takahe:
             i.pk: i
             for i in Identity.objects.filter(pk__in=to_load).select_related("domain")
         }
-        for pk, owner in seen.items():
+        for pk, instances in seen.items():
             identity = identities.get(pk)
             if identity is not None:
-                owner.__dict__["takahe_identity"] = identity
+                for owner in instances:
+                    owner.__dict__["takahe_identity"] = identity
 
     @staticmethod
     def get_identity_by_local_user(u: "NeoUser"):

--- a/neodb/tests/catalog/test_api.py
+++ b/neodb/tests/catalog/test_api.py
@@ -27,6 +27,10 @@ from catalog.models import (
     TVSeason,
     TVShow,
 )
+from catalog.models.recommendation import ItemSimilarity
+from common.models import SiteConfig
+from takahe.utils import Takahe
+from users.models import User
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)
@@ -587,3 +591,129 @@ def test_people_work_endpoint_groups_all_credits_by_item(live_server):
         "director",
     }
     assert [credit["role"] for credit in works[book.uuid]["credits"]] == ["author"]
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_book_sibling_endpoint_reports_unknown_and_merged(live_server):
+    """The status _get_item builds must survive pagination, not become a 200."""
+    with patch("catalog.models.item.Item.update_index"):
+        merged = Edition.objects.create(title="Merged Edition")
+        target = Edition.objects.create(title="Target Edition")
+        merged.merge_to(target)
+
+    response = requests.get(
+        f"{live_server.url}/api/book/{'0' * 22}/sibling/", timeout=5
+    )
+    assert response.status_code == 404
+    assert response.json()["message"] == "Item not found"
+
+    response = requests.get(
+        f"{live_server.url}/api/book/{merged.uuid}/sibling/",
+        timeout=5,
+        allow_redirects=False,
+    )
+    assert response.status_code == 302
+    # the sibling list of the target, not its detail route, which would answer
+    # a single object to a request for a list
+    assert response.headers["Location"] == f"{target.api_url}/sibling/"
+    assert response.json()["url"] == f"{target.api_url}/sibling/"
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_people_work_endpoint_404_matches_other_catalog_routes(live_server):
+    response = requests.get(f"{live_server.url}/api/people/{'0' * 22}/work/", timeout=5)
+    assert response.status_code == 404
+    assert response.json()["message"] == "Item not found"
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_summary_schemas_carry_the_current_field_names(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        person = People.objects.create(
+            localized_name=[{"lang": "en", "text": "Summary Person"}]
+        )
+        movie = Movie.objects.create(
+            title="Summary Movie",
+            localized_title=[{"lang": "en", "text": "Summary Movie"}],
+        )
+        ItemCredit.objects.create(
+            item=movie, person=person, role="director", name="Summary Person"
+        )
+
+    payload = requests.get(
+        f"{live_server.url}/api/people/{person.uuid}/work/", timeout=5
+    ).json()
+    item = payload["data"][0]["item"]
+    assert item["title"] == item["display_title"] == "Summary Movie"
+
+    payload = requests.get(
+        f"{live_server.url}/api/catalog/movie/{movie.uuid}/credit/", timeout=5
+    ).json()
+    summary = payload["data"][0]["person"]
+    assert summary["name"] == summary["display_name"] == "Summary Person"
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_similar_items_endpoint_is_public_and_paged(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Similar Seed")
+
+    response = requests.get(
+        f"{live_server.url}/api/catalog/item/{movie.uuid}/similar", timeout=5
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    # same envelope as every other list route
+    assert set(payload) == {"data", "pages", "count"}
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_similar_items_endpoint_honours_the_viewers_opt_out(live_server):
+    """Public, but a token still has to be read: auth=None would make the
+    caller anonymous and hand back recommendations they turned off."""
+    with patch("catalog.models.item.Item.update_index"):
+        movie = Movie.objects.create(title="Opt Out Seed")
+        other = Movie.objects.create(title="Opt Out Similar")
+    ItemSimilarity.objects.create(source=movie, target=other, score=1.0)
+    SiteConfig.set_system(enable_recommendations=True)
+    SiteConfig.reload()
+
+    user = User.register(email="optout@example.com", username="optoutuser")
+    app = Takahe.get_or_create_app(
+        "Similar Opt Out Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    url = f"{live_server.url}/api/catalog/item/{movie.uuid}/similar"
+    headers = {"Authorization": f"Bearer {token}"}
+
+    payload = requests.get(url, headers=headers, timeout=5).json()
+    assert [i["uuid"] for i in payload["data"]] == [other.uuid]
+
+    user.preference.disable_recommendations = True
+    user.preference.save(update_fields=["disable_recommendations"])
+
+    payload = requests.get(url, headers=headers, timeout=5).json()
+    assert payload == {"data": [], "pages": 0, "count": 0}
+
+    # the anonymous surface is unaffected by that user's preference
+    payload = requests.get(url, timeout=5).json()
+    assert [i["uuid"] for i in payload["data"]] == [other.uuid]
+
+
+@pytest.mark.django_db(databases="__all__", transaction=True)
+def test_podcast_episode_list_redirects_to_the_same_subresource(live_server):
+    with patch("catalog.models.item.Item.update_index"):
+        merged = Podcast.objects.create(title="Merged Show")
+        target = Podcast.objects.create(title="Target Show")
+        merged.merge_to(target)
+
+    response = requests.get(
+        f"{live_server.url}/api/podcast/{merged.uuid}/episode/",
+        timeout=5,
+        allow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == f"{target.api_url}/episode/"

--- a/neodb/tests/journal/test_api.py
+++ b/neodb/tests/journal/test_api.py
@@ -289,15 +289,15 @@ def test_user_collections_api_visibility():
     payload = get_collections(stranger)
     assert {c["uuid"] for c in payload["data"]} == {public.uuid}
 
-    payload = get_collections()
-    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+    # a token is required, like the rest of the /user/{handle} family
+    response = Client().get(f"/api/user/{owner.username}/collection/")
+    assert response.status_code == 401
 
-    owner.identity.anonymous_viewable = False
-    owner.identity.save(update_fields=["anonymous_viewable"])
-    payload = get_collections()
-    assert payload["count"] == 0
-
-    response = Client().get("/api/user/nosuchuser/collection/")
+    token = Takahe.refresh_token(app, stranger.identity.pk, stranger.pk)
+    response = Client().get(
+        "/api/user/nosuchuser/collection/",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert response.status_code == 404
 
 
@@ -378,15 +378,15 @@ def test_user_liked_collections_api():
         private.uuid,
     }
 
-    payload = get_liked()
-    assert {c["uuid"] for c in payload["data"]} == {public.uuid}
+    # a token is required, like the rest of the /user/{handle} family
+    response = Client().get(f"/api/user/{liker.username}/collection/liked/")
+    assert response.status_code == 401
 
-    liker.identity.anonymous_viewable = False
-    liker.identity.save(update_fields=["anonymous_viewable"])
-    payload = get_liked()
-    assert payload["count"] == 0
-
-    response = Client().get("/api/user/nosuchuser/collection/liked/")
+    token = Takahe.refresh_token(app, stranger.identity.pk, stranger.pk)
+    response = Client().get(
+        "/api/user/nosuchuser/collection/liked/",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     assert response.status_code == 404
 
 
@@ -1362,6 +1362,8 @@ def test_write_apis_on_merged_item_redirect_with_307():
             "/api/me/note/item/{}/",
             {"title": "Title", "content": "Content", "visibility": 0},
         ),
+        ("delete", "/api/me/shelf/item/{}", None),
+        ("delete", "/api/me/review/item/{}", None),
     ]
     for method, path, payload in cases:
         url = path.format(merged_item.uuid)
@@ -1421,6 +1423,11 @@ def test_write_apis_on_deleted_item_return_404():
         HTTP_AUTHORIZATION=authorization,
     )
     assert response.status_code == 404
+
+    for path in ("/api/me/shelf/item/{}", "/api/me/review/item/{}"):
+        url = path.format(item.uuid)
+        response = client.delete(url, HTTP_AUTHORIZATION=authorization)
+        assert response.status_code == 404, url
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -2310,3 +2317,246 @@ def test_featured_collection_hidden_after_owner_restricts():
     )
     assert response.status_code == 200
     assert response.json() == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_content_schemas_share_identity_and_body_field_names():
+    """B5/B6: one name for the body text, and an addressable id everywhere."""
+    user = User.register(email="shapes@example.com", username="shapesuser")
+    item = Edition.objects.create(title="Shapes Book")
+
+    app = Takahe.get_or_create_app(
+        "Schema Shape Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    authorization = f"Bearer {token}"
+    client = Client()
+
+    # the current name is accepted on input
+    response = client.post(
+        f"/api/me/review/item/{item.uuid}",
+        data=json.dumps({"title": "T", "content": "Review Content", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+
+    review = client.get(
+        f"/api/me/review/item/{item.uuid}", HTTP_AUTHORIZATION=authorization
+    ).json()
+    assert review["content"] == review["body"] == "Review Content"
+    # the uuid the dedicated GET route needs, no longer only parseable out of api_url
+    assert review["api_url"] == f"/api/review/{review['uuid']}"
+    assert review["id"].endswith(review["api_url"].replace("/api", ""))
+    assert review["owner"]["username"] == "shapesuser"
+
+    response = client.get(f"/api/review/{review['uuid']}")
+    assert response.status_code == 200
+
+    # the deprecated name still is too
+    response = client.post(
+        "/api/me/article/",
+        data=json.dumps({"title": "A", "body": "Article Body", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    article = response.json()
+    assert article["content"] == article["body"] == "Article Body"
+    assert article["owner"]["username"] == "shapesuser"
+    assert article["id"].endswith(article["url"])
+
+    response = client.post(
+        "/api/me/collection/",
+        data=json.dumps({"title": "C", "brief": "Collection Brief", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    collection = response.json()
+    assert collection["description"] == collection["brief"] == "Collection Brief"
+    assert collection["id"].endswith(collection["url"])
+
+    response = client.post(
+        f"/api/me/note/item/{item.uuid}/",
+        data=json.dumps({"title": "N", "content": "Note Content", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    note = response.json()
+    assert note["api_url"] == f"/api/me/note/{note['uuid']}"
+    assert note["owner"]["username"] == "shapesuser"
+
+    response = client.post(
+        f"/api/me/shelf/item/{item.uuid}",
+        data=json.dumps({"shelf_type": "complete", "visibility": 0}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    mark = client.get(
+        f"/api/me/shelf/item/{item.uuid}", HTTP_AUTHORIZATION=authorization
+    ).json()
+    assert mark["owner"]["username"] == "shapesuser"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_featured_collections_paginate_only_when_asked():
+    """B2: the bare list stays the default so existing clients keep working."""
+    user = User.register(email="featshape@example.com", username="featshapeuser")
+    with (
+        patch("journal.models.collection.Collection.sync_to_timeline"),
+        patch("journal.models.collection.Collection.update_index"),
+    ):
+        collection = Collection.objects.create(
+            owner=user.identity, title="Featured", brief="", visibility=0
+        )
+
+    app = Takahe.get_or_create_app(
+        "Featured Shape Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    authorization = f"Bearer {token}"
+    client = Client()
+    client.post(
+        f"/api/me/collection/featured/{collection.uuid}",
+        HTTP_AUTHORIZATION=authorization,
+    )
+
+    response = client.get(
+        "/api/me/collection/featured/", HTTP_AUTHORIZATION=authorization
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert [c["uuid"] for c in payload] == [collection.uuid]
+
+    response = client.get(
+        "/api/me/collection/featured/?page=1", HTTP_AUTHORIZATION=authorization
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["pages"] == 1
+    assert [c["uuid"] for c in payload["data"]] == [collection.uuid]
+
+    response = client.get(
+        "/api/me/collection/featured/?page=9", HTTP_AUTHORIZATION=authorization
+    )
+    assert response.json() == {"data": [], "pages": 1, "count": 1}
+
+    response = client.get(
+        "/api/me/collection/featured/?page=0", HTTP_AUTHORIZATION=authorization
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_collection_item_write_responses_agree():
+    """B15: add and update both answer with a Result."""
+    user = User.register(email="citem@example.com", username="citemuser")
+    item = Edition.objects.create(title="Collection Item Book")
+    with (
+        patch("journal.models.collection.Collection.sync_to_timeline"),
+        patch("journal.models.collection.Collection.update_index"),
+    ):
+        collection = Collection.objects.create(
+            owner=user.identity, title="Items", brief="", visibility=0
+        )
+
+    app = Takahe.get_or_create_app(
+        "Collection Item Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    authorization = f"Bearer {token}"
+    client = Client()
+
+    response = client.post(
+        f"/api/me/collection/{collection.uuid}/item/",
+        data=json.dumps({"item_uuid": item.uuid, "note": "first"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    assert response.json()["message"] == "OK"
+
+    response = client.put(
+        f"/api/me/collection/{collection.uuid}/item/{item.uuid}",
+        data=json.dumps({"note": "second"}),
+        content_type="application/json",
+        HTTP_AUTHORIZATION=authorization,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["message"] == "OK"
+    # the pre-Result body is still there for older clients
+    assert payload["note"] == "second"
+    assert payload["item"]["uuid"] == item.uuid
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_timeline_link_allows_anonymous():
+    """C5: it declared required auth while every /catalog/ neighbour is open."""
+    response = Client().get(
+        "/api/v1/timelines/link?url=https://example.org/nothing-here"
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_user_profile_is_public_while_its_subroutes_are_not():
+    """D1: the profile is readable without a token, everything under it is not."""
+    user = User.register(email="pubprof@example.com", username="pubprofuser")
+    app = Takahe.get_or_create_app(
+        "Profile Auth Tests",
+        "https://example.org",
+        "https://example.org/callback",
+        owner_pk=user.identity.pk,
+    )
+    token = Takahe.refresh_token(app, user.identity.pk, user.pk)
+    client = Client()
+
+    response = client.get(f"/api/user/{user.username}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["username"] == "pubprofuser"
+    assert payload["url"] == "/users/pubprofuser/"
+
+    # a token still works and still gets the blocking checks
+    response = client.get(
+        f"/api/user/{user.username}", HTTP_AUTHORIZATION=f"Bearer {token}"
+    )
+    assert response.status_code == 200
+    assert response.json()["username"] == "pubprofuser"
+
+    assert client.get("/api/user/nosuchuser").status_code == 404
+
+    # every subroute of the same handle keeps requiring one
+    for path in (
+        "/api/user/{}/calendar",
+        "/api/user/{}/shelf/wishlist",
+        "/api/user/{}/collection/",
+        "/api/user/{}/collection/liked/",
+    ):
+        url = path.format(user.username)
+        assert client.get(url).status_code == 401, url
+
+    # an identity that opted out of anonymous viewing is not served either
+    user.identity.anonymous_viewable = False
+    user.identity.save(update_fields=["anonymous_viewable"])
+    assert client.get(f"/api/user/{user.username}").status_code == 401
+    response = client.get(
+        f"/api/user/{user.username}", HTTP_AUTHORIZATION=f"Bearer {token}"
+    )
+    assert response.status_code == 200

--- a/neodb/tests/journal/test_n_plus_one.py
+++ b/neodb/tests/journal/test_n_plus_one.py
@@ -1487,3 +1487,48 @@ class TestItemPostsApiPrefetch:
             assert sum(table in s for s in sql) <= 1, table
         # the author domain rides along on the post query via select_related
         assert [s for s in sql if 'FROM "users_domain"' in s] == []
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestOwnerIdentityPrefetchOnApiLists:
+    """MarkSchema.owner and friends must not cost a lookup per row.
+
+    ``select_related("owner")`` gives every row its own ``APIdentity``, so the
+    prefetch has to prime all of them, not just the first seen for a pk.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="ownerpf@example.com", username="ownerpfuser")
+        for i in range(5):
+            book = Edition.objects.create(title=f"Owner Prefetch Book {i}")
+            Mark(self.user.identity, book).update(
+                ShelfType.WISHLIST, f"c{i}", None, [], 0
+            )
+        app = Takahe.get_or_create_app(
+            "Owner Prefetch Tests",
+            "https://example.org",
+            "https://example.org/callback",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(app, self.user.identity.pk, self.user.pk)
+
+    def test_shelf_api_no_per_row_identity_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connections["takahe"]) as ctx:
+            response = client.get(
+                "/api/me/shelf/wishlist",
+                HTTP_AUTHORIZATION=f"Bearer {self.token}",
+            )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["count"] == 5
+        assert all(m["owner"]["username"] == "ownerpfuser" for m in payload["data"])
+        single_identity = [
+            q
+            for q in ctx.captured_queries
+            if "users_identity" in q["sql"]
+            and 'WHERE "users_identity"."id" =' in q["sql"]
+        ]
+        # one is the auth lookup; a per-row miss would add five more
+        assert len(single_identity) <= 1, single_identity

--- a/neodb/users/apis.py
+++ b/neodb/users/apis.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from ninja import Schema, Status
 from ninja.schema import Field
 
-from common.api import NOT_FOUND, Result, api
+from common.api import NOT_FOUND, OptionalOAuthAccessTokenAuth, Result, api
 from mastodon.models import SocialAccount
 from users.models import APIdentity
 
@@ -111,19 +111,30 @@ def preference(request):
     "/user/{handle}",
     response={200: UserSchema, 401: Result, 403: Result, 404: Result},
     tags=["user"],
+    auth=OptionalOAuthAccessTokenAuth(),
 )
 def user(request, handle: str):
     """
     Get user's basic info
 
     More detailed info can be fetched from Mastodon API
+
+    Anonymous access is allowed, unless the identity has opted out of being
+    viewed without login. Everything under `/user/{handle}` still needs a
+    token.
     """
     try:
         target = APIdentity.get_by_handle(handle)
     except APIdentity.DoesNotExist:
         return NOT_FOUND
-    viewer = request.user.identity
-    if target.is_blocking(viewer) or target.is_blocked_by(viewer):
+    viewer = request.user.identity if request.user.is_authenticated else None
+    if not viewer:
+        # same gate as the web profile page and the piece queries: an identity
+        # that opted out of anonymous viewing is not served to a token-less
+        # caller either
+        if not target.anonymous_viewable:
+            return Status(401, {"message": "Login required"})
+    elif target.is_blocking(viewer) or target.is_blocked_by(viewer):
         return Status(403, {"message": "unavailable"})
     return Status(
         200,


### PR DESCRIPTION
Reads the 99 routes on the Ninja API against each other and closes the places where endpoints doing comparable work disagree. Every rename here is additive: the old name stays on the response and in the request schema, marked `deprecated`, so no client has to change.

Verified by diffing the generated OpenAPI document against `main`: **74 paths before and after, no route added or removed, and no response field removed.**

## For API client authors

**Nothing you send today stops working**, with three exceptions — anonymous `GET /user/{handle}/collection/` and `.../liked/` now answer `401`, `PUT /me/collection/{uuid}/item/{item_uuid}` returns a `Result` (with `item`/`note` still on it), and `GET /me/collection/featured/` is unchanged unless you pass `?page`. Details in the table further down.

**Renamed, both names work.** The old ones are accepted on input and still returned, marked `deprecated`, mirroring deprecations that already existed on `ItemSchema`/`PeopleSchema`. Migrate when convenient:

| Deprecated | Use instead | Where |
| --- | --- | --- |
| `body` | `content` | `ReviewSchema`, `ArticleSchema`, and their request bodies |
| `brief` | `description` | `CollectionSchema` and its request body |
| `display_title` | `title` | `ItemSummarySchema` |
| `display_name` | `name` | `PeopleSummarySchema` |

**New fields to reach for:**

- `ReviewSchema.uuid` — call `GET /api/review/{review_uuid}` without string-parsing the uuid back out of `api_url`.
- `id` on reviews, articles and collections — an absolute, fully qualified identifier, so cross-instance clients stop reconstructing the origin themselves.
- `owner` on marks, reviews, notes and articles — the author, which previously only collections exposed.
- `NoteSchema.api_url`.
- `RecommendationResult.pages` — one envelope reader now works everywhere, since all eight are `{data, pages, count}`.

**Now readable without a token:** `GET /user/{handle}`, `GET /catalog/item/{item_uuid}/similar` and `GET /v1/timelines/link`. Still send your token where you have one: `/similar` personalises on it (shelved-item exclusion, mark state, and the user's own recommendation opt-out), and `/v1/timelines/link` widens beyond public posts.

**Error handling that will now fire.** These paths used to answer `200` or the wrong shape, so code that never saw them may be untested:

- `GET /book/{item_uuid}/sibling/` answers `404` for an unknown edition and `302` for a merged one, instead of an empty page. Its `Location` points at the *sibling list* of the target, not the target's detail route — same for `/podcast/{item_uuid}/episode/`.
- `DELETE /me/shelf/item/{item_uuid}` and `DELETE /me/review/item/{item_uuid}` answer `307` for a merged item (replay the request against the returned url) and `404` for a deleted one.

**If you regenerate from the spec:** catalog path parameters are renamed `{uuid}` → `{item_uuid}` / `{people_uuid}`. Request URLs are byte-identical; only your generated method argument names move. Several routes also declare response codes they always could return (`403`, `401`, `302`), which may widen generated error unions.

**One bug fix worth checking for a workaround:** `api_url` on reviews, articles and collections used to emit a double slash (`/api//review/{uuid}`). It is now `/api/review/{uuid}`. Drop any string fix-up you had for it.

## Wrong responses

- `GET /book/{item_uuid}/sibling/` built a 404 or 302 in `_get_item` and then discarded it, so an unknown or merged edition paginated to a normal `200` with an empty page — and on the merged branch, a `200` carrying a stray `Location` header. The status now passes through, as it already does for `get_mark_logs_by_item`.
- `DELETE /me/shelf/item/{item_uuid}` and `DELETE /me/review/item/{item_uuid}` resolved the item with a bare `Item.get_by_url`, skipping both halves of the shared helper: a merged item was operated on in place instead of answering `307`, and a soft-deleted one was accepted instead of answering `404`. The disagreement was inside a single file — `DELETE .../progress` right below already did the right thing.
- `Piece.api_url` emitted `/api//review/x`, because `url` is already rooted. Reviews, articles and collections were all handing out that double-slash url.
- A merged item's `302` under an item subresource pointed at the item's *detail* route, so a client following it got a single object where it asked for a list. `_get_item` takes a subresource suffix now, fixing `/sibling/` and `/podcast/{item_uuid}/episode/`.

## Response shapes

- `RecommendationResult` gains `pages`, so all eight list envelopes are `{data, pages, count}` and one reader works across the API.
- The body text field is `content` on reviews and articles, as it already was on notes; a collection's `brief` is `description`. Both names are accepted on input and returned on output.
- `ReviewSchema` gains the `uuid` its own `GET /api/review/{review_uuid}` needs — until now recoverable only by string-parsing `api_url`. `id` (absolute) and `owner` are on the content schemas, so federated clients stop rebuilding the origin and an anonymous reader of a public review or article can see who wrote it.
- `ItemSummarySchema` and `PeopleSummarySchema` gain `title` and `name`, so the newer credit and work endpoints stop handing back only the names their full schemas mark deprecated.
- Adding and updating a collection item both answer with a `Result`.

## Declared responses

Matched to what the endpoints actually return: the missing `403`s on the logs, shelf-items, item-collection and item-posts routes; the unreachable `404`s off the two create routes; `302`/`404` on the sibling route; `401` wherever optional auth can still reject a bad token.

## Access

- `/catalog/item/{item_uuid}/similar` was the only private route under `/catalog/`. It takes **optional** auth rather than `auth=None`, because the body reads the caller for their opt-out, their shelved items and their mark state — `auth=None` would make a token client anonymous and serve recommendations to someone who had turned them off.
- `/v1/timelines/link` takes optional auth, so a logged-out client sees public posts.
- `/user/{handle}` is readable without a token, honouring `anonymous_viewable` the way the web profile page does. Everything under `/user/{handle}` still requires one.

## Behaviour changes worth a maintainer's eye

Three of these change what an existing client sees. Each is deliberate:

| Change | Before | After |
| --- | --- | --- |
| `GET /user/{handle}/collection/` and `.../collection/liked/` | anonymous `200` | `401` — the rest of the `/user/{handle}` family already required a token |
| `PUT /me/collection/{uuid}/item/{item_uuid}` | `CollectionItemSchema` | `Result`, matching the other collection writes; `item`/`note` remain on the response, deprecated |
| `GET /me/collection/featured/` | bare list only | bare list still, plus the standard envelope when `?page` is passed |

A related note for reviewers: after the first row, a logged-out caller can still read any single public collection by uuid via `/collection/{collection_uuid}`, just not enumerate a user's collections. That asymmetry is intentional here but is a reasonable thing to push back on.

## Naming

None of it changes a URL. Catalog paths name their parameter `{item_uuid}` or `{people_uuid}`, matching the journal routes — the path *template* moves in the OpenAPI document, the request URL does not, and no `reverse()` call depends on the names. The people-works `404` says `"Item not found"` like its neighbours. `List[...]` is `list[...]` throughout.

## Documented, not changed

Two behaviours were confirmed intended and only got a comment: a tag's `visibility: 1` collapsing to `2`, since there is no followers-only tag, and `/v1/timelines/link` being the one versioned path in an unversioned API.

## Also

`prefetch_takahe_identities` primed only the first `APIdentity` instance per pk, but `select_related("owner")` gives each row its own, so the new `owner` fields would have cost a `users_identity` query per row on a single-owner page. There is a query-count test that fails without the fix.

The `/api/me` example in `docs/api.md` showed four of seven fields, and a `url` as absolute where `User.url` returns site-relative.

## Not in this PR

Deliberately left for later, since each needs a decision rather than a fix: the always-`true` `GET /api/token`, the three pagination styles over post data, the drift between NeoDB's private `Post`/`Account` copies and takahe's, `UserSchema.username` meaning a handle on one route and a bare name on another, the trailing-slash exceptions, `reorder_items` as the only verb path, and the OpenAPI tag groupings.

## Testing

Full suite green locally (2382 passed; the three `tests/mastodon/test_lexicons.py` failures are the known ones from `/docs` not being mounted in the dev profile) and both CI jobs green on the fork. New tests cover each behavioural fix, and I checked that the three found in review each fail without their fix.
