### PR TITLE
style(catalog): color every site label and collapse long label lists

### DIFF
--- a/neodb/catalog/models/item.py
+++ b/neodb/catalog/models/item.py
@@ -1592,6 +1592,26 @@ class ExternalResource(models.Model):
     def __str__(self):
         return f"{self.pk}:{self.id_type}:{self.id_value or ''} ({self.url})"
 
+    # label order: these sites first, Fediverse last, others keep creation order
+    DISPLAY_PRIORITY: dict[SiteName, int] = {
+        SiteName.WikiData: 0,
+        SiteName.IMDB: 1,
+        SiteName.TMDB: 2,
+        SiteName.IGDB: 3,
+        SiteName.MusicBrainz: 4,
+        SiteName.GoogleBooks: 5,
+        SiteName.Fediverse: 99,
+    }
+
+    @classmethod
+    def sort_for_display(
+        cls, resources: "Iterable[ExternalResource]"
+    ) -> "list[ExternalResource]":
+        return sorted(
+            resources,
+            key=lambda r: (cls.DISPLAY_PRIORITY.get(r.site_name, 10), r.pk or 0),
+        )
+
     def has_cover(self) -> bool:
         return bool(self.cover) and self.cover != settings.DEFAULT_ITEM_COVER
 

--- a/neodb/catalog/templates/_item_card.html
+++ b/neodb/catalog/templates/_item_card.html
@@ -7,13 +7,7 @@
         <a href="{{ item.url }}">{{ item.display_title }}</a>
         <small>
           {% if not hide_category %}<span class="category">[{{ item.category.label }}]</span>{% endif %}
-          <span class="site-list">
-            {% for res in item.external_resources.all %}
-              <a href="{{ res.url }}"
-                 class="{{ res.site_name }}"
-                 rel="noopener noreferrer">{{ res.site_label }}</a>
-            {% endfor %}
-          </span>
+          {% include "_site_labels.html" with resources=item.external_resources.all %}
         </small>
       </h5>
     </hgroup>

--- a/neodb/catalog/templates/_item_card_metadata_base.html
+++ b/neodb/catalog/templates/_item_card_metadata_base.html
@@ -13,13 +13,7 @@
     <small>
       {% if item.year %}({{ item.year }}){% endif %}
       {% if not hide_category %}<span class="category">[{{ item.category.label }}]</span>{% endif %}
-      <span class="site-list">
-        {% for res in item.external_resources.all %}
-          <a href="{{ res.url }}"
-             class="{{ res.site_name }}"
-             rel="noopener noreferrer">{{ res.site_label }}</a>
-        {% endfor %}
-      </span>
+      {% include "_site_labels.html" with resources=item.external_resources.all %}
     </small>
   </h5>
   <small>

--- a/neodb/catalog/templates/_site_labels.html
+++ b/neodb/catalog/templates/_site_labels.html
@@ -1,14 +1,14 @@
 {% load duration %}
 {% comment %}
 resources: ExternalResource list; wikipedia: enable the WikiData popup
-Labels past the fourth are hidden behind a +N chip until clicked.
+Up to four labels render in full; from five on, only three plus a +N chip.
 {% endcomment %}
 {% with resources=resources|site_order %}
   {% with count=resources|length %}
     <span class="site-list{% if count > 4 %} collapsed{% endif %}">
       {% for res in resources %}
         <a href="{{ res.url }}"
-           class="{{ res.site_name }}{% if forloop.counter > 4 %} extra{% endif %}"
+           class="{{ res.site_name }}{% if count > 4 and forloop.counter > 3 %} extra{% endif %}"
            {% if wikipedia and res.site_name == 'wikidata' %} hx-get="{% url 'catalog:wikipedia_pages' item.url_path item.uuid res.id_value %}" hx-target="body" hx-swap="beforeend" {% endif %}
            rel="noopener noreferrer">{{ res.site_label }}</a>
       {% endfor %}
