### PR TITLE
refactor(logging): replace loguru with stdlib logging

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -463,9 +463,16 @@ LOGGING = {
             "callback": _hide_client_error_traceback,
         },
     },
+    "formatters": {
+        "console": {
+            "format": "{asctime} | {levelname:<8} | {name}:{funcName}:{lineno} - {message}",
+            "style": "{",
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            "formatter": "console",
             "filters": ["hide_client_error_traceback"],
         },
         "null": {"class": "logging.NullHandler"},
@@ -729,7 +736,6 @@ if SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.logging import ignore_logger
-    from sentry_sdk.integrations.loguru import LoguruIntegration
 
     ignore_logger("podcastparser")
     # A bad Host header is a client error, not a bug. The null handler in
@@ -745,7 +751,6 @@ if SENTRY_DSN:
         environment=sentry_env or "unknown",
         integrations=[
             DjangoIntegration(),
-            LoguruIntegration(event_format="{name}:{function}:{line} - {message}"),
         ],
         release=NEODB_VERSION,
         send_default_pii=True,

--- a/neodb/catalog/common/downloaders.py
+++ b/neodb/catalog/common/downloaders.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 import time
 from io import BytesIO, StringIO
@@ -11,7 +12,6 @@ import httpx
 import requests
 from django.conf import settings
 from django.core.cache import cache
-from loguru import logger
 from lxml import etree, html
 from PIL import Image
 from requests import Response
@@ -21,6 +21,8 @@ from common.models import SiteConfig, register_language_cache_refresh
 from common.sentry import count as sentry_count
 from common.sentry import url_domain
 from common.validators import is_valid_url
+
+logger = logging.getLogger(__name__)
 
 RESPONSE_OK = 0  # response is ready for pasring
 RESPONSE_INVALID_CONTENT = -1  # content not valid but no need to retry

--- a/neodb/catalog/common/migrations.py
+++ b/neodb/catalog/common/migrations.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import re
 import time
 import traceback
@@ -10,12 +11,13 @@ import django_rq
 from discord import Object, SyncWebhook
 from django.db import connection, models
 from django.utils import timezone
-from loguru import logger
 from rq.job import Job
 from tqdm import tqdm
 
 from common.models.site_config import SiteConfig
 from common.sentry import count as sentry_count
+
+logger = logging.getLogger(__name__)
 
 _CHAIN_KEY = "neodb:migration_enqueue:last_job_id"
 _CHAIN_TTL = 7 * 24 * 3600
@@ -464,7 +466,7 @@ def fix_missing_cover_20250821(days=0):
             i.cover = p.cover
             i.save()
             updated += 1
-    logger.success(f"{updated} items with missing covers has been fixed.")
+    logger.info(f"{updated} items with missing covers has been fixed.")
 
 
 def populate_credits_20260412(start_pk=0, batch_size=1000):
@@ -529,7 +531,7 @@ def populate_credits_20260412(start_pk=0, batch_size=1000):
         ItemCredit.objects.bulk_create(pending)
         created += len(pending)
 
-    logger.success(f"Credits: {created} created, last pk: {last_pk}")
+    logger.info(f"Credits: {created} created, last pk: {last_pk}")
 
 
 def populate_credits_extra_20260415(batch_size=1000):
@@ -629,7 +631,7 @@ def populate_credits_extra_20260415(batch_size=1000):
         logger.info(f"{model_cls.__name__}: {created} credits created")
         total_created += created
 
-    logger.success(f"Total credits created: {total_created}")
+    logger.info(f"Total credits created: {total_created}")
 
 
 def backfill_credits_from_relations_20260719(start_pk=0, batch_size=1000):
@@ -718,7 +720,7 @@ def backfill_credits_from_relations_20260719(start_pk=0, batch_size=1000):
         "migration",
         attributes={"name": "catalog.backfill_credits_from_relations.end"},
     )
