### PR TITLE
refactor(deps): replace bleach with nh3

### DIFF
--- a/neodb/boofilsic/settings.py
+++ b/neodb/boofilsic/settings.py
@@ -358,7 +358,6 @@ INSTALLED_APPS = [
     "django.contrib.humanize",
     "django.contrib.postgres",
     "django_rq",
-    "django_bleach",
     "django_jsonform",
     "tz_detect",
     "sass_processor",
@@ -681,9 +680,6 @@ LOGIN_URL = "/account/login"
 
 ADMIN_ENABLED = DEBUG
 ADMIN_URL = "neodb-admin"
-
-BLEACH_STRIP_COMMENTS = True
-BLEACH_STRIP_TAGS = True
 
 # Thumbnail setting
 # It is possible to optimize the image size even more: https://easy-thumbnails.readthedocs.io/en/latest/ref/optimize/

--- a/neodb/catalog/sites/rss.py
+++ b/neodb/catalog/sites/rss.py
@@ -4,7 +4,7 @@ import urllib.error
 import urllib.request
 from datetime import datetime
 
-import bleach
+import nh3
 import podcastparser
 from django.conf import settings
 from django.core.cache import cache
@@ -184,7 +184,7 @@ class RSS(AbstractSite):
                 guid=guid,
                 defaults={
                     "title": episode["title"],
-                    "brief": bleach.clean(episode.get("description") or "", strip=True),
+                    "brief": nh3.clean(episode.get("description") or "", tags=set()),
                     "description_html": episode.get("description_html"),
                     "cover_url": episode.get("episode_art_url"),
                     "media_url": media_url,

--- a/neodb/common/templates/_sidebar.html
+++ b/neodb/common/templates/_sidebar.html
@@ -4,7 +4,6 @@
 {% load mastodon %}
 {% load thumb %}
 {% load collection %}
-{% load bleach_tags %}
 {% load duration %}
 <aside class="grid__aside sidebar {% if bottom %}bottom{% endif %}">
   {% if request.user.unread_announcements %}

--- a/neodb/common/templates/_sidebar_anonymous.html
+++ b/neodb/common/templates/_sidebar_anonymous.html
@@ -3,7 +3,6 @@
 {% load mastodon %}
 {% load thumb %}
 {% load collection %}
-{% load bleach_tags %}
 <aside class="grid__aside sidebar">
   <section>
     {% if site_intro %}

--- a/neodb/common/templatetags/sanitize.py
+++ b/neodb/common/templatetags/sanitize.py
@@ -1,0 +1,17 @@
+import nh3
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def sanitize(value: str | None, tags: str = "") -> str:
+    """Strip unsafe HTML, keeping only `tags` (comma separated, nh3 defaults if omitted).
+
+    No `@stringfilter`: it would turn a null value into the literal "None".
+    """
+    if not value:
+        return ""
+    allowed = {t.strip() for t in tags.split(",") if t.strip()} if tags else None
+    return mark_safe(nh3.clean(str(value), tags=allowed))

--- a/neodb/journal/models/renderers.py
+++ b/neodb/journal/models/renderers.py
@@ -215,5 +215,5 @@ def render_spoiler_text(text, item):
 _post_allowed_tags = set(["a", "p", "span", "br", "div", "img"])
 
 
-def bleach_post_content(text):
+def sanitize_post_content(text: str) -> str:
     return nh3.clean(text, tags=_post_allowed_tags)

--- a/neodb/journal/templates/posts.html
+++ b/neodb/journal/templates/posts.html
@@ -1,4 +1,3 @@
-{% load bleach_tags %}
 {% load duration %}
 {% load humanize %}
 {% load i18n %}

--- a/neodb/journal/views/post.py
+++ b/neodb/journal/views/post.py
@@ -12,7 +12,7 @@ from common.models.lang import LOCALE_CHOICES, translate
 from common.models.misc import int_
 from common.sentry import record_activity
 from common.utils import AuthedHttpRequest, get_uuid_or_404
-from journal.models.renderers import bleach_post_content
+from journal.models.renderers import sanitize_post_content
 from takahe.models import Post
 from takahe.utils import Takahe
 from users.models import APIdentity
@@ -272,7 +272,7 @@ def post_translate(request, post_id: int):
     owner = APIdentity.by_takahe_identity(post.author)
     if not owner or _can_view_post(post, owner, viewer) != 1:
         raise PermissionDenied(_("Insufficient permission"))
-    text = bleach_post_content(post.content)
+    text = sanitize_post_content(post.content)
     text = translate(text, request.user.language, post.language)
     return HttpResponse(text)
 

--- a/neodb/social/templates/event/boosted.html
+++ b/neodb/social/templates/event/boosted.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load bleach_tags %}
 {% trans 'boosted your post' %}
 <blockquote>
   {% include "_event_post.html" with post=event.post %}

--- a/neodb/social/templates/event/follow_requested.html
+++ b/neodb/social/templates/event/follow_requested.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load bleach_tags %}
+{% load sanitize %}
 {% trans 'requested to follow you' %}
 <div>
   <span class="action">{% include 'users/profile_actions.html' with show_home=1 identity=event.identity %}</span>