@@ -16,7 +16,7 @@ Labels past the fourth are hidden behind a +N chip until clicked.
         <a class="more"
            role="button"
            tabindex="0"
-           _="on click or keyup[key=='Enter'] remove .collapsed from the closest .site-list">+{{ count|add:"-4" }}</a>
+           _="on click or keyup[key=='Enter'] remove .collapsed from the closest .site-list">+{{ count|add:"-3" }}</a>
       {% endif %}
     </span>
   {% endwith %}

--- a/neodb/catalog/templates/_site_labels.html
+++ b/neodb/catalog/templates/_site_labels.html
@@ -1,20 +1,23 @@
+{% load duration %}
 {% comment %}
 resources: ExternalResource list; wikipedia: enable the WikiData popup
-Labels past the third are hidden behind a +N chip until clicked.
+Labels past the fourth are hidden behind a +N chip until clicked.
 {% endcomment %}
-{% with count=resources|length %}
-  <span class="site-list{% if count > 3 %} collapsed{% endif %}">
-    {% for res in resources %}
-      <a href="{{ res.url }}"
-         class="{{ res.site_name }}{% if forloop.counter > 3 %} extra{% endif %}"
-         {% if wikipedia and res.site_name == 'wikidata' %} hx-get="{% url 'catalog:wikipedia_pages' item.url_path item.uuid res.id_value %}" hx-target="body" hx-swap="beforeend" {% endif %}
-         rel="noopener noreferrer">{{ res.site_label }}</a>
-    {% endfor %}
-    {% if count > 3 %}
-      <a class="more"
-         role="button"
-         tabindex="0"
-         _="on click or keyup[key=='Enter'] remove .collapsed from the closest .site-list">+{{ count|add:"-3" }}</a>
-    {% endif %}
-  </span>
+{% with resources=resources|site_order %}
+  {% with count=resources|length %}
+    <span class="site-list{% if count > 4 %} collapsed{% endif %}">
+      {% for res in resources %}
+        <a href="{{ res.url }}"
+           class="{{ res.site_name }}{% if forloop.counter > 4 %} extra{% endif %}"
+           {% if wikipedia and res.site_name == 'wikidata' %} hx-get="{% url 'catalog:wikipedia_pages' item.url_path item.uuid res.id_value %}" hx-target="body" hx-swap="beforeend" {% endif %}
+           rel="noopener noreferrer">{{ res.site_label }}</a>
+      {% endfor %}
+      {% if count > 4 %}
+        <a class="more"
+           role="button"
+           tabindex="0"
+           _="on click or keyup[key=='Enter'] remove .collapsed from the closest .site-list">+{{ count|add:"-4" }}</a>
+      {% endif %}
+    </span>
+  {% endwith %}
 {% endwith %}

--- a/neodb/catalog/templates/_site_labels.html
+++ b/neodb/catalog/templates/_site_labels.html
@@ -1,0 +1,20 @@
+{% comment %}
+resources: ExternalResource list; wikipedia: enable the WikiData popup
+Labels past the third are hidden behind a +N chip until clicked.
+{% endcomment %}
+{% with count=resources|length %}
+  <span class="site-list{% if count > 3 %} collapsed{% endif %}">
+    {% for res in resources %}
+      <a href="{{ res.url }}"
+         class="{{ res.site_name }}{% if forloop.counter > 3 %} extra{% endif %}"
+         {% if wikipedia and res.site_name == 'wikidata' %} hx-get="{% url 'catalog:wikipedia_pages' item.url_path item.uuid res.id_value %}" hx-target="body" hx-swap="beforeend" {% endif %}
+         rel="noopener noreferrer">{{ res.site_label }}</a>
+    {% endfor %}
+    {% if count > 3 %}
+      <a class="more"
+         role="button"
+         tabindex="0"
+         _="on click or keyup[key=='Enter'] remove .collapsed from the closest .site-list">+{{ count|add:"-3" }}</a>
+    {% endif %}
+  </span>
+{% endwith %}

