### PR TITLE
fix(journal): stop concurrent archive imports duplicating ratings

### DIFF
--- a/neodb/journal/importers/base.py
+++ b/neodb/journal/importers/base.py
@@ -59,7 +59,10 @@ class BaseImporter(Task):
             f"{self.metadata['skipped']} skipped, "
             f"{self.metadata['failed']} failed"
         )
-        self.save(update_fields=["metadata", "message"])
+        # edited_time is auto_now, which Django writes only when
+        # update_fields names it; a running task must stay distinguishable
+        # from one whose worker died
+        self.save(update_fields=["metadata", "message", "edited_time"])
 
     def run(self) -> None:
         raise NotImplementedError

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from loguru import logger
 
@@ -721,29 +721,38 @@ class NdjsonImporter(BaseImporter):
                 # Rating.update_item_rating treats it as a deletion
                 return "skipped"
             existing_rating = Rating.objects.filter(owner=owner, item=item).first()
-            if existing_rating:
-                if self._is_current(existing_rating, updated_dt, published_dt):
-                    return "skipped"
-                # (owner, item) is unique on Rating: inserting a second row
-                # raises IntegrityError, which marks the surrounding
-                # transaction for rollback and fails every later record too
-                existing_rating.grade = rating_grade
-                if published_dt:
-                    existing_rating.created_time = published_dt
-                existing_rating.visibility = visibility
-                existing_rating.metadata = metadata
-                existing_rating.save()
-                self._restore_edited_time(existing_rating, updated_dt)
-                return "imported"
-            rating = Rating.objects.create(
-                owner=owner,
-                item=item,
-                grade=rating_grade,
-                visibility=visibility,
-                metadata=metadata,
-                **({"created_time": published_dt} if published_dt else {}),
-            )
-            self._restore_edited_time(rating, updated_dt)
+            if not existing_rating:
+                try:
+                    # (owner, item) is unique, and a concurrent import can
+                    # insert the row between the lookup and here; the
+                    # savepoint keeps that from breaking later records too
+                    with transaction.atomic():
+                        rating = Rating.objects.create(
+                            owner=owner,
+                            item=item,
+                            grade=rating_grade,
+                            visibility=visibility,
+                            metadata=metadata,
+                            **({"created_time": published_dt} if published_dt else {}),
+                        )
+                except IntegrityError:
+                    existing_rating = Rating.objects.filter(
+                        owner=owner, item=item
+                    ).first()
+                    if not existing_rating:
+                        raise  # not the race; still a failed record
+                else:
+                    self._restore_edited_time(rating, updated_dt)
+                    return "imported"
+            if self._is_current(existing_rating, updated_dt, published_dt):
+                return "skipped"
+            existing_rating.grade = rating_grade
+            if published_dt:
+                existing_rating.created_time = published_dt
+            existing_rating.visibility = visibility
+            existing_rating.metadata = metadata
+            existing_rating.save()
+            self._restore_edited_time(existing_rating, updated_dt)
             return "imported"
         except Exception:
             logger.exception("Error importing rating")

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import IntegrityError
 from django.test import override_settings
 from django.utils.dateparse import parse_datetime
 from loguru import logger
@@ -902,6 +903,66 @@ class TestNdjsonExportImport:
         assert rating.created_time == self.dt2
         # the transaction is still usable — the old failure poisoned it
         assert Rating.objects.filter(owner=owner).count() == 1
