### PR TITLE
fix(takahe): accept a Question whose anyOf/oneOf is a single option object

### DIFF
--- a/takahe/activities/models/post_types.py
+++ b/takahe/activities/models/post_types.py
@@ -70,6 +70,9 @@ class QuestionData(BasePostDataType):
             options = data.pop("anyOf", None)
             if not options:
                 options = data.pop("oneOf", None)
+            # JSON-LD allows a lone value in place of a one-element list
+            if isinstance(options, dict):
+                options = [options]
             data["options"] = options
         # Some servers signal a finished poll with a boolean `closed`
         # rather than a datetime (Mastodon treats any truthy value as

--- a/takahe/tests/activities/models/test_post_types.py
+++ b/takahe/tests/activities/models/test_post_types.py
@@ -82,6 +82,14 @@ def test_question_post(config_system, identity, remote_identity, httpx_mock):
     assert question_data.options[1].votes == 1
 
 
+def test_question_single_option_object():
+    question = PostTypeData(
+        root={"type": "Question", "anyOf": {"name": "A", "type": "Note"}}
+    ).root
+    assert isinstance(question, QuestionData)
+    assert [o.name for o in question.options] == ["A"]
+
+
 def test_question_closed_datetime_marks_expired():
     question = PostTypeData(
         root={


### PR DESCRIPTION
A remote Question whose `anyOf`/`oneOf` holds a single option object instead of a list failed pydantic validation in `QuestionData`, so `Post.by_ap` raised and the incoming post was dropped. JSON-LD allows a lone value in place of a one-element list.

Fix: wrap a dict option in a list before validation. Adds a test with the payload shape from the report.

Ref: https://github.com/avaraline/incarnator/issues/23