### PR TITLE
fix(journal): save the mark dialog without reloading timeline and list pages

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -398,6 +398,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "hijack.middleware.HijackUserMiddleware",
     "common.middleware.IdentityMiddleware",
+    "common.middleware.HtmxLoginRedirectMiddleware",
     # "django.middleware.locale.LocaleMiddleware",
     "users.middlewares.LanguageMiddleware",
     "common.middleware.SafeTimezoneMiddleware",

--- a/neodb/common/middleware.py
+++ b/neodb/common/middleware.py
@@ -1,6 +1,7 @@
 import time
 
 import pytz
+from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
@@ -96,6 +97,25 @@ class SafeTimezoneMiddleware(MiddlewareMixin):
                 timezone.deactivate()
         else:
             timezone.deactivate()
+
+
+class HtmxLoginRedirectMiddleware(MiddlewareMixin):
+    """
+    htmx follows a login redirect transparently and swaps the login page into
+    the target, or drops it when the target swaps nothing, so an expired
+    session fails silently. Tell htmx to navigate to the login page instead.
+    """
+
+    def process_response(self, request, response):
+        if (
+            response.status_code in (301, 302)
+            and request.headers.get("HX-Request")
+            and response.get("Location", "").startswith(settings.LOGIN_URL)
+        ):
+            response["HX-Redirect"] = response["Location"]
+            response.status_code = 200
+            del response["Location"]
+        return response
 
 
 class IdentityMiddleware(MiddlewareMixin):

--- a/neodb/common/static/scss/_mark.scss
+++ b/neodb/common/static/scss/_mark.scss
@@ -4,6 +4,11 @@
   [type=radio] {
     margin-inline-end: .1em;
   }
+
+  .mark-form-error {
+    color: var(--pico-del-color);
+    margin-bottom: var(--pico-spacing);
+  }
 }
 
 .note-edit-buttons {

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -1184,10 +1184,16 @@ def prefetch_latest_posts(pieces: Sequence["Piece"]) -> None:
         piece.__dict__["latest_post"] = posts_by_id.get(post_id) if post_id else None
 
 
-def prefetch_pieces_for_posts(posts: list["Post"]) -> None:
-    """Batch-prefetch piece and item for a list of Post objects to avoid N+1 queries."""
+def prefetch_pieces_for_posts(
+    posts: list["Post"], viewer: APIdentity | None = None
+) -> None:
+    """
+    Batch-prefetch piece and item for a list of Post objects to avoid N+1 queries.
+    With a viewer, also attach the viewer's own Mark to each item as ``item.mark``
+    so the bookmark action can render its state without a query per post.
+    """
     from catalog.models import Item
-    from journal.models import ShelfMember
+    from journal.models import Mark, ShelfMember
 
     if not posts:
         return
@@ -1250,6 +1256,17 @@ def prefetch_pieces_for_posts(posts: list["Post"]) -> None:
             items,
             Item.external_resources_prefetch(with_metadata=True),
         )
+        if viewer:
+            marks = {}
+            for item in items:
+                m = Mark(viewer, item)
+                m.shelfmember = None
+                marks[item.pk] = m
+                item.mark = m
+            for sm in ShelfMember.objects.filter(
+                owner=viewer, item_id__in=items_by_id
+            ).select_related("parent"):
+                marks[sm.item_id].shelfmember = sm
 
 
 class PieceInteraction(models.Model):

--- a/neodb/journal/templates/_list_item.html
+++ b/neodb/journal/templates/_list_item.html
@@ -29,24 +29,7 @@
         </a>
       </span>
     {% elif request.user.is_authenticated and item.class_name != 'collection' %}
