### PR TITLE
fix(journal): note media on imported posts, registry as the only source of note media

### DIFF
--- a/neodb/catalog/management/commands/seed_catalog.py
+++ b/neodb/catalog/management/commands/seed_catalog.py
@@ -11,18 +11,20 @@ The site API keys for Google Books, IGDB and TMDB must be configured, or
 those categories fail to scrape.
 """
 
+import logging
 import time
 from typing import Any
 
 import django_rq
 from django.core.management.base import CommandParser
-from loguru import logger
 from rq import Worker
 
 from catalog.common import SiteManager
 from catalog.common.downloaders import DownloadError
 from catalog.sites import *  # noqa: F403
 from common.management.base import SiteCommand
+
+logger = logging.getLogger(__name__)
 
 # Queues the ingest fans out onto. get_resource_ready() puts related
 # resources (seasons, people) on "crawl", and those jobs enqueue more of

--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -27,10 +27,6 @@ from journal.models import (
     Tag,
     TagMember,
 )
-from journal.models.attachment import (
-    pending_source_for_post_attachment,
-    source_for_post_attachment,
-)
 from journal.models.renderers import RE_MD_IMAGE, normalize_image_src
 from takahe.models import Post
 from users.models import Task
@@ -218,46 +214,13 @@ class NdjsonExporter(Task):
         return attachments
 
     def _bundle_note_attachments(self, note: Note) -> list[dict[str, str]]:
-        """Attachment records for a Note, in descending order of fidelity.
+        """Attachment records for a Note, from the upload registry.
 
-        1. the linked post, which holds the original files;
-        2. the upload registry, which holds our own copy of them -- the only
-           source left once takahe has pruned the post;
-        3. the legacy ``attachments`` JSON, for notes the async backfill has
-           not reached yet.
-
-        Trying the registry before the JSON matters: a pruned post leaves the
-        JSON pointing at takahe media that no longer exists, which would
-        export as a URL with no file and restore as a dead link.
-
-        The post and the registry are merged rather than either/or: a note
-        restored from an archive can hold pointer rows (remote media never
-        downloaded) that could not be put on its post, and those must not
-        vanish from the next export just because the post carries the rest.
+        The registry is the one source for note media: it holds our own copy
+        of what was posted (the only thing left once takahe has pruned the
+        post) and a pointer row for remote media that was never downloaded.
         """
-        rows = list(note.attachment_records.all())
-        if note.latest_post:
-            attachments = self._bundle_post_attachments(note.latest_post)
-            if attachments:
-                on_post: set[str] = set()
-                for pa in note.latest_post.attachments.all():
-                    on_post.add(source_for_post_attachment(pa.pk))
-                    on_post.add(pending_source_for_post_attachment(pa.pk))
-                extra = [a for a in rows if a.source not in on_post]
-                return attachments + self._bundle_registered_attachments(extra)
-        attachments = self._bundle_registered_attachments(rows)
-        if attachments:
-            return attachments
-        for a in note.attachments or []:
-            url = a.get("url")
-            if not url:
-                continue
-            entry = {"mimetype": a.get("mimetype", ""), "url": url}
-            path = self._save_image(url)
-            if path:
-                entry["file"] = path
-            attachments.append(entry)
-        return attachments
+        return self._bundle_registered_attachments(list(note.attachment_records.all()))
 
     def run(self):
         self.ref_items = []

--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -15,6 +15,7 @@ from catalog.common import ProxiedImageDownloader
 from common.utils import GenerateDateUUIDMediaFilePath
 from journal.models import (
     Article,
+    Attachment,
     Collection,
     Comment,
     Note,
@@ -25,6 +26,10 @@ from journal.models import (
     ShelfMemberProgress,
     Tag,
     TagMember,
+)
+from journal.models.attachment import (
+    pending_source_for_post_attachment,
+    source_for_post_attachment,
 )
 from journal.models.renderers import RE_MD_IMAGE, normalize_image_src
 from takahe.models import Post
@@ -189,7 +194,9 @@ class NdjsonExporter(Task):
             attachments.append({"file": path, "mimetype": a.mimetype})
         return attachments
 
-    def _bundle_registered_attachments(self, note: Note) -> list[dict[str, str]]:
+    def _bundle_registered_attachments(
+        self, rows: list[Attachment]
+    ) -> list[dict[str, str]]:
         """Bundle a Note's registered uploads (``journal.Attachment`` rows).
 
         Rows are the only source that survives takahe pruning the post: the
@@ -199,7 +206,7 @@ class NdjsonExporter(Task):
         only, so they export like the legacy entries did.
         """
         attachments = []
-        for a in note.attachment_records.all():
+        for a in rows:
             url = a.url
             if not url:
                 continue
@@ -222,12 +229,23 @@ class NdjsonExporter(Task):
         Trying the registry before the JSON matters: a pruned post leaves the
         JSON pointing at takahe media that no longer exists, which would
         export as a URL with no file and restore as a dead link.
+
+        The post and the registry are merged rather than either/or: a note
+        restored from an archive can hold pointer rows (remote media never
+        downloaded) that could not be put on its post, and those must not
+        vanish from the next export just because the post carries the rest.
         """
+        rows = list(note.attachment_records.all())
         if note.latest_post:
             attachments = self._bundle_post_attachments(note.latest_post)
             if attachments:
-                return attachments
-        attachments = self._bundle_registered_attachments(note)
+                on_post: set[str] = set()
+                for pa in note.latest_post.attachments.all():
+                    on_post.add(source_for_post_attachment(pa.pk))
+                    on_post.add(pending_source_for_post_attachment(pa.pk))
+                extra = [a for a in rows if a.source not in on_post]
+                return attachments + self._bundle_registered_attachments(extra)
+        attachments = self._bundle_registered_attachments(rows)
         if attachments:
             return attachments
         for a in note.attachments or []:

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -602,10 +602,12 @@ class NdjsonImporter(BaseImporter):
                 existing.progress_value = progress_value
                 existing.visibility = visibility
                 existing.metadata = data.get("metadata") or {}
-                existing.save()
+                # post after the media below is registered, so the timeline
+                # post carries it; the final save runs the hook
+                existing.save(post_when_save=False)
                 note = existing
             else:
-                note = Note.objects.create(
+                note = Note(
                     item=item,
                     owner=owner,
                     title=title,
@@ -617,9 +619,7 @@ class NdjsonImporter(BaseImporter):
                     metadata=data.get("metadata") or {},
                     **({"created_time": published_dt} if published_dt else {}),
                 )
-            # TODO: the restored files are recorded on Note.attachments but
-            # never uploaded to Takahe, so the timeline post for an imported
-            # note carries no media.
+                note.save(post_when_save=False)
             note_attachments = []
             restored: list[Attachment] = []
             for atta in data.get("attachments") or []:
@@ -647,11 +647,9 @@ class NdjsonImporter(BaseImporter):
                 note.attachment_records.set(restored)
             if note_attachments:
                 note.attachments = note_attachments
-                note.save(
-                    update_fields=["attachments"],
-                    post_when_save=False,
-                    index_when_save=False,
-                )
+            # the deferred timeline post: Note.to_post_params uploads the
+            # freshly registered rows onto it
+            note.save(update_fields=["attachments"], index_when_save=False)
             self._restore_edited_time(note, updated_dt)
             return "imported"
         except Exception:

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -10,7 +10,6 @@ import zipfile
 from typing import Any, Callable, Dict
 from urllib.parse import urlparse
 
-from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
@@ -179,13 +178,9 @@ class NdjsonImporter(BaseImporter):
     ) -> Attachment | None:
         """Restore one bundled note attachment as a registered upload.
 
-        Registering here rather than reusing ``_store_bundled_file`` keeps the
-        bytes stored once: the legacy ``attachments`` JSON entry is derived
-        from the row via ``to_json()`` instead of being built separately.
-
-        Falls back to the exporter's recorded URL when the bundle carries no
-        file (the post was pruned, or its media lives elsewhere), which keeps
-        the attachment rather than dropping it.
+        Falls back to a pointer row on the exporter's recorded URL when the
+        bundle carries no file (the source never downloaded the media), which
+        keeps the attachment rather than dropping it.
         """
         mimetype = atta.get("mimetype", "")
         src = self._store_path(atta.get("file"))
@@ -203,7 +198,7 @@ class NdjsonImporter(BaseImporter):
         url = atta.get("url")
         if not url:
             return None
-        return Attachment.from_legacy_json(owner, {"url": url, "mimetype": mimetype})
+        return Attachment.pointer_for_url(owner, url, mimetype)
 
     def _restore_body_images(self, body: str, data: Dict[str, Any]) -> str:
         """Repoint inline markdown images at copies restored from the bundle.
@@ -621,37 +616,24 @@ class NdjsonImporter(BaseImporter):
                     **({"created_time": published_dt} if published_dt else {}),
                 )
                 note.save(post_when_save=False, index_when_save=False)
