### PR TITLE
fix(catalog): reject Douban mobile renders, keep crawling past item errors

### DIFF
--- a/neodb/catalog/management/commands/crawl.py
+++ b/neodb/catalog/management/commands/crawl.py
@@ -6,6 +6,7 @@ from loguru import logger
 from lxml import html
 
 from catalog.common import *
+from catalog.common.downloaders import DownloadError
 from common.management.base import SiteCommand
 
 
@@ -44,7 +45,18 @@ class Command(SiteCommand):
                             if u not in history:
                                 history.append(u)
                                 logger.info(f"Fetching {u}")
-                                site.get_resource_ready()
+                                try:
+                                    site.get_resource_ready()
+                                except DownloadError as e:
+                                    # Expected third-party failure -> warn, and
+                                    # keep crawling the rest of the queue.
+                                    logger.warning(
+                                        f"unable to fetch {u}", extra={"exception": e}
+                                    )
+                                except Exception as e:
+                                    logger.error(
+                                        f"error fetching {u}", extra={"exception": e}
+                                    )
                         else:
                             logger.warning(f"unable to parse {u}")
                     elif pattern and u.find(pattern) >= 0:

--- a/neodb/catalog/sites/douban.py
+++ b/neodb/catalog/sites/douban.py
@@ -86,6 +86,10 @@ class DoubanDownloader(ScrapDownloader):
             content = response.content.decode("utf-8")
             if content.find("关于豆瓣") == -1 and content.find("豆瓣评分") == -1:
                 return RESPONSE_NETWORK_ERROR
+            elif content.find("豆瓣(手机版)") != -1:
+                # Douban redirects a mobile user agent to m.douban.com, whose
+                # markup none of the parsers understand; retry another provider.
+                return RESPONSE_NETWORK_ERROR
             elif (
                 content.find("<title>页面不存在</title>") != -1
                 or content.find("呃... 你想访问的条目豆瓣不收录。") != -1

--- a/neodb/tests/core/test_downloaders.py
+++ b/neodb/tests/core/test_downloaders.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from PIL import Image
 
 from catalog.common.downloaders import (
+    RESPONSE_CENSORSHIP,
     RESPONSE_INVALID_CONTENT,
     RESPONSE_NETWORK_ERROR,
     RESPONSE_OK,
@@ -15,6 +16,7 @@ from catalog.common.downloaders import (
     ScraperResponse,
     get_mock_file,
 )
+from catalog.sites.douban import DoubanDownloader
 
 
 def _jpeg_bytes() -> bytes:
@@ -98,6 +100,36 @@ class TestBasicDownloaderValidateResponse:
         resp = MagicMock()
         resp.status_code = 301
         assert dl.validate_response(resp) == RESPONSE_INVALID_CONTENT
+
+
+class TestDoubanDownloaderValidateResponse:
+    def _resp(self, body: str) -> ScraperResponse:
+        return ScraperResponse(
+            "https://music.douban.com/subject/38557218/", body.encode("utf-8")
+        )
+
+    def test_desktop_page(self):
+        dl = DoubanDownloader("https://music.douban.com/subject/38557218/")
+        body = '<meta property="og:site_name" content="豆瓣" /><h1><span>x</span></h1>豆瓣评分'
+        assert dl.validate_response(self._resp(body)) == RESPONSE_OK
+
+    def test_mobile_page_retried(self):
+        # m.douban.com markup has no //h1/span, so parsing it raises ParseError;
+        # reject it as a network error to try the next provider instead.
+        dl = DoubanDownloader("https://music.douban.com/subject/38557218/")
+        body = '<meta property="og:site_name" content="豆瓣(手机版)" /><h1 class="title">x</h1>豆瓣评分'
+        assert dl.validate_response(self._resp(body)) == RESPONSE_NETWORK_ERROR
+
+    def test_unrelated_page(self):
+        dl = DoubanDownloader("https://music.douban.com/subject/38557218/")
+        assert (
+            dl.validate_response(self._resp("<html></html>")) == RESPONSE_NETWORK_ERROR
+        )
+
+    def test_removed_page(self):
+        dl = DoubanDownloader("https://music.douban.com/subject/38557218/")
+        body = "豆瓣评分<title>页面不存在</title>"
+        assert dl.validate_response(self._resp(body)) == RESPONSE_CENSORSHIP
 
 
 class TestDownloadError:


### PR DESCRIPTION
Douban redirects a mobile user agent from `music.douban.com/subject/N/` to `m.douban.com`, and a scraping provider's headless browser is sometimes served that page. It has no `//h1/span`, but it passed `validate_response`, so `DoubanMusic.scrape()` raised `ParseError` on the title.

- `DoubanDownloader.validate_response` now rejects the mobile render (`og:site_name` = `豆瓣(手机版)`) as a network error, so the downloader retries the next provider. That marker is absent from desktop subject pages and from search pages; a bare `m.douban.com` test would false-positive on desktop pages, and an `#content` test would break search.
- `crawl` caught nothing, so one bad page aborted the whole run. It now logs per-item failures and continues.