@@ -9,5 +9,5 @@
         onclick="navigator.clipboard.writeText(this.innerText);$(this).data('tooltip','copied');">@{{ event.identity.full_handle }}</code>
 </div>
 <blockquote class="tldr" _="on click toggle .tldr on me">
-  {{ event.identity.summary|bleach:"a,p,span,br"|default:"" }}
+  {{ event.identity.summary|sanitize:"a,p,span,br"|default:"" }}
 </blockquote>

--- a/neodb/social/templates/event/followed.html
+++ b/neodb/social/templates/event/followed.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load bleach_tags %}
+{% load sanitize %}
 {% trans 'followed you' %}
 <div>
   <span class="action">{% include 'users/profile_actions.html' with show_home=1 identity=event.identity %}</span>
@@ -9,5 +9,5 @@
         onclick="navigator.clipboard.writeText(this.innerText);$(this).data('tooltip','copied');">@{{ event.identity.full_handle }}</code>
 </div>
 <blockquote class="tldr" _="on click toggle .tldr on me">
-  {{ event.identity.summary|bleach:"a,p,span,br"|default:"" }}
+  {{ event.identity.summary|sanitize:"a,p,span,br"|default:"" }}
 </blockquote>

--- a/neodb/social/templates/event/liked.html
+++ b/neodb/social/templates/event/liked.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load bleach_tags %}
 {% trans 'liked your post' %}
 <blockquote>
   {% include "_event_post.html" with post=event.post %}

--- a/neodb/social/templates/event/mentioned.html
+++ b/neodb/social/templates/event/mentioned.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load bleach_tags %}
 {% trans 'mentioned you' %}
 <blockquote class="reply_to_post">
   {% include "_event_post.html" with post=event.post hide_actions=1 %}

--- a/neodb/social/templates/feed_events.html
+++ b/neodb/social/templates/feed_events.html
@@ -1,4 +1,3 @@
-{% load bleach_tags %}
 {% load static %}
 {% load i18n %}
 {% load l10n %}

--- a/neodb/tests/core/test_templatetags.py
+++ b/neodb/tests/core/test_templatetags.py
@@ -11,6 +11,7 @@ from common.templatetags.duration import (
     relative_uri,
 )
 from common.templatetags.highlight import highlight
+from common.templatetags.sanitize import sanitize
 from common.templatetags.strip_scheme import strip_scheme
 from common.templatetags.truncate import truncate
 
@@ -228,3 +229,30 @@ class TestTruncate:
     def test_exact_length(self):
         result = truncate("hello", "5")
         assert result == "hello"
+
+
+class TestSanitize:
+    def test_script_removed(self):
+        assert "<script>" not in sanitize("<p>hi</p><script>alert(1)</script>", "p")
+
+    def test_allowed_tags_kept(self):
+        assert sanitize("<p>hi<br></p>", "p,br") == "<p>hi<br></p>"
+
+    def test_disallowed_tag_unwrapped(self):
+        # nh3 drops the tag but keeps its text, unlike escaping it
+        assert sanitize("<div><p>hi</p></div>", "p") == "<p>hi</p>"
+
+    def test_event_handler_removed(self):
+        assert "onclick" not in sanitize('<a href="#" onclick="x()">hi</a>', "a")
+
+    def test_none_is_empty_not_the_string_none(self):
+        assert sanitize(None, "p") == ""
+
+    def test_empty_string(self):
+        assert sanitize("", "p") == ""
+
+    def test_no_tag_argument_uses_nh3_defaults(self):
+        assert sanitize("<p>hi</p>") == "<p>hi</p>"
+
+    def test_result_is_safe(self):
+        assert isinstance(sanitize("<p>hi</p>", "p"), SafeString)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "django>=5.2,<5.3",
     "django-anymail[mailgun,amazon-ses,sendgrid,mailjet,postal,mandrill,mailersend,brevo]>=13.0",
     "django-auditlog>=3.0.0",
