### PR TITLE
fix(security): resolve CodeQL code scanning alerts

### DIFF
--- a/neodb/catalog/common/downloaders.py
+++ b/neodb/catalog/common/downloaders.py
@@ -5,7 +5,7 @@ import time
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, Tuple, Union, cast
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 import filetype
 import httpx
@@ -31,6 +31,42 @@ RESPONSE_CENSORSHIP = -3  # censored, try sth special if possible
 RESPONSE_QUOTA_EXCEEDED = -4
 
 _mock_mode = False
+
+# query parameters that carry a credential; several sites (Google Books, Steam,
+# TMDB) pass their API key this way, so a downloader URL must never reach a log
+# or an error message verbatim
+_SECRET_QUERY_KEYS = frozenset(
+    {
+        "key",
+        "api_key",
+        "apikey",
+        "access_token",
+        "token",
+        "client_secret",
+        "secret",
+        "password",
+        "sig",
+        "signature",
+    }
+)
+
+
+def redact_url(url: str | None) -> str:
+    """Return `url` with the value of any credential-bearing query parameter
+    replaced, leaving the rest intact so logs stay useful."""
+    if not url:
+        return ""
+    try:
+        parts = urlparse(url)
+    except ValueError:
+        return "<malformed url>"
+    if not parts.query:
+        return url
+    redacted = [
+        (k, "***" if k.lower() in _SECRET_QUERY_KEYS else v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+    ]
+    return urlunparse(parts._replace(query=urlencode(redacted, safe="*")))
 
 
 def use_local_response(func):
@@ -75,7 +111,7 @@ class MockResponse:
             self.content = b"Error: response file not found"
             self.status_code = 404
             if ".jpg" not in self.url:
-                logger.warning(f"invalid mock response path for {url}")
+                logger.warning(f"invalid mock response path for {redact_url(url)}")
             return
         try:
             self.content = candidate.read_bytes()
@@ -84,7 +120,9 @@ class MockResponse:
             self.content = b"Error: response file not found"
             self.status_code = 404
             if ".jpg" not in self.url:
-                logger.warning(f"local response not found for {url} at {candidate}")
+                logger.warning(
+                    f"local response not found for {redact_url(url)} at {candidate}"
+                )
 
     @property
     def text(self):
@@ -181,7 +219,8 @@ class DownloadError(Exception):
         else:
             error = "Unknown Error"
         self.message = (
-            f"Download Failed: {error}{', ' + msg if msg else ''}, url: {self.url}"
+            f"Download Failed: {error}{', ' + msg if msg else ''}, "
+            f"url: {redact_url(self.url)}"
         )
         super().__init__(self.message)
 
@@ -455,7 +494,7 @@ class ImageDownloaderMixin:
                 if file_type is None or not (file_type.mime or "").startswith("image/"):
                     logger.error(
                         f"Unsupported image type: {content_type}",
-                        extra={"url": response.url},
+                        extra={"url": redact_url(response.url)},
                     )
                     return RESPONSE_NETWORK_ERROR
                 self.extention = file_type.extension
@@ -465,7 +504,8 @@ class ImageDownloaderMixin:
                 return RESPONSE_OK
             except Exception as e:
                 logger.error(
-                    f"Invalid downloaded image {e}", extra={"url": response.url}
+                    f"Invalid downloaded image {e}",
+                    extra={"url": redact_url(response.url)},
                 )
                 return RESPONSE_NETWORK_ERROR
         if response and response.status_code >= 400 and response.status_code < 500:

--- a/neodb/catalog/management/commands/seed_catalog.py
+++ b/neodb/catalog/management/commands/seed_catalog.py
@@ -11,18 +11,20 @@ The site API keys for Google Books, IGDB and TMDB must be configured, or
 those categories fail to scrape.
 """
 
+import logging
 import time
 from typing import Any
 
 import django_rq
 from django.core.management.base import CommandParser
-from loguru import logger
 from rq import Worker
 
 from catalog.common import SiteManager
 from catalog.common.downloaders import DownloadError
 from catalog.sites import *  # noqa: F403
 from common.management.base import SiteCommand
+
+logger = logging.getLogger(__name__)
 
 # Queues the ingest fans out onto. get_resource_ready() puts related
 # resources (seasons, people) on "crawl", and those jobs enqueue more of

--- a/neodb/catalog/views/edit.py
+++ b/neodb/catalog/views/edit.py
@@ -14,7 +14,6 @@ from django.http import Http404, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -39,6 +38,7 @@ from ..models import (
 )
 from ..models.people import People
 from ..sites import IMDB
+from common.validators import get_safe_redirect_url
 
 logger = logging.getLogger(__name__)
 
@@ -442,13 +442,9 @@ def unlink(request):
     if not resource.item:
         raise BadRequest(_("Invalid parameter"))
     # the confirmation page carries the original referer in `next`
-    next_url = request.POST.get("next") or request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        next_url,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        next_url = "/"
+    next_url = get_safe_redirect_url(
+        request.POST.get("next") or request.META.get("HTTP_REFERER")
+    )
     if not _is_confirmed(request):
         return _confirm(
             request,

--- a/neodb/catalog/views/view.py
+++ b/neodb/catalog/views/view.py
@@ -13,6 +13,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_http_methods
 
 from common.models import SiteConfig
+from common.validators import get_safe_redirect_url
 from common.utils import (
     CustomPaginator,
     PageLinksGenerator,
@@ -63,7 +64,9 @@ def retrieve_by_uuid(request, item_uid):
 
 
 def retrieve_redirect(request, item_path, item_uuid):
-    return redirect(f"/{item_path}/{item_uuid}", permanent=True)
+    # both parts are already constrained by the route regex; the check stops a
+    # "//host" path from being read back as a protocol-relative URL
+    return redirect(get_safe_redirect_url(f"/{item_path}/{item_uuid}"), permanent=True)
 
 
 @require_http_methods(["GET", "HEAD"])
@@ -189,7 +192,7 @@ def people_works(request, item_path, item_uuid, role):
     if final.is_deleted:
         raise Http404(_("Item no longer exists"))
     if final is not item:
-        return redirect(f"{final.url}/works/{role}")
+        return redirect(get_safe_redirect_url(f"{final.url}/works/{role}"))
     role_label = credit_role_label(role)
 
     # All roles this person has, for the role filter dropdown. Read from

--- a/neodb/common/models/music_format.py
+++ b/neodb/common/models/music_format.py
@@ -169,7 +169,9 @@ _MEDIA_FORMAT_ALIASES: dict[str, str] = {
     "录像带": "vcd",
 }
 
-_RE_SPLIT = re.compile(r"\s*[/,;，、；]\s*")
+# split on the delimiter alone and strip afterwards; surrounding `\s*` makes
+# the match ambiguous and costs quadratic time on runs of whitespace
+_RE_SPLIT = re.compile(r"[/,;，、；]")
 
 
 def _normalize_values(
@@ -194,7 +196,7 @@ def _normalize_values(
         else:
             # split compound values ("Album, EP") only when the whole
             # string does not match, then map each part
-            parts = [p for p in _RE_SPLIT.split(v) if p]
+            parts = [s for p in _RE_SPLIT.split(v) if (s := p.strip())]
             if len(parts) > 1:
                 result.extend(_normalize_values(parts, codes, aliases))
             else:

--- a/neodb/common/validators.py
+++ b/neodb/common/validators.py
@@ -112,17 +112,45 @@ def is_safe_url(url: str | None, allowed_hosts: set[str] | None = None) -> bool:
 
 
 def get_safe_redirect_url(url: str | None, default: str = "/") -> str:
-    """Return the URL if safe, otherwise return the default."""
-    if url and is_safe_url(url):
-        return url
-    return default
+    """Return the URL if safe, otherwise return the default.
+
+    The three helpers below each call the Django check inline and return the
+    checked value straight from its guarded branch, rather than sharing one
+    implementation. That shape is what marks the result as sanitized for taint
+    analysis; delegating to a wrapper, or negating the check and reassigning
+    the variable, leaves callers reported as open redirects.
+    """
+    if not url:
+        return default
+    if not url_has_allowed_host_and_scheme(
+        url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        return default
+    return url
 
 
 def sanitize_next_url(url: str | None) -> str | None:
     """Return the URL if safe for redirect, otherwise return None."""
-    return url if is_safe_url(url) else None
+    if not url:
+        return None
+    if not url_has_allowed_host_and_scheme(
+        url,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        return None
+    return url
 
 
 def get_safe_referer_url(request: HttpRequest, default: str = "/") -> str:
     """Get HTTP_REFERER if it's safe, otherwise return default."""
-    return get_safe_redirect_url(request.META.get("HTTP_REFERER", ""), default)
+    referer = request.META.get("HTTP_REFERER") or ""
+    if not url_has_allowed_host_and_scheme(
+        referer,
+        allowed_hosts=set(settings.SITE_DOMAINS),
+        require_https=settings.SSL_ONLY,
+    ):
+        return default
+    return referer

--- a/neodb/common/views.py
+++ b/neodb/common/views.py
@@ -5,7 +5,6 @@ from django.core.exceptions import DisallowedHost
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 
 from boofilsic import __version__
 from catalog.views import people_search as catalog_people_search, discover
@@ -17,6 +16,7 @@ from takahe.utils import Takahe
 from users.models.user import User
 
 from .api import api
+from .validators import get_safe_redirect_url
 from .models import SiteConfig
 
 
@@ -80,13 +80,10 @@ def home(request):
 
 
 def ap_redirect(request, uri):
-    redirect_to = request.get_full_path().replace("/~neodb~/", "/")
-    if not url_has_allowed_host_and_scheme(
-        redirect_to,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        redirect_to = "/"
+    # a path of "/~neodb~//host" would collapse into a protocol-relative URL
+    redirect_to = get_safe_redirect_url(
+        request.get_full_path().replace("/~neodb~/", "/")
+    )
     return redirect(redirect_to)
 
 

--- a/neodb/journal/static/js/calendar_yearview_blocks.js
+++ b/neodb/journal/static/js/calendar_yearview_blocks.js
@@ -15,6 +15,22 @@
             };
         }
 