--- a/neodb/catalog/templates/item_base.html
+++ b/neodb/catalog/templates/item_base.html
@@ -56,22 +56,7 @@
             {% if item.year %}({{ item.year }}){% endif %}
           </small>
         </h1>
-        <span class="site-list">
-          {% for res in item.display_resources %}
-            {% if res.site_name == 'wikidata' %}
-              <a href="{{ res.url }}"
-                 class="{{ res.site_name }}"
-                 hx-get="{% url 'catalog:wikipedia_pages' item.url_path item.uuid res.id_value %}"
-                 hx-target="body"
-                 hx-swap="beforeend"
-                 rel="noopener noreferrer">{{ res.site_label }}</a>
-            {% else %}
-              <a href="{{ res.url }}"
-                 class="{{ res.site_name }}"
-                 rel="noopener noreferrer">{{ res.site_label }}</a>
-            {% endif %}
-          {% endfor %}
-        </span>
+        {% include "_site_labels.html" with resources=item.display_resources wikipedia=True %}
       </div>
       <div id="item-cover" class="left">
         <img src="{{ item.cover_image_url|default:item.cover.url|default:item.default_cover_image_url|relative_uri }}"

--- a/neodb/common/static/scss/_sitelabel.scss
+++ b/neodb/common/static/scss/_sitelabel.scss
@@ -15,6 +15,22 @@
     white-space: nowrap;
   }
 
+  // "+N" chip; labels past the third stay hidden until it is clicked
+  .more {
+    cursor: pointer;
+    color: var(--pico-muted-color);
+    border-color: var(--pico-muted-border-color);
+    border-style: dashed;
+  }
+
+  &.collapsed .extra {
+    display: none;
+  }
+
+  &:not(.collapsed) .more {
+    display: none;
+  }
+
   .ao3 {
     border: none;
     color: white;
@@ -179,5 +195,76 @@
     background-color: #E1DCC5;
     border-color: #D3CCB0;
     font-weight: normal;
+  }
+
+  .bibliotekdk {
+    color: white;
+    background-color: #3333FF;
+    border: none;
+  }
+
+  .eReolen {
+    color: white;
+    background-color: #B81B40;
+    border: none;
+  }
+
+  .apple_podcast {
+    background: linear-gradient(135deg, #B150E2, #872EC4);
+    color: white;
+    border: none;
+  }
+
+  .worldcat {
+    color: white;
+    background-color: #1074C3;
+    border: none;
+  }
+
+  .mobygames {
+    color: #FFFFFF;
+    background-color: #07576D;
+    border: none;
+    font-weight: bold;
+  }
+
+  .storygraph {
+    color: #FFFFFF;
+    background-color: #2AB5C0;
+    border: none;
+    font-weight: bold;
+  }
+
+  .yt_music {
+    color: white;
+    background-color: #FF0000;
+    border: none;
+  }
+
+  .rateyourmusic {
+    color: #84C5FB;
+    background-color: #152238;
+    border: none;
+    font-weight: bold;
+  }
+
+  .anilist {
+    color: #FFFFFF;
+    background-color: #02A9FF;
+    border: none;
+    font-weight: bold;
+  }
+
+  .myanimelist {
+    color: white;
+    background-color: #2E51A2;
+    border: none;
+  }
+
+  .mangaupdates {
+    color: #FFFFFF;
+    background-color: #FF8C15;
+    border: none;
+    font-weight: bold;
   }
 }

--- a/neodb/common/static/scss/_sitelabel.scss
+++ b/neodb/common/static/scss/_sitelabel.scss
@@ -15,7 +15,7 @@
     white-space: nowrap;
   }
 
-  // "+N" chip; labels past the fourth stay hidden until it is clicked
+  // "+N" chip; with five or more labels, those past the third hide until clicked
   .more {
     cursor: pointer;
     color: var(--pico-muted-color);

--- a/neodb/common/static/scss/_sitelabel.scss
+++ b/neodb/common/static/scss/_sitelabel.scss
@@ -15,7 +15,7 @@
     white-space: nowrap;
   }
 