+
+    def test_ndjson_rating_recovers_when_lookup_misses_existing_row(self):
+        """A rating created after the lookup is updated, not re-inserted.
+
+        The blinded first lookup stands in for the row a concurrent import
+        commits in that window (NEODB-SOCIAL-7WA).
+        """
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        owner = self.user2.identity
+        Rating.objects.create(
+            item=self.book1, owner=owner, grade=5, visibility=0, created_time=self.dt
+        )
+        original_filter = Rating.objects.filter
+        lookups = []
+
+        def blind_first_lookup(*args, **kwargs):
+            lookups.append(kwargs)
+            if len(lookups) == 1:
+                return Rating.objects.none()
+            return original_filter(*args, **kwargs)
+
+        with mock.patch.object(Rating.objects, "filter", blind_first_lookup):
+            result = importer.import_rating(
+                {
+                    "visibility": 0,
+                    "content": {
+                        "withRegardTo": self.book1.absolute_url,
+                        "value": 9,
+                        "published": "2021-02-01T00:00:00Z",
+                    },
+                }
+            )
+        assert result == "imported"
+        rating = Rating.objects.get(owner=owner, item=self.book1)
+        assert rating.grade == 9
+        assert rating.created_time == self.dt2
+        assert Rating.objects.filter(owner=owner).count() == 1
+        # the savepoint rollback leaves later records importable
+        Rating.objects.create(item=self.book2, owner=owner, grade=3, visibility=0)
+        assert Rating.objects.filter(owner=owner).count() == 2
+
+    def test_ndjson_rating_reports_failure_when_row_stays_missing(self):
+        """An IntegrityError that is not the race is still a failed record."""
+        importer = NdjsonImporter.create(user=self.user2, file="x.zip", visibility=0)
+        importer.items = {self.book1.absolute_url: self.book1}
+        with mock.patch.object(
+            Rating.objects, "create", side_effect=IntegrityError("nope")
+        ):
+            result = importer.import_rating(
+                {
+                    "visibility": 0,
+                    "content": {
+                        "withRegardTo": self.book1.absolute_url,
+                        "value": 9,
+                        "published": "2021-02-01T00:00:00Z",
+                    },
+                }
+            )
+        assert result == "failed"
 
     def test_ndjson_every_exported_type_has_an_importer(self):
         """The two sides must agree on every record type name.

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import zipfile
@@ -11,7 +12,9 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import IntegrityError
-from django.test import override_settings
+from django.test import Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from loguru import logger
 from PIL import Image
@@ -33,7 +36,7 @@ from journal.models import *
 from journal.models.common import Debris
 from journal.search import JournalIndex
 from takahe.utils import Takahe
-from users.models import User
+from users.models import Task, User
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -1711,6 +1714,57 @@ class TestNdjsonExportImport:
         assert NdjsonImporter.validate_file(f)
         # left rewound so the view can still write the upload out
         assert f.tell() == 0
+
+    def test_ndjson_import_view_refuses_a_second_concurrent_import(self):
+        """One archive import at a time per user.
+
+        The only previous warning was a client-side confirm whose condition
+        tested a Task.status that does not exist, so it never matched.
+        """
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w") as z:
+            z.writestr("journal.ndjson", '{"server": "x"}\n')
+        archive = buf.getvalue()
+        client = Client()
+        client.force_login(self.user2, backend="mastodon.auth.OAuth2Backend")
+
+        def post():
+            with mock.patch.object(NdjsonImporter, "enqueue"):
+                return client.post(
+                    reverse("users:import_neodb"),
+                    {
+                        "format_type": "ndjson",
+                        "visibility": "0",
+                        "file": SimpleUploadedFile("x.zip", archive),
+                    },
+                )
+
+        post()
+        assert NdjsonImporter.objects.filter(user=self.user2).count() == 1
+        running = NdjsonImporter.latest_task(self.user2)
+        assert running is not None
+        running.state = Task.States.started
+        running.save()
+
+        post()
+        assert NdjsonImporter.objects.filter(user=self.user2).count() == 1
+
+        # the window runs from the last progress write, not from the start
+        long_ago = timezone.now() - datetime.timedelta(hours=4)
+        NdjsonImporter.objects.filter(pk=running.pk).update(created_time=long_ago)
+        post()
+        assert NdjsonImporter.objects.filter(user=self.user2).count() == 1
+
+        # a dead worker stops writing progress, and must not lock the user out
+        NdjsonImporter.objects.filter(pk=running.pk).update(edited_time=long_ago)
+        post()
+        assert NdjsonImporter.objects.filter(user=self.user2).count() == 2
+
+        NdjsonImporter.objects.filter(user=self.user2).update(
+            state=Task.States.complete
+        )
+        post()
+        assert NdjsonImporter.objects.filter(user=self.user2).count() == 3
 
     def test_ndjson_retitle_reimports_as_a_second_row(self):
         """Known limitation: the title is part of a Review's / Collection's /

--- a/neodb/users/views/data.py
+++ b/neodb/users/views/data.py
@@ -48,7 +48,7 @@ from journal.models import CrosspostRetry, Piece, ShelfType
 from journal.models.common import VisibilityType
 from takahe.models import InboxMessage
 from takahe.utils import Takahe
