### PR TITLE
fix(federation): do not retry a fan-out the remote refused

### DIFF
--- a/takahe/activities/models/fan_out.py
+++ b/takahe/activities/models/fan_out.py
@@ -1,11 +1,17 @@
+import logging
+
 import httpx
 from django.db import models
 
 from activities.models.timeline_event import TimelineEvent
+from core.exceptions import ActivityPubDeliveryError
 from core.ld import canonicalise
+from stator.exceptions import TryAgainLater
 from stator.models import State, StateField, StateGraph, StatorModel
 from users.models import Block, FollowStates, Identity
 from users.models.system_actor import SystemActor
+
+logger = logging.getLogger(__name__)
 
 
 class FanOutStates(StateGraph):
@@ -65,6 +71,36 @@ class FanOutStates(StateGraph):
         PostInteraction.transition_perform_queryset(
             boosts, PostInteractionStates.undone
         )
+
+    @classmethod
+    def _deliver(
+        cls,
+        sender: "Identity | SystemActor",
+        instance: "FanOut",
+        body: dict,
+    ) -> State | None:
+        """
+        Sends body to the recipient's inbox, signed by sender.
+
+        Returns a terminal state if it was refused for good, None to carry on,
+        and raises TryAgainLater if another attempt can still succeed.
+        """
+        try:
+            sender.signed_request(
+                method="post",
+                uri=(instance.identity.shared_inbox_uri or instance.identity.inbox_uri),
+                body=body,
+            )
+        except httpx.RequestError:
+            raise TryAgainLater() from None
+        except ActivityPubDeliveryError as error:
+            if error.retryable:
+                logger.info("FanOut %s was deferred: %s", instance.pk, error)
+                raise TryAgainLater() from None
+            # Resending the same activity cannot resolve any other 4xx
+            logger.info("FanOut %s was refused: %s", instance.pk, error)
+            return cls.failed
+        return None
 
     @classmethod
     def handle_new(cls, instance: "FanOut"):
@@ -145,33 +181,19 @@ class FanOutStates(StateGraph):
             case (FanOut.Types.post, False):
                 post = instance.subject_post
                 # Sign it (HTTP and, for public posts, LD) and send it
-                try:
-                    post.author.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=post.to_fan_out_ap(instance.type),
-                    )
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    post.author, instance, post.to_fan_out_ap(instance.type)
+                ):
+                    return state
 
             # Handle sending remote posts update
             case (FanOut.Types.post_edited, False):
                 post = instance.subject_post
                 # Sign it (HTTP and, for public posts, LD) and send it
-                try:
-                    post.author.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=post.to_fan_out_ap(instance.type),
-                    )
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    post.author, instance, post.to_fan_out_ap(instance.type)
+                ):
+                    return state
 
             # Handle deleting local posts
             case (FanOut.Types.post_deleted, True):
@@ -183,20 +205,12 @@ class FanOutStates(StateGraph):
             # Handle sending remote post deletes
             case (FanOut.Types.post_deleted, False):
                 post = instance.subject_post
-                # Send it to the remote inbox
-                try:
-                    post.author.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=post.to_fan_out_ap(instance.type),
-                    )
-                except ValueError:
-                    pass  # ignore 401 when identity deletion is processed by remote earlier
-                except httpx.RequestError:
-                    return
+                # Send it to the remote inbox; a 4xx is expected if the remote
+                # processed our identity deletion earlier
+                if state := cls._deliver(
+                    post.author, instance, post.to_fan_out_ap(instance.type)
+                ):
+                    return state
 
             # Handle local boosts/likes
             case (FanOut.Types.interaction, True):
@@ -242,23 +256,16 @@ class FanOutStates(StateGraph):
             case (FanOut.Types.interaction, False):
                 interaction = instance.subject_post_interaction
                 # Send it to the remote inbox
-                try:
-                    if interaction.type == interaction.Types.vote:
-                        body = interaction.to_create_ap()
-                    elif interaction.type == interaction.Types.pin:
-                        body = interaction.to_add_ap()
-                    else:
-                        body = interaction.to_ap()
-                    interaction.identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(body),
-                    )
-                except httpx.RequestError:
-                    return
+                if interaction.type == interaction.Types.vote:
+                    body = interaction.to_create_ap()
+                elif interaction.type == interaction.Types.pin:
+                    body = interaction.to_add_ap()
+                else:
+                    body = interaction.to_ap()
+                if state := cls._deliver(
+                    interaction.identity, instance, canonicalise(body)
+                ):
+                    return state
 
             # Handle undoing local boosts/likes
             case (FanOut.Types.undo_interaction, True):  # noqa:F841
@@ -292,53 +299,30 @@ class FanOutStates(StateGraph):
             case (FanOut.Types.undo_interaction, False):  # noqa:F841
                 interaction = instance.subject_post_interaction
                 # Send an undo to the remote inbox