-  // "+N" chip; labels past the third stay hidden until it is clicked
+  // "+N" chip; labels past the fourth stay hidden until it is clicked
   .more {
     cursor: pointer;
     color: var(--pico-muted-color);

--- a/neodb/common/templatetags/duration.py
+++ b/neodb/common/templatetags/duration.py
@@ -6,7 +6,7 @@ from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
-from catalog.models import item_categories
+from catalog.models import ExternalResource, item_categories
 from catalog.views import visible_categories as _visible_categories
 from common.models.country import country_display_name
 from common.models.duration import format_duration
@@ -90,6 +90,11 @@ def rating_star(value):
 @stringfilter
 def relative_uri(value: str) -> str:
     return str(value).replace(settings.SITE_INFO["site_url"], "") if value else value
+
+
+@register.filter
+def site_order(resources):
+    return ExternalResource.sort_for_display(resources)
 
 
 @register.filter

--- a/neodb/tests/catalog/test_site_labels.py
+++ b/neodb/tests/catalog/test_site_labels.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from django.test import Client
 
@@ -7,17 +9,28 @@ from catalog.models import Edition, ExternalResource, IdType
 def _edition_with_resources(title: str, id_types: list[IdType]) -> Edition:
     item = Edition.objects.create(title=title)
     for n, id_type in enumerate(id_types):
+        value = f"{title}-{n}"
+        if id_type == IdType.Fediverse:
+            value = f"https://fedi.example/items/{n}"
+        elif id_type == IdType.WikiData:
+            value = f"Q{n}"
         ExternalResource.objects.create(
             item=item,
             id_type=id_type,
-            id_value=f"{title}-{n}",
-            url=f"https://example.org/{title}/{n}",
+            id_value=value,
+            url=f"https://example.org/{value}",
         )
     return item
 
 
+def _label_classes(html: str) -> list[str]:
+    block = re.search(r'<span class="site-list[^"]*">(.*?)</span>', html, re.S)
+    assert block
+    return re.findall(r'class="([^"]+)"', block.group(1))
+
+
 @pytest.mark.django_db(databases="__all__")
-def test_item_page_collapses_labels_past_three():
+def test_item_page_collapses_labels_past_four():
     item = _edition_with_resources(
         "many",
         [
@@ -26,6 +39,7 @@ def test_item_page_collapses_labels_past_three():
             IdType.GoogleBooks,
             IdType.BooksTW,
             IdType.OpenLibrary,
+            IdType.Readmoo,
         ],
     )
     html = Client().get(item.url).content.decode()
@@ -35,12 +49,36 @@ def test_item_page_collapses_labels_past_three():
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_item_page_keeps_three_labels_flat():
+def test_item_page_keeps_four_labels_flat():
     item = _edition_with_resources(
-        "three", [IdType.DoubanBook, IdType.Goodreads, IdType.GoogleBooks]
+        "four",
+        [IdType.DoubanBook, IdType.Goodreads, IdType.GoogleBooks, IdType.BooksTW],
     )
     html = Client().get(item.url).content.decode()
     assert 'class="site-list"' in html
     assert "collapsed" not in html
     assert ' extra"' not in html
     assert 'class="more"' not in html
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_labels_order_priority_sites_first_and_fediverse_last():
+    item = _edition_with_resources(
+        "order",
+        [
+            IdType.Fediverse,
+            IdType.BooksTW,
+            IdType.GoogleBooks,
+            IdType.DoubanBook,
+            IdType.WikiData,
+        ],
+    )
+    html = Client().get(item.url).content.decode()
+    assert _label_classes(html) == [
+        "wikidata",
+        "googlebooks",
+        "bookstw",
+        "douban",
+        "fedi extra",
+        "more",
+    ]

--- a/neodb/tests/catalog/test_site_labels.py
+++ b/neodb/tests/catalog/test_site_labels.py
@@ -1,0 +1,46 @@
+import pytest
+from django.test import Client
+
+from catalog.models import Edition, ExternalResource, IdType
+
+
+def _edition_with_resources(title: str, id_types: list[IdType]) -> Edition:
+    item = Edition.objects.create(title=title)
+    for n, id_type in enumerate(id_types):
+        ExternalResource.objects.create(
+            item=item,
+            id_type=id_type,
+            id_value=f"{title}-{n}",
+            url=f"https://example.org/{title}/{n}",
+        )
+    return item
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_item_page_collapses_labels_past_three():
+    item = _edition_with_resources(
+        "many",
+        [
+            IdType.DoubanBook,
+            IdType.Goodreads,
+            IdType.GoogleBooks,
+            IdType.BooksTW,
+            IdType.OpenLibrary,
+        ],
+    )
+    html = Client().get(item.url).content.decode()
+    assert 'class="site-list collapsed"' in html
+    assert html.count(' extra"') == 2
+    assert ">+2</a>" in html
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_item_page_keeps_three_labels_flat():
+    item = _edition_with_resources(
+        "three", [IdType.DoubanBook, IdType.Goodreads, IdType.GoogleBooks]
+    )
+    html = Client().get(item.url).content.decode()
+    assert 'class="site-list"' in html
+    assert "collapsed" not in html
+    assert ' extra"' not in html
+    assert 'class="more"' not in html

--- a/neodb/tests/catalog/test_site_labels.py
+++ b/neodb/tests/catalog/test_site_labels.py
@@ -30,7 +30,7 @@ def _label_classes(html: str) -> list[str]:
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_item_page_collapses_labels_past_four():
+def test_item_page_collapses_to_three_from_five_labels():
     item = _edition_with_resources(
         "many",
         [
@@ -44,8 +44,8 @@ def test_item_page_collapses_labels_past_four():
     )
     html = Client().get(item.url).content.decode()
     assert 'class="site-list collapsed"' in html
-    assert html.count(' extra"') == 2
-    assert ">+2</a>" in html
+    assert html.count(' extra"') == 3
+    assert ">+3</a>" in html
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -78,7 +78,7 @@ def test_labels_order_priority_sites_first_and_fediverse_last():
         "wikidata",
         "googlebooks",
         "bookstw",
-        "douban",
+        "douban extra",
         "fedi extra",
         "more",
     ]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] You, as a human, have fully reviewed every single line of this PR
