### PR TITLE
fix(post): stop marking a post sensitive just because it has a summary

### DIFF
--- a/neodb/takahe/models.py
+++ b/neodb/takahe/models.py
@@ -1445,7 +1445,7 @@ class Post(models.Model):
                 "author": author,
                 "content": content,
                 "summary": summary or None,
-                "sensitive": bool(summary) or sensitive,
+                "sensitive": sensitive,
                 "local": True,
                 "visibility": visibility,
                 "hashtags": hashtags,
@@ -1522,7 +1522,7 @@ class Post(models.Model):
                 or None
             )
             self.summary = summary or None
-            self.sensitive = bool(summary) if sensitive is None else sensitive
+            self.sensitive = bool(sensitive)
             self.edited = edited or timezone.now()
             self.mentions.set(self.mentions_from_content(content, self.author))
             self.emojis.set(Emoji.emojis_from_content(content, None))

--- a/neodb/tests/journal/test_ap_object.py
+++ b/neodb/tests/journal/test_ap_object.py
@@ -406,6 +406,32 @@ class TestPostTypeData:
         assert related[0]["content"] == "Notes without progress"
         assert "progress" not in related[0]
 
+    def test_note_title_does_not_make_post_sensitive(self):
+        note = Note.objects.create(
+            item=self.book,
+            owner=self.identity,
+            title="Chapter one",
+            content="Plain note",
+            visibility=0,
+        )
+        post = Takahe.get_post(note.latest_post_id)
+        assert post is not None
+        assert post.summary == "Chapter one"
+        assert post.sensitive is False
+
+        note.sensitive = True
+        note.save()
+        post = Takahe.get_post(note.latest_post_id)
+        assert post is not None
+        assert post.sensitive is True
+
+        note.sensitive = False
+        note.save()
+        post = Takahe.get_post(note.latest_post_id)
+        assert post is not None
+        assert post.summary == "Chapter one"
+        assert post.sensitive is False
+
     def test_note_post_type_data_with_progress(self):
         note = Note.objects.create(
             item=self.book,

--- a/neodb/tests/journal/test_article.py
+++ b/neodb/tests/journal/test_article.py
@@ -144,6 +144,32 @@ class TestArticleModel:
         # No relatedWith on standalone article
         assert "relatedWith" not in post.type_data["object"]
 
+    def test_article_summary_does_not_make_post_sensitive(self):
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="Teaser",
+            body="Body",
+            summary="hand-written teaser",
+            visibility=0,
+        )
+        post = Takahe.get_post(article.latest_post_id)
+        assert post is not None
+        assert post.summary == "hand-written teaser"
+        assert post.sensitive is False
+
+        article = Article.update_local_article(
+            owner=self.identity,
+            title="Teaser",
+            body="Body",
+            summary="hand-written teaser",
+            sensitive=True,
+            visibility=0,
+            article=article,
+        )
+        post = Takahe.get_post(article.latest_post_id)
+        assert post is not None
+        assert post.sensitive is True
+
     def test_article_edit_reuses_post(self):
         article = Article.update_local_article(
             owner=self.identity,


### PR DESCRIPTION
## Problem

Takahe reuses the `summary` column for content warnings and derives the `sensitive` flag from it in `create_local` and `edit_local`. NeoDB stores Note titles and Article summaries in that same column, so every titled Note and every Article with a summary was federated as a content-warning post, even when the author left the sensitive checkbox off. Mastodon and most clients then collapse the body behind a "show more" button.

## Fix

`create_local` and `edit_local` in `neodb/takahe/models.py` now take the caller's explicit `sensitive` flag as is. Every caller already passes one (Comment and ShelfMember compute it from spoiler text, the compose views pass the checkbox, Note and Article pass their own field).

The upstream copy in `takahe/activities/models/post.py` is unchanged. It only serves the Mastodon API, where a non-empty `spoiler_text` is expected to imply sensitive.

## Tests

- Titled Note: post keeps the title in `summary` and `sensitive` stays false; toggling the Note's flag on and off follows through to the post.
- Article with a summary: same behaviour on create and edit.

Both new tests fail on main and pass with the fix. `tests/journal`, `tests/social`, `tests/mastodon`, `tests/users` pass apart from the three known `test_lexicons` failures that need `/docs` mounted.