-            note_attachments = []
             restored: list[Attachment] = []
             for atta in data.get("attachments") or []:
                 if not isinstance(atta, dict):
                     continue
                 a = self._restore_note_attachment(owner, atta)
-                if not a:
-                    continue
-                restored.append(a)
-                entry = a.to_json()
-                if entry["url"].startswith("/"):
-                    site = settings.SITE_INFO["site_url"].rstrip("/")
-                    entry["url"] = site + entry["url"]
-                    if entry["preview_url"].startswith("/"):
-                        entry["preview_url"] = site + entry["preview_url"]
-                note_attachments.append(entry)
+                if a:
+                    restored.append(a)
             # set, not add: this path now updates an existing note in place, and
             # each import registers freshly copied files, so adding would grow
-            # the note's media on every re-import of an edited record -- and
-            # attachment_list prefers rows, so it would render the duplicates.
-            # The archive is authoritative for the note's media, the legacy
-            # JSON included: attachment_list falls back to it once the rows
-            # are gone, so a stale copy would resurrect removed media.
+            # the note's media on every re-import of an edited record. The
+            # archive is authoritative for the note's media.
             if restored or note.attachment_records.exists():
                 note.attachment_records.set(restored)
-            note.attachments = note_attachments
             # the deferred timeline post and index: Note.to_post_params puts
             # exactly the restored rows on the post (clearing media the
             # archive no longer has), then the index doc gets the post id
             note.post_media_from_records = True
-            note.save(update_fields=["attachments"])
+            note.save()
             self._restore_edited_time(note, updated_dt)
             return "imported"
         except Exception:

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -602,9 +602,10 @@ class NdjsonImporter(BaseImporter):
                 existing.progress_value = progress_value
                 existing.visibility = visibility
                 existing.metadata = data.get("metadata") or {}
-                # post after the media below is registered, so the timeline
-                # post carries it; the final save runs the hook
-                existing.save(post_when_save=False)
+                # post and index after the media below is registered, so the
+                # timeline post carries it and the index doc has the post id;
+                # the final save runs both hooks
+                existing.save(post_when_save=False, index_when_save=False)
                 note = existing
             else:
                 note = Note(
@@ -619,7 +620,7 @@ class NdjsonImporter(BaseImporter):
                     metadata=data.get("metadata") or {},
                     **({"created_time": published_dt} if published_dt else {}),
                 )
-                note.save(post_when_save=False)
+                note.save(post_when_save=False, index_when_save=False)
             note_attachments = []
             restored: list[Attachment] = []
             for atta in data.get("attachments") or []:
@@ -640,16 +641,17 @@ class NdjsonImporter(BaseImporter):
             # each import registers freshly copied files, so adding would grow
             # the note's media on every re-import of an edited record -- and
             # attachment_list prefers rows, so it would render the duplicates.
-            # The archive is authoritative for the note's media; an imported
-            # note's post carries no attachments (to_post_params omits them),
-            # so there are no takahe-synced rows here to displace.
+            # The archive is authoritative for the note's media, the legacy
+            # JSON included: attachment_list falls back to it once the rows
+            # are gone, so a stale copy would resurrect removed media.
             if restored or note.attachment_records.exists():
                 note.attachment_records.set(restored)
-            if note_attachments:
-                note.attachments = note_attachments
-            # the deferred timeline post: Note.to_post_params uploads the
-            # freshly registered rows onto it
-            note.save(update_fields=["attachments"], index_when_save=False)
+            note.attachments = note_attachments
+            # the deferred timeline post and index: Note.to_post_params puts
+            # exactly the restored rows on the post (clearing media the
+            # archive no longer has), then the index doc gets the post id
+            note.post_media_from_records = True
+            note.save(update_fields=["attachments"])
             self._restore_edited_time(note, updated_dt)
             return "imported"
         except Exception:

--- a/neodb/journal/jobs/migrations.py
+++ b/neodb/journal/jobs/migrations.py
@@ -1,5 +1,13 @@
+import hashlib
 import logging
-from django.db.models import OuterRef, Subquery
+import mimetypes
+from typing import Any
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.core.files.storage import storages
+from django.db import transaction
+from django.db.models import OuterRef, Q, Subquery
 
 from catalog.models import Edition, item_content_types
 from journal.models import (
@@ -12,7 +20,12 @@ from journal.models import (
     ShelfMemberProgress,
     ShelfType,
 )
-from journal.models.attachment import is_owned_upload, link_attachments_to_piece
+from journal.models.attachment import (
+    SOURCE_MAX_LENGTH,
+    is_owned_upload,
+    link_attachments_to_piece,
+)
+from users.models import APIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +121,10 @@ def _backfill_bodies_20260818(model, field: str, migratable: bool = False) -> in
     for piece in pieces.iterator(chunk_size=200):
         text = getattr(piece, field) or ""
         try:
-            resolved = Attachment.resolve_body_paths(text)
-            link_attachments_to_piece(piece, text)
+            # savepoint per piece, see _backfill_notes_20260818
+            with transaction.atomic():
+                resolved = Attachment.resolve_body_paths(text)
+                link_attachments_to_piece(piece, text)
         except Exception as e:
             logger.warning(f"attachment backfill error on {piece}: {e}")
             continue
@@ -144,6 +159,128 @@ def _backfill_bodies_20260818(model, field: str, migratable: bool = False) -> in
     return count
 
 
+# --- legacy Note.attachments JSON -------------------------------------------
+# The column is deprecated; these helpers exist only to bring its entries into
+# the registry and go when it does.
+
+# takahe's own key prefixes, from ``takahe.models.upload_namer``.
+_TAKAHE_MEDIA_PREFIXES = ("attachments/", "attachment_thumbnails/")
+
+
+def _bounded_source(prefix: str, value: str) -> str:
+    """A ``source`` key for ``value`` that stays unique once bounded.
+
+    Truncating the value to fit the column silently merges any two values
+    sharing a prefix, so keep a readable head for debugging and let a digest
+    of the whole value carry uniqueness.
+    """
+    digest = hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:32]
+    head = value[:200]
+    return f"{prefix}:{head}:{digest}"[:SOURCE_MAX_LENGTH]
+
+
+def takahe_media_path(url: str) -> str | None:
+    """Storage-relative takahe path for ``url``, or ``None`` if not ours.
+
+    Note attachment URLs recorded in the legacy JSON point at takahe's media.
+    Resolving them back to a storage path lets the backfill copy the bytes for
+    notes whose post takahe has since pruned -- the only source left for them.
+
+    Works under both storage layouts, which differ more than they look:
+    locally takahe has its own FileSystemStorage served under
+    ``TAKAHE_MEDIA_URL``, while on S3 ``default`` and ``takahe`` are the *same*
+    backend on one bucket with one base URL, so ``TAKAHE_MEDIA_URL`` does not
+    appear in the URL at all. What identifies the file either way is takahe's
+    own key prefix, so match on that after stripping whichever mount the URL
+    came through.
+    """
+    if not url:
+        return None
+    if "://" in url:
+        parsed = urlparse(url)
+        # The URL on a federated post attachment is remote-controlled, and a
+        # path-only match would let a crafted path claim an object in our own
+        # bucket (worst when MEDIA_URL's path is "/", which makes any path
+        # look local). Require the host to be ours before trusting the path.
+        host = parsed.hostname or ""
+        allowed = set(getattr(settings, "SITE_DOMAINS", [settings.SITE_DOMAIN]))
+        for candidate in (
+            settings.MEDIA_URL,
+            settings.TAKAHE_MEDIA_URL,
+            # takahe_attachment_urls absolutizes against site_url, which a
+            # deployment may point at a host outside SITE_DOMAINS; without it
+            # here the reader would reject what our own writer produced and
+            # quietly downgrade every copy to a pointer row
+            settings.SITE_INFO["site_url"],
+        ):
+            candidate_host = urlparse(candidate).hostname if candidate else ""
+            if candidate_host:
+                allowed.add(candidate_host)
+        if host not in allowed:
+            return None
+        path = parsed.path
+    else:
+        path = url
+    for prefix in (settings.TAKAHE_MEDIA_URL, settings.MEDIA_URL):
+        prefix_path = urlparse(prefix).path if prefix and "://" in prefix else prefix
+        if prefix_path and path.startswith(prefix_path):
+            rel = path[len(prefix_path) :]
+            if rel.startswith(_TAKAHE_MEDIA_PREFIXES):
+                return rel
+    return None
+
+
+def register_legacy_attachment(
+    owner: APIdentity, entry: dict[str, Any]
+) -> Attachment | None:
+    """Register a legacy ``Note.attachments`` JSON entry.
+
+    The only path for a note whose post takahe has already pruned: the JSON
+    URL is all that is left. A URL that resolves into takahe's own media store
+    is copied; anything else (a proxy URL for remote media, or an off-site
+    URL) becomes a pointer row.
+    """
+    url = (entry.get("url") or "").strip()
+    if not url:
+        return None
+    mimetype = entry.get("mimetype") or ""
+    rel_path = takahe_media_path(url)
+    if rel_path:
+        source = _bounded_source("takahe-media", rel_path)
+        # a pointer left by an earlier failed copy is matched on the URL, so a
+        # rerun upgrades it in place rather than rendering the media twice
+        existing = (
+            Attachment.objects.filter(owner=owner)
+            .filter(Q(source=source) | Q(remote_url=url, file=""))
+            .first()
+        )
+        if existing and existing.file:
+            return existing
+        ext_hint = mimetypes.guess_extension(mimetype) or ""
+        copied = Attachment.copy_into_storage(
+            owner.pk, storages["takahe"], rel_path, ext_hint
+        )
+        if copied and existing:
+            existing.file = copied[0]
+            existing.size = copied[1]
+            existing.source = source
+            existing.save(update_fields=["file", "size", "source"])
+            return existing
+        if copied:
+            return Attachment.objects.create(
+                owner=owner,
+                file=copied[0],
+                mimetype=mimetype,
+                size=copied[1],
+                source=source,
+            )
+        if existing:
+            return existing
+    return Attachment.pointer_for_url(
+        owner, url, mimetype, entry.get("preview_url") or ""
+    )
+
+
 def _backfill_notes_20260818() -> int:
     """Register the attachments of every Note that has any.
 
@@ -158,28 +295,39 @@ def _backfill_notes_20260818() -> int:
     copy is what keeps the note renderable); remote media is recorded as a
     pointer, never downloaded.
 
-    The legacy JSON is deliberately not rewritten. ``Note.attachment_list``
-    prefers the rows, so the column simply stops being read -- and rewriting
-    it would mean saving Notes, which re-posts and re-indexes every one of
-    them (``Piece.save`` ignores ``update_fields`` for its side effects).
+    The legacy JSON is deliberately not rewritten: it is deprecated and only
+    this backfill reads it -- and rewriting it would mean saving Notes, which
+    re-posts and re-indexes every one of them (``Piece.save`` ignores
+    ``update_fields`` for its side effects). Notes that already hold rows are
+    skipped, so re-running the backfill (migration 0019 runs it once,
+    synchronously) only picks up notes it has not reached.
     """