- [x] You, as a human, have fully tested this PR


* **What kind of change does this PR introduce?**
- [ ] bug fix, including security or performance improvements
- [x] feature
- [ ] docs
- [x] other


* **What is the current behavior?**

Eleven sites render as plain bordered labels because `_sitelabel.scss` has no rule for them: Bibliotek.dk, eReolen, Apple Podcast, WorldCat, MobyGames, StoryGraph, YouTube Music, RateYourMusic, AniList, MyAnimeList and MangaUpdates.

An item with many external resources shows every label in database order, which crowds the title row on the item page and the header of item cards.


* **What is the new behavior?**

- Every site has a label color. Sources: Bibliotek.dk and WorldCat from their `theme-color` meta, StoryGraph and RateYourMusic from computed styles on the live site, eReolen from its logo, MobyGames from its logo SVG, MyAnimeList and Apple Podcast from brand color references, AniList and MangaUpdates from their favicon, YouTube Music red from the brand.
- The three label loops (item page, `_item_card.html`, `_item_card_metadata_base.html`) share one include, `_site_labels.html`.
- Labels are sorted by importance: WikiData, IMDb, TMDB, IGDB, MusicBrainz, Google Books first, Fediverse instances last, others keep creation order.
- Up to four labels render in full. With five or more, the first three render and a `+N` chip reveals the rest on click or Enter. The chip is inline, so it works on wide and narrow screens.

* **Does this PR introduce a breaking change?**

No.


* **Other information**:

Card templates still read only `url`, `site_name` and `site_label` from the slim prefetch, and `tests/catalog/test_search_n_plus_one.py` still passes. `tests/catalog/test_site_labels.py` covers the cutoff, the flat four-label case and the ordering.