-      <span>
-        {% if not mark.shelf_type %}
-          <a title="{% trans "add mark" %}"
-             hx-get="{% url 'journal:mark' item.uuid %}?shelf_type=wishlist"
-             hx-target="body"
-             hx-swap="beforeend">
-            <i class="fa-regular fa-bookmark"></i>
-          </a>
-        {% else %}
-          <a class="activated"
-             title="{% trans "update mark" %}"
-             hx-get="{% url 'journal:mark' item.uuid %}"
-             hx-target="body"
-             hx-swap="beforeend">
-            <i class="fa-solid fa-bookmark"></i>
-          </a>
-        {% endif %}
-      </span>
+      {% include "action_mark_item.html" with item=item mark=mark %}
     {% endif %}
   </span>
   {% include "_item_card.html" with item=item %}
@@ -80,18 +63,7 @@
         </section>
       {% endif %}
       {% if not collection_edit %}
-        {% if mark.shelf %}
-          <section>
-            <div class="action">{% include "action_open_post.html" with post=mark.shelfmember.latest_post %}</div>
-            <span class="action inline">
-              <span class="timestamp">{{ mark.created_time|date }} {{ mark.status_label }}</span>
-              {% comment %} <a href="{{mark.owner.url }}" title="@{{ mark.owner.handle }}">{{ mark.owner.display_name }}</a> {% endcomment %}
-            </span>
-            {% if mark.rating_grade %}{{ mark.rating_grade|rating_star }}{% endif %}
-            <span>{{ mark.comment.html|safe }}</span>
-            {% if mark.comment.latest_post %}<div id="replies_{{ mark.comment.latest_post.pk }}"></div>{% endif %}
-          </section>
-        {% endif %}
+        {% include "_list_item_mark.html" with item=item mark=mark %}
         {% if mark.review %}
           <section>
             <div class="action">{% include "action_open_post.html" with post=mark.review.latest_post %}</div>
@@ -107,19 +79,6 @@
               {% endif %}
             </span>
             {% if mark.review.latest_post %}<div id="replies_{{ mark.review.latest_post.pk }}"></div>{% endif %}
-          </section>
-        {% endif %}
-        {% if mark.tags %}
-          <section>
-            <span class="tag-list">
-              {% for tag in mark.tags %}
-                {% if forloop.counter <= 5 %}
-                  <span>
-                    <a href="{% url 'common:search' %}?c=journal&amp;q=tag:&quot;{{ tag }}&quot;">{{ tag }}</a>
-                  </span>
-                {% endif %}
-              {% endfor %}
-            </span>
           </section>
         {% endif %}
       {% endif %}