-    "django-bleach>=3.1.0",
     "django-compressor",
     "django-cors-headers",
     "django-environ>=0.11.2",

--- a/uv.lock
+++ b/uv.lock
@@ -226,24 +226,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bleach"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/5d/d5d45a38163ede3342d6ac1ca01b5d387329daadf534a25718f9a9ba818c/bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c", size = 199642, upload-time = "2022-06-27T14:40:08.177Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/87/508104336a2bc0c4cfdbdceedc0f44dc72da3abc0460c57e323ddd1b3257/bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a", size = 160897, upload-time = "2022-06-27T14:39:57.276Z" },
-]
-
-[package.optional-dependencies]
-css = [
-    { name = "tinycss2" },
-]
-
-[[package]]
 name = "blurhash-rs"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -701,19 +683,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/e5/2beb2b256775c4fc041ed60cb44f5d77acb6cde307f01567dcf2756721a7/django_auditlog-3.4.1.tar.gz", hash = "sha256:ad07b9db452d5fa8303822cccd78cd3fcb2c2863aeb6abe039ec45739b4d7e33", size = 91611, upload-time = "2025-12-18T08:56:35.378Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/37/3239143dddb34a3f64582c43f56587a80c9ac136cbd34fc215077f83beb9/django_auditlog-3.4.1-py3-none-any.whl", hash = "sha256:29958ecacfee00144127214f3ccef3f0c203c3659bcb6dd404a0f3d5551a10a5", size = 49541, upload-time = "2025-12-18T08:56:23.483Z" },
-]
-
-[[package]]
-name = "django-bleach"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bleach", extra = ["css"] },
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/d9/e50567bf752da972c4eb1e294af9692b656444341d115545e041c38e921c/django-bleach-3.1.0.tar.gz", hash = "sha256:766405a32b877a5beb6b377ace0d8bbe2a7d4d6304f04542aa14fd74b14398a7", size = 22197, upload-time = "2023-08-05T01:36:29.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/fd/e2cad28cfb86329e120486c1739ed66505cc1f089a28014e9322978e4a77/django_bleach-3.1.0-py2.py3-none-any.whl", hash = "sha256:8d9117ca08c182ee20daaf99abbf800154db5cdbcb66ef1252dd7bb542dcf19d", size = 13929, upload-time = "2023-08-05T01:36:27.663Z" },
 ]
 
 [[package]]