-    notes = Note.objects.exclude(attachments=[]).select_related("owner")
+    notes = (
+        Note.objects.exclude(attachments=[])
+        .filter(attachment_records__isnull=True)
+        .select_related("owner")
+    )
     count = 0
     for note in notes.iterator(chunk_size=200):
         try:
-            post = note.latest_post
-            registered = Attachment.sync_from_post(note, post) if post else []
-            if not registered:
-                rows = []
-                for entry in note.attachments or []:
-                    if not isinstance(entry, dict):
-                        continue
-                    a = Attachment.from_legacy_json(note.owner, entry)
-                    if a:
-                        rows.append(a)
-                if rows:
-                    note.attachment_records.add(*rows)
-                registered = rows
+            # a savepoint per note: under the migration's transaction a
+            # database error would otherwise abort every note after it (and
+            # the migration would still be recorded as applied); under the
+            # worker it is a plain transaction
+            with transaction.atomic():
+                post = note.latest_post
+                registered = Attachment.sync_from_post(note, post) if post else []
+                if not registered:
+                    rows = []
+                    for entry in note.attachments or []:
+                        if not isinstance(entry, dict):
+                            continue
+                        a = register_legacy_attachment(note.owner, entry)
+                        if a:
+                            rows.append(a)
+                    if rows:
+                        note.attachment_records.add(*rows)
+                    registered = rows
             if registered:
                 count += 1
         except Exception as e:

--- a/neodb/journal/migrations/0019_backfill_attachments.py
+++ b/neodb/journal/migrations/0019_backfill_attachments.py
@@ -1,32 +1,36 @@
 from django.db import migrations
 
-from catalog.common.migrations import enqueue_migration_job
+from journal.jobs.migrations import backfill_attachments_20260818
 
 
-def queue_backfill(apps: object, schema_editor: object) -> None:
-    enqueue_migration_job("journal.jobs.migrations:backfill_attachments_20260818")
+def backfill(apps: object, schema_editor: object) -> None:
+    # The real models, not the historical ones: the backfill copies Note
+    # media out of takahe's storage through Attachment.sync_from_post.
+    backfill_attachments_20260818()
 
 
 class Migration(migrations.Migration):
     """Register pre-existing user uploads in the attachment registry.
 
-    Runs in the background: Article / Review / Collection bodies only need
-    their existing files adopted in place, but Note media has to be copied out
-    of takahe's storage one object at a time, which is far too slow to hold a
-    deploy open.
+    Article / Review / Collection bodies have their existing files adopted in
+    place; Note media is copied out of takahe's storage into our own. Runs
+    synchronously: from this release ``Note.attachment_list`` reads the
+    registry only and nothing writes the legacy ``attachments`` JSON, so a
+    note left out of the registry would lose its media from the web, the API
+    and exports. Each piece is handled in its own savepoint; body linking is
+    idempotent and notes that already hold rows are skipped, so re-running
+    the backfill is safe.
 
-    Notes keep their legacy ``attachments`` JSON. ``Note.attachment_list``
-    prefers the new rows and falls back to the JSON, so cards keep rendering
-    while the job works through them; the column can be dropped in a
-    follow-up once deployments have completed the backfill.
+    The legacy column is deprecated and stays, with this backfill as its only
+    reader, until a later release drops it.
 
     Deployments old enough to hold images from before the
     ``upload/<identity_id>/`` convention should run ``neodb-manage
-    migrate_images`` first and then re-run this job: such an image cannot be
-    attributed to an owner safely, so it is skipped and would otherwise stay
-    outside the registry. The job logs a count of those. Note that
-    ``migrate_images`` reads Review and Collection only, so an Article body
-    with pre-convention paths needs moving by hand.
+    migrate_images`` first and then re-run ``backfill_attachments_20260818``:
+    such an image cannot be attributed to an owner safely, so it is skipped
+    and would otherwise stay outside the registry. The backfill logs a count
+    of those. Note that ``migrate_images`` reads Review and Collection only,
+    so an Article body with pre-convention paths needs moving by hand.
 
     A separate count covers images left unlinked for belonging to another user
     (a hotlink); those are expected and need nothing done.
@@ -37,5 +41,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(queue_backfill, migrations.RunPython.noop),
+        migrations.RunPython(backfill, migrations.RunPython.noop),
     ]

--- a/neodb/journal/models/attachment.py
+++ b/neodb/journal/models/attachment.py
@@ -19,18 +19,16 @@ renderable afterwards). Media on remote posts is never downloaded; it gets
 a pointer row carrying the URLs takahe already serves it under, mirroring
 how takahe's own ``PostAttachment`` represents media it has not cached.
 
-The legacy ``Note.attachments`` JSON is still the fallback read path while
-the async backfill runs; :attr:`Note.attachment_list` prefers rows and the
-column can be dropped once every deployment's backfill has completed.
+The legacy ``Note.attachments`` JSON is deprecated: nothing reads or writes
+it except the backfill in ``journal.jobs.migrations``, which also holds the
+helpers for it. The column can be dropped in a later release.
 """
 
-import hashlib
 import logging
 import mimetypes
 import os
 import uuid
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.files.base import File
@@ -38,6 +36,7 @@ from django.core.files.storage import Storage, default_storage, storages
 from django.db import models
 from django.utils import timezone
 
+from takahe.utils import Takahe
 from users.models import APIdentity
 
 from .renderers import RE_MD_IMAGE, normalize_image_src
@@ -60,9 +59,6 @@ def generate_attachment_path(identity_id: int | str, ext: str) -> str:
     return f"upload/{identity_id}/{year}/{uuid.uuid4()}.{ext.lstrip('.')}"
 
 
-# takahe's own key prefixes, from ``takahe.models.upload_namer``.
-_TAKAHE_MEDIA_PREFIXES = ("attachments/", "attachment_thumbnails/")
-
 # ``source`` values are the dedupe key, and the column is varchar(500), so
 # every one is truncated at construction -- a lookup built from an untruncated
 # string could never match the row that was stored, which would make the
@@ -72,23 +68,9 @@ SOURCE_MAX_LENGTH = 500
 # takahe's PostAttachment.remote_url is varchar(2500) in the real schema
 # (activities migration 0020), even though neodb/takahe/models.py still
 # mirrors it as 500. Matching the real column matters: truncating a longer
-# remote URL would store a broken one, and Note.attachment_list prefers these
-# rows over the intact legacy JSON, so the note's media would break.
+# remote URL would store a broken one, and these rows are what the note
+# renders, so its media would break.
 REMOTE_URL_MAX_LENGTH = 2500