-from users.models import Task
+from users.models import Task, User
 
 from .account import clear_preference_cache
 
@@ -1083,6 +1083,29 @@ def import_opml(request):
     return redirect(reverse("users:user_task_status", args=(task.type,)))
 
 
+def _neodb_import_in_progress(user: User) -> bool:
+    """Whether an archive import of either format is still running for user.
+
+    Both formats write the same journal, so a CSV import racing an NDJSON one
+    is as harmful as two of a kind.
+
+    Counted from ``edited_time``, not ``created_time`` as the export guards
+    do: an archive can take much longer than an hour to import. Each record
+    restamps it via ``BaseImporter.progress``, so only a task whose worker
+    died goes stale and stops locking the user out.
+    """
+    cutoff = timezone.now() - datetime.timedelta(hours=1)
+    for cls in (NdjsonImporter, CsvImporter):
+        task = cls.latest_task(user)
+        if (
+            task
+            and task.state not in [Task.States.complete, Task.States.failed]
+            and task.edited_time > cutoff
+        ):
+            return True
+    return False
+
+
 @login_required
 def import_neodb(request):
     if request.method == "POST":
@@ -1097,6 +1120,14 @@ def import_neodb(request):
             importer = NdjsonImporter
         else:
             raise BadRequest("Invalid file.")
+        # two concurrent imports both read the same (owner, item) as absent
+        # and both insert it, which breaks the unique constraint on
+        # Rating/ShelfMember and duplicates rows for the types without one
+        if _neodb_import_in_progress(request.user):
+            messages.add_message(
+                request, messages.INFO, _("Import in progress, please wait")
+            )
+            return redirect(reverse("users:data"))
         # format_type is chosen client-side, so the file itself still has to be
         # checked; otherwise a bad upload only surfaces as an opaque failure of
         # the background task


### PR DESCRIPTION
Sentry NEODB-SOCIAL-7WA: `IntegrityError: duplicate key value violates unique constraint "journal_rating_owner_id_item_id_f601d930_uniq"`, raised from `NdjsonImporter.import_rating` and logged as a failed record.

`import_rating` already looked the rating up before inserting, so the check itself was not wrong. The Sentry events show two distinct trace ids and two distinct `rqworker-pool` worker processes interleaved over the same nine seconds, for one user and 23 different items: **two archive imports were running at once**. Both read `(owner, item)` as absent, both inserted, and the loser hit the unique constraint.

Nothing on the server prevented that. `import_neodb` created and enqueued a task on every POST. The only warning was a client-side `confirm()` on the Douban form, gated on `import_task.status == "pending"` — `Task` has no `status` attribute, so it never matched.

### Changes

**`fix(journal)`** — backstop in the importer. `Rating.objects.create` runs in its own savepoint; on `IntegrityError` the row is re-read and takes the same update path an up-front hit would have taken, and is re-raised if there is still no row. The savepoint matters on its own: without it the error marks the surrounding transaction for rollback and every later record fails too.

**`fix(users)`** — the actual cause. One archive import per user at a time, across both formats since they write the same journal. The hour is counted from `edited_time` rather than `created_time` as the export guards do, because a full archive takes much longer than an hour to import and would stop being guarded halfway through. That needed `BaseImporter.progress()` to name `edited_time` in `update_fields`: Django writes an `auto_now` field only when `update_fields` lists it, so until now a working task looked untouched since it started and could not be told apart from one whose worker had died.

### Notes

- The guard is itself a read-then-write check, so two POSTs in the same second can still both pass it. It closes the window to sub-second; the importer savepoint covers the remainder.
- Reuses the existing `"Import in progress, please wait"` message rather than adding a phrase, to avoid regenerating the POT.
- `import_comment` has the same read-then-create shape, but `Comment` has no unique constraint, so the same race silently duplicates rows instead of raising. Not addressed here; the guard covers it at the source.

### Tests

Three new tests in `tests/journal/test_ndjson.py`: the recovery path (verified to fail with the production `IntegrityError` when the fix is reverted), the re-raise for an `IntegrityError` that is not this race, and the view guard including a long-running import and one whose worker died.