+        // Every value interpolated into the SVG markup below goes through this
+        // first: the plugin builds its chart as an HTML string, so an unescaped
+        // option value would be parsed as markup.
+        var escapeAttrMap = {
+            '&': '&amp;',
+            '"': '&quot;',
+            "'": '&#39;',
+            '<': '&lt;',
+            '>': '&gt;'
+        };
+        var escapeAttr = function (s) {
+            return String(s).replace(/[&"'<>]/g, function (ch) {
+                return escapeAttrMap[ch];
+            });
+        };
+
         // If the number less than 10, add a zero before it
         var prettyNumber = function (number) {
             return number < 10 ? '0' + number.toString() : number = number.toString();
@@ -88,13 +104,6 @@
 
                     var items = [];
                     var legend = '', items_str = '';
-                    var escapeAttr = function (s) {
-                        return String(s)
-                            .replaceAll('&', '&amp;')
-                            .replaceAll('"', '&quot;')
-                            .replaceAll('<', '&lt;')
-                            .replaceAll('>', '&gt;');
-                    };
                     if (obj_timestamp[data_date]) {
                         if (obj_timestamp[data_date].items) {
                             items = obj_timestamp[data_date].items;
@@ -106,28 +115,28 @@
                     }
 
                     var item_name = items[0]?items[0]:false;
-                    var color = settings.colors[item_name]?settings.colors[item_name]:settings.colors['default'];
+                    var color = escapeAttr(settings.colors[item_name]?settings.colors[item_name]:settings.colors['default']);
 
                     // Fill a square for the 1st item
                     item_html += '<rect class="day" ' + (items.length<2 ? 'rx="2" ry="2"' : '') + ' width="11" height="11" y="' + y + '" fill="' + color + match_today + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                     if (items.length === 2) { // Fill a trangle for the 2nd
                         var item_name_1 = items[1]?items[1]:false;
-                        var color_1 = settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default'];
+                        var color_1 = escapeAttr(settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default']);
                         item_html += '<polygon points="' + 0 + ',' + (y+11) + ' ' + 0 + ',' + y + ' ' + 11 + ',' + y + '" fill="' + color_1 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                     } else if (items.length === 3) { // Fill 2 rectangles for 2nd and 3rd
                         var item_name_1 = items[1]?items[1]:false;
-                        var color_1 = settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default'];
+                        var color_1 = escapeAttr(settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default']);
                         var item_name_2 = items[2]?items[2]:false;
-                        var color_2 = settings.colors[item_name_2]?settings.colors[item_name_2]:settings.colors['default'];
+                        var color_2 = escapeAttr(settings.colors[item_name_2]?settings.colors[item_name_2]:settings.colors['default']);
                         item_html += '<polygon points="' + 0 + ',' + (y+8) + ' ' + 0 + ',' + y + ' ' + 11 + ',' + y + ' ' + 11 + ',' + (y+8) + '" fill="' + color_1 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                         item_html += '<polygon points="' + 0 + ',' + (y+4) + ' ' + 0 + ',' + y + ' ' + 11 + ',' + y + ' ' + 11 + ',' + (y+4) + '" fill="' + color_2 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                     } else if (items.length === 4) { // Fill 3 cubes for 2nd, 3rd and 4th
                         var item_name_1 = items[1]?items[1]:false;
-                        var color_1 = settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default'];
+                        var color_1 = escapeAttr(settings.colors[item_name_1]?settings.colors[item_name_1]:settings.colors['default']);
                         var item_name_2 = items[2]?items[2]:false;
-                        var color_2 = settings.colors[item_name_2]?settings.colors[item_name_2]:settings.colors['default'];
+                        var color_2 = escapeAttr(settings.colors[item_name_2]?settings.colors[item_name_2]:settings.colors['default']);
                         var item_name_3 = items[3]?items[3]:false;
-                        var color_3 = settings.colors[item_name_3]?settings.colors[item_name_3]:settings.colors['default'];
+                        var color_3 = escapeAttr(settings.colors[item_name_3]?settings.colors[item_name_3]:settings.colors['default']);
                         item_html += '<polygon points="' + 0 + ',' + (y+11) + ' ' + 0 + ',' + (y+6) + ' ' + 6 + ',' + (y+6) + ' ' + 6 + ',' + (y+11) + '" fill="' + color_1 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                         item_html += '<polygon points="' + 0 + ',' + (y+6) + ' ' + 0 + ',' + y + ' ' + 6 + ',' + y + ' ' + 6 + ',' + (y+6) + '" fill="' + color_2 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
                         item_html += '<polygon points="' + 6 + ',' + (y+6) + ' ' + 6 + ',' + y + ' ' + 11 + ',' + y + ' ' + 11 + ',' + (y+6) + '" fill="' + color_3 + '" data-items="' + items_str + '" data-legend="' + legend + '" data-date="' + data_date + '"/>';
@@ -153,20 +162,20 @@
             // Add labels for Months
             for (var i = 0; i < month_position.length; i++) {
                 var item = month_position[i];
-                var month_name = item.month_index ? settings.month_names[item.month_index] : end_year;
+                var month_name = escapeAttr(item.month_index ? settings.month_names[item.month_index] : end_year);
                 loop_html += '<text x="' + item.x + '" y="-5" class="month">' + month_name + '</text>';
             }
 
             // Add labels for Weekdays
             if (settings.start_monday === true) {
-                loop_html += '<text text-anchor="middle" class="wday" dx="-12" dy="11">{0}</text>'.formatString(settings.day_names[0]) +
-                    '<text text-anchor="middle" class="wday" dx="-12" dy="36">{0}</text>'.formatString(settings.day_names[1]) +
-                    '<text text-anchor="middle" class="wday" dx="-12" dy="61">{0}</text>'.formatString(settings.day_names[2]) +
-                    '<text text-anchor="middle" class="wday" dx="-12" dy="86">{0}</text>'.formatString(settings.day_names[3]);
+                loop_html += '<text text-anchor="middle" class="wday" dx="-12" dy="11">{0}</text>'.formatString(escapeAttr(settings.day_names[0])) +
+                    '<text text-anchor="middle" class="wday" dx="-12" dy="36">{0}</text>'.formatString(escapeAttr(settings.day_names[1])) +
+                    '<text text-anchor="middle" class="wday" dx="-12" dy="61">{0}</text>'.formatString(escapeAttr(settings.day_names[2])) +
+                    '<text text-anchor="middle" class="wday" dx="-12" dy="86">{0}</text>'.formatString(escapeAttr(settings.day_names[3]));
             } else {
-                loop_html += '<text text-anchor="middle" class="wday" dx="-10" dy="22">{0}</text>'.formatString(settings.day_names[0]) +
-                    '<text text-anchor="middle" class="wday" dx="-10" dy="48">{0}</text>'.formatString(settings.day_names[1]) +
-                    '<text text-anchor="middle" class="wday" dx="-10" dy="74">{0}</text>'.formatString(settings.day_names[2]);
+                loop_html += '<text text-anchor="middle" class="wday" dx="-10" dy="22">{0}</text>'.formatString(escapeAttr(settings.day_names[0])) +
+                    '<text text-anchor="middle" class="wday" dx="-10" dy="48">{0}</text>'.formatString(escapeAttr(settings.day_names[1])) +
+                    '<text text-anchor="middle" class="wday" dx="-10" dy="74">{0}</text>'.formatString(escapeAttr(settings.day_names[2]));
             }
 
             // Fixed size with width= 721 and height = 110

--- a/neodb/journal/views/collection.py
+++ b/neodb/journal/views/collection.py
@@ -1,11 +1,11 @@
-from django.conf import settings
+import logging
+
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.core.signing import b62_encode
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -18,6 +18,7 @@ from common.utils import (
     get_page_size_from_request,
     get_uuid_or_404,
 )
+from common.validators import get_safe_referer_url
 from takahe.auth import _SigError, verify_http_signature
 from users.models import User
 
@@ -33,6 +34,8 @@ from .common import (
     require_piece_handle,
     target_identity_required,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -61,13 +64,7 @@ def add_to_collection(request: AuthedHttpRequest, item_uuid):
         collection = Collection.objects.get(owner=request.user.identity, id=cid)
         collection.append_item(item, note=request.POST.get("note"))
         record_activity("collection", "web")
-        referer = request.META.get("HTTP_REFERER") or ""
-        if not url_has_allowed_host_and_scheme(
-            referer,
-            allowed_hosts=set(settings.SITE_DOMAINS),
-            require_https=settings.SSL_ONLY,
-        ):
-            referer = "/"
+        referer = get_safe_referer_url(request)
         return HttpResponseRedirect(referer)
 
 
@@ -125,8 +122,10 @@ def _resolve_signed_viewer(request):
     try:
         return verify_http_signature(request), None
     except _SigError as e:
+        # reason to the log only, so the body cannot be used to probe internals
+        logger.info(f"HTTP signature rejected: {e}")
         return None, HttpResponse(
-            f"Bad signature: {e}", status=401, content_type="text/plain"
+            "Bad signature", status=401, content_type="text/plain"
         )
 
 
@@ -343,13 +342,7 @@ def collection_add_featured(request: AuthedHttpRequest, collection_uuid):
     FeaturedCollection.objects.update_or_create(
         owner=request.user.identity, target=collection
     )
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 
@@ -364,13 +357,7 @@ def collection_remove_featured(request: AuthedHttpRequest, collection_uuid):
     ).first()
     if fc:
         fc.delete()
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 
@@ -404,13 +391,7 @@ def collection_share(request: AuthedHttpRequest, collection_uuid):
             ) or ""
             if not share_collection(collection, comment, user, visibility, link):
                 return render_relogin(request)
-        referer = request.META.get("HTTP_REFERER") or ""
-        if not url_has_allowed_host_and_scheme(
-            referer,
-            allowed_hosts=set(settings.SITE_DOMAINS),
-            require_https=settings.SSL_ONLY,
-        ):
-            referer = "/"
+        referer = get_safe_referer_url(request)
         return HttpResponseRedirect(referer)
 
 

--- a/neodb/journal/views/common.py
+++ b/neodb/journal/views/common.py
@@ -1,7 +1,6 @@
 from functools import wraps
 
 import filetype
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, ObjectDoesNotExist, PermissionDenied
 from django.core.files.base import ContentFile
@@ -11,7 +10,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.cache import patch_cache_control, patch_vary_headers
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import last_modified, require_http_methods
 
@@ -41,6 +39,7 @@ from ..models import (
     q_owned_piece_visible_to_user,
 )
 from ..models.attachment import generate_attachment_path
+from common.validators import get_safe_redirect_url
 
 _ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 _MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB
@@ -300,13 +299,7 @@ def render_list(
 @require_http_methods(["GET", "POST"])
 def piece_delete(request, piece_uuid):
     piece = get_object_or_404(Piece, uid=get_uuid_or_404(piece_uuid))
-    return_url = request.GET.get("return_url") or ""
-    if not url_has_allowed_host_and_scheme(
-        return_url,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        return_url = "/"
+    return_url = get_safe_redirect_url(request.GET.get("return_url"))
     if not piece.is_deletable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "GET":

--- a/neodb/journal/views/mark.py
+++ b/neodb/journal/views/mark.py
@@ -7,7 +7,6 @@ from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseBase, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -19,6 +18,7 @@ from common.utils import AuthedHttpRequest, get_uuid_or_404
 from ..forms import CommentForm, MarkForm
 from ..models import Comment, Mark, ShelfManager, ShelfType
 from .common import render_list, render_relogin
+from common.validators import get_safe_referer_url
 
 logger = logging.getLogger(__name__)
 
@@ -28,13 +28,7 @@ _checkmark = "✔️".encode("utf-8")
 
 
 def _redirect_back(request: AuthedHttpRequest) -> HttpResponseRedirect:
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 
@@ -278,13 +272,7 @@ def comment(request: AuthedHttpRequest, item_uuid):
             if not comment:
                 raise Http404(_("Content not found"))
             comment.delete()
-            referer = request.META.get("HTTP_REFERER") or ""
-            if not url_has_allowed_host_and_scheme(
-                referer,
-                allowed_hosts=set(settings.SITE_DOMAINS),
-                require_https=settings.SSL_ONLY,
-            ):
-                referer = "/"
+            referer = get_safe_referer_url(request)
             return HttpResponseRedirect(referer)
         form = CommentForm(request.POST)
         if not form.is_valid():
@@ -315,13 +303,7 @@ def comment(request: AuthedHttpRequest, item_uuid):
         if share_to_mastodon:
             comment.sync_to_social_accounts(update_mode)
         comment.update_index()
-        referer = request.META.get("HTTP_REFERER") or ""
-        if not url_has_allowed_host_and_scheme(
-            referer,
-            allowed_hosts=set(settings.SITE_DOMAINS),
-            require_https=settings.SSL_ONLY,
-        ):
-            referer = "/"
+        referer = get_safe_referer_url(request)
         return HttpResponseRedirect(referer)
 
 

--- a/neodb/journal/views/note.py
+++ b/neodb/journal/views/note.py
@@ -1,17 +1,16 @@
 from django import forms
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest
 from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
 from catalog.models import Item
 from common.forms import NeoModelForm
 from common.sentry import record_activity
+from common.validators import get_safe_referer_url
 from common.utils import AuthedHttpRequest, get_uuid_or_404
 
 from ..models import Mark, Note, ShelfType
@@ -87,14 +86,7 @@ class NoteForm(NeoModelForm):
 
 
 def _return_url(request: AuthedHttpRequest) -> str:
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        return "/"
-    return referer
+    return get_safe_referer_url(request)
 
 
 @login_required

--- a/neodb/journal/views/post.py
+++ b/neodb/journal/views/post.py
@@ -4,7 +4,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -20,6 +19,7 @@ from users.models import APIdentity
 from ..forms import *
 from ..models import *
 from .common import conditional_get_for_anonymous
+from common.validators import get_safe_referer_url
 
 logger = logging.getLogger(__name__)
 
@@ -372,13 +372,7 @@ def post_compose(request: AuthedHttpRequest):
         attachments=attachments if attachments else None,
     )
     record_activity("post", "web")
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 
@@ -431,13 +425,7 @@ def post_edit(request: AuthedHttpRequest, post_id: int):
         post_pk=post.pk,
     )
     record_activity("post", "web")
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 

--- a/neodb/journal/views/tag.py
+++ b/neodb/journal/views/tag.py
@@ -1,9 +1,7 @@
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 from user_messages import api as msg
@@ -14,6 +12,7 @@ from users.models import APIdentity
 from ..forms import *
 from ..models import *
 from .common import render_list, target_identity_required
+from common.validators import get_safe_referer_url
 
 PAGE_SIZE = 10
 
@@ -59,13 +58,7 @@ def user_tag_edit(request):
         )
         if not tag or not tag_title:
             msg.error(request.user, _("Invalid tag"))
-            referer = request.META.get("HTTP_REFERER") or ""
-            if not url_has_allowed_host_and_scheme(
-                referer,
-                allowed_hosts=set(settings.SITE_DOMAINS),
-                require_https=settings.SSL_ONLY,
-            ):
-                referer = "/"
+            referer = get_safe_referer_url(request)
             return HttpResponseRedirect(referer)
         if request.POST.get("delete"):
             tag.delete()
@@ -80,13 +73,7 @@ def user_tag_edit(request):
             ).exists()
         ):
             msg.error(request.user, _("Duplicated tag."))
-            referer = request.META.get("HTTP_REFERER") or ""
-            if not url_has_allowed_host_and_scheme(
-                referer,
-                allowed_hosts=set(settings.SITE_DOMAINS),
-                require_https=settings.SSL_ONLY,
-            ):
-                referer = "/"
+            referer = get_safe_referer_url(request)
             return HttpResponseRedirect(referer)
         tag.update(
             tag_title,

--- a/neodb/journal/views/wrapped.py
+++ b/neodb/journal/views/wrapped.py
@@ -4,14 +4,12 @@ import datetime
 import logging
 from typing import Any
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Count, F
 from django.db.models.functions import ExtractMonth
 from django.http import HttpRequest, HttpResponseRedirect
 from django.http.response import HttpResponse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.generic.base import TemplateView
 
@@ -28,6 +26,7 @@ from journal.models.common import VisibilityType
 from mastodon.models.bluesky import EmbedObj
 from takahe.utils import Takahe
 from users.models import User
+from common.validators import get_safe_referer_url
 
 logger = logging.getLogger(__name__)
 
@@ -160,11 +159,5 @@ class WrappedShareView(LoginRequiredMixin, TemplateView):
                 logger.warning(f"wrapped post to {user.bluesky} failed: {e}")
                 sentry_count("crosspost.failure", attributes=attrs)
         messages.add_message(request, messages.INFO, _("Summary posted to timeline."))
-        referer = request.META.get("HTTP_REFERER") or ""
-        if not url_has_allowed_host_and_scheme(
-            referer,
-            allowed_hosts=set(settings.SITE_DOMAINS),
-            require_https=settings.SSL_ONLY,
-        ):
-            referer = "/"
+        referer = get_safe_referer_url(request)
         return HttpResponseRedirect(referer)

--- a/neodb/mastodon/models/common.py
+++ b/neodb/mastodon/models/common.py
@@ -118,7 +118,8 @@ class SocialAccount(TypedModel):
         values = {f: getattr(self, f) for f in fields}
         if type(self).objects.filter(pk=self.pk).update(**values):
             return True
-        logger.debug(f"{self} deleted while syncing, update discarded")
+        # identify the row by pk/type only: `self` also holds access tokens
+        logger.debug(f"({self.pk}){self.type} deleted while syncing, update discarded")
         self.pk = None  # as instance.delete() would, so later saves no-op
         return False
 

--- a/neodb/mastodon/models/threads.py
+++ b/neodb/mastodon/models/threads.py
@@ -120,12 +120,22 @@ class Threads:
         short_token = data.get("access_token")
         user_id = data.get("user_id")
 
-        # exchange for a 60-days token
-        url = f"https://graph.threads.net/access_token?grant_type=th_exchange_token&client_secret={SiteConfig.system.threads_app_secret}&access_token={short_token}"
+        # exchange for a 60-days token. The app secret and the token travel as
+        # params rather than inside the URL string, so neither the endpoint we
+        # log nor a requests exception (which quotes the full request URL)
+        # carries them; for the same reason only the exception type is logged.
+        url = "https://graph.threads.net/access_token"
         try:
-            response = get(url)
+            response = get(
+                url,
+                params={
+                    "grant_type": "th_exchange_token",
+                    "client_secret": SiteConfig.system.threads_app_secret,
+                    "access_token": short_token,
+                },
+            )
         except Exception as e:
-            logger.warning(f"Error {url} {e}")
+            logger.warning(f"Error {url} {type(e).__name__}")
             return None, None, None
         if response.status_code != 200:
             logger.warning(f"Error {url} {response.status_code}")
@@ -138,11 +148,13 @@ class Threads:
 
     @staticmethod
     def refresh_token(token: str) -> tuple[str, int] | tuple[None, None]:
-        url = f"https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token={token}"
+        url = "https://graph.threads.net/refresh_access_token"
         try:
-            response = get(url)
+            response = get(
+                url, params={"grant_type": "th_refresh_token", "access_token": token}
+            )
         except Exception as e:
-            logger.warning(f"Error {url} {e}")
+            logger.warning(f"Error {url} {type(e).__name__}")
             return None, None
         if response.status_code != 200:
             logger.warning(f"Error {url} {response.status_code}")
@@ -157,11 +169,17 @@ class Threads:
     def get_profile(
         token: str, user_id: str | None = None
     ) -> dict[str, str | int] | None:
-        url = f"https://graph.threads.net/v1.0/{user_id or 'me'}?fields=id,username,threads_profile_picture_url,threads_biography&access_token={token}"
+        url = f"https://graph.threads.net/v1.0/{user_id or 'me'}"
         try:
-            response = get(url)
+            response = get(
+                url,
+                params={
+                    "fields": "id,username,threads_profile_picture_url,threads_biography",
+                    "access_token": token,
+                },
+            )
         except Exception as e:
-            logger.warning(f"Error {url} {e}")
+            logger.warning(f"Error {url} {type(e).__name__}")
             return None
         if response.status_code != 200:
             logger.warning(f"Error {url} {response.status_code}")

--- a/neodb/social/views.py
+++ b/neodb/social/views.py
@@ -1,11 +1,9 @@
 from typing import Any, cast
 
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 
 from catalog.models import Edition, Item, ItemCategory, PodcastEpisode
@@ -17,6 +15,7 @@ from social.feed_grouping import FeedEvent, group_feed_events
 from takahe.models import Post, PostInteraction, TimelineEvent
 from takahe.utils import Takahe
 from users.models import APIdentity
+from common.validators import get_safe_referer_url
 
 PAGE_SIZE = 10
 MAX_UNREAD_DISPLAY = 99
@@ -226,13 +225,7 @@ def dismiss_notification(request):
     Takahe.get_events(request.user.identity.pk, _all_notification_types).update(
         seen=True
     )
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = reverse("social:notification")
+    referer = get_safe_referer_url(request, reverse("social:notification"))
     return redirect(referer)
 
 

--- a/neodb/takahe/auth.py
+++ b/neodb/takahe/auth.py
@@ -198,8 +198,10 @@ def http_signature_required(view_func: Callable) -> Callable:
             # read it via ``getattr`` or a typed shim.
             setattr(request, "signed_identity", verify_http_signature(request))
         except _SigError as e:
+            # the reason stays in our log; the response body is fixed so a
+            # caller cannot probe internals through it
             logger.info(f"HTTP signature rejected: {e}")
-            return HttpResponse(str(e), status=401, content_type="text/plain")
+            return HttpResponse("Bad signature", status=401, content_type="text/plain")
         return view_func(request, *args, **kwargs)
 
     return wrapped

--- a/neodb/takahe/views.py
+++ b/neodb/takahe/views.py
@@ -5,11 +5,12 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sessions.backends.signed_cookies import SessionStore
 from django.http import HttpRequest
 from django.shortcuts import redirect
-from django.utils.http import http_date, url_has_allowed_host_and_scheme
+from django.utils.http import http_date
 
 from common.utils import user_identity_required
 
 from .utils import Takahe
+from common.validators import get_safe_redirect_url
 
 
 @login_required
@@ -25,13 +26,7 @@ def auth_login(request):
     session["_auth_user_backend"] = "django.contrib.auth.backends.ModelBackend"
     session_key: str = session._get_session_key()  # type: ignore
 
-    redirect_url = request.GET.get("next") or ""
-    if not url_has_allowed_host_and_scheme(
-        redirect_url,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        redirect_url = "/"
+    redirect_url = get_safe_redirect_url(request.GET.get("next"))
     response = redirect(redirect_url)
     if request.session.get_expire_at_browser_close():
         max_age = None

--- a/neodb/users/views/account.py
+++ b/neodb/users/views/account.py
@@ -11,7 +11,6 @@ from django.core.exceptions import BadRequest, ValidationError
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
@@ -19,7 +18,10 @@ from catalog.models import ItemCategory
 from common.models import SiteConfig
 from common.sentry import record_activity, record_registration_captcha
 from common.utils import AuthedHttpRequest, client_ip
-from common.validators import sanitize_next_url
+from common.validators import (
+    get_safe_redirect_url,
+    sanitize_next_url,
+)
 from mastodon.models import (
     Email,
     EmailAccount,
@@ -487,13 +489,7 @@ def logout_takahe(response: HttpResponse):
 
 def auth_logout(request):
     auth.logout(request)
-    redirect_url = request.GET.get("next") or ""
-    if not url_has_allowed_host_and_scheme(
-        redirect_url,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        redirect_url = "/"
+    redirect_url = get_safe_redirect_url(request.GET.get("next"))
     return logout_takahe(redirect(redirect_url))
 
 

--- a/neodb/users/views/actions.py
+++ b/neodb/users/views/actions.py
@@ -1,12 +1,10 @@
 import json
 
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import BadRequest
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 
 from common.config import *
@@ -21,6 +19,7 @@ from takahe.utils import Takahe
 from ..models import APIdentity
 from .account import *
 from .data import *
+from common.validators import get_safe_referer_url
 
 
 def query_identity(request, handle):
@@ -183,13 +182,7 @@ def set_layout(request: AuthedHttpRequest):
 @require_http_methods(["POST"])
 def mark_announcements_read(request: AuthedHttpRequest):
     Takahe.mark_announcements_seen(request.user)
-    referer = request.META.get("HTTP_REFERER") or ""
-    if not url_has_allowed_host_and_scheme(
-        referer,
-        allowed_hosts=set(settings.SITE_DOMAINS),
-        require_https=settings.SSL_ONLY,
-    ):
-        referer = "/"
+    referer = get_safe_referer_url(request)
     return HttpResponseRedirect(referer)
 
 


### PR DESCRIPTION
Resolves the 41 open alerts on the code scanning dashboard.

Verified by running CodeQL 2.26.4 locally (the same version and query suites the repo's default setup uses) against both this branch and its parent. The parent run reproduces the dashboard exactly — 46 Python results, same rules, same file:line list — so the numbers below are like-for-like.

| | parent | this branch |
|---|---|---|
| Python results | 46 | **18** |
| JavaScript results | 1 | **0** |

All 18 remaining Python results are dismissed alerts (4 `full-ssrf`, 1 `polynomial-redos` in `takahe/auth.py`, 1 test assertion — all dismissed before this work — plus the 12 dismissed alongside it, listed at the bottom).

## Why the 22 redirect alerts were open

Every same-site redirect already called `url_has_allowed_host_and_scheme`, but in a shape taint analysis does not read as a sanitizer:

```python
if not url_has_allowed_host_and_scheme(referer, ...):
    referer = "/"
return HttpResponseRedirect(referer)     # still reported
```

The barrier only applies where the check **guards the returned value on its true branch**. `journal/views/note.py:_return_url` already did that and was the one referer redirect never reported — which is what identified the branch shape as the cause.

One non-obvious constraint, found by measuring rather than reasoning: **the barrier does not survive an extra function hop.** An initial version of this change routed everything through `get_safe_referer_url` → `get_safe_redirect_url`, and that made things *worse* — 25 alerts instead of 22, because it also broke `note.py`, which had been clean. So each of the three helpers in `common/validators.py` now calls the Django check inline and returns from its own guarded branch rather than delegating to a shared one. That is deliberate, and the comment on `get_safe_redirect_url` says so; collapsing them back into one implementation will silently reopen all 21 alerts.

Result: 22 → 1, and the one remaining is takahe's intentional redirect to a remote actor URL. **No behaviour change** — the fallback for an off-site value is the same as before.

## Real defects fixed

| Where | Problem |
|---|---|
| `mastodon/models/threads.py` | The token-exchange URL embedded `client_secret` **and** `access_token` in the query string, then logged it at WARNING on three branches. Secrets now travel as request params and the logged URL is the bare endpoint. |
| `catalog/common/downloaders.py` | Logged URLs carrying the Google Books, Steam and TMDB API keys. Added `redact_url()`. |
| `common/views.py` `ap_redirect` | A path of `/~neodb~//host` collapses into a protocol-relative URL. |
| `takahe/auth.py`, `journal/views/collection.py` | The signature-rejection reason was returned in the 401 body. |
| `common/models/music_format.py` | `\s*[/,;，、；]\s*` backtracks quadratically on runs of whitespace. |
| `journal/static/js/calendar_yearview_blocks.js` | The chart is built as an HTML string with unescaped option values. |

## Three deliberate tradeoffs

- **`threads.py` logs `type(e).__name__`, not `{e}`.** `requests` quotes the full request URL — query string included — in `ConnectionError`, so logging the exception text would re-leak the secret that moving it to `params` just removed.
- **The 401 body is a fixed `"Bad signature"`.** The reason still goes to the log. This matches what `takahe/users/views/activitypub.py:403` already returns.
- **The calendar's `escapeAttr` uses one global-regex `replace`, not chained `replaceAll` calls.** Same output; the regex form is the one recognised as an escaping sanitizer, and the `replaceAll` version did not clear the alert.

## Beyond the flagged lines

The scanner saw a subset of each defect; these siblings had the same bug and are fixed too:

- `threads.py` `refresh_token()` and `get_profile()` also put the access token in a logged URL.
- `DownloadError.message` also embedded the un-redacted URL.
- `seed_catalog.py` still imported `loguru` after 35a6f5f9 removed the dependency. The stale import failed the lint gate and would have raised at runtime.

## Alerts dismissed rather than fixed

Twelve, each with the justification recorded on the alert:

- **`downloaders.py` clear-text logging (4).** `redact_url()` genuinely masks the credential, but taint analysis cannot model a redaction, so the flow from API key to logger is still reported. Confirmed still reported in the local run with the redaction in place.
- **DPoP `ath` claim.** SHA-256 of the access token is mandated by RFC 9449 §4.2 — a token binding, not password storage.
- **WordPress importer path.** `uploaded_file` is a Django `UploadedFile` object, not a path.
- **`views_debug.py` stack traces (4).** Superuser/DEBUG-gated debug tool whose purpose is surfacing scrape errors; the full traceback is already withheld unless DEBUG is on.
- **takahe remote-actor redirect.** Off-site by design.
- **One test assertion.**

## Testing

`2485 passed, 3 failed` on the full suite — the three failures are the pre-existing `tests/mastodon/test_lexicons.py` ones that import from `/docs`, which the dev profile does not mount. `uv run pre-commit run -a` is clean.