-
-
-def bounded_source(prefix: str, value: str) -> str:
-    """A ``source`` key for ``value`` that stays unique once bounded.
-
-    Truncating the value to fit the column silently merges any two values
-    sharing a prefix -- and a remote URL runs to 2500 characters against a
-    500-character column, so two different URLs would collide and the second
-    lookup would return, and render, the first one's media. Keep a readable
-    head for debugging and let a digest of the whole value carry uniqueness.
-    """
-    digest = hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:32]
-    head = value[:200]
-    return f"{prefix}:{head}:{digest}"[:SOURCE_MAX_LENGTH]
 
 
 def source_for_post_attachment(pk: int) -> str:
@@ -153,57 +135,6 @@ def takahe_attachment_urls(atta: "PostAttachment") -> tuple[str, str]:
     full = file_url or proxy or remote
     preview = thumb_url or file_url or proxy or remote
     return full, preview
-
-
-def takahe_media_path(url: str) -> str | None:
-    """Storage-relative takahe path for ``url``, or ``None`` if not ours.
-
-    Note attachment URLs recorded in the legacy JSON point at takahe's media.
-    Resolving them back to a storage path lets the backfill copy the bytes for
-    notes whose post takahe has since pruned -- the only source left for them.
-
-    Works under both storage layouts, which differ more than they look:
-    locally takahe has its own FileSystemStorage served under
-    ``TAKAHE_MEDIA_URL``, while on S3 ``default`` and ``takahe`` are the *same*
-    backend on one bucket with one base URL, so ``TAKAHE_MEDIA_URL`` does not
-    appear in the URL at all. What identifies the file either way is takahe's
-    own key prefix, so match on that after stripping whichever mount the URL
-    came through.
-    """
-    if not url:
-        return None
-    if "://" in url:
-        parsed = urlparse(url)
-        # The URL on a federated post attachment is remote-controlled, and a
-        # path-only match would let a crafted path claim an object in our own
-        # bucket (worst when MEDIA_URL's path is "/", which makes any path
-        # look local). Require the host to be ours before trusting the path.
-        host = parsed.hostname or ""
-        allowed = set(getattr(settings, "SITE_DOMAINS", [settings.SITE_DOMAIN]))
-        for candidate in (
-            settings.MEDIA_URL,
-            settings.TAKAHE_MEDIA_URL,
-            # takahe_attachment_urls absolutizes against site_url, which a
-            # deployment may point at a host outside SITE_DOMAINS; without it
-            # here the reader would reject what our own writer produced and
-            # quietly downgrade every copy to a pointer row
-            settings.SITE_INFO["site_url"],
-        ):
-            candidate_host = urlparse(candidate).hostname if candidate else ""
-            if candidate_host:
-                allowed.add(candidate_host)
-        if host not in allowed:
-            return None
-        path = parsed.path
-    else:
-        path = url
-    for prefix in (settings.TAKAHE_MEDIA_URL, settings.MEDIA_URL):
-        prefix_path = urlparse(prefix).path if prefix and "://" in prefix else prefix
-        if prefix_path and path.startswith(prefix_path):
-            rel = path[len(prefix_path) :]
-            if rel.startswith(_TAKAHE_MEDIA_PREFIXES):
-                return rel
-    return None
 
 
 class Attachment(models.Model):
@@ -322,6 +253,36 @@ class Attachment(models.Model):
             "url": self.url,
             "preview_url": self.preview_url,
         }
+
+    def to_post_attachment(self) -> "PostAttachment | None":
+        """Upload this row's file to takahe as a post attachment.
+
+        Stamps ``source`` with the new attachment's id, so the row is never
+        uploaded twice and ``sync_from_post`` later dedupes onto it instead of
+        copying the media back. Returns None for a pointer row (no file) or a
+        failed upload, which is logged rather than raised so a caller building
+        a post never aborts over one file.
+        """
+        if not self.file:
+            return None
+        filename = os.path.basename(self.file.name or "") or "attachment"
+        mimetype = self.mimetype or mimetypes.guess_type(filename)[0] or ""
+        try:
+            with self.file.open("rb") as f:
+                if mimetype.startswith("image/"):
+                    pa = Takahe.upload_image(
+                        self.owner_id, filename, f.read(), mimetype, self.description
+                    )
+                else:
+                    pa = Takahe.upload_attachment(
+                        self.owner_id, filename, f, mimetype, self.description
+                    )
+        except Exception as e:
+            logger.warning(f"error uploading attachment {self}: {e}")
+            return None
+        self.source = source_for_post_attachment(pa.pk)
+        self.save(update_fields=["source"])
+        return pa
 
     def clear_cover_references(self) -> int:
         """Reset any cover naming this file back to the default.
@@ -473,7 +434,7 @@ class Attachment(models.Model):
     # --- takahe media -----------------------------------------------------
 
     @classmethod
-    def _copy_into_storage(
+    def copy_into_storage(
         cls, owner_id: int, storage: Storage, name: str, ext_hint: str = ""
     ) -> tuple[str, int] | None:
         """Copy a takahe file into our storage as ``(new_path, size)``.
