### PR TITLE
fix(ap): send Note title as ActivityStreams name, keep title for older peers

### DIFF
--- a/docs/internals/activitypub.md
+++ b/docs/internals/activitypub.md
@@ -58,7 +58,7 @@ reviews):
     - `Rating` — `value` is the grade (integer 1-10); `worst` is always 1, `best` always 10
     - `Comment` — `content` is the comment text
     - `Review` — `name` is the title, `content` the body, `mediaType` is `text/markdown` (see [Review](#review))
-    - `Note` — `content` is the note text
+    - `Note` — `name` is the title, `content` the note text (older instances sent the title as `title`; it is still emitted alongside `name`, and readers accept either)
     - `Shelf` — the lightweight envelope of a Collection or Shelf (see [Collections and shelves](#collections-and-shelves))
 - `tag` carries the catalog items referenced by the activity. Each item's `type`
   is one of `Edition`, `Movie`, `TVShow`, `TVSeason`, `TVEpisode`, `Album`,

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -579,7 +579,7 @@ class NdjsonImporter(BaseImporter):
             item = self.items.get(content_data.get("withRegardTo", ""))
             if not item:
                 raise KeyError(f"Could not find item: {data.get('item', '')}")
-            title = content_data.get("title", "")
+            title = Note.title_from_ap_object(content_data, "") or ""
             content = content_data.get("content", "")
             sensitive = content_data.get("sensitive", False)
             progress = content_data.get("progress", {})

--- a/neodb/journal/models/note.py
+++ b/neodb/journal/models/note.py
@@ -167,6 +167,9 @@ class Note(Content):
         d = {
             "id": self.absolute_url,
             "type": "Note",
+            "name": self.title,
+            # pre-name peers and backups read ``title``; keep it until they
+            # are gone
             "title": self.title,
             "content": self.content,
             "sensitive": self.sensitive,
@@ -183,13 +186,21 @@ class Note(Content):
             }
         return d
 
+    @staticmethod
+    def title_from_ap_object(obj: dict[str, Any], default: str | None) -> str | None:
+        """AS ``name`` wins; ``title`` is what older NeoDB peers sent."""
+        for key in ("name", "title"):
+            if key in obj:
+                return obj[key]
+        return default
+
     @override
     @classmethod
     def params_from_ap_object(cls, post, obj, piece):
         content: str = obj.get("content", "").strip()
         attachments: list[dict[str, object]] = []
         params: dict[str, object] = {
-            "title": obj.get("title", post.summary),
+            "title": cls.title_from_ap_object(obj, post.summary),
             "content": content,
             "sensitive": obj.get("sensitive", post.sensitive),
             "attachments": attachments,

--- a/neodb/tests/journal/test_ap_object.py
+++ b/neodb/tests/journal/test_ap_object.py
@@ -82,6 +82,7 @@ class TestApObjectStructure:
         obj = note.ap_object
         assert obj["type"] == "Note"
         assert obj["content"] == "Some reading notes"
+        assert obj["name"] is None
         assert obj["title"] is None
         assert obj["sensitive"] is False
         assert obj["id"] == note.absolute_url
@@ -117,6 +118,8 @@ class TestApObjectStructure:
             visibility=0,
         )
         obj = note.ap_object
+        # AS ``name`` is canonical; ``title`` stays for pre-name peers
+        assert obj["name"] == "Spoiler warning"
         assert obj["title"] == "Spoiler warning"
         assert obj["sensitive"] is True
 
@@ -632,6 +635,24 @@ class TestUpdateByApObject:
         assert params["content"] == "Simple note"
         assert params["progress_value"] is None
         assert params["progress_type"] is None
+
+    def test_note_title_from_ap_object(self):
+        """``name`` is canonical, ``title`` is the pre-name spelling, and the
+        post summary is the fallback when a peer sends neither."""
+        post = _make_remote_post(self.identity.pk)
+        post.summary = "from summary"
+        base = {"type": "Note", "content": "x"}
+        both = Note.params_from_ap_object(
+            post, {**base, "name": "new", "title": "old"}, None
+        )
+        assert both["title"] == "new"
+        legacy = Note.params_from_ap_object(post, {**base, "title": "old"}, None)
+        assert legacy["title"] == "old"
+        # an explicit empty name is a real value, not a missing one
+        empty = Note.params_from_ap_object(post, {**base, "name": None}, None)
+        assert empty["title"] is None
+        neither = Note.params_from_ap_object(post, base, None)
+        assert neither["title"] == "from summary"
 
     def test_note_round_trip(self):
         """Full round-trip: create Note, export ap_object, re-import via update_by_ap_object."""


### PR DESCRIPTION
## Problem

`Note.ap_object` carried its title in a `title` key. That key is not an ActivityStreams property, and it disagrees with every other NeoDB piece: `Review`, `Article` and the `Shelf` envelope all use the AS `name` property for the same thing. General AP servers that read `name` see no title on a NeoDB note.

## Change

- `Note.ap_object` now emits `name`, and keeps `title` alongside it so peers and backups that predate this change still parse.
- Inbound `params_from_ap_object` prefers `name`, falls back to `title`, then to the post summary. An explicit null `name` stays a real value, matching the old `title` behaviour.
- The NDJSON importer reads through the same helper, so archives written by older instances still restore note titles.
- `docs/internals/activitypub.md` documents `name` as the title and records `title` as the compatibility key.

The reader logic lives in one small `Note.title_from_ap_object` helper, shared by the federation path and the importer, so the two cannot drift.

## Compatibility

Both directions keep working during the transition:

| peer | sends | this version reads |
| --- | --- | --- |
| new | `name` + `title` | `name` |
| old | `title` only | `title` |
| non-NeoDB AP | `name` | `name` |

`title` can be dropped from the writer once enough of the network has upgraded.

## Tests

New and updated cases in `tests/journal/test_ap_object.py` cover both keys on the writer side, `name` winning over `title`, the `title`-only legacy shape, an explicit null `name`, and the summary fallback.

Full journal suite passes: 916 tests.