-    logger.success(
+    logger.info(
         f"Backfill complete: {created} created, {skipped} already present, "
         f"{no_name} skipped (person has no name); {total} relations scanned."
     )
@@ -749,7 +751,7 @@ def link_credits_20260412():
             linked += 1
         elif len(matches) > 1:
             ambiguous += 1
-    logger.success(f"Linked: {linked}, ambiguous: {ambiguous}, total: {total}")
+    logger.info(f"Linked: {linked}, ambiguous: {ambiguous}, total: {total}")
 
 
 def reindex_people_20260417():
@@ -792,7 +794,7 @@ def reindex_people_20260417():
         docs = people_index.people_to_docs(pg.get_page(p).object_list)
         indexed += people_index.replace_docs(docs)
         seen += len(docs)
-    logger.success(f"People reindex complete: {indexed} of {seen} docs indexed.")
+    logger.info(f"People reindex complete: {indexed} of {seen} docs indexed.")
 
 
 def edition_normalize_publisher_imprint_20260428(batch_size: int = 1000) -> None:
@@ -914,7 +916,7 @@ def edition_normalize_publisher_imprint_20260428(batch_size: int = 1000) -> None
                 pbar.update(1)
 
     deleted, _ = ItemCredit.objects.filter(role="imprint").delete()
-    logger.success(
+    logger.info(
         f"Edition publisher/imprint normalization: {converted} updated, "
         f"{deleted} orphan imprint credits deleted"
     )

--- a/neodb/catalog/common/rate_limit.py
+++ b/neodb/catalog/common/rate_limit.py
@@ -31,14 +31,16 @@ Failure modes are advisory rather than fatal:
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 from typing import TYPE_CHECKING
 
 import django_rq
-from loguru import logger
 
 from .downloaders import get_mock_mode
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from redis.client import Script

--- a/neodb/catalog/common/sites.py
+++ b/neodb/catalog/common/sites.py
@@ -8,6 +8,7 @@ ResourceContent persists as an ExternalResource which may link to an Item
 """
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from hashlib import md5
@@ -17,7 +18,6 @@ import django_rq
 import requests
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
-from loguru import logger
 
 from common.models import SiteConfig
 from common.models.misc import uniq
@@ -27,6 +27,8 @@ from common.validators import is_valid_url
 
 from ..models import ExternalResource, IdType, Item, SiteName
 from .downloaders import DownloadError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/neodb/catalog/jobs/creator_verify.py
+++ b/neodb/catalog/jobs/creator_verify.py
@@ -1,9 +1,9 @@
+import logging
 from urllib.parse import urlparse
 
 import django_rq
 from django.db import transaction
 from django.utils import timezone
-from loguru import logger
 
 from common.utils import discord_send
 from common.validators import is_valid_url
@@ -16,6 +16,8 @@ from ..models import (
     match_creator_identity,
     resolve_creator_identity,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def enqueue_creator_verification(claim: VerifiedCreator, user: User) -> None:

--- a/neodb/catalog/jobs/discover.py
+++ b/neodb/catalog/jobs/discover.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import timedelta
 from typing import Any
@@ -7,7 +8,6 @@ from django.core.cache import cache
 from django.db.models import Count, Exists, F, OuterRef, Q
 from django.db.models.query import prefetch_related_objects
 from django.utils import timezone
-from loguru import logger
 
 from catalog.models import *
 from catalog.sites.fedi import FediverseInstance
@@ -23,6 +23,8 @@ from journal.models import (
 )
 from takahe.models import Identity
 from takahe.utils import Post
+
+logger = logging.getLogger(__name__)
 
 MAX_ITEMS_PER_PERIOD = 12
 MAX_DAYS_FOR_PERIOD = 96

--- a/neodb/catalog/jobs/podcast.py
+++ b/neodb/catalog/jobs/podcast.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -5,11 +6,12 @@ from datetime import timedelta
 from django.db import close_old_connections, connections
 from django.db.models import Max
 from django.utils import timezone
-from loguru import logger
 
 from catalog.models import IdType, Podcast, PodcastEpisode
 from catalog.sites import RSS
 from common.models import BaseJob, JobManager
+
+logger = logging.getLogger(__name__)
 
 FRESH_DELAY = timedelta(hours=2)
 MID_DELAY = timedelta(hours=12)

--- a/neodb/catalog/jobs/recommendation.py
+++ b/neodb/catalog/jobs/recommendation.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from collections import defaultdict
 from datetime import timedelta
@@ -6,7 +7,6 @@ import numpy as np
 from django.db import transaction
 from django.db.models import Count
 from django.utils import timezone
-from loguru import logger
 from scipy.sparse import csr_matrix
 
 from catalog.models import (
@@ -26,6 +26,8 @@ from common.models import BaseJob, JobManager, SiteConfig
 from journal.models import ShelfMember
 from takahe.models import Identity as TakaheIdentity
 from users.models import APIdentity
+
+logger = logging.getLogger(__name__)
 
 
 def _non_discoverable_identity_ids() -> set[int]:

--- a/neodb/catalog/jobs/stats.py
+++ b/neodb/catalog/jobs/stats.py
@@ -1,11 +1,13 @@
+import logging
 from datetime import timedelta
 
 from django.core.cache import cache
-from loguru import logger
 
 from catalog.models import item_categories
 from catalog.views import visible_categories
 from common.models import BaseJob, JobManager
+
+logger = logging.getLogger(__name__)
 
 
 @JobManager.register

--- a/neodb/catalog/management/commands/catalog.py
+++ b/neodb/catalog/management/commands/catalog.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 import time
 import uuid
 from datetime import timedelta
@@ -13,7 +12,6 @@ from django.core.files.storage import default_storage
 from django.core.paginator import Paginator
 from django.db.models import Count, F, Q
 from django.utils import timezone
-from loguru import logger
 from tqdm import tqdm
 
 from catalog.common.sites import SiteManager
@@ -33,6 +31,8 @@ from catalog.search.external import ExternalSources
 from catalog.sites.fedi import FediverseInstance
 from common.management.base import SiteCommand
 from common.models import detect_language, uniq
+
+logger = logging.getLogger(__name__)
 
 _CONFIRM = "confirm deleting collection? [Y/N] "
 _HELP_TEXT = """
@@ -150,10 +150,8 @@ class Command(SiteCommand):
         parser.add_argument(
             "--log-level",
             choices=[
-                "TRACE",
                 "DEBUG",
                 "INFO",
-                "SUCCESS",
                 "WARNING",
                 "ERROR",
                 "CRITICAL",
@@ -910,8 +908,7 @@ class Command(SiteCommand):
         self.fix = options["fix"]
 
         log_level = options.get("log_level", "INFO")
-        logger.remove()
-        logger.add(sys.stderr, level=log_level)
+        logging.getLogger().setLevel(log_level)
         logging.getLogger("rq").setLevel(logging.WARNING)
 
         index = CatalogIndex.instance()

--- a/neodb/catalog/management/commands/crawl.py
+++ b/neodb/catalog/management/commands/crawl.py
@@ -1,13 +1,15 @@
+import logging
 import re
 from typing import cast
 from urllib.parse import urljoin
 
-from loguru import logger
 from lxml import html
 
 from catalog.common import *
 from catalog.common.downloaders import DownloadError
 from common.management.base import SiteCommand
+
+logger = logging.getLogger(__name__)
 
 
 class Command(SiteCommand):

--- a/neodb/catalog/models/book.py
+++ b/neodb/catalog/models/book.py
@@ -18,13 +18,13 @@ work data seems asymmetric (a book links to a work, but may not listed in that w
 """
 
 import ast
+import logging
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from ninja import Field
 
 from common.models import normalize_price, uniq
@@ -49,6 +49,8 @@ from .item import (
 )
 from .people import PeopleRole
 from .utils import *
+
+logger = logging.getLogger(__name__)
 
 
 def _coerce_legacy_string_list(value) -> list[str]:

--- a/neodb/catalog/models/creator.py
+++ b/neodb/catalog/models/creator.py
@@ -1,11 +1,13 @@
+import logging
 import re
 from typing import TYPE_CHECKING, Iterable
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 
 from .item import Item
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser

--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import uuid
 from enum import Enum
@@ -15,7 +16,6 @@ from django.db import IntegrityError, connection, models, transaction
 from django.db.models import Q, QuerySet, prefetch_related_objects
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from ninja import Field, Schema
 from polymorphic.models import PolymorphicModel
 
@@ -44,6 +44,8 @@ from .common import (
     SiteName,
 )
 from .utils import item_cover_path, resource_cover_path
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser

--- a/neodb/catalog/models/tv.py
+++ b/neodb/catalog/models/tv.py
@@ -25,12 +25,12 @@ For now, we follow Douban convention, but keep an eye on it in case it breaks it
 
 """
 
+import logging
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from ninja import Field, Schema
 
 from common.models import (
@@ -62,6 +62,8 @@ from .item import (
 )
 from .people import PeopleRole
 from .utils import normalize_legacy_video_metadata
+
+logger = logging.getLogger(__name__)
 
 
 class _TVCreditResolverMixin(Schema):

--- a/neodb/catalog/recommendation.py
+++ b/neodb/catalog/recommendation.py
@@ -6,6 +6,7 @@ Three surfaces, all visibility- and pref-gated by Preference.show_recommendation
 - from_your_circles(viewer): recent shelves from followees
 """
 
+import logging
 from collections import defaultdict
 from datetime import timedelta
 from heapq import nlargest
@@ -14,7 +15,6 @@ from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Count, QuerySet
 from django.utils import timezone
-from loguru import logger
 
 from common.models import SiteConfig
 from journal.models import ShelfMember, q_piece_visible_to_user
@@ -31,6 +31,8 @@ from .models import (
     Work,
     item_content_types,
 )
+
+logger = logging.getLogger(__name__)
 
 # Item classes that should never appear as recommendation targets.
 # - TVShow: container; users typically mark TVSeasons

--- a/neodb/catalog/search/index.py
+++ b/neodb/catalog/search/index.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import timedelta
 from functools import cached_property, reduce
@@ -5,11 +6,12 @@ from typing import TYPE_CHECKING, Iterable, cast
 
 import django_rq
 from django_redis import get_redis_connection
-from loguru import logger
 from rq.job import Job
 
 from common.models.misc import int_
 from common.search import Index, QueryParser, SearchResult
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from catalog.models import Item

--- a/neodb/catalog/search/people_index.py
+++ b/neodb/catalog/search/people_index.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, Iterable, cast
@@ -5,10 +6,11 @@ from typing import TYPE_CHECKING, Iterable, cast
 import django_rq
 from django.db.models import Count
 from django_redis import get_redis_connection
-from loguru import logger
 from rq.job import Job
 
 from common.search import Index, QueryParser, SearchResult
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from catalog.models import People

--- a/neodb/catalog/search/utils.py
+++ b/neodb/catalog/search/utils.py
@@ -1,11 +1,11 @@
 import hashlib
 
 import django_rq
+import logging
 from auditlog.context import set_actor
 from django.conf import settings
 from django.core.cache import cache
 from django.db.models import prefetch_related_objects
-from loguru import logger
 from rq.job import Job
 
 from catalog.common import (
@@ -20,6 +20,8 @@ from users.models import User
 
 from ..models import Edition, Item, TVSeason
 from .index import CatalogIndex, CatalogQueryParser
+
+logger = logging.getLogger(__name__)
 
 
 def query_index(

--- a/neodb/catalog/sites/anilist.py
+++ b/neodb/catalog/sites/anilist.py
@@ -10,6 +10,7 @@ lookup id so myanimelist.py (and Wikidata's P4086/P4087) lands on existing
 items instead of creating duplicates.
 """
 
+import logging
 import re
 import threading
 from collections import OrderedDict
@@ -19,7 +20,6 @@ from typing import Any, cast
 import httpx
 import requests
 from django.conf import settings
-from loguru import logger
 from requests.exceptions import RequestException
 
 from catalog.common import *
@@ -36,6 +36,8 @@ from catalog.models import (
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models.lang import detect_language
 from journal.models.renderers import html_to_text
+
+logger = logging.getLogger(__name__)
 
 _API_URL = "https://graphql.anilist.co"
 

--- a/neodb/catalog/sites/apple_music.py
+++ b/neodb/catalog/sites/apple_music.py
@@ -9,10 +9,10 @@ Scraping the website directly.
 """
 
 import json
+import logging
 from datetime import timedelta
 
 from django.utils.dateparse import parse_duration
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
@@ -23,6 +23,8 @@ from common.models.lang import (
 from common.models.misc import uniq
 
 from .douban import *
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/apple_podcast.py
+++ b/neodb/catalog/sites/apple_podcast.py
@@ -1,13 +1,15 @@
+import logging
 from urllib.parse import quote_plus
 
 import httpx
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
 from catalog.search import *
 
 from .rss import RSS
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/bandcamp.py
+++ b/neodb/catalog/sites/bandcamp.py
@@ -7,7 +7,6 @@ from typing import cast
 import dateparser
 import dns.resolver
 import httpx
-from loguru import logger
 from lxml import html
 from lxml.html import HtmlElement
 
@@ -166,10 +165,10 @@ class Bandcamp(AbstractSite):
                         )
                     )
             except httpx.ReadTimeout:
-                logger.warning("Bandcamp search timeout", extra={"query": q})
+                _logger.warning("Bandcamp search timeout", extra={"query": q})
                 record_search_failure(SiteName.Bandcamp.value, "timeout")
             except Exception as e:
-                logger.error(
+                _logger.error(
                     "Bandcamp search error", extra={"query": q, "exception": e}
                 )
                 record_search_failure(SiteName.Bandcamp.value, "error")

--- a/neodb/catalog/sites/bangumi.py
+++ b/neodb/catalog/sites/bangumi.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import (
@@ -170,10 +169,12 @@ class Bangumi(AbstractSite):
                             )
                         )
             except httpx.ReadTimeout:
-                logger.warning("Bangumi search timeout", extra={"query": q})
+                _logger.warning("Bangumi search timeout", extra={"query": q})
                 record_search_failure(cls.SITE_NAME.value, "timeout")
             except Exception as e:
-                logger.error("Bangumi search error", extra={"query": q, "exception": e})
+                _logger.error(
+                    "Bangumi search error", extra={"query": q, "exception": e}
+                )
                 record_search_failure(cls.SITE_NAME.value, "error")
         return results
 

--- a/neodb/catalog/sites/douban_movie.py
+++ b/neodb/catalog/sites/douban_movie.py
@@ -1,7 +1,7 @@
 import json
+import logging
 import re
 
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
@@ -15,6 +15,8 @@ from common.models.misc import int_
 
 from .douban import DoubanDownloader, DoubanSearcher, extract_people_links_from_anchors
 from .tmdb import TMDB_TV, search_tmdb_by_imdb_id
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/douban_personage.py
+++ b/neodb/catalog/sites/douban_personage.py
@@ -1,7 +1,7 @@
+import logging
 import re
 from urllib.parse import urlencode
 
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.downloaders import BasicDownloader
@@ -9,6 +9,8 @@ from catalog.models import *
 from common.models.lang import detect_language
 
 from .douban import DoubanDownloader
+
+logger = logging.getLogger(__name__)
 
 DOUBAN_PERSONAGE_WORKS_PAGE_SIZE = 100
 

--- a/neodb/catalog/sites/fedi.py
+++ b/neodb/catalog/sites/fedi.py
@@ -1,10 +1,10 @@
+import logging
 import re
 from urllib.parse import quote_plus, urlparse
 
 import httpx
 from django.conf import settings
 from django.core.validators import URLValidator
-from loguru import logger
 
 from catalog.common import (
     AbstractSite,
@@ -33,6 +33,8 @@ from catalog.models import (
 )
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import SiteConfig
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/goodreads.py
+++ b/neodb/catalog/sites/goodreads.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from datetime import datetime
 from typing import cast
@@ -6,7 +7,6 @@ from urllib.parse import quote_plus
 
 import httpx
 from django.utils.timezone import make_aware
-from loguru import logger
 from lxml import html
 from lxml.html import HtmlElement
 
@@ -23,6 +23,8 @@ from catalog.models.utils import binding_to_format, detect_isbn_asin
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import detect_language
 from journal.models.renderers import html_to_text
+
+logger = logging.getLogger(__name__)
 
 
 class GoodreadsDownloader(RetryDownloader):

--- a/neodb/catalog/sites/google_books.py
+++ b/neodb/catalog/sites/google_books.py
@@ -1,14 +1,16 @@
+import logging
 import re
 from urllib.parse import quote_plus
 
 import httpx
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import isbn_10_to_13
 from catalog.search import *
 from common.models import SiteConfig, detect_language
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/igdb.py
+++ b/neodb/catalog/sites/igdb.py
@@ -6,6 +6,7 @@ use (e.g. "portal-2") as id, which is different from real id in IGDB API
 
 import datetime
 import json
+import logging
 import threading
 import time
 from urllib.parse import quote_plus
@@ -15,7 +16,6 @@ import requests
 from django.conf import settings
 from django.core.cache import cache
 from igdb.wrapper import IGDBWrapper
-from loguru import logger
 
 from common.models import normalize_game_platforms
 
@@ -24,6 +24,8 @@ from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import *
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models import SiteConfig
+
+logger = logging.getLogger(__name__)
 
 _cache_key = "igdb_access_token"
 

--- a/neodb/catalog/sites/mangaupdates.py
+++ b/neodb/catalog/sites/mangaupdates.py
@@ -10,19 +10,21 @@ the numeric form, ``int(slug, 36)``. Legacy ``series.html?id=N`` numbers are a
 different id space that the API no longer serves, so they are not matched.
 """
 
+import logging
 import re
 import threading
 from typing import Any
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.rate_limit import RedisRateLimiter
 from catalog.models import Edition, IdType, ItemCategory, SiteName
 from catalog.search import ExternalSearchResultItem, record_search_failure
 from common.models.lang import detect_language, normalize_languages
+
+logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.mangaupdates.com/v1"
 

--- a/neodb/catalog/sites/musicbrainz.py
+++ b/neodb/catalog/sites/musicbrainz.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.rate_limit import RedisRateLimiter
@@ -211,7 +210,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
             downloader = MusicBrainzDownloader(api_url, headers=headers)
             response_data = downloader.download().json()
         except Exception as e:
-            logger.error(f"Failed to fetch MusicBrainz data: {e}")
+            _logger.error(f"Failed to fetch MusicBrainz data: {e}")
             raise ParseError(self, f"Failed to fetch data from MusicBrainz API: {e}")
 
         return self._parse_release_group_data(response_data)
@@ -288,7 +287,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
                     cover_image_url = self._get_cover_art_url(release_id)
                     isrc = _extract_first_isrc(release_data)
             except Exception as e:
-                logger.warning(f"Failed to get detailed release info: {e}")
+                _logger.warning(f"Failed to get detailed release info: {e}")
 
         metadata = {
             "title": title,
@@ -357,7 +356,7 @@ class MusicBrainzReleaseGroup(AbstractSite):
                 # If no front cover found, use first image
                 return cover_data["images"][0].get("image", "")
         except Exception as e:
-            logger.debug(f"No cover art found for release {release_id}: {e}")
+            _logger.debug(f"No cover art found for release {release_id}: {e}")
 
         return None
 
@@ -400,7 +399,7 @@ class MusicBrainzRelease(AbstractSite):
             downloader = MusicBrainzDownloader(api_url, headers=headers)
             response_data = downloader.download().json()
         except Exception as e:
-            logger.error(f"Failed to fetch MusicBrainz release data: {e}")
+            _logger.error(f"Failed to fetch MusicBrainz release data: {e}")
             raise ParseError(self, f"Failed to fetch data from MusicBrainz API: {e}")
 
         return self._parse_release_data(response_data)
@@ -524,7 +523,7 @@ class MusicBrainzRelease(AbstractSite):
                 # If no front cover found, use first image
                 return cover_data["images"][0].get("image", "")
         except Exception as e:
-            logger.debug(f"No cover art found for release {release_id}: {e}")
+            _logger.debug(f"No cover art found for release {release_id}: {e}")
 
         return None
 
@@ -616,17 +615,19 @@ class MusicBrainzRelease(AbstractSite):
                         )
 
             except httpx.TimeoutException:
-                logger.warning("MusicBrainz release search timeout", extra={"query": q})
+                _logger.warning(
+                    "MusicBrainz release search timeout", extra={"query": q}
+                )
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
             except httpx.HTTPError as e:
                 # MusicBrainz 503s and transport errors are transient -> warn.
-                logger.warning(
+                _logger.warning(
                     "MusicBrainz release search error",
                     extra={"query": q, "exception": e},
                 )
                 record_search_failure(SiteName.MusicBrainz.value, "error")
             except Exception as e:
-                logger.error(
+                _logger.error(
                     "MusicBrainz release search error",
                     extra={"query": q, "exception": e},
                 )
@@ -686,11 +687,11 @@ class MusicBrainzRelease(AbstractSite):
                 response.raise_for_status()
                 data = response.json()
             except httpx.TimeoutException:
-                logger.warning("MusicBrainz field search timeout", extra={"query": q})
+                _logger.warning("MusicBrainz field search timeout", extra={"query": q})
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
                 return results
             except Exception as e:
-                logger.error(
+                _logger.error(
                     "MusicBrainz field search error",
                     extra={"query": q, "exception": e},
                 )
@@ -768,7 +769,7 @@ class MusicBrainzArtist(AbstractSite):
             )
             data = downloader.download().json()
         except Exception as e:
-            logger.error(f"Failed to fetch MusicBrainz artist data: {e}")
+            _logger.error(f"Failed to fetch MusicBrainz artist data: {e}")
             raise ParseError(
                 self, f"Failed to fetch data from MusicBrainz API: {e}"
             ) from e
@@ -912,19 +913,19 @@ class MusicBrainzArtist(AbstractSite):
                 response.raise_for_status()
                 data = response.json()
             except httpx.TimeoutException:
-                logger.warning("MusicBrainz artist search timeout", extra={"query": q})
+                _logger.warning("MusicBrainz artist search timeout", extra={"query": q})
                 record_search_failure(SiteName.MusicBrainz.value, "timeout")
                 return results
             except httpx.HTTPError as e:
                 # MusicBrainz 503s and transport errors are transient -> warn.
-                logger.warning(
+                _logger.warning(
                     "MusicBrainz artist search error",
                     extra={"query": q, "exception": e},
                 )
                 record_search_failure(SiteName.MusicBrainz.value, "error")
                 return results
             except Exception as e:
-                logger.error(
+                _logger.error(
                     "MusicBrainz artist search error",
                     extra={"query": q, "exception": e},
                 )

--- a/neodb/catalog/sites/myanimelist.py
+++ b/neodb/catalog/sites/myanimelist.py
@@ -12,13 +12,13 @@ AniList (idMal) and Wikidata (P4086/P4087) already file MAL ids as lookup
 ids, so a fetch here lands on the item they created rather than a duplicate.
 """
 
+import logging
 import threading
 from collections import OrderedDict
 from typing import Any
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.downloaders import DownloadError
@@ -39,6 +39,8 @@ from journal.models.renderers import html_to_text
 # Shared title-language policy: romaji is assigned, never detected, and no two
 # titles claim one language.
 from .anilist import _UNKNOWN_LANG, _localized
+
+logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.myanimelist.net/v2"
 

--- a/neodb/catalog/sites/openlibrary.py
+++ b/neodb/catalog/sites/openlibrary.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import threading
 from datetime import datetime
@@ -5,7 +6,6 @@ from urllib.parse import quote_plus
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.rate_limit import RedisRateLimiter
@@ -14,6 +14,8 @@ from catalog.models.utils import detect_isbn_asin, isbn_10_to_13
 from catalog.search import *
 from common.models import SiteConfig, detect_language
 from common.models.lang import normalize_language
+
+logger = logging.getLogger(__name__)
 
 # OpenLibrary serves 1 req/s to unidentified clients and 3 req/s to callers
 # that send an app name plus a contact address, and warns that a generic or

--- a/neodb/catalog/sites/rss.py
+++ b/neodb/catalog/sites/rss.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.validators import URLValidator
 from django.utils.timezone import make_aware
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.downloaders import (
@@ -205,11 +204,11 @@ class RSS(AbstractSite):
     def scrape_additional_data(self):
         feed = self.parse_feed_from_url(self.url)
         if not feed:
-            logger.warning(f"unable to parse RSS {self.url}")
+            _logger.warning(f"unable to parse RSS {self.url}")
             return False
         item = self.get_item()
         if not item:
-            logger.warning(f"item for RSS {self.url} not found")
+            _logger.warning(f"item for RSS {self.url} not found")
             return False
         self.update_episodes_from_feed(item, feed)
         return True

--- a/neodb/catalog/sites/spotify.py
+++ b/neodb/catalog/sites/spotify.py
@@ -9,7 +9,6 @@ import dateparser
 import httpx
 import requests
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
@@ -182,12 +181,14 @@ class Spotify(AbstractSite):
                             )
                         )
                 else:
-                    logger.warning(f"Spotify search '{q}' no results found.")
+                    _logger.warning(f"Spotify search '{q}' no results found.")
             except httpx.ReadTimeout:
-                logger.warning("Spotify search timeout", extra={"query": q})
+                _logger.warning("Spotify search timeout", extra={"query": q})
                 record_search_failure(SiteName.Spotify.value, "timeout")
             except Exception as e:
-                logger.error("Spotify search error", extra={"query": q, "exception": e})
+                _logger.error(
+                    "Spotify search error", extra={"query": q, "exception": e}
+                )
                 record_search_failure(SiteName.Spotify.value, "error")
         return results
 
@@ -256,10 +257,10 @@ class Spotify(AbstractSite):
                         )
                     )
             except httpx.ReadTimeout:
-                logger.warning("Spotify field search timeout", extra={"query": q})
+                _logger.warning("Spotify field search timeout", extra={"query": q})
                 record_search_failure(SiteName.Spotify.value, "timeout")
             except Exception as e:
-                logger.error(
+                _logger.error(
                     "Spotify field search error", extra={"query": q, "exception": e}
                 )
                 record_search_failure(SiteName.Spotify.value, "error")

--- a/neodb/catalog/sites/tmdb.py
+++ b/neodb/catalog/sites/tmdb.py
@@ -16,7 +16,6 @@ from urllib.parse import quote_plus
 
 import httpx
 from django.conf import settings
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
@@ -272,12 +271,12 @@ class TMDB_Movie(AbstractSite):
                                 )
                             )
                 else:
-                    logger.warning(f"TMDB search '{q}' no results found.")
+                    _logger.warning(f"TMDB search '{q}' no results found.")
             except httpx.ReadTimeout:
-                logger.warning("TMDb search timeout", extra={"query": q})
+                _logger.warning("TMDb search timeout", extra={"query": q})
                 record_search_failure(SiteName.TMDB.value, "timeout")
             except Exception as e:
-                logger.error("TMDb search error", extra={"query": q, "exception": e})
+                _logger.error("TMDb search error", extra={"query": q, "exception": e})
                 record_search_failure(SiteName.TMDB.value, "error")
         return results[offset : offset + page_size]
 
@@ -696,10 +695,12 @@ class TMDB_Person(AbstractSite):
         try:
             data = BasicDownloader(api_url).download().json()
         except Exception as e:
-            logger.error(f"TMDB combined_credits fetch failed for {self.id_value}: {e}")
+            _logger.error(
+                f"TMDB combined_credits fetch failed for {self.id_value}: {e}"
+            )
             return []
         if not isinstance(data, dict):
-            logger.error(
+            _logger.error(
                 f"TMDB combined_credits response is invalid for {self.id_value}"
             )
             return []

--- a/neodb/catalog/sites/wikidata.py
+++ b/neodb/catalog/sites/wikidata.py
@@ -4,9 +4,9 @@ Wikidata API integration
 Uses the Wikidata REST API: https://www.wikidata.org/wiki/Wikidata:REST_API
 """
 
+import logging
 from urllib.parse import quote, urlencode
 
-from loguru import logger
 
 from catalog.common import (
     AbstractSite,
@@ -34,6 +34,8 @@ from catalog.models import (
 )
 from catalog.sites.openlibrary import OpenLibrary
 from common.models.lang import SITE_PREFERRED_LANGUAGES
+
+logger = logging.getLogger(__name__)
 
 
 # Wikidata Entity IDs for classification

--- a/neodb/catalog/sites/worldcat.py
+++ b/neodb/catalog/sites/worldcat.py
@@ -1,13 +1,15 @@
 import json
+import logging
 import re
 
-from loguru import logger
 
 from catalog.common import *
 from catalog.models import *
 from catalog.models.utils import detect_isbn_asin, isbn_10_to_13
 from common.models import detect_language
 from common.models.lang import normalize_language
+
+logger = logging.getLogger(__name__)
 
 
 @SiteManager.register

--- a/neodb/catalog/sites/youtube_music.py
+++ b/neodb/catalog/sites/youtube_music.py
@@ -13,16 +13,18 @@ Scraping strategy:
   Mock mode: reads fixture keyed to self.url (contains the MPREb_ browse response).
 """
 
+import logging
 import re
 
 import requests
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.downloaders import get_mock_mode
 from catalog.models import *
 from common.models import SiteConfig, normalize_album_types, parse_duration_text
 from common.models.lang import detect_language
+
+logger = logging.getLogger(__name__)
 
 _INNERTUBE_URL = "https://music.youtube.com/youtubei/v1/browse"
 _INNERTUBE_HEADERS = {

--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any
 
 import django_rq
@@ -16,7 +17,6 @@ from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from common.models.lang import get_current_locales
 from common.sentry import record_catalog_edit
@@ -39,6 +39,8 @@ from ..models import (
 )
 from ..models.people import People
 from ..sites import IMDB
+
+logger = logging.getLogger(__name__)
 
 fetch_works_for_person_task = people_works.fetch_works_for_person_task
 

--- a/neodb/catalog/views_debug.py
+++ b/neodb/catalog/views_debug.py
@@ -4,6 +4,7 @@ Access: DEBUG=True allows anyone, otherwise requires superuser.
 """
 
 import json
+import logging
 import time
 import traceback
 
@@ -11,7 +12,6 @@ from django.conf import settings
 from django.http import Http404, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from .common import (
     BasicDownloader,
@@ -21,19 +21,21 @@ from .common import (
     SiteManager,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def _debug_payload(error: str, logs: list[str]) -> dict:
     """Return error payload, including traceback only when DEBUG is on.
 
-    In production we always log the traceback server-side via loguru so
-    operators can investigate, but never expose it in the HTTP response.
+    In production we always log the traceback server-side so operators can
+    investigate, but never expose it in the HTTP response.
     """
     payload: dict = {"error": error, "logs": logs}
     tb = traceback.format_exc()
     if settings.DEBUG:
         payload["traceback"] = tb
     else:
-        logger.error("scraper_debug error: {} {}", error, tb)
+        logger.error("scraper_debug error: %s %s", error, tb)
     return payload
 
 

--- a/neodb/common/api.py
+++ b/neodb/common/api.py
@@ -1,10 +1,10 @@
+import logging
 from typing import Any
 
 from django.conf import settings
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.utils.functional import lazy
-from loguru import logger
 from ninja import Field, NinjaAPI, Schema, Status
 from pydantic import AliasChoices
 from ninja.pagination import PageNumberPagination as NinjaPageNumberPagination
@@ -14,6 +14,8 @@ from catalog.models import Item
 from common.models import SiteConfig
 from takahe.utils import Takahe
 from users.models.apidentity import APIdentity
+
+logger = logging.getLogger(__name__)
 
 PERMITTED_WRITE_METHODS = ["PUT", "POST", "DELETE", "PATCH"]
 PERMITTED_READ_METHODS = ["GET", "HEAD", "OPTIONS"]

--- a/neodb/common/management/commands/cron.py
+++ b/neodb/common/management/commands/cron.py
@@ -1,7 +1,9 @@
-from loguru import logger
+import logging
 
 from common.management.base import SiteCommand
 from common.models import JobManager
+
+logger = logging.getLogger(__name__)
 
 # @JobManager.register
 # class DummyJob(BaseJob):

--- a/neodb/common/models/cron.py
+++ b/neodb/common/models/cron.py
@@ -1,11 +1,13 @@
+import logging
 from datetime import timedelta
 
 import django_rq
-from loguru import logger
 from rq.job import Job
 from rq.registry import ScheduledJobRegistry
 
 from common.models.site_config import SiteConfig
+
+logger = logging.getLogger(__name__)
 
 
 class BaseJob:

--- a/neodb/common/models/lang.py
+++ b/neodb/common/models/lang.py
@@ -22,6 +22,7 @@ https://en.wikipedia.org/wiki/IETF_language_tag
 """
 
 import hashlib
+import logging
 import re
 from collections.abc import Callable
 from typing import Any
@@ -38,9 +39,10 @@ from lingua import (
     LanguageDetector,
     LanguageDetectorBuilder,
 )
-from loguru import logger
 
 from common.models.site_config import SiteConfig
+
+logger = logging.getLogger(__name__)
 
 FALLBACK_LANGUAGE = "en"
 # Copy: SiteConfig rewrites this list in place, and settings.PREFERRED_LANGUAGES

--- a/neodb/common/models/site_config.py
+++ b/neodb/common/models/site_config.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from typing import ClassVar
 
 import pydantic
@@ -7,10 +8,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
 from django.db.utils import DatabaseError, ProgrammingError
 from django.utils.translation import trans_real
-from loguru import logger
 
 from common.config import resolve_email_settings
 from common.models.genre import DEFAULT_GENRE_CATEGORIES
+
+logger = logging.getLogger(__name__)
 
 # Bounds for SystemOptions.registration_captcha_items; 0 disables the captcha.
 CAPTCHA_MIN_ITEMS = 4

--- a/neodb/common/search/index.py
+++ b/neodb/common/search/index.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import cached_property
 from json import JSONDecodeError
@@ -6,7 +7,6 @@ from typing import Iterable, List, Self, cast
 
 import httpx
 from django.conf import settings
-from loguru import logger
 from requests import RequestException
 from typesense.exceptions import ObjectNotFound, TypesenseClientError
 from typesense.sync.client import Client
@@ -21,6 +21,8 @@ from typesense.types.multi_search import MultiSearchRequestSchema
 
 from common.models.site_config import SiteConfig
 from common.sentry import count as sentry_count
+
+logger = logging.getLogger(__name__)
 
 # Exceptions that any Typesense network operation may raise.
 # typesense 2.x uses httpx for transport and, after exhausting node retries,

--- a/neodb/common/setup.py
+++ b/neodb/common/setup.py
@@ -1,6 +1,6 @@
+import logging
 from django.conf import settings
 from django.core.checks import Error, Warning
-from loguru import logger
 
 from catalog.search import CatalogIndex, PeopleIndex
 from common.models import JobManager, SiteConfig
@@ -10,6 +10,8 @@ from takahe.models import Domain as TakaheDomain
 from takahe.models import Identity as TakaheIdentity
 from takahe.models import Relay as TakaheRelay
 from takahe.utils import Takahe
+
+logger = logging.getLogger(__name__)
 
 
 class Setup:

--- a/neodb/common/utils.py
+++ b/neodb/common/utils.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 import uuid
 from typing import TYPE_CHECKING
 
@@ -13,11 +14,12 @@ from django.db.models.fields.files import FieldFile
 from django.http import Http404, HttpRequest, HttpResponseRedirect, QueryDict
 from django.utils import timezone
 from django.utils.translation import gettext as _
-from loguru import logger
 from storages.backends.s3boto3 import S3Boto3Storage
 
 from .config import ITEMS_PER_PAGE, ITEMS_PER_PAGE_OPTIONS, PAGE_LINK_NUMBER
 from .models import int_
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from users.models import APIdentity, User

--- a/neodb/common/validators.py
+++ b/neodb/common/validators.py
@@ -1,4 +1,5 @@
 import ipaddress
+import logging
 import socket
 from urllib.parse import urlparse
 
@@ -6,8 +7,9 @@ from cachetools import TTLCache
 from django.conf import settings
 from django.http import HttpRequest
 from django.utils.http import url_has_allowed_host_and_scheme
-from loguru import logger
 from validators import url as _url_validate
+
+logger = logging.getLogger(__name__)
 
 # In-process TTL cache for hostname → public-IP resolution. Avoids paying the
 # DNS roundtrip twice when validating then fetching the same remote, and stays

--- a/neodb/common/views_manage.py
+++ b/neodb/common/views_manage.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from collections.abc import Callable
 from functools import partial
@@ -14,12 +15,13 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, TemplateView
 from django_jsonform.forms.fields import JSONFormField
-from loguru import logger
 
 from catalog.jobs.recommendation import BuildItemSimilarity, BuildUserRecommendations
 from common.config import hide_secret
 from common.models import SiteConfig
 from common.models.site_config import CAPTCHA_MAX_ITEMS
+
+logger = logging.getLogger(__name__)
 
 
 def superuser_required(view_func):

--- a/neodb/journal/exporters/ndjson.py
+++ b/neodb/journal/exporters/ndjson.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -9,7 +10,6 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db.models.fields.files import ImageFieldFile
 from django.utils import timezone
-from loguru import logger
 
 from catalog.common import ProxiedImageDownloader
 from common.utils import GenerateDateUUIDMediaFilePath
@@ -29,6 +29,8 @@ from journal.models import (
 from journal.models.renderers import RE_MD_IMAGE, normalize_image_src
 from takahe.models import Post
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 # Content subclasses carried on the journal stream, in the order they are
 # written. Enumerated rather than walked via ``Content.__subclasses__()``:

--- a/neodb/journal/importers/base.py
+++ b/neodb/journal/importers/base.py
@@ -1,14 +1,16 @@
 import datetime
+import logging
 from typing import Dict, List, Literal, Optional
 
 from django.conf import settings
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 
 from catalog.common.sites import SiteManager
 from catalog.models import Edition, IdType, Item, SiteName
 from journal.models import ShelfType
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 _PREFERRED_SITES = [
     SiteName.Fediverse,

--- a/neodb/journal/importers/csv.py
+++ b/neodb/journal/importers/csv.py
@@ -1,16 +1,18 @@
 import csv
+import logging
 import os
 import tempfile
 import zipfile
 from typing import Dict
 
 from django.utils import timezone
-from loguru import logger
 
 from catalog.models import ItemCategory
 from journal.models import Mark, Note, Review
 
 from .base import BaseImporter
+
+logger = logging.getLogger(__name__)
 
 # The members run() reads, and therefore the only ones worth accepting.
 _CSV_CATEGORIES = [

--- a/neodb/journal/importers/douban.py
+++ b/neodb/journal/importers/douban.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import datetime
 
@@ -5,7 +6,6 @@ import openpyxl
 import pytz
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from loguru import logger
 from markdownify import markdownify as md
 
 from catalog.common import *
@@ -17,6 +17,8 @@ from common.validators import is_valid_url
 from journal.models import *
 from journal.views.common import generate_upload_path
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 _tz_sh = pytz.timezone("Asia/Shanghai")
 

--- a/neodb/journal/importers/goodreads.py
+++ b/neodb/journal/importers/goodreads.py
@@ -1,10 +1,10 @@
 import csv
+import logging
 from datetime import datetime
 
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _
-from loguru import logger
 from markdownify import markdownify as md
 
 from catalog.common import *
@@ -13,6 +13,8 @@ from catalog.models import *
 from catalog.models.utils import detect_isbn_asin
 from journal.models import *
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 SHELF_MAP = {
     "read": ShelfType.COMPLETE,

--- a/neodb/journal/importers/letterboxd.py
+++ b/neodb/journal/importers/letterboxd.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 import os
 import tempfile
 import zipfile
@@ -9,7 +10,6 @@ from random import randint
 import pytz
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext as _
-from loguru import logger
 from markdownify import markdownify as md
 
 from catalog.common import *
@@ -17,6 +17,8 @@ from catalog.common.downloaders import *
 from catalog.models import *
 from journal.models import *
 from users.models import *
+
+logger = logging.getLogger(__name__)
 
 _tz_sh = pytz.timezone("Asia/Shanghai")
 

--- a/neodb/journal/importers/ndjson.py
+++ b/neodb/journal/importers/ndjson.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import mimetypes
 import os
 import re
@@ -14,7 +15,6 @@ from django.core.files import File
 from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
 from django.utils import timezone
-from loguru import logger
 
 from catalog.models import ExternalResource, Item
 from catalog.sites.fedi import FediverseInstance
@@ -42,6 +42,8 @@ from takahe.utils import Takahe
 from users.models import APIdentity
 
 from .base import BaseImporter
+
+logger = logging.getLogger(__name__)
 
 
 class NdjsonImporter(BaseImporter):

--- a/neodb/journal/importers/opml.py
+++ b/neodb/journal/importers/opml.py
@@ -1,14 +1,16 @@
+import logging
 from contextlib import nullcontext
 
 import listparser
 from django.utils.translation import gettext as _
-from loguru import logger
 
 from catalog.common import *
 from catalog.common.downloaders import *
 from catalog.sites.rss import RSS
 from journal.models import *
 from users.models.task import Task
+
+logger = logging.getLogger(__name__)
 
 
 class OPMLImporter(Task):

--- a/neodb/journal/importers/rym.py
+++ b/neodb/journal/importers/rym.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 import datetime
 import fcntl
+import logging
 import os
 import re
 import tempfile
@@ -10,7 +11,6 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _
-from loguru import logger
 
 from catalog.common import SiteManager
 from catalog.models import Album, Item
@@ -20,6 +20,8 @@ from catalog.sites.spotify import Spotify
 from common.models import SiteConfig
 from journal.models import Mark, Review, ShelfType
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 RYM_HEADER_PREFIX = "RYM Album,"
 OWNERSHIP_TO_SHELF = {

--- a/neodb/journal/importers/steam.py
+++ b/neodb/journal/importers/steam.py
@@ -1,10 +1,10 @@
+import logging
 from datetime import datetime, timedelta
 from typing import Iterable, List, Optional, TypedDict
 
 import pytz
 import requests
 from django.utils import timezone
-from loguru import logger
 from requests import RequestException
 
 from catalog.common.downloaders import DownloadError
@@ -16,6 +16,8 @@ from journal.models.mark import Mark
 from journal.models.shelf import ShelfType
 
 from .base import BaseImporter
+
+logger = logging.getLogger(__name__)
 
 # with reference to
 # - https://developer.valvesoftware.com/wiki/Steam_Web_API

--- a/neodb/journal/importers/storygraph.py
+++ b/neodb/journal/importers/storygraph.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import logging
 import os
 import re
 from urllib.parse import quote_plus
@@ -8,7 +9,6 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _
-from loguru import logger
 from markdownify import markdownify as md
 
 from catalog.common import *
@@ -18,6 +18,8 @@ from catalog.search.index import CatalogIndex, CatalogQueryParser
 from common.models import SiteConfig
 from journal.models import *
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 SHELF_MAP = {
     "read": ShelfType.COMPLETE,

--- a/neodb/journal/importers/trakt.py
+++ b/neodb/journal/importers/trakt.py
@@ -1,16 +1,18 @@
 import json
+import logging
 import os
 import tempfile
 import zipfile
 
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 
 from catalog.common.sites import SiteManager
 from catalog.models import IdType, Item
 from catalog.models.tv import TVShow
 from journal.models import Collection, Mark, ShelfType
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 
 class TraktImporter(Task):

--- a/neodb/journal/importers/wordpress.py
+++ b/neodb/journal/importers/wordpress.py
@@ -1,9 +1,9 @@
 import datetime
+import logging
 from email.utils import parsedate_to_datetime
 from typing import Any
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from loguru import logger
 from lxml import etree
 from markdownify import markdownify as md
 
@@ -11,6 +11,8 @@ from catalog.common.downloaders import BasicImageDownloader
 from journal.models import Article
 
 from .base import BaseImporter
+
+logger = logging.getLogger(__name__)
 
 _NS = {
     "excerpt": "http://wordpress.org/export/1.2/excerpt/",

--- a/neodb/journal/jobs/list_sync.py
+++ b/neodb/journal/jobs/list_sync.py
@@ -23,14 +23,16 @@ servers could otherwise drive the worker into excessive DB cost).
 from __future__ import annotations
 
 import importlib
+import logging
 from datetime import timedelta
 from typing import Any
 
 import django_rq
-from loguru import logger
 
 from common.validators import is_valid_url
 from takahe.auth import sign_get
+
+logger = logging.getLogger(__name__)
 
 MAX_FETCH_ATTEMPTS = 3
 RETRY_DELAY = timedelta(minutes=5)

--- a/neodb/journal/jobs/migrations.py
+++ b/neodb/journal/jobs/migrations.py
@@ -1,5 +1,5 @@
+import logging
 from django.db.models import OuterRef, Subquery
-from loguru import logger
 
 from catalog.models import Edition, item_content_types
 from journal.models import (
@@ -13,6 +13,8 @@ from journal.models import (
     ShelfType,
 )
 from journal.models.attachment import is_owned_upload, link_attachments_to_piece
+
+logger = logging.getLogger(__name__)
 
 
 def backfill_member_progress_from_notes_20260720(batch_size: int = 1000) -> int:

--- a/neodb/journal/models/article.py
+++ b/neodb/journal/models/article.py
@@ -1,3 +1,4 @@
+import logging
 import mimetypes
 import re
 from typing import Any
@@ -10,7 +11,6 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
-from loguru import logger
 from markdownify import markdownify as md
 
 from catalog.models.utils import piece_cover_path
@@ -23,6 +23,8 @@ from .attachment import link_attachments_to_piece
 from .common import Piece, VisibilityType
 from .renderers import render_md, sanitize_md_images
 from .tag import Tag as TagModel
+
+logger = logging.getLogger(__name__)
 
 _RE_SPOILER_TAG = re.compile(r'<(div|span)\sclass="spoiler">.*</(div|span)>')
 

--- a/neodb/journal/models/attachment.py
+++ b/neodb/journal/models/attachment.py
@@ -25,6 +25,7 @@ column can be dropped once every deployment's backfill has completed.
 """
 
 import hashlib
+import logging
 import mimetypes
 import os
 import uuid
@@ -36,11 +37,12 @@ from django.core.files.base import File
 from django.core.files.storage import Storage, default_storage, storages
 from django.db import models
 from django.utils import timezone
-from loguru import logger
 
 from users.models import APIdentity
 
 from .renderers import RE_MD_IMAGE, normalize_image_src
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from takahe.models import Post, PostAttachment

--- a/neodb/journal/models/collection.py
+++ b/neodb/journal/models/collection.py
@@ -1,3 +1,4 @@
+import logging
 import mimetypes
 import re
 from collections.abc import Iterator
@@ -13,7 +14,6 @@ from django.urls import reverse
 from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
-from loguru import logger
 
 from catalog.models import CatalogCollection, Item, ItemCategory, item_categories
 from catalog.models.utils import piece_cover_path
@@ -27,6 +27,8 @@ from users.models import APIdentity, User
 from .common import Piece
 from .itemlist import AP_PAGE_SIZE, List, ListMember, list_add, list_remove
 from .renderers import render_md, render_text
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser

--- a/neodb/journal/models/common.py
+++ b/neodb/journal/models/common.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import uuid
 from abc import abstractmethod
@@ -17,7 +18,6 @@ from django.db import models
 from django.db.models import CharField, Q, prefetch_related_objects
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from polymorphic.models import PolymorphicModel
 from user_messages import api as messages
 
@@ -38,6 +38,8 @@ from ..search import JournalIndex
 from .atproto import build_document_rkey
 from .crosspost import CrosspostRetry
 from .mixins import UserOwnedObjectMixin
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from django.db.models.fields.related_descriptors import ManyRelatedManager

--- a/neodb/journal/models/itemlist.py
+++ b/neodb/journal/models/itemlist.py
@@ -1,3 +1,4 @@
+import logging
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -7,7 +8,6 @@ import django_rq
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 
 from catalog.models import Item, ItemCategory
 from catalog.models.item import item_content_types
@@ -17,6 +17,8 @@ from takahe.utils import Takahe
 from users.models import APIdentity
 
 from .common import Piece, VisibilityType
+
+logger = logging.getLogger(__name__)
 
 list_add = django.dispatch.Signal()
 list_remove = django.dispatch.Signal()

--- a/neodb/journal/models/shelf.py
+++ b/neodb/journal/models/shelf.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -6,7 +7,6 @@ from django.conf import settings
 from django.db import connection, models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from polymorphic.models import ContentType, PolymorphicManager
 
 from catalog.models import Item, ItemCategory, item_categories
@@ -26,6 +26,8 @@ from .atproto import (
 from .common import q_item_in_category
 from .itemlist import List, ListMember
 from .renderers import render_post_with_macro, render_rating, render_spoiler_text
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .comment import Comment

--- a/neodb/journal/models/utils.py
+++ b/neodb/journal/models/utils.py
@@ -1,8 +1,8 @@
+import logging
 from auditlog.context import set_actor
 from django.conf import settings
 from django.db import transaction
 from django.db.utils import IntegrityError
-from loguru import logger
 
 from catalog.models import Item
 from journal.search import JournalIndex
@@ -19,6 +19,8 @@ from .rating import Rating
 from .review import Review
 from .shelf import ShelfLogEntry, ShelfMember
 from .tag import Tag, TagMember
+
+logger = logging.getLogger(__name__)
 
 
 def cleanup_deleted_post(post_pk: int) -> None:

--- a/neodb/journal/search/index.py
+++ b/neodb/journal/search/index.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections.abc import Iterable
 from datetime import datetime
@@ -9,7 +10,6 @@ from typing import TYPE_CHECKING
 import django_rq
 from dateutil.relativedelta import relativedelta
 from django.db.models import QuerySet
-from loguru import logger
 from rq import Retry
 
 from catalog.models import Item, item_categories
@@ -20,6 +20,8 @@ from takahe.models import Identity as TakaheIdentity
 from takahe.models import Post
 from takahe.utils import Takahe
 from users.models.apidentity import APIdentity
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from journal.models import Piece

--- a/neodb/journal/views/mark.py
+++ b/neodb/journal/views/mark.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from django.conf import settings
@@ -9,7 +10,6 @@ from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from catalog.models import *
 from common.models.lang import translate
@@ -19,6 +19,8 @@ from common.utils import AuthedHttpRequest, get_uuid_or_404
 from ..forms import CommentForm, MarkForm
 from ..models import Comment, Mark, ShelfManager, ShelfType
 from .common import render_list, render_relogin
+
+logger = logging.getLogger(__name__)
 
 PAGE_SIZE = 10
 

--- a/neodb/journal/views/post.py
+++ b/neodb/journal/views/post.py
@@ -1,3 +1,4 @@
+import logging
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
@@ -6,7 +7,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from common.models.lang import LOCALE_CHOICES, translate
 from common.models.misc import int_
@@ -20,6 +20,8 @@ from users.models import APIdentity
 from ..forms import *
 from ..models import *
 from .common import conditional_get_for_anonymous
+
+logger = logging.getLogger(__name__)
 
 
 def _can_view_post(post: Post, owner: APIdentity, viewer: APIdentity | None) -> int:

--- a/neodb/journal/views/wrapped.py
+++ b/neodb/journal/views/wrapped.py
@@ -1,6 +1,7 @@
 import base64
 import calendar
 import datetime
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -13,7 +14,6 @@ from django.http.response import HttpResponse
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
-from loguru import logger
 
 from catalog.models import (
     AvailableItemCategory,
@@ -28,6 +28,8 @@ from journal.models.common import VisibilityType
 from mastodon.models.bluesky import EmbedObj
 from takahe.utils import Takahe
 from users.models import User
+
+logger = logging.getLogger(__name__)
 
 _type_emoji = {
     "movie": "🎬",

--- a/neodb/mastodon/jobs.py
+++ b/neodb/mastodon/jobs.py
@@ -1,11 +1,13 @@
+import logging
 from datetime import timedelta
 
 from django.db.models import Q
 from django.utils import timezone
-from loguru import logger
 
 from common.models import BaseJob, JobManager
 from mastodon.models import MastodonApplication, detect_server_info
+
+logger = logging.getLogger(__name__)
 
 
 @JobManager.register

--- a/neodb/mastodon/models/bluesky.py
+++ b/neodb/mastodon/models/bluesky.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import json
+import logging
 import re
 import secrets
 import time
@@ -20,7 +21,6 @@ from django.core.cache import cache
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import timezone
-from loguru import logger
 
 from common.models import SiteConfig, jsondata
 from takahe.utils import Takahe
@@ -38,6 +38,8 @@ from .bluesky_oauth import (
     send_par,
 )
 from .common import SocialAccount
+
+logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from catalog.models import Item

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from django.core.cache import cache
@@ -5,10 +6,11 @@ from django.db import models
 from django.db.models.functions import Lower, Upper
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from typedmodels.models import TypedModel
 
 from common.sentry import count as sentry_count
+
+logger = logging.getLogger(__name__)
 
 # Domain-level circuit breaker — covers webfinger / check_alive failures
 # (i.e. the instance itself is unreachable).

--- a/neodb/mastodon/models/email.py
+++ b/neodb/mastodon/models/email.py
@@ -1,3 +1,4 @@
+import logging
 import secrets
 
 import django_rq
@@ -7,11 +8,12 @@ from django.core.mail import send_mail
 from django.core.signing import b62_encode
 from django.http import HttpRequest
 from django.utils.translation import gettext as _
-from loguru import logger
 
 from common.models import SiteConfig
 
 from .common import SocialAccount
+
+logger = logging.getLogger(__name__)
 
 _code_ttl = 60 * 15
 

--- a/neodb/mastodon/models/mastodon.py
+++ b/neodb/mastodon/models/mastodon.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import random
 import re
 import secrets
@@ -20,7 +21,6 @@ from django.utils import timezone
 
 # from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 
 from common.models import SiteConfig, jsondata
 from common.sentry import count as sentry_count
@@ -28,6 +28,8 @@ from common.validators import is_valid_url
 from takahe.utils import Takahe
 
 from .common import SocialAccount
+
+logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from catalog.models import Item

--- a/neodb/mastodon/models/threads.py
+++ b/neodb/mastodon/models/threads.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import re
 import secrets
 import typing
@@ -11,12 +12,13 @@ from django.core.exceptions import RequestAborted
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import timezone
-from loguru import logger
 
 from common.models import SiteConfig, jsondata
 from takahe.utils import Takahe
 
 from .common import SocialAccount
+
+logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from catalog.models import Item

--- a/neodb/mastodon/views/bluesky.py
+++ b/neodb/mastodon/views/bluesky.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import urlencode
 
 from django.contrib.auth.decorators import login_required
@@ -7,7 +8,6 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from common.models import SiteConfig
 from common.sentry import count as sentry_count
@@ -17,6 +17,8 @@ from users.login_proof import verify_login_proof
 from ..models import Bluesky, BlueskyAccount
 from ..models.bluesky_oauth import get_client_metadata
 from .common import client_ip, disconnect_identity, process_verified_account
+
+logger = logging.getLogger(__name__)
 
 # Cap failed authorization starts per client IP so the server cannot be
 # used to relay identity probing against ATProto handles.

--- a/neodb/mastodon/views/threads.py
+++ b/neodb/mastodon/views/threads.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import re
 
 from django.contrib.auth.decorators import login_required
@@ -11,7 +12,6 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from common.models import SiteConfig
 from common.sentry import count as sentry_count
@@ -20,6 +20,8 @@ from users.login_proof import verify_login_proof
 
 from ..models import Threads, ThreadsAccount
 from .common import disconnect_identity, process_verified_account
+
+logger = logging.getLogger(__name__)
 
 
 @require_http_methods(["POST"])

--- a/neodb/takahe/ap_handlers.py
+++ b/neodb/takahe/ap_handlers.py
@@ -1,7 +1,7 @@
+import logging
 from time import sleep
 from typing import Any
 
-from loguru import logger
 
 from catalog.models import Item
 from common.sentry import count as sentry_count
@@ -26,6 +26,8 @@ from users.models.apidentity import APIdentity
 
 from .models import Identity, Post, Report, TimelineEvent
 from .utils import Takahe
+
+logger = logging.getLogger(__name__)
 
 _supported_ap_catalog_item_types = [
     "Edition",

--- a/neodb/takahe/auth.py
+++ b/neodb/takahe/auth.py
@@ -19,6 +19,7 @@ unknown signer, stale Date, malformed base64) is rejected outright.
 
 import base64
 import binascii
+import logging
 import re
 import time
 from email.utils import formatdate
@@ -33,10 +34,11 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.http import parse_http_date
-from loguru import logger
 
 from takahe.models import Config, Identity
 from takahe.utils import Takahe
+
+logger = logging.getLogger(__name__)
 
 _DATE_SKEW_LIMIT = 300
 _REQUIRED_HEADERS = ("(request-target)", "host", "date")

--- a/neodb/takahe/jobs.py
+++ b/neodb/takahe/jobs.py
@@ -1,12 +1,14 @@
+import logging
 from datetime import timedelta
 
 from django.core.cache import cache
 from django.utils import timezone
-from loguru import logger
 
 from common.models import BaseJob, JobManager
 from journal.models import Comment, Review, ShelfMember
 from takahe.models import Domain, Identity, Post
+
+logger = logging.getLogger(__name__)
 
 
 @JobManager.register

--- a/neodb/takahe/management/commands/takahe.py
+++ b/neodb/takahe/management/commands/takahe.py
@@ -1,4 +1,4 @@
-from loguru import logger
+import logging
 from tqdm import tqdm
 
 from catalog.common import *
@@ -6,6 +6,8 @@ from catalog.models import *
 from common.management.base import SiteCommand
 from takahe.utils import *
 from users.models import User as NeoUser
+
+logger = logging.getLogger(__name__)
 
 
 class Command(SiteCommand):

--- a/neodb/takahe/search.py
+++ b/neodb/takahe/search.py
@@ -1,9 +1,11 @@
+import logging
 import time
 
 from django.urls import reverse
-from loguru import logger
 
 from users.models import APIdentity
+
+logger = logging.getLogger(__name__)
 
 
 def _get_local_url_for_ap_identity(uri):

--- a/neodb/takahe/utils.py
+++ b/neodb/takahe/utils.py
@@ -1,4 +1,5 @@
 import io
+import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -10,12 +11,13 @@ from django.core.signing import b62_encode
 from django.db.models import QuerySet
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 from PIL import Image
 
 from common.models import SiteConfig
 
 from .models import *
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from users.models import User as NeoUser

--- a/neodb/tests/journal/test_csv.py
+++ b/neodb/tests/journal/test_csv.py
@@ -1,17 +1,19 @@
 import csv
+import logging
 import os
 import zipfile
 from tempfile import TemporaryDirectory
 
 import pytest
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 
 from catalog.models import Edition, IdType, Movie, TVEpisode, TVSeason, TVShow
 from journal.exporters import CsvExporter
 from journal.importers import CsvImporter
 from journal.models import *
 from users.models import User
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/tests/journal/test_ndjson.py
+++ b/neodb/tests/journal/test_ndjson.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import os
 import zipfile
 from io import BytesIO
@@ -16,7 +17,6 @@ from django.test import Client, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from loguru import logger
 from PIL import Image
 
 from catalog.models import (
@@ -37,6 +37,8 @@ from journal.models.common import Debris
 from journal.search import JournalIndex
 from takahe.utils import Takahe
 from users.models import Task, User
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/neodb/users/jobs/captcha_pool.py
+++ b/neodb/users/jobs/captcha_pool.py
@@ -1,9 +1,11 @@
+import logging
 from datetime import timedelta
 
-from loguru import logger
 
 from common.models import BaseJob, JobManager
 from users.registration_captcha import is_enabled, refresh_pools
+
+logger = logging.getLogger(__name__)
 
 
 @JobManager.register

--- a/neodb/users/jobs/cleanup.py
+++ b/neodb/users/jobs/cleanup.py
@@ -1,13 +1,15 @@
+import logging
 import os
 import shutil
 from datetime import timedelta
 
 from django.utils import timezone
-from loguru import logger
 
 from common.models import BaseJob, JobManager, SiteConfig
 from journal.models import CrosspostRetry
 from users.models import Task
+
+logger = logging.getLogger(__name__)
 
 _TASK_FILE_KEYS = ("file", "matched_file")
 

--- a/neodb/users/jobs/sync.py
+++ b/neodb/users/jobs/sync.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
@@ -6,11 +7,12 @@ from functools import partial
 from django.db import close_old_connections, connections
 from django.db.models import F
 from django.utils import timezone
-from loguru import logger
 
 from common.models import BaseJob, JobManager
 from common.sentry import count as sentry_count
 from users.models import User
+
+logger = logging.getLogger(__name__)
 
 _NON_EMAIL_ACCOUNT_TYPES = [
     "mastodon.mastodonaccount",

--- a/neodb/users/models/apidentity.py
+++ b/neodb/users/models/apidentity.py
@@ -1,3 +1,4 @@
+import logging
 from functools import cached_property
 from typing import TYPE_CHECKING, Self
 
@@ -5,7 +6,6 @@ from django.conf import settings
 from django.db import models
 from django.db.models.functions import Upper
 from django.utils import timezone
-from loguru import logger
 
 from common.models import SiteConfig
 from mastodon.models.mastodon import MastodonAccount
@@ -13,6 +13,8 @@ from takahe.utils import Takahe
 
 from .preference import Preference
 from .user import User
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from catalog.models import VerifiedCreator

--- a/neodb/users/models/task.py
+++ b/neodb/users/models/task.py
@@ -1,16 +1,18 @@
+import logging
 from typing import Self
 
 import django_rq
 from auditlog.context import set_actor
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 from typedmodels.models import TypedModel
 from user_messages import api as msg
 
 from users.middlewares import activate_language_for_user
 
 from .user import User
+
+logger = logging.getLogger(__name__)
 
 
 class Task(TypedModel):

--- a/neodb/users/models/user.py
+++ b/neodb/users/models/user.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import timedelta
 from functools import cached_property
@@ -16,7 +17,6 @@ from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
-from loguru import logger
 
 from common.models import SiteConfig
 from mastodon.models import (
@@ -27,6 +27,8 @@ from mastodon.models import (
     ThreadsAccount,
 )
 from takahe.utils import Takahe
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .apidentity import APIdentity

--- a/neodb/users/registration_captcha.py
+++ b/neodb/users/registration_captcha.py
@@ -24,6 +24,7 @@ client payload.
 import hashlib
 import io
 import json
+import logging
 import random
 import secrets
 from itertools import pairwise
@@ -34,7 +35,6 @@ from django.core.cache import cache
 from django.db.models import Count
 from django.http import HttpRequest
 from django.utils import timezone
-from loguru import logger
 from PIL import Image
 
 from catalog.models import (
@@ -50,6 +50,8 @@ from catalog.models import (
 )
 from common.models import SiteConfig
 from journal.models import ShelfMember, q_item_in_category
+
+logger = logging.getLogger(__name__)
 
 CAPTCHA_TTL = 5 * 60
 CAPTCHA_MAX_REGENERATIONS = 2

--- a/neodb/users/views/data.py
+++ b/neodb/users/views/data.py
@@ -1,6 +1,7 @@
 import copy
 import csv
 import datetime
+import logging
 import os
 import shutil
 
@@ -16,7 +17,6 @@ from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 
 from catalog.common import SiteManager
 from catalog.models import Item, SiteName
@@ -51,6 +51,8 @@ from takahe.utils import Takahe
 from users.models import Task, User
 
 from .account import clear_preference_cache
+
+logger = logging.getLogger(__name__)
 
 
 def preferences(request):

--- a/neodb/users/views/steam.py
+++ b/neodb/users/views/steam.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from urllib.parse import urlencode
 
@@ -6,7 +7,8 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from loguru import logger
+
+logger = logging.getLogger(__name__)
 
 STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
 STEAM_ID_RE = re.compile(r"https://steamcommunity\.com/openid/id/(\d+)")

--- a/neodb/users/views/webauthn.py
+++ b/neodb/users/views/webauthn.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 import time
 
 from django.conf import settings
@@ -9,7 +10,6 @@ from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
-from loguru import logger
 from webauthn import (
     generate_authentication_options,
     generate_registration_options,
@@ -31,6 +31,8 @@ from users.login_proof import verify_login_proof
 
 from ..models import WebAuthnCredential
 from .account import auth_login
+
+logger = logging.getLogger(__name__)
 
 _VALID_TRANSPORTS = {"usb", "nfc", "ble", "hybrid", "internal"}
 _CHALLENGE_TIMEOUT = 300  # 5 minutes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "igdb-api-v4>=0.3.3",
     "lingua-language-detector>=2.2.0",
     "listparser>=0.20",
-    "loguru>=0.7.2",
     "lxml>=6.1.1",
     "markdownify>=0.13.1",
     "mistune>=3.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1433,19 +1433,6 @@ wheels = [
 ]
 
 [[package]]
-name = "loguru"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
-]
-
-[[package]]
 name = "lxml"
 version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1759,7 +1746,6 @@ dependencies = [
     { name = "libsass" },
     { name = "lingua-language-detector" },
     { name = "listparser" },
-    { name = "loguru" },
     { name = "lxml" },
     { name = "markdown-it-py" },
     { name = "markdownify" },
@@ -1855,7 +1841,6 @@ requires-dist = [
     { name = "libsass", specifier = ">=0.23.0" },
     { name = "lingua-language-detector", specifier = ">=2.2.0" },
     { name = "listparser", specifier = ">=0.20" },
-    { name = "loguru", specifier = ">=0.7.2" },
     { name = "lxml", specifier = ">=6.1.1" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "markdownify", specifier = ">=0.13.1" },
@@ -3105,15 +3090,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
-]
-
-[[package]]
-name = "win32-setctime"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

loguru installs its own stderr sink at import time. There is no `logger.configure()` or startup `logger.add()` anywhere in the tree, and no `LOGURU_LEVEL` in the compose files or env samples, so that default sink stays at DEBUG with `diagnose=True`.

Two consequences:

- `NEODB_LOG_LEVEL` (`settings.LOGGING`, and the value shown on the manage page) governed only the ~50 stdlib logger sites. The 845 loguru call sites printed at DEBUG in production regardless.
- `diagnose=True` adds local variable values to every loguru traceback, which is not something you want in production logs.

`takahe/` already uses stdlib logging, so one process ran two sinks, at two levels, in two formats. This unifies them.

Upstream has not cut a loguru release since 0.7.3 (December 2024), but that is not the argument here. The argument is the level control and the single pipeline.

## What changed

- 104 modules: `from loguru import logger` becomes `logger = logging.getLogger(__name__)`. The six `catalog/sites/` modules that already defined a `_logger` now use that one, instead of carrying two loggers.
- `LOGGING` gains a console formatter that keeps loguru's shape, so stdlib records read the same way loguru records used to:
  `2026-09-07 01:50:18,542 | INFO     | catalog.demo:<module>:9 - message`
  Previously the stdlib handler had no formatter and printed bare messages.
- `logger.success` becomes `logger.info` (7 sites in `catalog/common/migrations.py`). loguru's SUCCESS sits between INFO and WARNING and has no stdlib equivalent.
- `catalog` management command: sets the root logger level instead of removing and re-adding a sink. `--log-level` drops the `TRACE` and `SUCCESS` choices, which no longer exist. Nothing in the tree passed either.
- `views_debug.py`: the one brace-style call becomes `%s`.
- Sentry: `LoguruIntegration` dropped. The default `LoggingIntegration` captures the same records at the same thresholds, and the two `ignore_logger` calls are unaffected.
- `loguru` removed from `pyproject.toml` and `uv.lock`.

Nothing used `bind`, `contextualize`, `opt`, `catch`, `enqueue`, or file sinks. The existing `extra={...}` call sites were already stdlib syntax and port unchanged.

## Verification

- An AST audit of every `logger.*` call site: no loguru-only methods left, no kwargs stdlib logging rejects, and no `extra=` key that collides with a real `LogRecord` attribute.
- Full suite in the dev cluster: 2477 passed. The only failures are the three pre-existing `tests/mastodon/test_lexicons.py` ones that need `/docs` mounted.
- CI green.
- Runtime check: `NEODB_LOG_LEVEL=INFO` now actually suppresses DEBUG from these loggers, `logger.exception` keeps its traceback, and the command's `setLevel` path takes effect.

## Worth knowing before merge

Sentry issue titles move from loguru's `{name}:{function}:{line} - {message}` to the stdlib integration's own grouping, so existing issues regroup once after deploy.