@@ -529,14 +490,14 @@ class Attachment(models.Model):
         ext_hint = mimetypes.guess_extension(mimetype) or ""
         takahe_storage = storages["takahe"]
         copied = (
-            cls._copy_into_storage(
+            cls.copy_into_storage(
                 owner.pk, takahe_storage, atta.file.name or "", ext_hint
             )
             if copy_file and atta.file
             else None
         )
         copied_thumb = (
-            cls._copy_into_storage(
+            cls.copy_into_storage(
                 owner.pk, takahe_storage, atta.thumbnail.name or "", ext_hint
             )
             if copied and atta.thumbnail
@@ -584,64 +545,25 @@ class Attachment(models.Model):
         )
 
     @classmethod
-    def from_legacy_json(
-        cls, owner: APIdentity, entry: dict[str, Any]
+    def pointer_for_url(
+        cls, owner: APIdentity, url: str, mimetype: str = "", preview_url: str = ""
     ) -> "Attachment | None":
-        """Register a legacy ``Note.attachments`` JSON entry.
+        """A row for media we hold no file of, deduped on the URL.
 
-        The only path available for notes whose post takahe has already
-        pruned: the JSON URL is all that is left. A URL that resolves into
-        takahe's own media store is copied; anything else (a proxy URL for
-        remote media, or an off-site URL) becomes a pointer row.
+        Used when an archive entry carries a URL but no file, so the note keeps
+        the attachment rather than dropping it.
         """
-        url = (entry.get("url") or "").strip()
+        url = (url or "").strip()[:REMOTE_URL_MAX_LENGTH]
         if not url:
             return None
-        mimetype = entry.get("mimetype") or ""
-        # both keys are derived up front: a failed copy below falls through to
-        # the pointer branch, and a later rerun has to recognise the row it
-        # left behind rather than adding a second one for the same media
-        url_source = bounded_source("url", url)
-        rel_path = takahe_media_path(url)
-        if rel_path:
-            source = bounded_source("takahe-media", rel_path)
-            existing = cls.objects.filter(
-                owner=owner, source__in=[source, url_source]
-            ).first()
-            if existing and existing.file:
-                return existing
-            ext_hint = mimetypes.guess_extension(mimetype) or ""
-            copied = cls._copy_into_storage(
-                owner.pk, storages["takahe"], rel_path, ext_hint
-            )
-            if copied and existing:
-                # a pointer left by an earlier failed copy: upgrade it in place,
-                # or the note would render this attachment twice
-                existing.file = copied[0]
-                existing.size = copied[1]
-                existing.source = source
-                existing.save(update_fields=["file", "size", "source"])
-                return existing
-            if copied:
-                return cls.objects.create(
-                    owner=owner,
-                    file=copied[0],
-                    mimetype=mimetype,
-                    size=copied[1],
-                    source=source,
-                )
-            if existing:
-                return existing
-        source = url_source
-        existing = cls.objects.filter(owner=owner, source=source).first()
+        existing = cls.objects.filter(owner=owner, remote_url=url, file="").first()
         if existing:
             return existing
         return cls.objects.create(
             owner=owner,
-            remote_url=url[:REMOTE_URL_MAX_LENGTH],
-            remote_preview_url=(entry.get("preview_url") or "")[:REMOTE_URL_MAX_LENGTH],
-            mimetype=mimetype,
-            source=source,
+            remote_url=url,
+            remote_preview_url=(preview_url or "")[:REMOTE_URL_MAX_LENGTH],
+            mimetype=mimetype or "",
         )
 
     @classmethod

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -44,6 +44,11 @@ _separaters = {"–", "―", "−", "—", "-"}
 class Note(Content):
     post_when_save = True
     index_when_save = True
+    # Set by the NDJSON importer before the save that posts: the registry
+    # rows then describe the post's media exactly, including "none". Off by
+    # default, so an ordinary save never touches media the Mastodon API put
+    # on the post.
+    post_media_from_records: bool = False
 
     class ProgressType(models.TextChoices):
         PAGE = "page", _("Page")
@@ -339,17 +344,17 @@ class Note(Content):
         return pa
 
     def _build_post_attachments(self) -> list | None:
-        """Takahe attachments for registry rows not yet on the note's post.
+        """Takahe attachments matching the registry rows, or None to keep.
 
         A note composed through the Mastodon API gets its media the other way
         round: the post carries it first and ``Attachment.sync_from_post``
-        mirrors it into rows stamped with a ``takahe:`` source. Only rows
-        without a source -- files the NDJSON importer restored -- are
-        uploaded here. Returns None when there is nothing to upload so the
-        post's media is left untouched (``edit_local`` treats None as "keep").
+        mirrors it into rows, so this only runs when the importer has flagged
+        the rows as authoritative. Rows already on the post are kept, files
+        not on it are uploaded, and post media no row describes (a previous
+        import, or media the archive no longer has) is dropped -- an empty
+        list clears the post. Pointer rows have no file and cannot be posted.
         """
-        rows = [a for a in self.attachment_records.all() if a.file]
-        if all(a.source for a in rows):
+        if not self.post_media_from_records:
             return None
         post = self.latest_post
         on_post: dict[str, "PostAttachment"] = {}
@@ -357,17 +362,15 @@ class Note(Content):
             # both source forms sync_from_post writes
             on_post[source_for_post_attachment(pa.pk)] = pa
             on_post[pending_source_for_post_attachment(pa.pk)] = pa
-        # the rows are authoritative here: media the current rows do not
-        # describe (e.g. left from a previous import) is dropped from the post
         attachments = []
-        for a in rows:
+        for a in self.attachment_records.all():
             if a.source in on_post:
                 attachments.append(on_post[a.source])
-            elif not a.source:
+            elif a.file:
                 pa = self._upload_attachment(a)
                 if pa:
                     attachments.append(pa)
-        return attachments or None
+        return attachments
 
     def to_post_params(self):
         footer = f'\n<p>—<br><a href="{self.item.absolute_url}">{self.item.display_title}</a> {self.progress_display}\n</p>'
@@ -379,8 +382,8 @@ class Note(Content):
             "sensitive": self.sensitive,
             "reply_to_pk": post.pk if post else None,
         }
-        # "attachments" is passed only when there is media to add, so an
-        # ordinary edit leaves the post's media unchanged
+        # "attachments" is passed only on an import, so an ordinary edit
+        # leaves the post's media unchanged
         attachments = self._build_post_attachments()
         if attachments is not None:
             params["attachments"] = attachments

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -1,16 +1,30 @@
+import logging
+import mimetypes
+import os
 import re
 from functools import cached_property
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from catalog.models import Item
+from takahe.utils import Takahe
 
-from .attachment import Attachment, takahe_attachment_urls
+from .attachment import (
+    Attachment,
+    pending_source_for_post_attachment,
+    source_for_post_attachment,
+    takahe_attachment_urls,
+)
 from .common import Content
 from .renderers import render_text
 from .shelf import ShelfMember
+
+if TYPE_CHECKING:
+    from takahe.models import PostAttachment
+
+logger = logging.getLogger(__name__)
 
 _progress = re.compile(
     r"(.*\s)?(?P<prefix>(p|pg|page|ch|chapter|pt|part|e|ep|episode|trk|track|cycle))(\s|\.|#)*(?P<value>([\d\:\.\-]+))\s*(?P<postfix>(%))?(\s|\n|\.|。)?$",
@@ -302,17 +316,75 @@ class Note(Content):
                 params["attachments"] = attachments
         return params
 
+    def _upload_attachment(self, a: Attachment) -> "PostAttachment | None":
+        filename = os.path.basename(a.file.name or "") or "attachment"
+        mimetype = a.mimetype or mimetypes.guess_type(filename)[0] or ""
+        try:
+            with a.file.open("rb") as f:
+                if mimetype.startswith("image/"):
+                    pa = Takahe.upload_image(
+                        self.owner.pk, filename, f.read(), mimetype, a.description
+                    )
+                else:
+                    pa = Takahe.upload_attachment(
+                        self.owner.pk, filename, f, mimetype, a.description
+                    )
+        except Exception as e:
+            logger.warning(f"error uploading note attachment {a}: {e}")
+            return None
+        # settle the row: never uploaded twice, and sync_from_post dedupes
+        # onto it instead of copying the media back a second time
+        a.source = source_for_post_attachment(pa.pk)
+        a.save(update_fields=["source"])
+        return pa
+
+    def _build_post_attachments(self) -> list | None:
+        """Takahe attachments for registry rows not yet on the note's post.
+
+        A note composed through the Mastodon API gets its media the other way
+        round: the post carries it first and ``Attachment.sync_from_post``
+        mirrors it into rows stamped with a ``takahe:`` source. Only rows
+        without a source -- files the NDJSON importer restored -- are
+        uploaded here. Returns None when there is nothing to upload so the
+        post's media is left untouched (``edit_local`` treats None as "keep").
+        """
+        rows = [a for a in self.attachment_records.all() if a.file]
+        if all(a.source for a in rows):
+            return None
+        post = self.latest_post
+        on_post: dict[str, "PostAttachment"] = {}
+        for pa in post.attachments.all() if post else []:
+            # both source forms sync_from_post writes
+            on_post[source_for_post_attachment(pa.pk)] = pa
+            on_post[pending_source_for_post_attachment(pa.pk)] = pa
+        # the rows are authoritative here: media the current rows do not
+        # describe (e.g. left from a previous import) is dropped from the post
+        attachments = []
+        for a in rows:
+            if a.source in on_post:
+                attachments.append(on_post[a.source])
+            elif not a.source:
+                pa = self._upload_attachment(a)
+                if pa:
+                    attachments.append(pa)
+        return attachments or None
+
     def to_post_params(self):
         footer = f'\n<p>—<br><a href="{self.item.absolute_url}">{self.item.display_title}</a> {self.progress_display}\n</p>'
         post = self.shelfmember.latest_post if self.shelfmember else None
-        return {
+        params = {
             "summary": self.title,
             "content": self.content,
             "append_content": footer,
             "sensitive": self.sensitive,
             "reply_to_pk": post.pk if post else None,
-            # not passing "attachments" so it won't change
         }
+        # "attachments" is passed only when there is media to add, so an
+        # ordinary edit leaves the post's media unchanged
+        attachments = self._build_post_attachments()
+        if attachments is not None:
+            params["attachments"] = attachments
+        return params
 
     @classmethod
     def strip_footer(cls, content: str) -> tuple[str, str | None, str | None]:

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -1,6 +1,3 @@
-import logging
-import mimetypes
-import os
 import re
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, override
@@ -9,13 +6,11 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from catalog.models import Item
-from takahe.utils import Takahe
 
 from .attachment import (
     Attachment,
     pending_source_for_post_attachment,
     source_for_post_attachment,
-    takahe_attachment_urls,
 )
 from .common import Content
 from .renderers import render_text
@@ -23,8 +18,6 @@ from .shelf import ShelfMember
 
 if TYPE_CHECKING:
     from takahe.models import PostAttachment
-
-logger = logging.getLogger(__name__)
 
 _progress = re.compile(
     r"(.*\s)?(?P<prefix>(p|pg|page|ch|chapter|pt|part|e|ep|episode|trk|track|cycle))(\s|\.|#)*(?P<value>([\d\:\.\-]+))\s*(?P<postfix>(%))?(\s|\n|\.|。)?$",
@@ -65,6 +58,10 @@ class Note(Content):
     title = models.TextField(blank=True, null=True, default=None)
     content = models.TextField(blank=False, null=False)
     sensitive = models.BooleanField(default=False, null=False)
+    # Deprecated. Media lives in the ``Attachment`` registry (see
+    # ``attachment_records`` / ``attachment_list``); nothing writes this
+    # column any more and only the backfill in ``journal.jobs.migrations``
+    # reads it. Kept until a later release drops it.
     attachments = models.JSONField(default=list)
     progress_type = models.CharField(
         max_length=50,
@@ -217,12 +214,12 @@ class Note(Content):
     @classmethod
     def params_from_ap_object(cls, post, obj, piece):
         content: str = obj.get("content", "").strip()
-        attachments: list[dict[str, object]] = []
+        # media is not a field here: update_by_ap_object mirrors the post's
+        # attachments into the registry after the save
         params: dict[str, object] = {
             "title": cls.title_from_ap_object(obj, post.summary),
             "content": content,
             "sensitive": obj.get("sensitive", post.sensitive),
-            "attachments": attachments,
         }
         if post.local:
             # for local post, strip footer and detect progress from content
@@ -242,20 +239,6 @@ class Note(Content):
                     params["progress_type"] = Note.ProgressType(t)
                 except ValueError:
                     pass
-        if post:
-            for atta in post.attachments.all():
-                # not full_url()/thumbnail_url(): those raise on a schemeless
-                # URL, which is what takahe serves whenever TAKAHE_MEDIA_URL is
-                # relative (the settings default). See takahe_attachment_urls.
-                url, preview_url = takahe_attachment_urls(atta)
-                attachments.append(
-                    {
-                        "type": (atta.mimetype or "unknown").split("/")[0],
-                        "mimetype": atta.mimetype,
-                        "url": url,
-                        "preview_url": preview_url,
-                    }
-                )
         return params
 
     @override
@@ -277,27 +260,17 @@ class Note(Content):
             # Note media is uploaded to takahe through the Mastodon API, so
             # this is where it enters the registry. Local media is copied into
             # our own storage (takahe hard-prunes posts); remote media only
-            # gets a pointer row. The legacy ``attachments`` JSON that
-            # ``params_from_ap_object`` wrote is left untouched -- it stays the
-            # fallback read path until the async backfill has run everywhere.
+            # gets a pointer row.
             Attachment.sync_from_post(note, post)
         return note
 
     @property
-    def attachment_list(self) -> list:
-        """Attachments to render, preferring registry rows.
-
-        Falls back to the legacy ``attachments`` JSON for notes the async
-        backfill has not reached yet. Both shapes expose ``type`` / ``url`` /
-        ``preview_url``, so templates read them identically.
-        """
+    def attachment_list(self) -> list[Attachment]:
+        """Registry rows to render, in creation order."""
         # .all() so a prefetch is honored; Attachment.Meta.ordering keeps the
         # sequence stable, which the templates depend on (their lightbox
         # anchors are keyed off forloop.counter)
-        rows = list(self.attachment_records.all())
-        if rows:
-            return rows
-        return self.attachments or []
+        return list(self.attachment_records.all())
 
     @cached_property
     def shelfmember(self) -> ShelfMember | None:
@@ -320,28 +293,6 @@ class Note(Content):
             if attachments:
                 params["attachments"] = attachments
         return params
-
-    def _upload_attachment(self, a: Attachment) -> "PostAttachment | None":
-        filename = os.path.basename(a.file.name or "") or "attachment"
-        mimetype = a.mimetype or mimetypes.guess_type(filename)[0] or ""
-        try:
-            with a.file.open("rb") as f:
-                if mimetype.startswith("image/"):
-                    pa = Takahe.upload_image(
-                        self.owner.pk, filename, f.read(), mimetype, a.description
-                    )
-                else:
-                    pa = Takahe.upload_attachment(
-                        self.owner.pk, filename, f, mimetype, a.description
-                    )
-        except Exception as e:
-            logger.warning(f"error uploading note attachment {a}: {e}")
-            return None
-        # settle the row: never uploaded twice, and sync_from_post dedupes
-        # onto it instead of copying the media back a second time
-        a.source = source_for_post_attachment(pa.pk)
-        a.save(update_fields=["source"])
-        return pa
 
     def _build_post_attachments(self) -> list | None:
         """Takahe attachments matching the registry rows, or None to keep.
@@ -366,8 +317,8 @@ class Note(Content):
         for a in self.attachment_records.all():
             if a.source in on_post:
                 attachments.append(on_post[a.source])
-            elif a.file:
-                pa = self._upload_attachment(a)
+            else:
+                pa = a.to_post_attachment()
                 if pa:
                     attachments.append(pa)
         return attachments

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -1,11 +1,13 @@
 import io
 import logging
+import mimetypes
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from blurhash_rs import blurhash_encode
 from django.conf import settings
 from django.core.cache import cache
+from django.core.files import File
 from django.core.files.images import ImageFile
 from django.core.signing import b62_encode
 from django.db.models import QuerySet
@@ -717,6 +719,31 @@ class Takahe:
             blurhash=hash,
         )
         attachment.save()
+        return attachment
+
+    @staticmethod
+    def upload_attachment(
+        author_pk: int,
+        filename: str,
+        content: File,
+        mimetype: str,
+        description: str = "",
+    ) -> PostAttachment:
+        """Store non-image media (audio/video) as a post attachment.
+
+        Mirrors the non-image branch of takahe's Mastodon media upload: no
+        thumbnail or blurhash, and the stored name keeps an extension so the
+        web server serves it with the right Content-Type.
+        """
+        attachment = PostAttachment.objects.create(
+            mimetype=mimetype,
+            name=description or None,
+            state="fetched",
+            author_id=author_pk,
+        )
+        if "." not in filename.rsplit("/", 1)[-1]:
+            filename += mimetypes.guess_extension(mimetype) or ""
+        attachment.file.save(filename or "attachment", content)
         return attachment
 
     @staticmethod

--- a/neodb/tests/journal/test_attachment.py
+++ b/neodb/tests/journal/test_attachment.py
@@ -17,9 +17,13 @@ from django.utils import timezone
 from PIL import Image
 
 from catalog.models import Edition
-from journal.jobs.migrations import backfill_attachments_20260818
+from journal.jobs.migrations import (
+    backfill_attachments_20260818,
+    register_legacy_attachment,
+    takahe_media_path,
+)
 from journal.models import Article, Attachment, Collection, Note, Review
-from journal.models.attachment import takahe_attachment_urls, takahe_media_path
+from journal.models.attachment import takahe_attachment_urls
 from journal.models.utils import remove_data_by_identity
 from takahe.models import Post, PostAttachment
 from takahe.utils import Takahe
@@ -530,20 +534,11 @@ class TestNoteAttachments:
             )
         )
 
-    def test_attachment_list_falls_back_to_legacy_json(self):
-        legacy = [
-            {
-                "type": "image",
-                "mimetype": "image/png",
-                "url": "/media/attachments/2026/1/2/a.png",
-                "preview_url": "/media/attachment_thumbnails/2026/1/2/a.png",
-            }
-        ]
-        note = self._note(legacy)
-        assert note.attachment_list == legacy
-
-    def test_attachment_list_prefers_registry_rows(self):
+    def test_attachment_list_ignores_deprecated_json(self):
+        """The legacy column is deprecated: rows are the only thing rendered,
+        and a note holding nothing but stale JSON renders no media."""
         note = self._note([{"type": "image", "mimetype": "", "url": "/legacy.png"}])
+        assert note.attachment_list == []
         a = Attachment.register(self.identity, ContentFile(_png_bytes()), "png")
         note.attachment_records.add(a)
         assert note.attachment_list == [a]
@@ -553,7 +548,7 @@ class TestNoteAttachments:
             "attachments/2026/1/2/copied.png", ContentFile(_png_bytes())
         )
         entry = {"mimetype": "image/png", "url": settings.TAKAHE_MEDIA_URL + rel}
-        a = Attachment.from_legacy_json(self.identity, entry)
+        a = register_legacy_attachment(self.identity, entry)
         assert a is not None
         assert a.file
         # a real copy into our own storage, not a pointer at takahe's
@@ -561,7 +556,7 @@ class TestNoteAttachments:
         assert default_storage.exists(_name(a.file))
         assert a.size > 0
         # deduped on source, so a second pass does not copy again
-        again = Attachment.from_legacy_json(self.identity, entry)
+        again = register_legacy_attachment(self.identity, entry)
         assert again is not None and again.pk == a.pk
 
     def test_recovered_copy_upgrades_the_fallback_pointer(self):
@@ -573,33 +568,34 @@ class TestNoteAttachments:
         )
         entry = {"mimetype": "image/png", "url": settings.TAKAHE_MEDIA_URL + rel}
 
-        with mock.patch.object(Attachment, "_copy_into_storage", return_value=None):
-            pointer = Attachment.from_legacy_json(self.identity, entry)
+        with mock.patch.object(Attachment, "copy_into_storage", return_value=None):
+            pointer = register_legacy_attachment(self.identity, entry)
         assert pointer is not None
         assert not pointer.file
         assert Attachment.objects.count() == 1
 
-        recovered = Attachment.from_legacy_json(self.identity, entry)
+        recovered = register_legacy_attachment(self.identity, entry)
         assert recovered is not None
         assert recovered.pk == pointer.pk
         assert recovered.file
         assert Attachment.objects.count() == 1
 
     def test_long_urls_sharing_a_prefix_stay_distinct(self):
-        """The source key is bounded to fit the column; truncating a 2500-char
-        URL would merge two distinct ones and render the wrong media."""
+        """Pointer rows dedupe on the full URL, so two long URLs sharing a
+        prefix stay two rows, and the same URL twice stays one."""
         shared = "https://far.example/" + ("c" * 600)
-        first = Attachment.from_legacy_json(
+        first = register_legacy_attachment(
             self.identity, {"url": shared + "/one.png", "mimetype": "image/png"}
         )
-        second = Attachment.from_legacy_json(
+        second = register_legacy_attachment(
             self.identity, {"url": shared + "/two.png", "mimetype": "image/png"}
         )
         assert first is not None and second is not None
         assert first.pk != second.pk
-        assert first.source != second.source
         assert first.remote_url.endswith("/one.png")
         assert second.remote_url.endswith("/two.png")
+        again = Attachment.pointer_for_url(self.identity, shared + "/one.png")
+        assert again is not None and again.pk == first.pk
 
     def test_from_legacy_json_keeps_remote_url_as_pointer(self):
         entry = {
@@ -607,7 +603,7 @@ class TestNoteAttachments:
             "url": "https://remote.example/x.png",
             "preview_url": "https://remote.example/t.png",
         }
-        a = Attachment.from_legacy_json(self.identity, entry)
+        a = register_legacy_attachment(self.identity, entry)
         assert a is not None
         assert not a.file
         assert a.remote_url == "https://remote.example/x.png"
@@ -759,7 +755,7 @@ class TestSyncFromPost:
             file=ContentFile(_png_bytes(), name="flaky.png"),
             remote_url="https://takahe.example/flaky.png",
         )
-        with mock.patch.object(Attachment, "_copy_into_storage", return_value=None):
+        with mock.patch.object(Attachment, "copy_into_storage", return_value=None):
             rows = Attachment.sync_from_post(note, post)
         assert len(rows) == 1
         pending = rows[0]
@@ -795,23 +791,6 @@ class TestSyncFromPost:
             "/media/" in rows[0].remote_url
         )
 
-    def test_legacy_json_survives_a_relative_takahe_media_url(self):
-        """The same call existed in params_from_ap_object before this branch,
-        so note ingestion itself was already exposed to it."""
-        note, post = self._note_with_post(local=False)
-        PostAttachment.objects.create(
-            post=post,
-            author_id=self.identity.pk,
-            mimetype="image/png",
-            file=ContentFile(_png_bytes(), name="legacy.png"),
-        )
-        with mock.patch.object(storages["takahe"], "base_url", "/media/"):
-            params = Note.params_from_ap_object(post, {"content": "x"}, None)
-        entries = params["attachments"]
-        assert len(entries) == 1
-        assert entries[0]["url"].startswith("http")
-        assert entries[0]["preview_url"].startswith("http")
-
     def test_long_remote_url_is_not_truncated(self):
         """takahe stores remote_url as varchar(2500); truncating at 500 would
         persist a broken URL, and attachment_list prefers rows over the intact
@@ -827,7 +806,7 @@ class TestSyncFromPost:
 
     def test_long_legacy_url_survives_registration(self):
         long_url = "https://far.example/" + ("b" * 1200) + ".png"
-        a = Attachment.from_legacy_json(
+        a = register_legacy_attachment(
             self.identity, {"url": long_url, "mimetype": "image/png"}
         )
         assert a is not None

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -33,8 +33,13 @@ from catalog.models import (
 from journal.exporters import NdjsonExporter
 from journal.importers import CsvImporter, NdjsonImporter
 from journal.models import *
+from journal.models.attachment import (
+    source_for_post_attachment,
+    takahe_attachment_urls,
+)
 from journal.models.common import Debris
 from journal.search import JournalIndex
+from takahe.models import PostAttachment
 from takahe.utils import Takahe
 from users.models import Task, User
 
@@ -1610,6 +1615,107 @@ class TestNdjsonExportImport:
         # per-item notes replay too; append_item alone is a no-op for a member
         # already on the list
         assert c2.get_member_for_item(self.book1).note == "edited"
+
+    def _note_with_media(self, content: str, mimetype: str, ext: str) -> Note:
+        owner1 = self.user1.identity
+        note = Note.objects.create(
+            owner=owner1,
+            item=self.book1,
+            title="N",
+            content="see attached",
+            visibility=0,
+            created_time=self.dt,
+        )
+        if mimetype.startswith("image/"):
+            buf = BytesIO()
+            Image.new("RGB", (4, 4), "blue").save(buf, format="PNG")
+            payload = buf.getvalue()
+        else:
+            payload = content.encode()
+        a = Attachment.register(owner1, ContentFile(payload), ext, mimetype=mimetype)
+        note.attachment_records.add(a)
+        return note
+
+    def test_ndjson_imported_note_post_carries_media(self, tmp_path):
+        """Restored note media reaches the timeline post, once, and settles.
+
+        The importer used to post the note before its files were restored, so
+        the note card showed the images but the post (and every federated
+        copy) had none.
+        """
+        owner2 = self.user2.identity
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            note = self._note_with_media("", "image/png", "png")
+            exporter = NdjsonExporter.create(user=self.user1)
+            exporter.run()
+            path = exporter.metadata["file"]
+            NdjsonImporter.create(user=self.user2, file=path, visibility=0).run()
+
+            imported = Note.objects.get(owner=owner2, item=self.book1)
+            rows = list(imported.attachment_records.all())
+            assert len(rows) == 1
+            post = imported.latest_post
+            assert post is not None
+            attached = list(post.attachments.all())
+            assert len(attached) == 1
+            assert attached[0].mimetype == "image/png"
+            assert attached[0].author.pk == owner2.pk
+            url, preview = takahe_attachment_urls(attached[0])
+            assert url and preview
+            # the row is stamped so neither this path nor sync_from_post
+            # copies the same media again
+            assert rows[0].source == source_for_post_attachment(attached[0].pk)
+            assert Attachment.sync_from_post(imported, post) == rows
+            assert imported.attachment_records.count() == 1
+
+            # an unchanged archive is a no-op for the media too
+            importer = NdjsonImporter.create(user=self.user2, file=path, visibility=0)
+            importer.run()
+            assert importer.metadata["skipped"] >= 1
+            assert Attachment.objects.filter(owner=owner2).count() == 1
+            assert PostAttachment.objects.filter(author_id=owner2.pk).count() == 1
+
+            # an edit replays: the archive's media replaces the post's, not
+            # accumulates on it
+            note.content = "edited"
+            note.save()
+            self._roundtrip(self.user1, self.user2)
+            imported = Note.objects.get(owner=owner2, item=self.book1)
+            assert imported.content == "edited"
+            assert imported.attachment_records.count() == 1
+            post = imported.latest_post
+            assert post is not None
+            replaced = list(post.attachments.all())
+            assert len(replaced) == 1
+            assert replaced[0].pk != attached[0].pk
+
+    def test_ndjson_imported_note_non_image_media(self, tmp_path):
+        owner2 = self.user2.identity
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            self._note_with_media("not really audio", "audio/mpeg", "mp3")
+            self._roundtrip(self.user1, self.user2)
+            imported = Note.objects.get(owner=owner2, item=self.book1)
+            post = imported.latest_post
+            assert post is not None
+            attached = list(post.attachments.all())
+            assert len(attached) == 1
+            assert attached[0].mimetype == "audio/mpeg"
+            assert (attached[0].file.name or "").endswith(".mp3")
+            assert not attached[0].thumbnail
+
+    def test_note_post_params_leave_api_media_alone(self):
+        """Rows mirrored from a post (``takahe:`` source) are never re-uploaded,
+        and a note without media passes no ``attachments`` at all."""
+        owner1 = self.user1.identity
+        note = Note.objects.create(
+            owner=owner1, item=self.book1, content="plain", visibility=0
+        )
+        assert "attachments" not in note.to_post_params()
+        a = Attachment.register(owner1, ContentFile(b"x"), "png", mimetype="image/png")
+        a.source = source_for_post_attachment(999999)
+        a.save(update_fields=["source"])
+        note.attachment_records.add(a)
+        assert "attachments" not in note.to_post_params()
 
     def test_ndjson_article_edit_and_language_round_trip(self):
         owner1 = self.user1.identity

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1667,6 +1667,9 @@ class TestNdjsonExportImport:
             assert rows[0].source == source_for_post_attachment(attached[0].pk)
             assert Attachment.sync_from_post(imported, post) == rows
             assert imported.attachment_records.count() == 1
+            # indexed after the post exists, so status search can find it
+            stored = JournalIndex.instance().get_doc(str(post.pk))
+            assert stored and stored["post_id"] == [post.pk]
 
             # an unchanged archive is a no-op for the media too
             importer = NdjsonImporter.create(user=self.user2, file=path, visibility=0)
@@ -1689,6 +1692,59 @@ class TestNdjsonExportImport:
             assert len(replaced) == 1
             assert replaced[0].pk != attached[0].pk
 
+            # media removed at the source is removed from the post and the
+            # legacy JSON fallback, so nothing resurrects it
+            note.attachment_records.clear()
+            note.content = "media gone"
+            note.save()
+            self._roundtrip(self.user1, self.user2)
+            imported = Note.objects.get(owner=owner2, item=self.book1)
+            assert imported.content == "media gone"
+            assert imported.attachment_list == []
+            post = imported.latest_post
+            assert post is not None
+            assert post.attachments.count() == 0
+
+    def test_ndjson_export_keeps_pointer_rows_beside_post_media(self, tmp_path):
+        """A restored note can hold a pointer row (remote media never
+        downloaded) that cannot go on its post; the next export must carry it
+        alongside the post's media instead of hiding it behind the post."""
+        owner2 = self.user2.identity
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            self._note_with_media("", "image/png", "png")
+            self._roundtrip(self.user1, self.user2)
+            imported = Note.objects.get(owner=owner2, item=self.book1)
+            post = imported.latest_post
+            assert post is not None and post.attachments.count() == 1
+            pointer = Attachment.from_legacy_json(
+                owner2,
+                {
+                    "url": "https://media.example.org/remote.png",
+                    "mimetype": "image/png",
+                },
+            )
+            assert pointer is not None
+            imported.attachment_records.add(pointer)
+
+            exporter = NdjsonExporter.create(user=self.user2)
+            with mock.patch(
+                "journal.exporters.ndjson.ProxiedImageDownloader.download_image",
+                return_value=(None, ""),
+            ):
+                exporter.run()
+            with zipfile.ZipFile(exporter.metadata["file"]) as zf:
+                journal = zf.read("journal.ndjson").decode()
+            record = next(
+                r
+                for r in (json.loads(line) for line in journal.splitlines()[1:])
+                if r.get("type") == "Note"
+            )
+            entries = record["attachments"]
+            assert len(entries) == 2
+            assert entries[0]["file"].startswith("attachments/")
+            assert entries[1]["url"] == "https://media.example.org/remote.png"
+            assert "file" not in entries[1]
+
     def test_ndjson_imported_note_non_image_media(self, tmp_path):
         owner2 = self.user2.identity
         with override_settings(MEDIA_ROOT=str(tmp_path)):
@@ -1704,18 +1760,20 @@ class TestNdjsonExportImport:
             assert not attached[0].thumbnail
 
     def test_note_post_params_leave_api_media_alone(self):
-        """Rows mirrored from a post (``takahe:`` source) are never re-uploaded,
-        and a note without media passes no ``attachments`` at all."""
+        """Without the importer's flag a save never passes ``attachments``, so
+        media the Mastodon API put on the post stays as it is. With the flag,
+        the rows are the truth, including "none"."""
         owner1 = self.user1.identity
         note = Note.objects.create(
             owner=owner1, item=self.book1, content="plain", visibility=0
         )
         assert "attachments" not in note.to_post_params()
         a = Attachment.register(owner1, ContentFile(b"x"), "png", mimetype="image/png")
-        a.source = source_for_post_attachment(999999)
-        a.save(update_fields=["source"])
         note.attachment_records.add(a)
         assert "attachments" not in note.to_post_params()
+        note.attachment_records.clear()
+        note.post_media_from_records = True
+        assert note.to_post_params()["attachments"] == []
 
     def test_ndjson_article_edit_and_language_round_trip(self):
         owner1 = self.user1.identity

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1187,10 +1187,11 @@ class TestNdjsonExportImport:
     def test_ndjson_bundles_absolute_local_media(self, tmp_path):
         """An absolute URL on our own site is copied from storage, not fetched.
 
-        import_note records restored attachments as site_url + MEDIA_URL, so
-        a re-export saw a URL that did not start with a relative MEDIA_URL
-        and fell through to the HTTP downloader — which is_valid_url blocks
-        for an internal host, silently dropping the file from the bundle.
+        A pointer row can hold an absolute URL on our own site (older imports
+        wrote them that way). A re-export saw a URL that did not start with a
+        relative MEDIA_URL and fell through to the HTTP downloader — which
+        is_valid_url blocks for an internal host, silently dropping the file
+        from the bundle.
         """
         with override_settings(MEDIA_ROOT=str(tmp_path)):
             buf = BytesIO()
@@ -1203,27 +1204,17 @@ class TestNdjsonExportImport:
             )
             assert not absolute.startswith(settings.MEDIA_URL)
 
-            # a note whose media is only reachable through its stored
-            # attachments JSON — exactly what import_note writes back
             note = Note.objects.create(
                 item=self.book1,
                 owner=self.user1.identity,
                 content="see attached",
                 visibility=0,
             )
-            note.attachments = [
-                {
-                    "type": "image",
-                    "mimetype": "image/png",
-                    "url": absolute,
-                    "preview_url": "",
-                }
-            ]
-            note.save(
-                update_fields=["attachments"],
-                post_when_save=False,
-                index_when_save=False,
+            pointer = Attachment.pointer_for_url(
+                self.user1.identity, absolute, "image/png"
             )
+            assert pointer is not None and not pointer.file
+            note.attachment_records.add(pointer)
 
             exporter = NdjsonExporter.create(user=self.user1)
             exporter.run()
@@ -1716,12 +1707,8 @@ class TestNdjsonExportImport:
             imported = Note.objects.get(owner=owner2, item=self.book1)
             post = imported.latest_post
             assert post is not None and post.attachments.count() == 1
-            pointer = Attachment.from_legacy_json(
-                owner2,
-                {
-                    "url": "https://media.example.org/remote.png",
-                    "mimetype": "image/png",
-                },
+            pointer = Attachment.pointer_for_url(
+                owner2, "https://media.example.org/remote.png", "image/png"
             )
             assert pointer is not None
             imported.attachment_records.add(pointer)


### PR DESCRIPTION
Fixes #971

The NDJSON importer already restored a note's bundled files into media storage and the attachment registry, but it posted the note to the timeline before that, and `Note.to_post_params` passed no attachments. The note card showed the images while the post, and every federated copy of it, had none.

## Changes

- `import_note` saves the note without posting or indexing, restores the media, and posts and indexes on the final save, so the timeline post carries the media and the search document has the post id. The save hook still handles visibility changes and crossposting as before.
- `Note.to_post_params` passes `attachments` only when the importer has set `post_media_from_records`. The registry rows are then the exact media set: rows already on the post are kept, restored files are uploaded, and post media no row describes is dropped, so an archive that no longer has attachments clears them. The legacy `attachments` JSON is overwritten too, so `attachment_list` cannot fall back to removed media. An ordinary save never touches media the Mastodon API put on the post. After an upload the row is stamped `takahe:<pk>`, so a later `Attachment.sync_from_post` dedupes onto it instead of copying the media back.
- `Takahe.upload_attachment` covers audio and video, which `upload_image` cannot take. It mirrors the non-image branch of takahe's Mastodon media upload.
- The exporter merges registry rows the post does not cover (pointer rows for remote media that cannot be posted) with the post's media, instead of hiding them behind a non-empty post.

## Tests

- imported note post carries the media once, the row is stamped, `sync_from_post` dedupes, the index doc has the post id, an unchanged re-import adds nothing, an edit replays and replaces the post's media, and media removed at the source is cleared from the post and the legacy JSON
- a pointer row on a restored note exports alongside the post's media
- non-image (audio) attachment lands on the post with its extension and no thumbnail
- `to_post_params` passes no `attachments` without the flag, and an empty list with it when the note has no media

## Registry as the only source of note media

Note media had three representations: the takahe post attachments, the `Attachment` registry rows, and the legacy `Note.attachments` JSON with a fallback in `attachment_list`. The JSON was still written on every Mastodon-originated fetch and by the importer, and the exporter picked between three tiers. The third commit makes the registry the only thing read and written:

- `Note.attachment_list` returns registry rows only. Templates read the same `type` / `url` / `preview_url` attributes they already handled.
- `params_from_ap_object` no longer rebuilds the JSON. `sync_from_post` already mirrors a post's media into rows after the save.
- The importer registers rows and no longer writes the JSON. The exporter bundles a note's registry rows and nothing else.
- Migration 0019 now runs the backfill synchronously instead of queuing it as a background job, so a deployment that has not applied it yet runs it exactly once. Each piece runs in a savepoint and notes that already hold rows are skipped. Deployments that already applied 0019 are unaffected, since Django does not re-run an applied migration.
- Uploading a registry row to takahe is `Attachment.to_post_attachment`, shared rather than a Note private.
- The helpers that only serve the legacy JSON (`takahe_media_path`, `register_legacy_attachment`, the `takahe-media:` source) live with the backfill in `journal.jobs.migrations`, not on the model. The importer only needs a pointer row for a URL-only archive entry and uses the small `Attachment.pointer_for_url`.
- The column stays and is marked deprecated. The backfill is its only reader. It can be dropped in a later release together with those helpers.

Caveat: the exporter no longer reads the post, so a note posted from a Mastodon client seconds before an export, before the `post_created` job has mirrored its rows, exports without media.

## Unrelated fix carried along

`seed_catalog.py` landed on main after the loguru removal but still imported it, so the type check and its test module failed on every branch. The fourth commit swaps it to stdlib logging.

## Out of scope

Plain (non-journal) post import is still a stub in `NdjsonImporter.import_post`. That is a separate feature.