@@ -1718,7 +1687,6 @@ dependencies = [
     { name = "django" },
     { name = "django-anymail", extra = ["amazon-ses", "postal", "sendgrid"] },
     { name = "django-auditlog" },
-    { name = "django-bleach" },
     { name = "django-cache-url" },
     { name = "django-compressor" },
     { name = "django-cors-headers" },
@@ -1813,7 +1781,6 @@ requires-dist = [
     { name = "django", specifier = ">=5.2,<5.3" },
     { name = "django-anymail", extras = ["mailgun", "amazon-ses", "sendgrid", "mailjet", "postal", "mandrill", "mailersend", "brevo"], specifier = ">=13.0" },
     { name = "django-auditlog", specifier = ">=3.0.0" },
-    { name = "django-bleach", specifier = ">=3.1.0" },
     { name = "django-cache-url", specifier = ">=3.4.5" },
     { name = "django-compressor" },
     { name = "django-cors-headers" },
@@ -2824,18 +2791,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tinycss2"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/5a/576828164b5486f319c4323915b915a8af3fa4a654bbb6f8fc8e87b5cb17/tinycss2-1.1.1.tar.gz", hash = "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf", size = 65703, upload-time = "2021-11-22T17:59:14.235Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/7b/5dba39bf0572f1f28e2844f08f74a73482a381de1d1feac3bbc6b808051e/tinycss2-1.1.1-py3-none-any.whl", hash = "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8", size = 21883, upload-time = "2021-11-22T17:59:08.603Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3023,15 +2978,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/5c/8ad4e9c8e2eb97f434f74058ff7de955aa47e255ab549d7381c80262318e/webauthn-2.8.0.tar.gz", hash = "sha256:cb3a49abbddb3a757e60c58f8b2b10ca20ef451935b97dfd7e9beedaabff7b10", size = 134197, upload-time = "2026-06-13T03:05:02.148Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/3d/3f63c83078ba9e5f95674192c3f6913453ee42c8aff2b1678fbe292dcfe9/webauthn-2.8.0-py3-none-any.whl", hash = "sha256:357f068a9eaa95455d97e6aa4d89c9893f4fec2cff32bba74b0fc73b5cb743b7", size = 73409, upload-time = "2026-06-13T03:05:01.148Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/a0/8fd707bcb776a7be556bad06a2ea5fb9bd519df78ef8e26f70ccf0f38bff/webencodings-0.6.1.tar.gz", hash = "sha256:565f9ad031c702dae404e27a099e3e09186a3ab1b9520f06d215502b651fd910", size = 15001, upload-time = "2026-08-15T14:22:57.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c6/040cbc72480d789a5f40d63fb484d3106554c4dfa2d2b70ad5022057750f/webencodings-0.6.1-py3-none-any.whl", hash = "sha256:7fab6269c8bf237c657876b52058ccb182e861518d1c695c1a9aaa8c1c105d5b", size = 8745, upload-time = "2026-08-15T14:22:56.31Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] You, as a human, have fully reviewed every single line of this PR
- [ ] You, as a human, have fully tested this PR


* **What kind of change does this PR introduce?**
- [ ] bug fix, including security or performance improvements
- [ ] feature
- [ ] docs
- [x] other (dependency maintenance)


* **What is the current behavior?**

`bleach` is no longer maintained. It reached the project only through `django-bleach`, which supplied the `bleach` template filter and pulled in `bleach`, `tinycss2` and `webencodings`.

`nh3` is already a direct dependency, and `journal/models/renderers.py` already sanitizes post content with it. So only three call sites still used the old library.


* **What is the new behavior?**

`django-bleach` is dropped and the remaining call sites move to `nh3`.

- `pyproject.toml` drops `django-bleach`. The lock diff is 54 pure deletions: `bleach`, `django-bleach`, `tinycss2`, `webencodings`. Nothing else moved.
- `settings.py` drops `django_bleach` from `INSTALLED_APPS` and both `BLEACH_STRIP_*` settings. Nothing else read them.
- New `common/templatetags/sanitize.py` replaces django-bleach's `bleach` filter, so `|bleach:"a,p,span,br"` becomes `|sanitize:"a,p,span,br"`. It deliberately avoids `@stringfilter`, which would render a null `identity.summary` as the literal string `None`, and it marks its own result safe the way django-bleach did internally.
- All 10 `{% load bleach_tags %}` lines are removed. Only 2 templates actually used the filter, but a stale `{% load %}` of a missing library is a render-time `TemplateSyntaxError`, so the other 8 had to go too.
- `bleach_post_content` is renamed to `sanitize_post_content`. It already called `nh3`; only the name was a leftover.

Two intentional behavior changes:

1. `catalog/sites/rss.py` used `bleach.clean(description, strip=True)`. Despite the argument name, that did not strip all tags. It kept bleach's default inline allowlist (`a`, `b`, `i`, `em`, `strong`, `code`, `ul`, `ol`, `li`, `blockquote`, `abbr`, `acronym`) and removed the rest. `Item.brief` is a plain-text field rendered autoescaped, so those surviving tags displayed literally. `nh3.clean(..., tags=set())` now strips every tag and keeps the text. `<script>` content is dropped rather than flattened into the text. This affects newly ingested podcast episodes only.

2. The new filter uses nh3's default attribute policy for the two fediverse profile summaries it sanitizes. Compared to bleach, that adds `rel="noopener noreferrer"` on links and allows a slightly wider set of safe attributes and URL schemes. This matches how `sanitize_post_content` already calls nh3.


* **Does this PR introduce a breaking change?**

No. No migration and no config change are needed. Anyone carrying a local `BLEACH_*` setting can delete it, as nothing reads those any more.


* **Other information**:

Verified:

- In a freshly resolved environment, `import bleach` and `import django_bleach` both fail, and the suite still runs.
- All 242 templates in the repo compile, which is what proves no stale `{% load %}` survives. That failure mode is invisible to an import check.
- 2498 tests collect with no import error.
- 8 new tests cover the filter: script and event handler stripping, allowed tags kept, disallowed tags unwrapped, `None` in gives `""` out rather than `"None"`, and the result is a `SafeString`.
- `pre-commit run --files ...` passes on every changed file, `uv-lock` and `ty` included.
