### PR TITLE
perf(catalog): batch the queries behind the search index update

### DIFF
--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -296,6 +296,10 @@ class Item(PolymorphicModel):
     # discover surfaces so they neither render nor trigger the per-item tag
     # aggregation that was the NEODB-SOCIAL-7KW slow query.
     tags: list[str] | None = None
+    #: Values ``to_indexable_doc`` would otherwise query per item, filled in by
+    #: ``prepare_indexable_batch``; not DB fields. None means "not batched".
+    _indexable_tags: list[str] | None = None
+    _indexable_mark_count: int | None = None
     uid = models.UUIDField(default=uuid.uuid4, editable=False, db_index=True)
     title = models.CharField(_("title"), max_length=1000, default="")
     brief = models.TextField(_("description"), blank=True, default="")
@@ -659,6 +663,12 @@ class Item(PolymorphicModel):
                 company.extend(names)
             else:
                 people.extend(names)
+        tags = self._indexable_tags
+        if tags is None:
+            tags = TagManager.indexable_tags_for_item(self)
+        mark_count = self._indexable_mark_count
+        if mark_count is None:
+            mark_count = self.mark_count
         doc = {
             "id": str(self.pk),
             "item_id": [self.pk],
@@ -666,8 +676,8 @@ class Item(PolymorphicModel):
             "title": self.to_indexable_titles(),
             # Aggregate public tags here (at index time, async) rather than on
             # every page render; read paths reuse this indexed value.
-            "tag": TagManager.indexable_tags_for_item(self),
-            "mark_count": self.mark_count,
+            "tag": tags,
+            "mark_count": mark_count,
             "language": getattr(self, "language", None) or [],
             "people": people,
             "company": company,
@@ -827,6 +837,26 @@ class Item(PolymorphicModel):
             prefetch_related_objects(podcastepisodes, "program")
         if performanceproductions:
             prefetch_related_objects(performanceproductions, "show")
+
+    @staticmethod
+    def prepare_indexable_batch(items: "list[Item]") -> None:
+        """Load everything ``to_indexable_doc`` needs for a batch of items.
+
+        Without this each item costs one query for its credits, one for its
+        public tags, one for its mark count, and for a TVSeason one more for
+        the parent title (Sentry: NEODB-SOCIAL-7W5).
+        """
+        from journal.models import Mark, TagManager
+
+        if not items:
+            return
+        prefetch_related_objects(items, Item.credits_prefetch())
+        Item.prefetch_parent_items(items)
+        tags = TagManager.indexable_tags_for_items([i.pk for i in items])
+        mark_counts = Mark.get_mark_count_for_items(items)
+        for i in items:
+            i._indexable_tags = tags.get(i.pk, [])
+            i._indexable_mark_count = mark_counts.get(i.pk, 0)
 
     @staticmethod
     def credits_prefetch() -> models.Prefetch:

--- a/neodb/catalog/search/index.py
+++ b/neodb/catalog/search/index.py
@@ -245,7 +245,11 @@ class CatalogIndex(Index):
 
     @classmethod
     def items_to_docs(cls, items: "Iterable[Item]") -> list[dict]:
-        docs = [i.to_indexable_doc() for i in items]
+        from catalog.models import Item
+
+        item_list = list(items)
+        Item.prepare_indexable_batch(item_list)
+        docs = [i.to_indexable_doc() for i in item_list]
         return [d for d in docs if d]
 
     def delete_all(self):
@@ -257,12 +261,10 @@ class CatalogIndex(Index):
     def replace_items(self, item_ids):
         from catalog.models import Item
 
-        items = Item.objects.filter(pk__in=item_ids)
-        docs = [
-            i.to_indexable_doc()
-            for i in items
-            if not i.is_deleted and not i.merged_to_item_id
-        ]
+        items = list(Item.objects.filter(pk__in=item_ids))
+        indexable = [i for i in items if not i.is_deleted and not i.merged_to_item_id]
+        Item.prepare_indexable_batch(indexable)
+        docs = [i.to_indexable_doc() for i in indexable]
         if docs:
             self.replace_docs(docs)
         if len(docs) < len(item_ids):

--- a/neodb/journal/models/mark.py
+++ b/neodb/journal/models/mark.py
@@ -4,7 +4,8 @@ from functools import cached_property
 from typing import Any, Iterable, Sequence
 
 from django.db import IntegrityError, transaction
-from django.db.models import F, QuerySet
+from django.db.models import Count, F, Q, QuerySet
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -31,6 +32,14 @@ from .shelf import (
     ShelfMember,
     ShelfType,
 )
+
+
+#: Item types whose mark count also counts marks on their child items, mapped
+#: to the path that leads from a child's ``ShelfMember`` row to its parent id.
+ROLLED_UP_MARK_COUNT_TYPES = {
+    "Podcast": "item__podcastepisode__program_id",
+    "TVSeason": "item__tvepisode__season_id",
+}
 
 
 class Mark:
@@ -608,7 +617,7 @@ class Mark:
 
     @staticmethod
     def get_mark_count_for_item(item: Item) -> int:
-        if item.get_type() in ["Podcast", "TVSeason"]:
+        if item.get_type() in ROLLED_UP_MARK_COUNT_TYPES:
             return (
                 ShelfMember.objects.filter(item_id__in=item.child_item_ids + [item.pk])
                 .values("owner_id")
@@ -617,3 +626,49 @@ class Mark:
             )
         else:
             return ShelfMember.objects.filter(item=item).count()
+
+    @staticmethod
+    def get_mark_count_for_items(items: "Iterable[Item]") -> dict[int, int]:
+        """Mark count for many items, in a constant number of queries.
+
+        Same counts as ``get_mark_count_for_item``: rows for a plain item, and
+        owners over the item and its children for the types that roll their
+        children up. The returned map holds an entry for every item.
+        """
+        item_list = list(items)
+        counts: dict[int, int] = {i.pk: 0 for i in item_list}
+        rolled_up: dict[str, list[int]] = {t: [] for t in ROLLED_UP_MARK_COUNT_TYPES}
+        plain_ids: list[int] = []
+        for i in item_list:
+            item_type = i.get_type()
+            if item_type in rolled_up:
+                rolled_up[item_type].append(i.pk)
+            else:
+                plain_ids.append(i.pk)
+        if plain_ids:
+            rows = (
+                ShelfMember.objects.filter(item_id__in=plain_ids)
+                .values("item_id")
+                .annotate(n=Count("id"))
+            )
+            for row in rows:
+                counts[row["item_id"]] = row["n"]
+        for item_type, root_ids in rolled_up.items():
+            if not root_ids:
+                continue
+            # A mark on a child rolls up to its parent, so map every row back
+            # to its root before counting owners. The join is a reverse
+            # one-to-one, so a row on a root itself yields NULL and falls back
+            # to its own item id.
+            parent_field = ROLLED_UP_MARK_COUNT_TYPES[item_type]
+            rows = (
+                ShelfMember.objects.filter(
+                    Q(item_id__in=root_ids) | Q(**{f"{parent_field}__in": root_ids})
+                )
+                .annotate(root_id=Coalesce(F(parent_field), F("item_id")))
+                .values("root_id")
+                .annotate(n=Count("owner_id", distinct=True))
+            )
+            for row in rows:
+                counts[row["root_id"]] = row["n"]
+        return counts

--- a/neodb/journal/models/tag.py
+++ b/neodb/journal/models/tag.py
@@ -1,7 +1,7 @@
 import re
 from datetime import timedelta
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 from django.core.cache import cache
 from django.core.validators import RegexValidator
@@ -121,24 +121,42 @@ class Tag(List):
             self._refresh_mark_index(item)
 
 
+INDEXABLE_TAGS_PER_ITEM = 20
+
+
 class TagManager:
     @staticmethod
-    def indexable_tags_for_item(item):
-        tags = (
-            item.tag_set.all()
-            .filter(visibility=0)
-            .values("title")
-            .annotate(frequency=Count("owner"))
-            .order_by("-frequency")[:20]
+    def _clean_tag_titles(titles: "Iterable[str]") -> list[str]:
+        return sorted(
+            {t for t in map(Tag.deep_cleanup_title, titles) if t and t != "_"}
         )
-        tag_titles = sorted(
-            [
-                t
-                for t in set(map(lambda t: Tag.deep_cleanup_title(t["title"]), tags))
-                if t and t != "_"
-            ]
+
+    @staticmethod
+    def indexable_tags_for_item(item) -> list[str]:
+        return TagManager.indexable_tags_for_items([item.pk])[item.pk]
+
+    @staticmethod
+    def indexable_tags_for_items(item_ids: "Iterable[int]") -> dict[int, list[str]]:
+        """Public tag titles for indexing, for many items in one query.
+
+        The returned map holds an entry for every id, so a caller can tell an
+        item with no public tag from an item that was not asked for.
+        """
+        ids = list(item_ids)
+        if not ids:
+            return {}
+        by_item: dict[int, list[str]] = {i: [] for i in ids}
+        rows = (
+            TagMember.objects.filter(item_id__in=ids, parent__visibility=0)
+            .values("item_id", "parent__title")
+            .annotate(frequency=Count("parent__owner"))
+            .order_by("item_id", "-frequency")
         )
-        return tag_titles
+        for row in rows:
+            titles = by_item[row["item_id"]]
+            if len(titles) < INDEXABLE_TAGS_PER_ITEM:
+                titles.append(row["parent__title"])
+        return {i: TagManager._clean_tag_titles(t) for i, t in by_item.items()}
 
     @staticmethod
     def tag_item_for_owner(

--- a/neodb/tests/catalog/test_search_n_plus_one.py
+++ b/neodb/tests/catalog/test_search_n_plus_one.py
@@ -6,10 +6,24 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
-from catalog.models import Edition, ExternalResource, IdType, Item, TVSeason, TVShow
+from catalog.models import (
+    Edition,
+    ExternalResource,
+    IdType,
+    Item,
+    ItemCredit,
+    Podcast,
+    PodcastEpisode,
+    TVEpisode,
+    TVSeason,
+    TVShow,
+)
 from catalog.search.index import CatalogIndex, CatalogSearchResult
 from catalog.search.utils import query_index
+from journal.models import Mark, ShelfType, TagManager
+from users.models import User
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -231,3 +245,142 @@ class TestSearchExternalResourcesSlim:
                 "search external_resources prefetch still selects "
                 f"other_lookup_ids: {q['sql']}"
             )
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCatalogIndexBatchNoNPlusOne:
+    """NEODB-SOCIAL-7W5: ``CatalogIndex.replace_items`` built every document on
+    its own, so each item in the batch cost one query for its credits, one for
+    its public tags and one for its mark count, plus one for the parent title
+    of a TVSeason. Batch them, so the count stays flat as the batch grows.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.owner = User.register(email="idxn1a@test.com", username="idxn1a").identity
+        self.other = User.register(email="idxn1b@test.com", username="idxn1b").identity
+
+    def _make_editions(self, count: int, prefix: str) -> list[Edition]:
+        editions = []
+        for n in range(count):
+            edition = Edition.objects.create(title=f"{prefix} {n}")
+            ItemCredit.objects.create(item=edition, role="author", name=f"Author {n}")
+            Mark(self.owner, edition).update(
+                ShelfType.COMPLETE, visibility=0, tags=["sci-fi", "read"]
+            )
+            editions.append(edition)
+        return editions
+
+    @staticmethod
+    def _replace_items(item_ids: list[int]):
+        """Run ``replace_items`` against a mocked index, returning the queries.
+
+        Only ``replace_docs``/``delete_docs`` reach Typesense, so a mock stands
+        in for ``self`` and the database work under test runs unchanged.
+        """
+        index = MagicMock(spec=CatalogIndex)
+        with CaptureQueriesContext(connection) as ctx:
+            CatalogIndex.replace_items(index, item_ids)
+        return index, ctx.captured_queries
+
+    def test_query_count_does_not_grow_with_batch_size(self):
+        # Same class mix in both batches: a polymorphic load costs one query
+        # per concrete class, which would otherwise mask the difference.
+        small = self._make_editions(2, "Small")
+        large = self._make_editions(6, "Large")
+
+        index_small, q_small = self._replace_items([i.pk for i in small])
+        index_large, q_large = self._replace_items([i.pk for i in large])
+
+        # Sanity: each batch produced one document per item.
+        assert len(index_small.replace_docs.call_args[0][0]) == 2
+        assert len(index_large.replace_docs.call_args[0][0]) == 6
+
+        assert len(q_large) == len(q_small), (
+            f"replace_items fired {len(q_large)} queries for 6 items but only "
+            f"{len(q_small)} for 2, so it still scales with the batch. Extra "
+            f"SQL: {[q['sql'] for q in q_large][len(q_small) :]}"
+        )
+
+    def test_batched_docs_match_the_per_item_values(self):
+        tagged = Edition.objects.create(title="Tagged")
+        Mark(self.owner, tagged).update(
+            ShelfType.COMPLETE, visibility=0, tags=["sci-fi"]
+        )
+        Mark(self.other, tagged).update(
+            ShelfType.COMPLETE, visibility=0, tags=["sci-fi", "epic"]
+        )
+        bare = Edition.objects.create(title="Bare")
+        show = TVShow.objects.create(
+            localized_title=[{"lang": "en", "text": "Batched Show"}]
+        )
+        season = TVSeason.objects.create(
+            localized_title=[{"lang": "en", "text": "Batched Show Season 1"}], show=show
+        )
+        episode = TVEpisode.objects.create(season=season, episode_number=1)
+        # The season rolls its episodes up, so this counts two distinct owners.
+        Mark(self.owner, season).update(ShelfType.COMPLETE, visibility=0)
+        Mark(self.other, episode).update(ShelfType.COMPLETE, visibility=0)
+        podcast = Podcast.objects.create(
+            localized_title=[{"lang": "en", "text": "Batched Podcast"}],
+            primary_lookup_id_type=IdType.RSS,
+            primary_lookup_id_value="https://example.com/batched.xml",
+        )
+        podcast_episode = PodcastEpisode.objects.create(
+            localized_title=[{"lang": "en", "text": "Batched Episode"}],
+            program=podcast,
+            guid="batched-guid",
+            pub_date=timezone.now(),
+        )
+        # The same owner on both, so the rollup must not double count.
+        Mark(self.owner, podcast).update(ShelfType.COMPLETE, visibility=0)
+        Mark(self.owner, podcast_episode).update(ShelfType.COMPLETE, visibility=0)
+
+        items = [tagged, bare, season, podcast]
+        expected = {
+            i.pk: (
+                TagManager.indexable_tags_for_item(i),
+                Mark.get_mark_count_for_item(i),
+            )
+            for i in items
+        }
+        # Sanity: the batch covers tags, no tags at all, and a child rollup.
+        assert len(expected[tagged.pk][0]) == 2
+        assert expected[tagged.pk][1] == 2
+        assert expected[bare.pk] == ([], 0)
+        assert expected[season.pk][1] == 2
+        assert expected[podcast.pk][1] == 1
+
+        index, _ = self._replace_items([i.pk for i in items])
+        docs = {int(d["id"]): d for d in index.replace_docs.call_args[0][0]}
+        for pk, (tags, mark_count) in expected.items():
+            assert docs[pk]["tag"] == tags
+            assert docs[pk]["mark_count"] == mark_count
+
+    def test_season_title_includes_the_show_without_a_per_item_lookup(self):
+        show = TVShow.objects.create(
+            localized_title=[{"lang": "en", "text": "Parent Show"}]
+        )
+        seasons = [
+            TVSeason.objects.create(
+                localized_title=[{"lang": "en", "text": f"Parent Show Season {n}"}],
+                show=show,
+            )
+            for n in range(1, 4)
+        ]
+
+        index, queries = self._replace_items([s.pk for s in seasons])
+        docs = index.replace_docs.call_args[0][0]
+        assert all("Parent Show" in d["title"] for d in docs)
+
+        # The N+1 signature is Django's ``.get()`` on the show FK; the
+        # polymorphic batch load uses ``IN (...)`` and no LIMIT.
+        offending = [
+            q
+            for q in queries
+            if 'FROM "catalog_tvshow"' in q["sql"] and "LIMIT 21" in q["sql"]
+        ]
+        assert offending == [], (
+            f"replace_items fired {len(offending)} per-season catalog_tvshow "
+            "FK lookup(s); expected 0."
+        )


### PR DESCRIPTION
Fixes the N+1 that Sentry reports as NEODB-SOCIAL-7W5.

## Problem

`CatalogIndex.replace_items()` loaded the batch with a plain
`Item.objects.filter(pk__in=item_ids)` and then built each document on its own.
`Item.to_indexable_doc()` costs three queries per item:

1. `role_credits` -> `_credits_with_person()`, an `ItemCredit`/`People` join
2. `TagManager.indexable_tags_for_item()`, a `journal_tag` frequency aggregate
3. `mark_count` -> `Mark.get_mark_count_for_item()`, a `ShelfMember` count

A TVSeason costs a fourth, because `to_indexable_titles()` reads
`parent_item.to_indexable_titles()` and loads the show FK.

`_update_catalog_index_task` pops up to 1000 ids at a time, so a single flush
could fire several thousand queries. The same path is used by the
`catalog idx-rebuild` command over the whole catalog.

## Change

`Item.prepare_indexable_batch()` loads everything the documents need up front:

- `prefetch_related_objects(items, Item.credits_prefetch())`, which
  `_credits_with_person()` already honours
- the existing `Item.prefetch_parent_items()`, which covers the TVSeason show
- `TagManager.indexable_tags_for_items()`, one grouped query for the batch
- `Mark.get_mark_count_for_items()`, one query for plain items plus one per
  rolled-up type

The results land in two per-instance caches that `to_indexable_doc()` reads,
with the old per-item calls kept as the fallback, so the twelve subclass
overrides that call `super().to_indexable_doc()` need no change.

`replace_items()` and `items_to_docs()` both call it, so the flush task and
`idx-rebuild` are fixed together.

## Counts are unchanged

`indexable_tags_for_item()` now delegates to the batch version, so the two
cannot drift. The rolled-up Podcast/TVSeason mark count maps each child's
`ShelfMember` row back to its parent in SQL (one `LEFT OUTER JOIN` and a
`COALESCE`) instead of listing child ids per item; the generated SQL was
checked to make sure the filter and the annotation share one join alias.

## Tests

Three cases in `tests/catalog/test_search_n_plus_one.py`. Without the change
they fail with 20 queries for 6 items against 8 for 2, and 3 per-season
`catalog_tvshow` lookups. The correctness test compares the batched documents
against the per-item values for a tagged item, an item with no tags or marks,
a TVSeason whose episode is marked by another owner, and a Podcast whose
episode is marked by the same owner as the program (so the distinct count
must not double count).

Full suite: 2490 passed, with the three known `tests/mastodon/test_lexicons.py`
failures that come from `/docs` not being mounted in the dev profile.

## Separate finding, not addressed here

`replace_items()` computes `deletes = set(item_ids) - set(i.pk for i in items)`,
so an item that is deleted or merged but whose row still exists is never
removed from the index by this path. That behaviour is pre-existing and is
preserved unchanged.