-                try:
-                    if interaction.type == interaction.Types.pin:
-                        body = interaction.to_remove_ap()
-                    else:
-                        body = interaction.to_undo_ap()
-                    interaction.identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(body),
-                    )
-                except httpx.RequestError:
-                    return
+                if interaction.type == interaction.Types.pin:
+                    body = interaction.to_remove_ap()
+                else:
+                    body = interaction.to_undo_ap()
+                if state := cls._deliver(
+                    interaction.identity, instance, canonicalise(body)
+                ):
+                    return state
 
             # Handle sending identity edited to remote
             case (FanOut.Types.identity_edited, False):
                 identity = instance.subject_identity
-                try:
-                    identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(instance.subject_identity.to_update_ap()),
-                    )
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    identity, instance, canonicalise(identity.to_update_ap())
+                ):
+                    return state
 
             # Handle sending identity deleted to remote
             case (FanOut.Types.identity_deleted, False):
                 identity = instance.subject_identity
-                try:
-                    identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(instance.subject_identity.to_delete_ap()),
-                    )
-                except httpx.RequestError:
-                    return
-                except ValueError:
-                    pass  # do not retry if 4xx
+                if state := cls._deliver(
+                    identity, instance, canonicalise(identity.to_delete_ap())
+                ):
+                    return state
 
             # Handle move for local follower
             case (FanOut.Types.identity_moved, True):
@@ -355,17 +339,10 @@ class FanOutStates(StateGraph):
             case (FanOut.Types.identity_moved, False):
                 identity = instance.subject_identity
                 if identity.has_moved() and identity.aliases:
-                    try:
-                        identity.signed_request(
-                            method="post",
-                            uri=(
-                                instance.identity.shared_inbox_uri
-                                or instance.identity.inbox_uri
-                            ),
-                            body=canonicalise(identity.to_move_ap()),
-                        )
-                    except httpx.RequestError:
-                        return
+                    if state := cls._deliver(
+                        identity, instance, canonicalise(identity.to_move_ap())
+                    ):
+                        return state
 
             # Sending identity edited/deleted to local is a no-op
             case (FanOut.Types.identity_edited, True):
@@ -385,36 +362,24 @@ class FanOutStates(StateGraph):
 
             case (FanOut.Types.tag_featured, False):
                 identity = instance.subject_identity
-                try:
-                    identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(instance.subject_hashtag.to_add_ap(identity)),
-                    )
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    identity,
+                    instance,
+                    canonicalise(instance.subject_hashtag.to_add_ap(identity)),
+                ):
+                    return state
 
             case (FanOut.Types.tag_unfeatured, True):
                 pass
 
             case (FanOut.Types.tag_unfeatured, False):
                 identity = instance.subject_identity
-                try:
-                    identity.signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=canonicalise(
-                            instance.subject_hashtag.to_remove_ap(identity)
-                        ),
-                    )
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    identity,
+                    instance,
+                    canonicalise(instance.subject_hashtag.to_remove_ap(identity)),
+                ):
+                    return state
 
             # Forward a third-party LD-signed activity concerning a local
             # thread (AP 7.1.2). The document is re-sent exactly as
@@ -423,19 +388,10 @@ class FanOutStates(StateGraph):
             case (FanOut.Types.forward, False):
                 if not instance.subject_document:
                     return cls.skipped
-                try:
-                    SystemActor().signed_request(
-                        method="post",
-                        uri=(
-                            instance.identity.shared_inbox_uri
-                            or instance.identity.inbox_uri
-                        ),
-                        body=instance.subject_document,
-                    )
-                except ValueError:
-                    pass  # remote refused the forward; it's best-effort
-                except httpx.RequestError:
-                    return
+                if state := cls._deliver(
+                    SystemActor(), instance, instance.subject_document
+                ):
+                    return state
 
             # Forwards are only ever created for remote followers
             case (FanOut.Types.forward, True):

