### PR TITLE
Merge Weblate translations and align Weblate output with makemessages

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -116,12 +116,22 @@ django-admin makemessages --no-wrap --no-obsolete --keep-pot -l zh_Hans -l zh_Ha
 django-admin compilemessages
 ```
 
-`--no-wrap` keeps each `msgid` and `msgstr` on one line. Weblate rewraps the .po
-files that it writes. A locale that you regenerate here can therefore conflict
-with Weblate on the wrapping alone, with no change to any translation. Compare
-the two sides message by message before you resolve such a conflict, and make
-sure that no message is lost. Note that a text diff hides obsolete `#~` entries,
-which makes translations that are still present look lost.
+`--no-wrap` keeps each `msgid` and `msgstr` on one line and `--no-obsolete`
+drops removed strings. The Weblate component is configured to write the same
+form: "Long lines wrapping" is set to "Only wrap lines at newlines", "Remove
+obsolete strings" is on, and "Report msgid bugs to" is off, so that Weblate does
+not rewrite the `Report-Msgid-Bugs-To` header that `makemessages` blanks. Keep
+these two sides in sync. If one of them changes, every regenerated locale
+conflicts with Weblate on formatting alone.
+
+Weblate pushes its commits to the `weblate` branch of the fork configured as its
+push URL. Merge that branch into `main` with a merge commit, never a squash or
+rebase merge. Weblate rebases its local commits onto `main`, and it can only
+skip them when `main` already contains them. If a conflict must be resolved by
+hand, compare the two sides message by message with polib, keyed on
+`(msgctxt, msgid)`, and make sure that no translation is lost. A text diff
+hides obsolete `#~` entries, which makes translations that are still present
+look lost.
 
 Preview documentation:
 ```

--- a/neodb/locale/da_DK/LC_MESSAGES/django.po
+++ b/neodb/locale/da_DK/LC_MESSAGES/django.po
@@ -8699,6 +8699,14 @@ msgstr ""
 "Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" "
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "Importeringsmetode"
@@ -8848,6 +8856,19 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Vælg <code>.xlsx</code> eksporteret fra <a href=\"https://doufen.org\" "
+"target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:314
 #, fuzzy

--- a/neodb/locale/de/LC_MESSAGES/django.po
+++ b/neodb/locale/de/LC_MESSAGES/django.po
@@ -8722,6 +8722,14 @@ msgstr ""
 "Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://"
 "doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "Importier-Methode"
@@ -8873,6 +8881,19 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Wähle die <code>.xlsx</code> Datei aus, welche von <a href=\"https://"
+"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a> exportiert wurde"
 
 #: users/templates/users/data.html:314
 #, fuzzy

--- a/neodb/locale/es/LC_MESSAGES/django.po
+++ b/neodb/locale/es/LC_MESSAGES/django.po
@@ -8223,6 +8223,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -8358,6 +8366,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/eu/LC_MESSAGES/django.po
+++ b/neodb/locale/eu/LC_MESSAGES/django.po
@@ -7950,6 +7950,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -8085,6 +8093,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/fa/LC_MESSAGES/django.po
+++ b/neodb/locale/fa/LC_MESSAGES/django.po
@@ -7914,6 +7914,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -8049,6 +8057,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/fr/LC_MESSAGES/django.po
+++ b/neodb/locale/fr/LC_MESSAGES/django.po
@@ -8701,6 +8701,14 @@ msgstr ""
 "Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://"
 "doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "Méthode d'import"
@@ -8850,6 +8858,19 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Sélectionnez le fichier <code>.xlsx</code> exporté depuis <a href=\"https://"
+"doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:314
 #, fuzzy

--- a/neodb/locale/it/LC_MESSAGES/django.po
+++ b/neodb/locale/it/LC_MESSAGES/django.po
@@ -8710,6 +8710,14 @@ msgstr ""
 "Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" "
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "Metodo d'importazione"
@@ -8858,6 +8866,19 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Seleziona<code>.xlsx</code>esportato da <a href=\"https://doufen.org\" "
+"target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:314
 #, fuzzy

--- a/neodb/locale/ja/LC_MESSAGES/django.po
+++ b/neodb/locale/ja/LC_MESSAGES/django.po
@@ -7914,6 +7914,14 @@ msgstr ""
 "<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポー"
 "トした<code>.xlsx</code>ファイルを選択してください"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "インポート方法"
@@ -8068,6 +8076,21 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
+"坟)</a>でエクスポート時に<mark>書籍・映画・音楽・ゲーム・ドラマ</mark>と"
+"<mark>レビュー</mark>にチェックを入れてください。<br>豆伴(豆坟)からエクスポー"
+"トした<code>.xlsx</code>ファイルを選択してください"
 
 #: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."

--- a/neodb/locale/lmo/LC_MESSAGES/django.po
+++ b/neodb/locale/lmo/LC_MESSAGES/django.po
@@ -7769,6 +7769,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -7903,6 +7911,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/lzh/LC_MESSAGES/django.po
+++ b/neodb/locale/lzh/LC_MESSAGES/django.po
@@ -7760,6 +7760,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -7893,6 +7901,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/pt/LC_MESSAGES/django.po
+++ b/neodb/locale/pt/LC_MESSAGES/django.po
@@ -8602,6 +8602,14 @@ msgstr ""
 "Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" "
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "Método de importação"
@@ -8746,6 +8754,19 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Selecionar<code>.xlsx</code> exportado de <a href=\"https://doufen.org\" "
+"target=\"_blank\" rel=\"noopener\">Doufen</a>"
 
 #: users/templates/users/data.html:314
 #, fuzzy

--- a/neodb/locale/pt_BR/LC_MESSAGES/django.po
+++ b/neodb/locale/pt_BR/LC_MESSAGES/django.po
@@ -6,9 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: dev@neodb.social.NOSPAM\n"
 "POT-Creation-Date: 2026-08-23 15:40-0400\n"
-"PO-Revision-Date: 2026-08-14 19:05+0000\n"
+"PO-Revision-Date: 2026-09-02 01:51+0000\n"
 "Last-Translator: Havokdan <havokdan@yahoo.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "neodb/neodb/pt_BR/>\n"
@@ -4599,10 +4599,8 @@ msgstr ""
 "Um domínio por linha. Deixe em branco para permitir qualquer instância."
 
 #: common/views_manage.py:508
-#, fuzzy
-#| msgid "Registration failed"
 msgid "Registration Captcha Items"
-msgstr "Falha no cadastro"
+msgstr "Registro de itens de Captcha"
 
 #: common/views_manage.py:512
 msgid ""
@@ -4611,16 +4609,24 @@ msgid ""
 "carry no title text, so this cannot be solved with a screen reader: if you "
 "enable it, keep another way in, such as an invite link."
 msgstr ""
+"Número de capas de item que um novo usuário deve classificar em duas linhas "
+"de categoria antes de escolher um nome de usuário. 0 desativa o captcha; 5-6 "
+"é recomendado. As capas não possuem texto de título, então isso não pode ser "
+"resolvido com um leitor de tela: se você ativá-lo, mantenha outra maneira de "
+"acesso, como um link de convite."
 
 #: common/views_manage.py:520
 msgid "Registration Captcha Minimum Marks"
-msgstr ""
+msgstr "Mínimo de Marcas de Captcha de Registro"
 
 #: common/views_manage.py:523
 msgid ""
 "Marks an item needs before the captcha treats it as well known enough to be "
 "recognizable. Categories with too few such items fall back to any item."
 msgstr ""
+"Marca um item como necessário antes que o captcha o trate como "
+"suficientemente conhecido para ser reconhecível. Categorias com muito poucos "
+"desses itens recorrem a qualquer item."
 
 #: common/views_manage.py:529
 msgid "Enable Mastodon Login"
@@ -5971,16 +5977,12 @@ msgstr ""
 "aqui para exibir:"
 
 #: journal/templates/_sidebar_collection_filter.html:32
-#, fuzzy
-#| msgid "books dropped"
 msgid "dropped"
-msgstr "livros abadonados"
+msgstr "abadonados"
 
 #: journal/templates/_sidebar_collection_filter.html:33
-#, fuzzy
-#| msgid "No credits yet."
 msgid "not marked yet"
-msgstr "Ainda não há créditos."
+msgstr "ainda não marcado"
 
 #: journal/templates/_sidebar_search_journal.html:6
 msgid "filter by one of these statuses"
@@ -8056,61 +8058,60 @@ msgstr "Token"
 
 #: users/templates/users/captcha.html:4
 msgid "Sort every cover to continue."
-msgstr ""
+msgstr "Organize todas as capas para continuar."
 
 #: users/templates/users/captcha.html:5
 msgid "All sorted. Select Confirm."
-msgstr ""
+msgstr "Tudo organizado. Selecione Confirmar."
 
 #: users/templates/users/captcha.html:6
 msgid "Cover selected. Now choose a row."
-msgstr ""
+msgstr "Capa selecionada. Agora escolha uma linha."
 
 #: users/templates/users/captcha.html:7
 msgid "Time is up. Reload to try again."
-msgstr ""
+msgstr "O tempo acabou. Recarregue para tentar novamente."
 
 #: users/templates/users/captcha.html:26
 msgid "One quick check"
-msgstr ""
+msgstr "Uma verificação rápida"
 
 #: users/templates/users/captcha.html:28
 msgid ""
 "Put every cover into the row it belongs to. Drag it, or select a cover and "
 "then select a row."
 msgstr ""
+"Coloque cada capa na linha a que pertence. Arraste-a ou selecione uma capa e "
+"depois selecione uma linha."
 
 #: users/templates/users/captcha.html:41 users/templates/users/captcha.html:43
-#, fuzzy
-#| msgid "cover"
 msgid "Item cover"
-msgstr "capa"
+msgstr "Capa do item"
 
 #: users/templates/users/captcha.html:59
 #, python-format
 msgid "Move selected cover to %(label)s"
-msgstr ""
+msgstr "Mover a capa selecionada para %(label)s"
 
 #: users/templates/users/captcha.html:77
-#, fuzzy
-#| msgid "Confirm Import"
 msgid "Confirm"
-msgstr "Confirmar Importação"
+msgstr "Confirmar"
 
 #: users/templates/users/captcha.html:84
 #, python-format
 msgid "Show me another set (%(counter)s left)"
 msgid_plural "Show me another set (%(counter)s left)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Mostre-me outro conjunto (%(counter)s restantes)"
+msgstr[1] "Mostre-me outros conjuntos (%(counter)s restantes)"
 
 #: users/templates/users/captcha_solved.html:30
 msgid "Nicely sorted"
-msgstr ""
+msgstr "Bem organizado"
 
 #: users/templates/users/captcha_solved.html:31
 msgid "That is all we needed. Let's get you a username."
 msgstr ""
+"Isso é tudo o que precisávamos. Vamos arrumar um nome de usuário para você."
 
 #: users/templates/users/captcha_solved.html:34
 #: users/templates/users/login.html:63
@@ -8170,6 +8171,18 @@ msgid ""
 msgstr ""
 "Selecione o arquivo <code>.xlsx</code> exportado do <a href=\"https://"
 "doufen.org\" target=\"_blank\" rel=\"noopener\">Doufen</a>"
+
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+"Um arquivo Douban exportado por <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> está no formato NDJSON do "
+"próprio NeoDB; carregue-o em <a href=\"#import-neodb-archive\">Importar "
+"arquivo NeoDB</a> abaixo."
 
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
@@ -8337,6 +8350,16 @@ msgstr ""
 "Envie um arquivo <code>.zip</code> contendo arquivos <code>.csv</code> ou "
 "<code>.ndjson</code> exportados do NeoDB."
 
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"Um arquivo Douban exportado por <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> está no mesmo formato e é "
+"importado aqui."
+
 #: users/templates/users/data.html:314
 msgid "Existing data may be overwritten."
 msgstr "Os dados existentes podem ser substituídos."
@@ -8383,7 +8406,7 @@ msgstr "Download"
 
 #: users/templates/users/data.html:496
 msgid "Import and Export Articles (WordPress)"
-msgstr ""
+msgstr "Importar e Exportar Artigos (WordPress)"
 
 #: users/templates/users/data.html:499
 msgid ""
@@ -8391,30 +8414,37 @@ msgid ""
 "WordPress and most blogging tools can read and write. Marks, reviews and "
 "notes are not included: use the NeoDB archive above for those."
 msgstr ""
+"Seus artigos são trocados como posts do WordPress no formato WXR, que o "
+"WordPress e a maioria das ferramentas de blogs podem ler e escrever. Marcas, "
+"avaliações e notas não estão incluídas: use o arquivo NeoDB acima para esses."
 
 #: users/templates/users/data.html:502
 msgid ""
 "Article title, body, excerpt, tags, dates and featured image are exchanged. "
 "Comments and custom fields are ignored."
 msgstr ""
+"Título do artigo, corpo, trecho, etiquetas, datas e imagem em destaque são "
+"trocados. Comentários e campos personalizados são ignorados."
 
 #: users/templates/users/data.html:505
 msgid ""
 "The body is converted between Markdown and HTML, so formatting is kept but "
 "the text is not character-for-character identical."
 msgstr ""
+"O corpo é convertido entre Markdown e HTML, então a formatação é mantida, "
+"mas o texto não é idêntico caractere por caractere."
 
 #: users/templates/users/data.html:512
-#, fuzzy
-#| msgid "Export marks and reviews in XLSX (Doufen format)"
 msgid "Export articles in WordPress format"
-msgstr "Exportar marcações e análises em XLSX (formato Doufen)"
+msgstr "Exportar artigos no formato WordPress"
 
 #: users/templates/users/data.html:519
 msgid ""
 "In WordPress, go to <b>Tools</b> - <b>Export</b> - <b>Posts</b> to download "
 "an <code>.xml</code> file, then upload it below."
 msgstr ""
+"No WordPress, vá em <b>Ferramentas</b> - <b>Exportar</b> - <b>Publicações</"
+"b> para baixar um arquivo <code>.xml</code>, depois envie-o abaixo."
 
 #: users/templates/users/data.html:522
 msgid ""
@@ -8422,6 +8452,9 @@ msgid ""
 "password-protected posts are always imported as mentioned-only, so nothing "
 "unpublished becomes public."
 msgstr ""
+"Apenas publicações publicadas usam a visibilidade abaixo. Rascunhos, "
+"pendentes, privados e publicações protegidas por senha são sempre importados "
+"como somente mencionados, portanto nada não publicado se torna público."
 
 #: users/templates/users/data.html:560
 msgid "View Annual Summary"
@@ -9227,29 +9260,25 @@ msgid "Registration is for invitation only"
 msgstr "O cadastro é apenas por convite"
 
 #: users/views/account.py:266 users/views/account.py:338
-#, fuzzy
-#| msgid "Timestamp"
 msgid "Time is up"
-msgstr "Marcação de tempo"
+msgstr "O tempo acabou"
 
 #: users/views/account.py:267 users/views/account.py:310
 #: users/views/account.py:339
 msgid "Please log in again to continue registration."
-msgstr ""
+msgstr "Por favor, faça login novamente para continuar o registro."
 
 #: users/views/account.py:313
 msgid "That is not quite right. Here is a new set."
-msgstr ""
+msgstr "Isso não está exatamente certo. Aqui está um novo conjunto."
 
 #: users/views/account.py:325
 msgid "Too many attempts"
-msgstr ""
+msgstr "Muitas tentativas"
 
 #: users/views/account.py:326
-#, fuzzy
-#| msgid "Too many attempts, please try again later."
 msgid "Please try again later."
-msgstr "Muitas tentativas, tente novamente mais tarde."
+msgstr "Por favor, tente novamente mais tarde."
 
 #: users/views/account.py:415
 msgid "Username already taken. Please try again."

--- a/neodb/locale/ru/LC_MESSAGES/django.po
+++ b/neodb/locale/ru/LC_MESSAGES/django.po
@@ -7876,6 +7876,14 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Doufen</a>"
 msgstr ""
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr ""
@@ -8009,6 +8017,13 @@ msgstr ""
 msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
+msgstr ""
+
+#: users/templates/users/data.html:330
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 
 #: users/templates/users/data.html:314

--- a/neodb/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hans/LC_MESSAGES/django.po
@@ -5,11 +5,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: dev@neodb.social.NOSPAM\n"
 "POT-Creation-Date: 2026-08-23 15:40-0400\n"
-"PO-Revision-Date: 2026-08-08 21:19+0000\n"
-"Last-Translator: reducedradius "
-"<137701630+flytothehighest@users.noreply.github.com>\n"
+"PO-Revision-Date: 2026-09-02 01:51+0000\n"
+"Last-Translator: Hosted Weblate user 54392 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
 "projects/neodb/neodb/zh_Hans/>\n"
 "Language: zh_Hans\n"
@@ -7181,7 +7181,7 @@ msgstr "投票"
 
 #: takahe/models.py:453
 msgid "Display Name"
-msgstr ""
+msgstr "显示名称"
 
 #: takahe/models.py:455
 msgid "Bio"
@@ -7189,11 +7189,11 @@ msgstr "简介"
 
 #: takahe/models.py:457
 msgid "Manually approve new followers"
-msgstr ""
+msgstr "手动批准新关注者"
 
 #: takahe/models.py:461
 msgid "Include profile, marks and posts in discovery"
-msgstr ""
+msgstr "在发现中包含个人资料、标记和帖子"
 
 #: takahe/models.py:464
 msgid "Include posts in search results"
@@ -7201,11 +7201,11 @@ msgstr "在搜索结果中包含帖文"
 
 #: takahe/models.py:482
 msgid "Profile picture"
-msgstr ""
+msgstr "个人资料图片"
 
 #: takahe/models.py:489
 msgid "Header picture"
-msgstr ""
+msgstr "背景图片"
 
 #: users/models/task.py:22
 msgid "Started"
@@ -7983,8 +7983,8 @@ msgstr ""
 msgid ""
 "A Douban archive exported by <a href=\"https://doubak.com\" "
 "target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
-"format instead; upload it under <a "
-"href=\"#import-neodb-archive\">Import NeoDB Archive</a> below."
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
 msgstr ""
 "由 <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">豆备 "
 "Doubak</a> 导出的豆瓣档案是 NeoDB 自己的 NDJSON 格式，请用下方的<a "
@@ -8151,8 +8151,8 @@ msgstr ""
 #: users/templates/users/data.html:330
 msgid ""
 "A Douban archive exported by <a href=\"https://doubak.com\" "
-"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and "
-"is imported here."
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
 msgstr ""
 "由 <a href=\"https://doubak.com\" target=\"_blank\" rel=\"noopener\">豆备 "
 "Doubak</a> 导出的豆瓣档案是同一种格式，也在这里导入。"
@@ -8717,7 +8717,7 @@ msgstr "关闭"
 
 #: users/templates/users/register.html:112
 msgid "Cut the sh*t and get me in!"
-msgstr "完全了解并同意站规和协议，现在开始使用。"
+msgstr "别废话，赶紧让我用!"
 
 #: users/templates/users/relationship_list.html:17
 msgid "export"

--- a/neodb/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/neodb/locale/zh_Hant/LC_MESSAGES/django.po
@@ -8590,6 +8590,14 @@ msgstr ""
 "墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴"
 "(豆墳)導出的<code>.xlsx</code>文件"
 
+#: users/templates/users/data.html:45
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in NeoDB's own NDJSON "
+"format instead; upload it under <a href=\"#import-neodb-archive\">Import "
+"NeoDB Archive</a> below."
+msgstr ""
+
 #: users/templates/users/data.html:34 users/templates/users/data.html:256
 msgid "Import Method"
 msgstr "匯入方式"
@@ -8739,6 +8747,20 @@ msgid ""
 "Upload a <code>.zip</code> file containing <code>.csv</code> or "
 "<code>.ndjson</code> files exported from NeoDB."
 msgstr ""
+
+#: users/templates/users/data.html:330
+#, fuzzy
+#| msgid ""
+#| "Select <code>.xlsx</code> exported from <a href=\"https://doufen.org\" "
+#| "target=\"_blank\" rel=\"noopener\">Doufen</a>"
+msgid ""
+"A Douban archive exported by <a href=\"https://doubak.com\" "
+"target=\"_blank\" rel=\"noopener\">Doubak</a> is in the same format and is "
+"imported here."
+msgstr ""
+"在<a href=\"https://doufen.org\" target=\"_blank\" rel=\"noopener\">豆伴(豆"
+"墳)</a>導出時勾選<mark>書影音遊劇</mark>和<mark>評論</mark>。<br>選擇從豆伴"
+"(豆墳)導出的<code>.xlsx</code>文件"
 
 #: users/templates/users/data.html:314
 #, fuzzy


### PR DESCRIPTION
Merges the pending Weblate commit (zh_Hans and pt_BR translations, plus the msgmerge add-on update) that Weblate could not rebase onto `main`.

## Why Weblate was stuck

The repo stores `zh_Hans` in `makemessages --no-wrap` form, while the Weblate component wrote PO files wrapped at 77 columns. Weblate rebases its local commits onto `main` with its gettext merge driver disabled, so a wrap-only difference plus adjacent header changes was a hard conflict.

## Resolution

- `zh_Hans`: keep the no-wrap file regenerated on `main` and apply the five translations added on Weblate (`Display Name`, `Manually approve new followers`, `Include profile, marks and posts in discovery`, `Profile picture`, `Header picture`). Weblate's rewording of `Cut the sh*t and get me in!` is not taken. Verified with polib keyed on `(msgctxt, msgid)`: exactly 5 msgstr changes vs `main`, no translation lost; `msgfmt -c` passes; translate-toolkit round trip at Weblate's new wrap setting is byte-identical.
- The other 14 locales merged cleanly and are identical to Weblate's copies.
- `docs/development.md`: record the Weblate settings that match `makemessages` and the merge-commit rule.

## Weblate component settings changed alongside this PR

- Long lines wrapping: only wrap at newlines (like `xgettext --no-wrap`). Also makes the msgmerge add-on pass `--no-wrap`.
- Remove obsolete strings: on, matching `--no-obsolete`.
- Report msgid bugs to: off, so Weblate stops rewriting the header line that `makemessages` blanks.
- Push on commit: on.

## Landing this PR

**Merge with a merge commit, not squash or rebase.** Weblate's local commit `07c9c44b` is a parent of the merge commit here; with a merge commit, Weblate's next rebase finds nothing to replay and the alert clears on its own. If it is squashed, use "Reset and discard" in Weblate's repository maintenance afterwards (safe: 0 pending units).

After landing, the msgmerge add-on will rewrite the other 14 locales into no-wrap form in one "Update translation files" commit. `zh_Hans` should be untouched by that commit. Their `#~` entries go away later, as Weblate next saves each locale.
