### PR TITLE
Send guests to login for deep search pages instead of 404

### DIFF
--- a/neodb/catalog/views/search.py
+++ b/neodb/catalog/views/search.py
@@ -4,9 +4,10 @@ from urllib.parse import urlparse
 import django_rq
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.db.models import prefetch_related_objects
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -50,7 +51,9 @@ def guest_page_limit(request) -> int:
     """Last result page an anonymous visitor may open, 0 when uncapped.
 
     Deep pagination is expensive to serve, so crawlers are held to the
-    configured page while signed-in users keep the full result set.
+    configured page while signed-in users keep the full result set. The
+    page links stay visible past the limit; opening one sends the visitor
+    to the login page and back to that page after sign-in.
     """
     if request.user.is_authenticated:
         return 0
@@ -303,13 +306,11 @@ def search(request):
     excl = hidden_categories(request)
     page_limit = guest_page_limit(request)
     if page_limit and p > page_limit:
-        raise Http404(_("Page not found"))
+        return redirect_to_login(request.get_full_path())
     per_page = get_page_size_from_request(request)
     items, num_pages, __, by_cat, q = query_index(
         keywords, categories, p, exclude_categories=excl, per_page=per_page
     )
-    if page_limit:
-        num_pages = min(num_pages, page_limit)
     # Include duplicates attached as `dupe_to`: the template renders them
     # via a nested {% include '_list_item.html' %} loop, so they need the
     # same prefetches/attachments to avoid N+1 in templates.
@@ -358,7 +359,7 @@ def people_search(request):
         return url_response
     page_limit = guest_page_limit(request)
     if page_limit and p > page_limit:
-        raise Http404(_("Page not found"))
+        return redirect_to_login(request.get_full_path())
     parser = PeopleQueryParser(
         keywords, page=p, page_size=per_page, people_type=people_type
     )
@@ -368,8 +369,6 @@ def people_search(request):
     search_error = result is not None and bool(result.error)
     items = [] if result is None or search_error else result.items
     num_pages = 0 if result is None or search_error else result.pages
-    if page_limit:
-        num_pages = min(num_pages, page_limit)
     return render(
         request,
         "search_results_people.html",

--- a/neodb/tests/catalog/test_guest_search_limit.py
+++ b/neodb/tests/catalog/test_guest_search_limit.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+from django.conf import settings
 from django.test import Client
 
 from common.models import SiteConfig
@@ -9,6 +11,13 @@ from users.models import User
 LIMIT = 3
 # items, num_pages, count, facets, q
 EMPTY_RESULT = ([], 500, 0, {}, "book")
+
+
+def assert_login_redirect(response, target: str) -> None:
+    assert response.status_code == 302
+    location = urlparse(response.url)
+    assert location.path == settings.LOGIN_URL
+    assert parse_qs(location.query)["next"] == [target]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -30,9 +39,10 @@ class TestGuestSearchPageLimit:
         ) as mocked:
             return Client().get(url), mocked
 
-    def test_guest_blocked_past_limit(self):
-        response, mocked = self._guest_get(f"/search?q=book&page={LIMIT + 1}")
-        assert response.status_code == 404
+    def test_guest_sent_to_login_past_limit(self):
+        url = f"/search?q=book&page={LIMIT + 1}"
+        response, mocked = self._guest_get(url)
+        assert_login_redirect(response, url)
         # the gate must come before the index is queried, or it saves nothing
         mocked.assert_not_called()
 
@@ -40,9 +50,9 @@ class TestGuestSearchPageLimit:
         response, __ = self._guest_get(f"/search?q=book&page={LIMIT}")
         assert response.status_code == 200
 
-    def test_guest_pagination_stops_at_limit(self):
+    def test_guest_pagination_shows_pages_past_limit(self):
         response, __ = self._guest_get("/search?q=book&page=1")
-        assert response.context["pagination"].end_page == LIMIT
+        assert response.context["pagination"].end_page > LIMIT
 
     def test_user_not_limited(self):
         user = User.register(email="pager@example.com", username="pager")
@@ -59,8 +69,9 @@ class TestGuestSearchPageLimit:
         SiteConfig.reload()
         assert SiteConfig.system.guest_search_max_pages == 1
         response, __ = self._guest_get("/search?q=book&page=2")
-        assert response.status_code == 404
+        assert_login_redirect(response, "/search?q=book&page=2")
 
-    def test_guest_blocked_on_people_search(self):
-        response = Client().get(f"/search?c=people&q=tolkien&page={LIMIT + 1}")
-        assert response.status_code == 404
+    def test_guest_sent_to_login_on_people_search(self):
+        url = f"/search?c=people&q=tolkien&page={LIMIT + 1}"
+        response = Client().get(url)
+        assert_login_redirect(response, url)


### PR DESCRIPTION
The guest search page limit (`guest_search_max_pages`) currently hides every
result page past the limit from anonymous visitors: the pagination bar stops at
the limit and opening a later page returns 404.

This keeps the cost protection but changes what the visitor sees:

- The pagination bar shows the real page range again for anonymous visitors,
  so the result set no longer looks truncated.
- Opening a page past the limit redirects to the login page with
  `next` set to that search URL, so the visitor lands back on the page they
  clicked after signing in.

The gate still runs before `query_index` / `PeopleIndex.search`, so a deep page
request from a crawler still costs nothing to serve. Both `search` and
`people_search` are covered.

Tests in `tests/catalog/test_guest_search_limit.py` are updated to assert the
302 and its `next` target, and that the page range extends past the limit.