--- a/takahe/tests/activities/models/test_fan_out_delivery.py
+++ b/takahe/tests/activities/models/test_fan_out_delivery.py
@@ -1,0 +1,139 @@
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from activities.models import FanOut, FanOutStates, Post, PostInteraction
+from stator.exceptions import TryAgainLater
+from users.models import Identity
+
+INBOX = "https://remote.test/@test/inbox/"
+
+
+@pytest.fixture(autouse=True)
+def _enable_federation(settings):
+    original = settings.SETUP.NO_FEDERATION
+    settings.SETUP.NO_FEDERATION = False
+    yield
+    settings.SETUP.NO_FEDERATION = original
+
+
+def _post_fan_out(identity: Identity, remote_identity: Identity) -> FanOut:
+    post = Post.create_local(author=identity, content="<p>Hello</p>")
+    return FanOut.objects.create(
+        identity=remote_identity,
+        type=FanOut.Types.post,
+        subject_post=Post.objects.get(pk=post.pk),
+    )
+
+
+def _interaction_fan_out(identity: Identity, remote_identity: Identity) -> FanOut:
+    post = Post.create_local(author=identity, content="<p>Hello</p>")
+    interaction = PostInteraction.objects.create(
+        identity=identity,
+        post=Post.objects.get(pk=post.pk),
+        type=PostInteraction.Types.like,
+    )
+    return FanOut.objects.create(
+        identity=remote_identity,
+        type=FanOut.Types.interaction,
+        subject_post=interaction.post,
+        subject_post_interaction=interaction,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_refused_interaction_delivery_is_not_resent(
+    identity: Identity,
+    remote_identity: Identity,
+    config_system,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    An inbox that refuses with a 403 refuses every resend, so the fan-out
+    fails instead of retrying for days.
+    """
+    fan_out = _interaction_fan_out(identity, remote_identity)
+    httpx_mock.add_response(
+        url=INBOX,
+        status_code=403,
+        content=b"Forbidden",
+    )
+
+    stator.run_single_cycle()
+    assert FanOut.objects.get(pk=fan_out.pk).state == FanOutStates.failed
+    # And nothing sends it a second time
+    stator.run_single_cycle()
+    assert len(httpx_mock.get_requests(url=INBOX, method="POST")) == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_refused_post_delivery_fails(
+    identity: Identity,
+    remote_identity: Identity,
+    config_system,
+    httpx_mock: HTTPXMock,
+):
+    """
+    Refusals are handled the same way for every remote delivery type.
+    """
+    fan_out = _post_fan_out(identity, remote_identity)
+    httpx_mock.add_response(url=INBOX, status_code=400, content=b"nope")
+
+    assert FanOutStates.handle_new(fan_out) == FanOutStates.failed
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_deferred_delivery_is_retried(
+    identity: Identity,
+    remote_identity: Identity,
+    config_system,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A retryable refusal keeps the fan-out queued.
+    """
+    fan_out = _post_fan_out(identity, remote_identity)
+    httpx_mock.add_response(url=INBOX, status_code=429)
+
+    with pytest.raises(TryAgainLater):
+        FanOutStates.handle_new(FanOut.objects.get(pk=fan_out.pk))
+    stator.run_single_cycle()
+    assert FanOut.objects.get(pk=fan_out.pk).state == FanOutStates.new
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_unreachable_inbox_is_retried(
+    identity: Identity,
+    remote_identity: Identity,
+    config_system,
+    stator,
+    httpx_mock: HTTPXMock,
+):
+    """
+    A connection failure is not a refusal; the fan-out stays queued.
+    """
+    fan_out = _post_fan_out(identity, remote_identity)
+    httpx_mock.add_exception(httpx.ReadTimeout("timed out"))
+
+    stator.run_single_cycle()
+    assert FanOut.objects.get(pk=fan_out.pk).state == FanOutStates.new
+
+
+@pytest.mark.django_db
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+def test_accepted_delivery_is_sent(
+    identity: Identity,
+    remote_identity: Identity,
+    config_system,
+    httpx_mock: HTTPXMock,
+):
+    fan_out = _post_fan_out(identity, remote_identity)
+    httpx_mock.add_response(url=INBOX, status_code=202)
+
+    assert FanOutStates.handle_new(fan_out) == FanOutStates.sent


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] You, as a human, have fully reviewed every single line of this PR
- [ ] You, as a human, have fully tested this PR


* **What kind of change does this PR introduce?**
- [x] bug fix, including security or performance improvements
- [ ] feature
- [ ] docs
- [ ] other


* **What is the current behavior?** (Link to an open issue if applicable)

`FanOutStates.handle_new` catches only `httpx.RequestError` around each remote delivery, so a 4xx answer raises `ActivityPubDeliveryError` out of the handler. Stator logs it as an exception and re-queues the fan-out every ten minutes for three days, even when the inbox refuses the activity permanently.

Three of the ten delivery cases avoided the exception with a bare `except ValueError: pass`, which also swallowed unrelated `ValueError`s.

* **What is the new behavior?**

All ten remote deliveries go through one `_deliver` helper, matching the handling `Follow` already got in 4b04777:

- a connection error, 408 or 429 raises `TryAgainLater`, so the fan-out is attempted again next cycle
- any other 4xx is logged at info and ends the fan-out in `failed`, since resending the same activity cannot change the answer
- only `ActivityPubDeliveryError` is caught now, not every `ValueError`

The helper also removes the ten repeated `shared_inbox_uri or inbox_uri` blocks.

* **Does this PR introduce a breaking change?**

No. `post_deleted`, `identity_deleted` and `forward` now end in `failed` rather than `sent` when a remote refuses them. Both states are terminal and deleted after a day, and nothing queries them.

* **Other information**:

New tests in `takahe/tests/activities/models/test_fan_out_delivery.py` cover refusal, retryable refusal, connection failure and success. They fail on the current code with the exception this fixes.