--- a/neodb/journal/templates/_list_item_mark.html
+++ b/neodb/journal/templates/_list_item_mark.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+{% load user_actions %}
+{% load duration %}
+{# the viewer's own mark details on a list card; the mark dialog swaps this in place after saving #}
+<div {% if request.user.is_authenticated and mark.owner.pk == request.user.identity.pk %}data-mark-detail="{{ item.uuid }}"{% endif %}
+     {% if oob %}hx-swap-oob="outerHTML:[data-mark-detail='{{ item.uuid }}']"{% endif %}>
+  {% if mark.shelf %}
+    <section>
+      <div class="action">{% include "action_open_post.html" with post=mark.shelfmember.latest_post %}</div>
+      <span class="action inline">
+        <span class="timestamp">{{ mark.created_time|date }} {{ mark.status_label }}</span>
+      </span>
+      {% if mark.rating_grade %}{{ mark.rating_grade|rating_star }}{% endif %}
+      <span>{{ mark.comment.html|safe }}</span>
+      {% if mark.comment.latest_post %}<div id="replies_{{ mark.comment.latest_post.pk }}"></div>{% endif %}
+    </section>
+  {% endif %}
+  {% if mark.tags %}
+    <section>
+      <span class="tag-list">
+        {% for tag in mark.tags %}
+          {% if forloop.counter <= 5 %}
+            <span>
+              <a href="{% url 'common:search' %}?c=journal&amp;q=tag:&quot;{{ tag }}&quot;">{{ tag }}</a>
+            </span>
+          {% endif %}
+        {% endfor %}
+      </span>
+    </section>
+  {% endif %}
+</div>

--- a/neodb/journal/templates/_mark_form_error.html
+++ b/neodb/journal/templates/_mark_form_error.html
@@ -1,0 +1,8 @@
+<p class="mark-form-error" role="alert">
+  <i class="fa-solid fa-circle-exclamation"></i>
+  {{ msg }}
+  {% if secondary_msg %}
+    <br>
+    <small>{{ secondary_msg }}</small>
+  {% endif %}
+</p>

--- a/neodb/journal/templates/action_mark_item.html
+++ b/neodb/journal/templates/action_mark_item.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+{% load user_actions %}
+{% if not mark %}
+  {% get_mark_for_item item as mark %}
+{% endif %}
+{# data-mark-item marks this as the viewer's own state, so a save from the mark dialog can refresh it in place #}
+<span {% if request.user.is_authenticated and mark.owner.pk == request.user.identity.pk %}data-mark-item="{{ item.uuid }}"{% endif %}
+      {% if oob %}hx-swap-oob="outerHTML:[data-mark-item='{{ item.uuid }}']"{% endif %}>
+  {% if not mark.shelf_type %}
+    <a title="{% trans "add mark" %}"
+       hx-get="{% url 'journal:mark' item.uuid %}?shelf_type=wishlist&amp;inline=1"
+       hx-target="body"
+       hx-swap="beforeend">
+      <i class="fa-regular fa-bookmark"></i>
+    </a>
+  {% else %}
+    <a class="activated"
+       title="{% trans "update mark" %}"
+       hx-get="{% url 'journal:mark' item.uuid %}?inline=1"
+       hx-target="body"
+       hx-swap="beforeend">
+      <i class="fa-solid fa-bookmark"></i>
+    </a>
+  {% endif %}
+</span>

--- a/neodb/journal/templates/mark.html
+++ b/neodb/journal/templates/mark.html
@@ -17,8 +17,12 @@
       <strong>{% trans "Mark" %} - {{ item.display_title }}</strong>
     </header>
     <div>
-      <form method="post" action="{% url 'journal:mark' item.uuid %}">
+      <form method="post"
+            action="{% url 'journal:mark' item.uuid %}"
+            hx-post="{% url 'journal:mark' item.uuid %}"
+            hx-swap="none">
         {% csrf_token %}
+        {% if inline %}<input type="hidden" name="inline" value="1">{% endif %}
         {% if shelf_statuses %}
           <input type="hidden"
                  id="mark-status"
@@ -135,14 +139,18 @@
           </fieldset>
         </div>
       </div>
+      <div id="mark-form-error"></div>
     </form>
     <div>
       {% if mark.id %}
         <form id="mark_delete"
               action="{% url 'journal:mark' mark.item.uuid %}"
+              hx-post="{% url 'journal:mark' mark.item.uuid %}"
+              hx-swap="none"
               method="post">
           {% csrf_token %}
           <input type="hidden" name="delete" value="1">
+          {% if inline %}<input type="hidden" name="inline" value="1">{% endif %}
           <a>
             <button class="secondary"
                     onclick="return confirm('{% trans "Sure to delete mark, comment and tags for this item?" %}')">

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -20,6 +20,7 @@ from common.models.misc import int_
 from common.utils import (
     AuthedHttpRequest,
     CustomPaginator,
+    HTTPResponseHXRedirect,
     PageLinksGenerator,
     get_uuid_or_404,
     target_identity_required,
@@ -171,13 +172,16 @@ def conditional_get_for_anonymous(get_timestamp):
 
 
 def render_relogin(request):
+    login_url = reverse("mastodon:login") + "?domain=" + request.user.mastodon.domain
+    if request.headers.get("HX-Request"):
+        # the error page relies on a meta refresh, which an htmx swap cannot
+        # run, so send the browser straight to the re-authentication step
+        return HTTPResponseHXRedirect(login_url)
     return render(
         request,
         "common/error.html",
         {
-            "url": reverse("mastodon:login")
-            + "?domain="
-            + request.user.mastodon.domain,
+            "url": login_url,
             "msg": _("Data saved but unable to crosspost to Fediverse instance."),
             "secondary_msg": _(
                 "Redirecting to your Fediverse instance now to re-authenticate."

--- a/neodb/journal/views/mark.py
+++ b/neodb/journal/views/mark.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseBase, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -25,6 +25,79 @@ PAGE_SIZE = 10
 _checkmark = "✔️".encode("utf-8")
 
 
+def _redirect_back(request: AuthedHttpRequest) -> HttpResponseRedirect:
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        referer = "/"
+    return HttpResponseRedirect(referer)
+
+
+def _mark_saved_response(request: AuthedHttpRequest, item: Item) -> HttpResponseBase:
+    """
+    After the mark dialog saves or deletes: a plain form submit goes back to
+    the referer as before. An htmx submit from an item page reloads it, while
+    an inline one (timeline, list cards) closes the dialog and refreshes the
+    bookmark icons of that item in place.
+    """
+    if not request.headers.get("HX-Request"):
+        return _redirect_back(request)
+    if not request.POST.get("inline"):
+        response = HttpResponse(status=204)
+        response["HX-Refresh"] = "true"
+        return response
+    response = HttpResponse(_mark_oob_content(request, item))
+    response["HX-Trigger"] = "close_dialog"
+    return response
+
+
+def _mark_oob_content(request: AuthedHttpRequest, item: Item) -> bytes:
+    """
+    Out-of-band fragments that refresh every card of ``item`` on the page:
+    the bookmark action and, on list cards, the viewer's mark details.
+    """
+    mark = Mark(request.user.identity, item)
+    context = {"item": item, "mark": mark, "oob": True}
+    return (
+        render(request, "action_mark_item.html", context).content
+        + render(request, "_list_item_mark.html", context).content
+    )
+
+
+def _mark_error_response(
+    request: AuthedHttpRequest,
+    msg: str,
+    secondary_msg: str = "",
+    saved_item: Item | None = None,
+) -> HttpResponse:
+    """
+    Show a message inside the open mark dialog, keeping it open. When the
+    mark was saved anyway, also refresh the bookmark icons of that item.
+    """
+    response = render(
+        request,
+        "_mark_form_error.html",
+        {"msg": msg, "secondary_msg": secondary_msg},
+    )
+    if saved_item:
+        response.content += _mark_oob_content(request, saved_item)
+    response["HX-Retarget"] = "#mark-form-error"
+    response["HX-Reswap"] = "innerHTML"
+    return response
+
+
+def _form_error_text(form: MarkForm) -> str:
+    parts = []
+    for field, errors in form.errors.items():
+        label = form.fields[field].label if field in form.fields else ""
+        text = " ".join(str(e) for e in errors)
+        parts.append(f"{label}: {text}" if label else text)
+    return "; ".join(parts)
+
+
 @login_required
 @require_http_methods(["POST"])
 def wish(request: AuthedHttpRequest, item_uuid):
@@ -36,14 +109,7 @@ def wish(request: AuthedHttpRequest, item_uuid):
         )
     record_activity("mark", "web")
     if request.GET.get("back"):
-        referer = request.META.get("HTTP_REFERER") or ""
-        if not url_has_allowed_host_and_scheme(
-            referer,
-            allowed_hosts=set(settings.SITE_DOMAINS),
-            require_https=settings.SSL_ONLY,
-        ):
-            referer = "/"
-        return HttpResponseRedirect(referer)
+        return _redirect_back(request)
     return HttpResponse(_checkmark)
 
 
@@ -100,6 +166,7 @@ def mark(request: AuthedHttpRequest, item_uuid):
             {
                 "item": item,
                 "mark": mark,
+                "inline": bool(request.GET.get("inline")),
                 "form": MarkForm(
                     initial={
                         "text": mark.comment_text or "",
@@ -118,14 +185,7 @@ def mark(request: AuthedHttpRequest, item_uuid):
     else:
         if request.POST.get("delete", default=False):
             mark.delete()
-            referer = request.META.get("HTTP_REFERER") or ""
-            if not url_has_allowed_host_and_scheme(
-                referer,
-                allowed_hosts=set(settings.SITE_DOMAINS),
-                require_https=settings.SSL_ONLY,
-            ):
-                referer = "/"
-            return HttpResponseRedirect(referer)
+            return _mark_saved_response(request, item)
         else:
             form = MarkForm(request.POST)
             if form.is_valid():
@@ -151,30 +211,22 @@ def mark(request: AuthedHttpRequest, item_uuid):
                         if str(e) == "422"
                         else str(e)
                     )
+                    msg = _("Data saved but unable to crosspost to Fediverse instance.")
+                    if request.headers.get("HX-Request"):
+                        return _mark_error_response(request, msg, err, item)
                     return render(
                         request,
                         "common/error.html",
-                        {
-                            "msg": _(
-                                "Data saved but unable to crosspost to Fediverse instance."
-                            ),
-                            "secondary_msg": err,
-                        },
+                        {"msg": msg, "secondary_msg": err},
                     )
                 record_activity("mark", "web")
-                referer = request.META.get("HTTP_REFERER") or ""
-                if not url_has_allowed_host_and_scheme(
-                    referer,
-                    allowed_hosts=set(settings.SITE_DOMAINS),
-                    require_https=settings.SSL_ONLY,
-                ):
-                    referer = "/"
-                return HttpResponseRedirect(referer)
+                return _mark_saved_response(request, item)
             else:
-                # In a real app we'd handle form errors better, but preserving existing behavior of falling through or erroring
-                # For now, let's just log and redirect or error if really invalid.
-                # The original code didn't strictly validate structure, just tried to cast things.
                 logger.warning(f"Mark form invalid: {form.errors}")
+                if request.headers.get("HX-Request"):
+                    return _mark_error_response(
+                        request, _("Invalid input"), _form_error_text(form)
+                    )
                 raise BadRequest(_("Invalid input"))
 
 

--- a/neodb/social/templates/_event_post.html
+++ b/neodb/social/templates/_event_post.html
@@ -47,12 +47,7 @@
                      {% if request.user.is_authenticated %} data-comment-href="{% url 'journal:comment' item.uuid %}" {% endif %}
                      data-position="{{ piece.metadata.position | default:0 }}"><i class="fa-solid fa-circle-play"></i></a>
                 {% else %}
-                  <a title="{% trans "mark" %}"
-                     hx-get="{% url 'journal:mark' item.uuid %}?shelf_type=wishlist"
-                     hx-target="body"
-                     hx-swap="beforeend">
-                    <i class="fa-regular fa-bookmark"></i>
-                  </a>
+                  {% include "action_mark_item.html" with item=item mark=None %}
                 {% endif %}
               </span>
             {% endif %}

--- a/neodb/social/views.py
+++ b/neodb/social/views.py
@@ -201,7 +201,9 @@ def data(request):
         .order_by("-id")[:PAGE_SIZE]
     )
     _add_interaction_to_events(events, identity_id)
-    prefetch_pieces_for_posts([e.subject_post for e in events if e.subject_post_id])
+    prefetch_pieces_for_posts(
+        [e.subject_post for e in events if e.subject_post_id], request.user.identity
+    )
     # events are TimelineEvent rows; the type checker can't see Django's implicit
     # id/_id attributes that FeedEvent declares, so assert the shape at this boundary.
     grouped = group_feed_events(cast(list[FeedEvent], events))

--- a/neodb/tests/journal/test_mark.py
+++ b/neodb/tests/journal/test_mark.py
@@ -101,6 +101,235 @@ def test_mark_editor_embeds_recent_and_popular_tags(client):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_mark_dialog_inline_flag_and_htmx_forms(client):
+    user = User.register(email="mark-inline@example.com", username="markinline")
+    book = Edition.objects.create(title="Inline Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    url = reverse("journal:mark", args=[book.uuid])
+
+    html = client.get(url).content.decode()
+    assert f'hx-post="{url}"' in html
+    assert 'name="inline"' not in html
+
+    html = client.get(f"{url}?inline=1&shelf_type=wishlist").content.decode()
+    assert 'name="inline" value="1"' in html
+
+
+def _mark_post_data(**extra):
+    data = {
+        "status": "complete",
+        "rating_grade": "8",
+        "text": "great",
+        "visibility": "0",
+        "tags": "",
+        "mark_date": "",
+    }
+    data.update(extra)
+    return data
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_save_plain_post_redirects_back(client):
+    user = User.register(email="mark-plain@example.com", username="markplain")
+    book = Edition.objects.create(title="Plain Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    response = client.post(
+        reverse("journal:mark", args=[book.uuid]),
+        _mark_post_data(),
+        HTTP_REFERER="/timeline/",
+    )
+    assert response.status_code == 302
+    assert response["Location"] == "/timeline/"
+    assert Mark(user.identity, book).shelf_type == ShelfType.COMPLETE
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_save_from_item_page_refreshes(client):
+    user = User.register(email="mark-page@example.com", username="markpage")
+    book = Edition.objects.create(title="Page Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    response = client.post(
+        reverse("journal:mark", args=[book.uuid]),
+        _mark_post_data(),
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 204
+    assert response["HX-Refresh"] == "true"
+    assert Mark(user.identity, book).shelf_type == ShelfType.COMPLETE
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_save_inline_closes_dialog_and_swaps_icon(client):
+    user = User.register(email="mark-oob@example.com", username="markoob")
+    book = Edition.objects.create(title="OOB Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    url = reverse("journal:mark", args=[book.uuid])
+
+    response = client.post(url, _mark_post_data(inline="1"), HTTP_HX_REQUEST="true")
+    assert response.status_code == 200
+    assert response["HX-Trigger"] == "close_dialog"
+    assert "HX-Refresh" not in response
+    html = response.content.decode()
+    assert f"hx-swap-oob=\"outerHTML:[data-mark-item='{book.uuid}']\"" in html
+    assert f'data-mark-item="{book.uuid}"' in html
+    assert "fa-solid fa-bookmark" in html
+    assert f'hx-get="{url}?inline=1"' in html
+    # list cards get their mark details refreshed too
+    assert f"hx-swap-oob=\"outerHTML:[data-mark-detail='{book.uuid}']\"" in html
+    assert "great" in html
+    assert Mark(user.identity, book).shelf_type == ShelfType.COMPLETE
+
+    response = client.post(url, {"delete": "1", "inline": "1"}, HTTP_HX_REQUEST="true")
+    assert response.status_code == 200
+    assert response["HX-Trigger"] == "close_dialog"
+    html = response.content.decode()
+    assert "fa-regular fa-bookmark" in html
+    assert f'hx-get="{url}?shelf_type=wishlist&amp;inline=1"' in html
+    assert Mark(user.identity, book).shelf_type is None
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_save_crosspost_failure_shows_error_page_over_htmx(client, monkeypatch):
+    user = User.register(email="mark-xpost@example.com", username="markxpost")
+    book = Edition.objects.create(title="Crosspost Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+    def fail(*args, **kwargs):
+        raise ValueError("422")
+
+    monkeypatch.setattr(Mark, "update", fail)
+    response = client.post(
+        reverse("journal:mark", args=[book.uuid]),
+        _mark_post_data(inline="1"),
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+    assert response["HX-Retarget"] == "#mark-form-error"
+    assert response["HX-Reswap"] == "innerHTML"
+    assert "HX-Trigger" not in response
+    html = response.content.decode()
+    assert "Data saved but unable to crosspost" in html
+    assert "Content too long" in html
+    assert f"hx-swap-oob=\"outerHTML:[data-mark-item='{book.uuid}']\"" in html
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_save_invalid_input_shows_error_in_dialog(client):
+    user = User.register(email="mark-invalid@example.com", username="markinvalid")
+    book = Edition.objects.create(title="Invalid Book")
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    url = reverse("journal:mark", args=[book.uuid])
+
+    response = client.post(
+        url, _mark_post_data(inline="1", visibility="9"), HTTP_HX_REQUEST="true"
+    )
+    assert response.status_code == 200
+    assert response["HX-Retarget"] == "#mark-form-error"
+    html = response.content.decode()
+    assert "Invalid input" in html
+    assert "hx-swap-oob" not in html
+    assert Mark(user.identity, book).shelf_type is None
+
+    response = client.post(url, _mark_post_data(visibility="9"))
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_mark_htmx_post_without_session_redirects_to_login(client):
+    book = Edition.objects.create(title="Anonymous Book")
+    response = client.post(
+        reverse("journal:mark", args=[book.uuid]),
+        _mark_post_data(inline="1"),
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+    assert response["HX-Redirect"].startswith("/account/login")
+    assert "Location" not in response
+
+    response = client.post(
+        reverse("journal:mark", args=[book.uuid]), _mark_post_data(inline="1")
+    )
+    assert response.status_code == 302
+    assert response["Location"].startswith("/account/login")
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_list_card_mark_details_are_swappable_for_viewer(client):
+    user = User.register(email="mark-card@example.com", username="markcard")
+    other = User.register(email="mark-card2@example.com", username="markcard2")
+    book = Edition.objects.create(title="Card Book")
+    Mark(user.identity, book).update(ShelfType.COMPLETE, "mine", 7, ["x"], 0)
+    Mark(other.identity, book).update(ShelfType.COMPLETE, "theirs", 6, ["y"], 0)
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+
+    own = client.get(
+        reverse(
+            "journal:user_mark_list",
+            kwargs={
+                "user_name": user.identity.handle,
+                "shelf_type": "complete",
+                "item_category": "book",
+            },
+        )
+    ).content.decode()
+    assert f'data-mark-detail="{book.uuid}"' in own
+    assert "mine" in own
+
+    theirs = client.get(
+        reverse(
+            "journal:user_mark_list",
+            kwargs={
+                "user_name": other.identity.handle,
+                "shelf_type": "complete",
+                "item_category": "book",
+            },
+        )
+    ).content.decode()
+    assert "data-mark-detail=" not in theirs
+    assert "theirs" in theirs
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_timeline_bookmark_reflects_viewer_mark(client):
+    user = User.register(email="mark-feed@example.com", username="markfeed")
+    other = User.register(email="mark-feed2@example.com", username="markfeed2")
+    marked = Edition.objects.create(title="Marked Feed Book")
+    unmarked = Edition.objects.create(title="Unmarked Feed Book")
+    Mark(other.identity, marked).update(ShelfType.COMPLETE, "a", 8, visibility=0)
+    Mark(other.identity, unmarked).update(ShelfType.COMPLETE, "b", 8, visibility=0)
+    Mark(user.identity, marked).update(ShelfType.WISHLIST, visibility=0)
+    client.force_login(user, backend="mastodon.auth.OAuth2Backend")
+    marked_url = reverse("journal:mark", args=[marked.uuid])
+    unmarked_url = reverse("journal:mark", args=[unmarked.uuid])
+
+    # own timeline shows own post with a solid icon
+    html = client.get(reverse("social:data")).content.decode()
+    assert f'data-mark-item="{marked.uuid}"' in html
+    assert f'hx-get="{marked_url}?inline=1"' in html
+
+    # another user's post renders the viewer's state, not the author's
+    shelfmember = Mark(other.identity, unmarked).shelfmember
+    assert shelfmember is not None and shelfmember.latest_post is not None
+    post_url = reverse(
+        "journal:post_view",
+        kwargs={
+            "handle": other.identity.handle,
+            "post_pk": shelfmember.latest_post.pk,
+        },
+    )
+    html = client.get(post_url).content.decode()
+    assert f'data-mark-item="{unmarked.uuid}"' in html
+    assert f'hx-get="{unmarked_url}?shelf_type=wishlist&amp;inline=1"' in html
+    assert "fa-solid fa-bookmark" not in html
+
+    # anonymous viewer gets a hollow icon that is not a refresh target
+    client.logout()
+    html = client.get(post_url).content.decode()
+    assert "data-mark-item=" not in html
+    assert "fa-regular fa-bookmark" in html
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_tag_suggestions_endpoint_is_gone(client):
     user = User.register(email="gone@example.com", username="goneuser")
     client.force_login(user, backend="mastodon.auth.OAuth2Backend")

--- a/neodb/tests/social/test_timeline_n_plus_one.py
+++ b/neodb/tests/social/test_timeline_n_plus_one.py
@@ -49,6 +49,20 @@ class TestTimelineDataNPlusOne:
             + "; ".join(q["sql"][:120] for q in individual_piecepost)
         )
 
+    def test_no_per_post_viewer_mark_queries(self):
+        """The bookmark icon state must come from one batched ShelfMember query."""
+        with CaptureQueriesContext(connections["default"]) as ctx:
+            response = self.client.get("/timeline/data")
+        assert response.status_code == 200
+        assert response.content.decode().count("data-mark-item=") == NUM_ITEMS
+        # a per-post lookup filters on one item ("item_id" = %s), the batch on IN
+        per_post = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if '"journal_shelfmember"."item_id" =' in q["sql"]
+        ]
+        assert per_post == []
+
     def test_main_query_matches_undismissed_ordering_index(self):
         """The feed predicate must match Takahe's partial identity/-id index."""
         with CaptureQueriesContext(connections["takahe"]) as ctx:


### PR DESCRIPTION
## Summary

The mark dialog opened through htmx, but its Save and Delete forms were plain POSTs that redirected to the referer, so the whole timeline reloaded and lost its scroll position. This PR makes the dialog save in place and keeps the surrounding page in sync.

- Save and Delete submit through htmx. From the timeline and list cards the view answers with out-of-band fragments (the bookmark action and, on list cards, the viewer's mark details) swapped into every card of that item, plus a `close_dialog` trigger. Nothing reloads.
- From item pages the view answers with `HX-Refresh`, so the item page behaves as before.
- The timeline bookmark icon now reflects the viewer's own mark (hollow or solid). The viewer's marks are loaded with one batched `ShelfMember` query in `prefetch_pieces_for_posts`; a query-count test guards it.
- Invalid input and crosspost failures on an htmx submit show a short message under the Save button inside the dialog. When the mark was saved but the crosspost failed, the icons still refresh.
- `render_relogin` redirects htmx requests straight to the Mastodon login, because the error page relied on a meta refresh that a swap cannot run.
- New `HtmxLoginRedirectMiddleware` turns a `login_required` redirect into `HX-Redirect` for htmx requests, so an expired session sends the browser to the login page instead of failing silently.

## Behaviour notes

- On your own shelf list page, an item moved to another shelf stays visible until the next reload. Its icon and details update.
- Profile post pages are unchanged. They render posts without item cards, so the bookmark never shows there.

## Test plan

- [x] `tests/journal/test_mark.py`: dialog flag, plain redirect, item-page refresh, inline save/delete OOB response, invalid input and crosspost errors in dialog, anonymous htmx redirect, list card details, timeline icon state
- [x] `tests/social/test_timeline_n_plus_one.py`: no per-post shelf-member query
- [x] Full suite in the dev cluster
- [x] Browser: timeline save, delete and re-add without reload; shelf list card save without reload; item page save still refreshes; error message rendered in the dialog
